### PR TITLE
fix(tenant): use BUNKER_RELAYS env var for default relay

### DIFF
--- a/api/src/api/tenant.rs
+++ b/api/src/api/tenant.rs
@@ -55,12 +55,12 @@ impl Tenant {
         }
     }
 
-    /// Get relay URL with fallback to default
+    /// Get relay URL with fallback to first BUNKER_RELAYS entry
     pub fn relay_url(&self) -> String {
         self.get_settings()
             .ok()
             .and_then(|s| s.relay)
-            .unwrap_or_else(|| "wss://relay.damus.io".to_string())
+            .unwrap_or_else(get_default_relay)
     }
 
     /// Get email from address with fallback
@@ -286,15 +286,33 @@ fn validate_domain(domain: &str) -> Result<(), TenantError> {
     Ok(())
 }
 
+/// Get default relay URL from BUNKER_RELAYS environment variable
+fn get_default_relay() -> String {
+    std::env::var("BUNKER_RELAYS")
+        .ok()
+        .and_then(|relays| {
+            relays
+                .split(',')
+                .map(|s| s.trim())
+                .find(|s| !s.is_empty())
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_else(|| "wss://relay.damus.io".to_string())
+}
+
 /// Create default tenant settings JSON
 fn get_default_settings(domain: &str) -> String {
+    let default_relay = get_default_relay();
     let settings = TenantSettings {
-        relay: Some("wss://relay.damus.io".to_string()),
+        relay: Some(default_relay.clone()),
         email_from: Some(format!("noreply@{}", domain)),
     };
 
     serde_json::to_string(&settings).unwrap_or_else(|_| {
-        r#"{"relay":"wss://relay.damus.io","auto_provisioned":true}"#.to_string()
+        format!(
+            r#"{{"relay":"{}","email_from":"noreply@{}"}}"#,
+            default_relay, domain
+        )
     })
 }
 
@@ -394,8 +412,13 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_tenant_relay_url_fallback() {
         use chrono::Utc;
+
+        // Clear any existing BUNKER_RELAYS to test default fallback
+        std::env::remove_var("BUNKER_RELAYS");
+
         let tenant = Tenant {
             id: 1,
             domain: "test.com".to_string(),
@@ -405,7 +428,31 @@ mod tests {
             updated_at: Utc::now(),
         };
 
+        // Without BUNKER_RELAYS, should fall back to relay.damus.io
         assert_eq!(tenant.relay_url(), "wss://relay.damus.io");
+    }
+
+    #[test]
+    #[serial]
+    fn test_tenant_relay_url_from_bunker_relays_env() {
+        use chrono::Utc;
+
+        // Set BUNKER_RELAYS - should use first relay
+        std::env::set_var("BUNKER_RELAYS", "wss://relay1.example.com,wss://relay2.example.com");
+
+        let tenant = Tenant {
+            id: 1,
+            domain: "test.com".to_string(),
+            name: "Test".to_string(),
+            settings: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        assert_eq!(tenant.relay_url(), "wss://relay1.example.com");
+
+        // Clean up
+        std::env::remove_var("BUNKER_RELAYS");
     }
 
     #[test]

--- a/database/migrations/0002_update_tenant_relay_defaults.sql
+++ b/database/migrations/0002_update_tenant_relay_defaults.sql
@@ -1,0 +1,13 @@
+-- Migration: Remove hardcoded relay.damus.io from tenant settings
+-- After this migration, tenants without a relay setting will use BUNKER_RELAYS env var
+-- This fixes tenants that were auto-provisioned with the old hardcoded default
+
+-- Remove the relay field from settings for tenants using relay.damus.io
+-- This allows the application to use BUNKER_RELAYS environment variable as fallback
+UPDATE tenants
+SET settings = (settings::jsonb - 'relay')::text,
+    updated_at = NOW()
+WHERE settings IS NOT NULL
+  AND settings::jsonb->>'relay' = 'wss://relay.damus.io';
+
+


### PR DESCRIPTION
- Add get_default_relay() to read first non-empty relay from BUNKER_RELAYS
- Fix relay parsing to trim all entries before selecting first non-empty one
- Fix get_default_settings() fallback to include email_from field
- Add tests for env var relay configuration
- Fall back to wss://relay.damus.io when BUNKER_RELAYS is unset