### PR TITLE
fix: add migrations directory to Dockerfile rust-builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ COPY ./core ./core
 COPY ./keycast ./keycast
 COPY ./cluster-hashring ./cluster-hashring
 COPY ./tools ./tools
+COPY ./database/migrations ./database/migrations
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock
 


### PR DESCRIPTION
## Summary
- Add `COPY ./database/migrations ./database/migrations` to the rust-builder stage
- The `sqlx::migrate!` macro requires the migrations directory at compile time
- Without this, Docker builds fail with "error canonicalizing migration directory"

## Test plan
- [x] Docker build completes successfully
- [x] Image pushed to all registries (POC, staging, test, production)