### PR TITLE
feat: add TLS support to sqlx with tls-rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ once_cell = "1.2"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sqlx = { version = "0.8.6", features = [ "runtime-tokio", "postgres", "migrate", "macros", "chrono", "derive", "json" ] }
+sqlx = { version = "0.8.6", features = [ "runtime-tokio", "postgres", "migrate", "macros", "chrono", "derive", "json", "tls-rustls" ] }
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/tests/qa/Cargo.toml
+++ b/tests/qa/Cargo.toml
@@ -49,7 +49,7 @@ base64 = "0.22"
 rand = "0.8"
 
 # Database (for direct assertions)
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "tls-rustls"] }
 
 # Utilities
 thiserror = "2.0"


### PR DESCRIPTION
## Summary
- Add `tls-rustls` feature to sqlx in workspace Cargo.toml
- Add `tls-rustls` feature to sqlx in tests/qa/Cargo.toml

Enables TLS connections for PostgreSQL using rustls (pure Rust TLS), recommended for container deployments.