### PR TITLE
feat: add /reset-password to AASA for iOS deep links

### DIFF
--- a/web/static/.well-known/apple-app-site-association
+++ b/web/static/.well-known/apple-app-site-association
@@ -18,6 +18,10 @@
           {
             "/": "/verify-email",
             "comment": "Email verification deep link"
+          },
+          {
+            "/": "/reset-password",
+            "comment": "Password reset deep link"
           }
         ]
       },
@@ -37,6 +41,10 @@
           {
             "/": "/verify-email",
             "comment": "Email verification deep link"
+          },
+          {
+            "/": "/reset-password",
+            "comment": "Password reset deep link"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Adds `/reset-password` path to `apple-app-site-association` for both app IDs (`co.openvine.keycastFlutterDemo` and `co.openvine.app`)
- Enables iOS universal links to intercept password reset URLs, opening them in the Flutter app instead of Safari
- `/verify-email` was already present; this adds the missing `/reset-password` counterpart

## Notes
- Android `assetlinks.json` doesn't need changes — Android uses `intent-filter` patterns in `AndroidManifest.xml` for path matching
- The AASA file is already served by the Rust API at `login.divine.video/.well-known/apple-app-site-association` via explicit route handlers in `main.rs`

## Test plan
- [ ] Deploy and verify `https://login.divine.video/.well-known/apple-app-site-association` returns the updated file with `/reset-password` paths
- [ ] Test on iOS that tapping a `https://login.divine.video/reset-password?token=...` link opens the app instead of Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)