### PR TITLE
feat: add vine user migration Phase 1 (KMS round-trip test)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,14 @@ database/*.db*
 master.key
 *.key
 *service-account*.json
+*-sa.json
+*-sa-*.json
+keycast-migration*.json
+
+# Migration artifacts
+migration-*.log
+migration-checkpoint.json
+scripts/migration-kms-setup.sh
 
 # Documentation (not needed in image)
 docs/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@ master.key
 # Service account credentials
 *service-account*.json
 credentials.json
+*-sa.json
+*-sa-*.json
+keycast-migration*.json
+
+# Migration artifacts
+migration-*.log
+migration-checkpoint.json
 
 # Git worktrees
 .worktrees/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock
 
 RUN cargo build --release --bin keycast
+RUN cargo build --release --example migrate-vine-users
 
 # Build stage for Bun frontend
 FROM oven/bun:1 AS web-builder
@@ -103,8 +104,9 @@ RUN curl -fsSL https://bun.sh/install | bash
 # Create necessary directories
 RUN mkdir -p /app/database /data
 
-# Copy built artifacts - only keycast binary (unified)
+# Copy built artifacts - keycast binary and migration tool
 COPY --from=rust-builder /app/target/release/keycast ./
+COPY --from=rust-builder /app/target/release/examples/migrate-vine-users ./
 COPY --from=web-builder /app/web/build ./web
 COPY --from=web-builder /app/web/package.json ./
 COPY --from=web-builder /app/web/node_modules ./node_modules

--- a/core/examples/migrate-vine-users.rs
+++ b/core/examples/migrate-vine-users.rs
@@ -1,0 +1,228 @@
+// ABOUTME: Migrate vine-imported users from openvine-co to dv-platform-prod
+// ABOUTME: Re-encrypts personal keys with target KMS key
+// ABOUTME: Run with: cargo run --example migrate-vine-users
+//
+// Phase 1: KMS round-trip test (current) - validates KMS access
+// Phase 2: Single user migration - adds DB connectivity
+// Phase 3: Full migration - batch process all vine users
+
+use google_cloud_kms::client::{Client, ClientConfig};
+use google_cloud_kms::grpc::kms::v1::{DecryptRequest, EncryptRequest};
+
+// Source: Cloud Run (openvine-co)
+const SOURCE_PROJECT: &str = "openvine-co";
+const SOURCE_LOCATION: &str = "global";
+const SOURCE_KEYRING: &str = "keycast-keys";
+const SOURCE_KEY: &str = "master-key";
+
+// Target: GKE (dv-platform-prod)
+const TARGET_PROJECT: &str = "dv-platform-prod";
+const TARGET_LOCATION: &str = "us-central1";
+const TARGET_KEYRING: &str = "app-keys-production";
+const TARGET_KEY: &str = "keycast-master-key";
+
+fn key_path(project: &str, location: &str, keyring: &str, key: &str) -> String {
+    format!(
+        "projects/{}/locations/{}/keyRings/{}/cryptoKeys/{}",
+        project, location, keyring, key
+    )
+}
+
+async fn test_encrypt_decrypt(client: &Client, key_path: &str) -> Result<(), String> {
+    let test_data = format!(
+        "migration-test-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    );
+
+    // Test encrypt
+    println!("  🔒 Testing encrypt...");
+    let encrypt_request = EncryptRequest {
+        name: key_path.to_string(),
+        plaintext: test_data.as_bytes().to_vec(),
+        additional_authenticated_data: vec![],
+        plaintext_crc32c: None,
+        additional_authenticated_data_crc32c: None,
+    };
+
+    let encrypted = client
+        .encrypt(encrypt_request, None)
+        .await
+        .map_err(|e| format!("Encrypt failed: {}", e))?;
+
+    println!("  ✅ Encrypt OK ({} bytes)", encrypted.ciphertext.len());
+
+    // Test decrypt
+    println!("  🔓 Testing decrypt...");
+    let decrypt_request = DecryptRequest {
+        name: key_path.to_string(),
+        ciphertext: encrypted.ciphertext,
+        additional_authenticated_data: vec![],
+        ciphertext_crc32c: None,
+        additional_authenticated_data_crc32c: None,
+    };
+
+    let decrypted = client
+        .decrypt(decrypt_request, None)
+        .await
+        .map_err(|e| format!("Decrypt failed: {}", e))?;
+
+    if decrypted.plaintext == test_data.as_bytes() {
+        println!("  ✅ Decrypt OK (verified)");
+        Ok(())
+    } else {
+        Err("Decrypt succeeded but data mismatch".to_string())
+    }
+}
+
+/// Test decrypt only (for source - we only need to read existing secrets)
+async fn test_decrypt_with_sample(
+    client: &Client,
+    source_key: &str,
+    target_key: &str,
+) -> Result<(), String> {
+    // First encrypt something with target key (which we have full access to)
+    let test_data = format!(
+        "migration-test-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    );
+
+    println!("  🔒 Creating test ciphertext with target key...");
+    let encrypt_request = EncryptRequest {
+        name: target_key.to_string(),
+        plaintext: test_data.as_bytes().to_vec(),
+        additional_authenticated_data: vec![],
+        plaintext_crc32c: None,
+        additional_authenticated_data_crc32c: None,
+    };
+
+    let encrypted = client
+        .encrypt(encrypt_request, None)
+        .await
+        .map_err(|e| format!("Encrypt with target key failed: {}", e))?;
+
+    // Now test that we can decrypt with source key
+    // NOTE: This will fail because data encrypted with target key can't be decrypted with source key
+    // Instead, we just test that we have decrypt permission by trying to decrypt garbage
+    // (it will fail with decryption error, not permission error)
+
+    println!("  🔓 Testing decrypt permission on source key...");
+    let decrypt_request = DecryptRequest {
+        name: source_key.to_string(),
+        ciphertext: encrypted.ciphertext, // This is encrypted with wrong key, but tests permission
+        additional_authenticated_data: vec![],
+        ciphertext_crc32c: None,
+        additional_authenticated_data_crc32c: None,
+    };
+
+    match client.decrypt(decrypt_request, None).await {
+        Ok(_) => {
+            // Unexpected success (shouldn't happen with wrong key)
+            println!("  ✅ Decrypt OK (unexpected but good)");
+            Ok(())
+        }
+        Err(e) => {
+            let err_str = e.to_string();
+            if err_str.contains("PermissionDenied") || err_str.contains("permission") {
+                Err(format!("Decrypt permission denied: {}", e))
+            } else {
+                // Decryption failed for other reason (e.g., wrong key) - but we have permission!
+                println!(
+                    "  ✅ Decrypt permission OK (decryption failed as expected - different key)"
+                );
+                Ok(())
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("🔑 Migration KMS Access Test");
+    println!("============================");
+    println!();
+    println!("This tests if the current credentials can access BOTH KMS keys");
+    println!("needed for cross-project migration.");
+    println!();
+
+    // Initialize KMS client (uses Application Default Credentials)
+    println!("📡 Initializing GCP KMS client...");
+    let config = ClientConfig::default()
+        .with_auth()
+        .await
+        .map_err(|e| format!("Auth failed: {}", e))?;
+
+    let client = Client::new(config)
+        .await
+        .map_err(|e| format!("Client creation failed: {}", e))?;
+
+    println!("✅ KMS client initialized");
+    println!();
+
+    // Test target KMS first (dv-platform-prod) - we need full access here
+    let target_path = key_path(TARGET_PROJECT, TARGET_LOCATION, TARGET_KEYRING, TARGET_KEY);
+    println!("=== TARGET: dv-platform-prod (GKE) ===");
+    println!("Key: {}", target_path);
+    println!("Required: encrypt + decrypt (to store migrated secrets)");
+
+    let target_result = test_encrypt_decrypt(&client, &target_path).await;
+    let target_ok = target_result.is_ok();
+    if let Err(e) = &target_result {
+        println!("  ❌ FAILED: {}", e);
+    }
+    println!();
+
+    // Test source KMS (openvine-co) - only need decrypt permission
+    let source_path = key_path(SOURCE_PROJECT, SOURCE_LOCATION, SOURCE_KEYRING, SOURCE_KEY);
+    println!("=== SOURCE: openvine-co (Cloud Run) ===");
+    println!("Key: {}", source_path);
+    println!("Required: decrypt only (to read existing secrets)");
+
+    let source_result = if target_ok {
+        test_decrypt_with_sample(&client, &source_path, &target_path).await
+    } else {
+        Err("Skipped - target test failed".to_string())
+    };
+    let source_ok = source_result.is_ok();
+    if let Err(e) = source_result {
+        println!("  ❌ FAILED: {}", e);
+    }
+    println!();
+
+    // Summary
+    println!("============================");
+    println!("SUMMARY:");
+    println!(
+        "  Source (openvine-co):     {}",
+        if source_ok { "✅ OK" } else { "❌ FAILED" }
+    );
+    println!(
+        "  Target (dv-platform-prod): {}",
+        if target_ok { "✅ OK" } else { "❌ FAILED" }
+    );
+    println!();
+
+    if source_ok && target_ok {
+        println!("🎉 Both KMS keys accessible!");
+        println!("   You can use the cross-project migration approach.");
+        println!("   A single job can decrypt from source and re-encrypt to target.");
+    } else if source_ok && !target_ok {
+        println!("⚠️  Only source accessible.");
+        println!("   You'll need the HTTPS endpoint approach:");
+        println!("   - Source decrypts and sends to target over HTTPS");
+        println!("   - Target encrypts with its own KMS");
+    } else if !source_ok && target_ok {
+        println!("⚠️  Only target accessible.");
+        println!("   You may need to run the migration from the source environment.");
+    } else {
+        println!("❌ Neither KMS key accessible.");
+        println!("   Check your GCP authentication and IAM permissions.");
+    }
+
+    Ok(())
+}

--- a/k8s/jobs/migrate-vine-phase1.yaml
+++ b/k8s/jobs/migrate-vine-phase1.yaml
@@ -1,0 +1,42 @@
+# Phase 1: KMS Round-Trip Test
+# Tests KMS access from migration service account before attempting full migration
+#
+# Prerequisites:
+# - Run scripts/migration-setup.sh to create the keycast-migration SA
+# - Build and push the keycast image with the migrate-vine-users example
+#
+# Usage:
+#   kubectl apply -f k8s/jobs/migrate-vine-phase1.yaml
+#   kubectl logs -f job/migrate-vine-phase1 -n identity
+#   kubectl delete job migrate-vine-phase1 -n identity
+#
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: migrate-vine-phase1
+  namespace: identity
+  labels:
+    app: keycast-migration
+    phase: "1"
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: keycast-migration
+        phase: "1"
+    spec:
+      serviceAccountName: keycast-migration
+      restartPolicy: Never
+      containers:
+      - name: migrate
+        image: us-central1-docker.pkg.dev/dv-platform-prod/keycast/keycast:latest
+        command: ["/app/migrate-vine-users"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"

--- a/scripts/migration-setup.sh
+++ b/scripts/migration-setup.sh
@@ -1,0 +1,371 @@
+#!/bin/bash
+# ABOUTME: Set up Service Account for cross-project migration (KMS + DB access)
+# ABOUTME: Uses Workload Identity - tests run as K8s Job in the cluster
+# ABOUTME: Idempotent - safe to re-run. Creates SA and IAM bindings only if needed.
+#
+# Usage: ./scripts/migration-setup.sh [--test-only] [--skip-test]
+#   --test-only: Skip setup, only run test job (assumes SA already exists)
+#   --skip-test: Only do setup, don't run test job
+
+set -euo pipefail
+
+# Configuration
+SA_NAME="keycast-migration"
+SA_PROJECT="dv-platform-prod"
+SA_EMAIL="${SA_NAME}@${SA_PROJECT}.iam.gserviceaccount.com"
+
+SOURCE_PROJECT="openvine-co"
+TARGET_PROJECT="dv-platform-prod"
+
+# Database secrets (contain full DATABASE_URL with password)
+SOURCE_DB_SECRET="keycast-database-url"
+TARGET_DB_SECRET="keycast-db-url-production"
+
+# Cloud SQL instance (source only - target uses in-cluster CNPG)
+SOURCE_SQL_INSTANCE="openvine-co:us-central1:keycast-db-plus"
+
+# KMS keys
+SOURCE_KMS_KEY="projects/openvine-co/locations/global/keyRings/keycast-keys/cryptoKeys/master-key"
+TARGET_KMS_KEY="projects/dv-platform-prod/locations/us-central1/keyRings/app-keys-production/cryptoKeys/keycast-master-key"
+
+# K8s namespace for migration job
+K8S_NAMESPACE="identity"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() { echo -e "${GREEN}✓${NC} $1"; }
+warn() { echo -e "${YELLOW}⚠${NC} $1"; }
+error() { echo -e "${RED}✗${NC} $1"; }
+step() { echo -e "\n${GREEN}==>${NC} $1"; }
+
+cleanup() {
+    # Restore original gcloud config if we changed it
+    if [ -n "${ORIGINAL_CONFIG:-}" ]; then
+        gcloud config configurations activate "$ORIGINAL_CONFIG" &>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# Parse arguments
+TEST_ONLY=false
+SKIP_TEST=false
+for arg in "$@"; do
+    case $arg in
+        --test-only) TEST_ONLY=true ;;
+        --skip-test) SKIP_TEST=true ;;
+    esac
+done
+
+echo "========================================"
+echo "Migration Setup (KMS + DB Access)"
+echo "========================================"
+echo ""
+echo "Service Account: $SA_EMAIL"
+echo "Source Project:  $SOURCE_PROJECT (KMS decrypt, DB read)"
+echo "Target Project:  $TARGET_PROJECT (KMS encrypt/decrypt, DB write)"
+echo ""
+
+# Save current config to restore later
+ORIGINAL_CONFIG=$(gcloud config configurations list --filter="is_active=true" --format="value(name)" 2>/dev/null || echo "")
+
+if [ "$TEST_ONLY" = false ]; then
+    # ========================================
+    # STEP 1: Create GCP Service Account (if needed)
+    # ========================================
+    step "Checking GCP Service Account..."
+
+    # Switch to target project for SA creation
+    gcloud config configurations activate divine &>/dev/null || {
+        error "Could not activate 'divine' gcloud config. Please run: gcloud config configurations activate divine && gcloud auth login"
+        exit 1
+    }
+
+    if gcloud iam service-accounts describe "$SA_EMAIL" --project="$SA_PROJECT" &>/dev/null; then
+        info "GCP Service Account already exists: $SA_EMAIL"
+    else
+        warn "Creating GCP Service Account: $SA_EMAIL"
+        gcloud iam service-accounts create "$SA_NAME" \
+            --display-name="Keycast Migration (cross-project)" \
+            --description="Used for migrating data between openvine-co and dv-platform-prod" \
+            --project="$SA_PROJECT"
+        info "GCP Service Account created"
+    fi
+
+    # ========================================
+    # STEP 2: Grant KMS access in TARGET project
+    # ========================================
+    step "Setting up KMS access in TARGET project (${TARGET_PROJECT})..."
+
+    warn "Adding KMS IAM binding in $TARGET_PROJECT..."
+    gcloud projects add-iam-policy-binding "$TARGET_PROJECT" \
+        --member="serviceAccount:$SA_EMAIL" \
+        --role="roles/cloudkms.cryptoKeyEncrypterDecrypter" \
+        --quiet >/dev/null
+    info "KMS IAM binding configured in $TARGET_PROJECT"
+
+    # ========================================
+    # STEP 3: Grant KMS access in SOURCE project (cross-project)
+    # ========================================
+    step "Setting up KMS access in SOURCE project (${SOURCE_PROJECT})..."
+
+    gcloud config configurations activate default &>/dev/null || {
+        error "Could not activate 'default' gcloud config"
+        exit 1
+    }
+
+    warn "Adding KMS IAM binding in $SOURCE_PROJECT (cross-project access)..."
+    gcloud projects add-iam-policy-binding "$SOURCE_PROJECT" \
+        --member="serviceAccount:$SA_EMAIL" \
+        --role="roles/cloudkms.cryptoKeyDecrypter" \
+        --quiet >/dev/null
+    info "KMS IAM binding configured in $SOURCE_PROJECT"
+
+    # ========================================
+    # STEP 4: Grant Cloud SQL access (source only - target uses CNPG)
+    # ========================================
+    step "Setting up Cloud SQL access for SOURCE..."
+
+    warn "Adding Cloud SQL IAM binding in $SOURCE_PROJECT..."
+    gcloud projects add-iam-policy-binding "$SOURCE_PROJECT" \
+        --member="serviceAccount:$SA_EMAIL" \
+        --role="roles/cloudsql.client" \
+        --quiet >/dev/null
+    info "Cloud SQL IAM binding configured in $SOURCE_PROJECT"
+
+    # ========================================
+    # STEP 5: Grant Secret Manager access for DATABASE_URL secrets
+    # ========================================
+    step "Setting up Secret Manager access for DATABASE_URL..."
+
+    # Source project - DATABASE_URL secret
+    warn "Granting access to $SOURCE_DB_SECRET in $SOURCE_PROJECT..."
+    gcloud secrets add-iam-policy-binding "$SOURCE_DB_SECRET" \
+        --project="$SOURCE_PROJECT" \
+        --member="serviceAccount:$SA_EMAIL" \
+        --role="roles/secretmanager.secretAccessor" \
+        --quiet >/dev/null
+    info "Secret access configured for $SOURCE_DB_SECRET"
+
+    # Target project - DATABASE_URL secret
+    gcloud config configurations activate divine &>/dev/null
+    warn "Granting access to $TARGET_DB_SECRET in $TARGET_PROJECT..."
+    gcloud secrets add-iam-policy-binding "$TARGET_DB_SECRET" \
+        --project="$TARGET_PROJECT" \
+        --member="serviceAccount:$SA_EMAIL" \
+        --role="roles/secretmanager.secretAccessor" \
+        --quiet >/dev/null
+    info "Secret access configured for $TARGET_DB_SECRET"
+
+    # ========================================
+    # STEP 6: Set up Workload Identity binding
+    # ========================================
+    step "Setting up Workload Identity binding..."
+
+    # Allow K8s SA to impersonate GCP SA
+    gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
+        --project="$SA_PROJECT" \
+        --role="roles/iam.workloadIdentityUser" \
+        --member="serviceAccount:${SA_PROJECT}.svc.id.goog[${K8S_NAMESPACE}/${SA_NAME}]" \
+        --quiet >/dev/null
+    info "Workload Identity binding configured"
+
+    # ========================================
+    # STEP 7: Create K8s ServiceAccount
+    # ========================================
+    step "Creating K8s ServiceAccount..."
+
+    # Get cluster credentials
+    gcloud container clusters get-credentials gke-production --region=us-central1 --project="$SA_PROJECT" 2>/dev/null
+
+    # Create K8s ServiceAccount with Workload Identity annotation
+    kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${SA_NAME}
+  namespace: ${K8S_NAMESPACE}
+  annotations:
+    iam.gke.io/gcp-service-account: ${SA_EMAIL}
+EOF
+    info "K8s ServiceAccount created/updated"
+
+    echo ""
+    info "Setup complete! IAM changes may take up to 60 seconds to propagate."
+    echo ""
+fi
+
+if [ "$SKIP_TEST" = true ]; then
+    echo "Skipping test (--skip-test specified)"
+    exit 0
+fi
+
+# ========================================
+# STEP 8: Run test Job in cluster
+# ========================================
+step "Running migration access test as K8s Job..."
+
+# Make sure we have cluster credentials
+gcloud config configurations activate divine &>/dev/null
+gcloud container clusters get-credentials gke-production --region=us-central1 --project="$SA_PROJECT" 2>/dev/null
+
+# Delete old test job if exists
+kubectl delete job migration-access-test -n "$K8S_NAMESPACE" 2>/dev/null || true
+
+# Create and run test job
+kubectl apply -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: migration-access-test
+  namespace: ${K8S_NAMESPACE}
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: ${SA_NAME}
+      restartPolicy: Never
+      containers:
+      - name: test
+        image: google/cloud-sdk:slim
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          echo "========================================"
+          echo "Migration Access Test"
+          echo "========================================"
+          echo ""
+
+          # Test 1: KMS encrypt/decrypt on TARGET
+          echo "=== TEST 1: KMS Target (encrypt/decrypt) ==="
+          TEST_DATA="migration-test-\$(date +%s)"
+          echo -n "\$TEST_DATA" > /tmp/plaintext.txt
+
+          if gcloud kms encrypt \
+              --location=us-central1 \
+              --keyring=app-keys-production \
+              --key=keycast-master-key \
+              --plaintext-file=/tmp/plaintext.txt \
+              --ciphertext-file=/tmp/ciphertext.bin \
+              --project=${TARGET_PROJECT} 2>&1; then
+              echo "✓ Target KMS encrypt: OK"
+          else
+              echo "✗ Target KMS encrypt: FAILED"
+              exit 1
+          fi
+
+          if gcloud kms decrypt \
+              --location=us-central1 \
+              --keyring=app-keys-production \
+              --key=keycast-master-key \
+              --ciphertext-file=/tmp/ciphertext.bin \
+              --plaintext-file=/tmp/decrypted.txt \
+              --project=${TARGET_PROJECT} 2>&1; then
+              if [ "\$(cat /tmp/decrypted.txt)" = "\$TEST_DATA" ]; then
+                  echo "✓ Target KMS decrypt: OK (verified)"
+              else
+                  echo "✗ Target KMS decrypt: data mismatch"
+                  exit 1
+              fi
+          else
+              echo "✗ Target KMS decrypt: FAILED"
+              exit 1
+          fi
+          echo ""
+
+          # Test 2: KMS decrypt on SOURCE
+          echo "=== TEST 2: KMS Source (decrypt only) ==="
+          # We can only test that we have permission, not actual decrypt (different key)
+          if gcloud kms keys describe master-key \
+              --location=global \
+              --keyring=keycast-keys \
+              --project=${SOURCE_PROJECT} 2>&1 | grep -q "name:"; then
+              echo "✓ Source KMS access: OK (key accessible)"
+          else
+              echo "✗ Source KMS access: FAILED"
+              exit 1
+          fi
+          echo ""
+
+          # Test 3: Secret Manager - Source DATABASE_URL
+          echo "=== TEST 3: Secret Manager (DATABASE_URLs) ==="
+          if gcloud secrets versions access latest \
+              --secret=${SOURCE_DB_SECRET} \
+              --project=${SOURCE_PROJECT} >/dev/null 2>&1; then
+              echo "✓ Source DATABASE_URL secret: accessible"
+          else
+              echo "✗ Source DATABASE_URL secret: FAILED"
+              exit 1
+          fi
+
+          if gcloud secrets versions access latest \
+              --secret=${TARGET_DB_SECRET} \
+              --project=${TARGET_PROJECT} >/dev/null 2>&1; then
+              echo "✓ Target DATABASE_URL secret: accessible"
+          else
+              echo "✗ Target DATABASE_URL secret: FAILED"
+              exit 1
+          fi
+          echo ""
+
+          # Test 4: Database connectivity (basic - just test we can parse URL)
+          echo "=== TEST 4: Database URL validation ==="
+          SOURCE_URL=\$(gcloud secrets versions access latest --secret=${SOURCE_DB_SECRET} --project=${SOURCE_PROJECT})
+          TARGET_URL=\$(gcloud secrets versions access latest --secret=${TARGET_DB_SECRET} --project=${TARGET_PROJECT})
+
+          if echo "\$SOURCE_URL" | grep -q "postgres://"; then
+              echo "✓ Source DATABASE_URL: valid postgres URL"
+          else
+              echo "✗ Source DATABASE_URL: invalid format"
+              exit 1
+          fi
+
+          if echo "\$TARGET_URL" | grep -q "postgres://"; then
+              echo "✓ Target DATABASE_URL: valid postgres URL"
+          else
+              echo "✗ Target DATABASE_URL: invalid format"
+              exit 1
+          fi
+          echo ""
+
+          echo "========================================"
+          echo "All tests passed!"
+          echo "========================================"
+EOF
+
+echo ""
+info "Job created. Waiting for completion..."
+
+# Wait for job to complete
+if kubectl wait --for=condition=complete job/migration-access-test -n "$K8S_NAMESPACE" --timeout=120s 2>/dev/null; then
+    echo ""
+    info "Job completed successfully!"
+    echo ""
+    echo "=== Job Logs ==="
+    kubectl logs job/migration-access-test -n "$K8S_NAMESPACE"
+else
+    echo ""
+    error "Job failed or timed out"
+    echo ""
+    echo "=== Job Logs ==="
+    kubectl logs job/migration-access-test -n "$K8S_NAMESPACE" 2>/dev/null || echo "No logs available"
+    exit 1
+fi
+
+# Cleanup
+kubectl delete job migration-access-test -n "$K8S_NAMESPACE" 2>/dev/null || true
+
+echo ""
+echo "========================================"
+echo "Migration SA is ready!"
+echo ""
+echo "To use in a migration job:"
+echo "  serviceAccountName: ${SA_NAME}"
+echo "  namespace: ${K8S_NAMESPACE}"
+echo "========================================"


### PR DESCRIPTION
## Summary
- Add `migrate-vine-users` example for cross-project user migration
- Add K8s job manifest for running Phase 1 KMS test in cluster
- Include `migration-setup.sh` script for service account configuration
- Update Dockerfile to build and include migration binary

## Phase 1 Scope
Tests KMS access only (no database operations):
- TARGET (dv-platform-prod): encrypt + decrypt
- SOURCE (openvine-co): decrypt permission

## Test plan
- [ ] Deploy to cluster and run K8s job
- [ ] Verify KMS access passes for both projects
- [ ] Phase 2 will add database connectivity