### PR TITLE
fix: update cors configuration to allow login from divine.video

### DIFF
--- a/keycast-oauth-unified.yaml
+++ b/keycast-oauth-unified.yaml
@@ -47,8 +47,8 @@ spec:
               value: "true"
             - name: GCP_PROJECT_ID
               value: "openvine-co"
-            - name: CORS_ALLOWED_ORIGIN
-              value: "https://login.divine.video"
+            - name: ALLOWED_ORIGINS
+              value: "https://login.divine.video,https://divine.video"
             - name: APP_URL
               value: "https://login.divine.video"
             - name: FROM_EMAIL

--- a/unified-service-deploy.yaml
+++ b/unified-service-deploy.yaml
@@ -47,8 +47,8 @@ spec:
               value: "true"
             - name: GCP_PROJECT_ID
               value: "openvine-co"
-            - name: CORS_ALLOWED_ORIGIN
-              value: "https://login.divine.video"
+            - name: ALLOWED_ORIGINS
+              value: "https://login.divine.video,https://divine.video"
             - name: APP_URL
               value: "https://login.divine.video"
             - name: FROM_EMAIL

--- a/unified-service.yaml
+++ b/unified-service.yaml
@@ -47,8 +47,8 @@ spec:
               value: "true"
             - name: GCP_PROJECT_ID
               value: "openvine-co"
-            - name: CORS_ALLOWED_ORIGIN
-              value: "https://login.divine.video"
+            - name: ALLOWED_ORIGINS
+              value: "https://login.divine.video,https://divine.video"
             - name: APP_URL
               value: "https://login.divine.video"
             - name: FROM_EMAIL


### PR DESCRIPTION
Users on Discord are reporting that they can't log in to the web app. I tried it myself and got a "cors" error. 

I took a quick look and i guess we just need to update the cors settings. However it used `CORS_ALLOWED_ORIGIN` but in the code I see it actually reads from `ALLOWED_ORIGINS` so changed that part too:[https://github.com/divinevideo/keycast/blob/32acaad6191064c15d39f1f51085e5310e0faf9c/keycast/src/main.rs#L522-L523](https://github.com/divinevideo/keycast/blob/32acaad6191064c15d39f1f51085e5310e0faf9c/keycast/src/main.rs#L522-L523) Feel free to close it directly if I'm completely wrong here ;)