### PR TITLE
fix: store verification token in users table for idempotent re-verification

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1191,14 +1191,15 @@ pub async fn verify_email(
             let mut tx = pool.begin().await?;
 
             sqlx::query(
-                "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, email_verification_token, created_at, updated_at)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
             )
             .bind(&oauth_data.user_pubkey)
             .bind(tenant_id)
             .bind(email)
             .bind(password_hash)
             .bind(true) // email_verified = true
+            .bind(&req.token) // Keep token for idempotent re-verification
             .bind(now)
             .bind(now)
             .execute(&mut *tx)
@@ -1230,7 +1231,8 @@ pub async fn verify_email(
                     tenant_id,
                     email,
                     password_hash,
-                    true, // email_verified = true
+                    true,             // email_verified = true
+                    Some(&req.token), // Keep token for idempotent re-verification
                 )
                 .await?;
 

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -227,7 +227,7 @@ impl UserRepository {
         Ok(())
     }
 
-    /// Create a new user with email/password and verified status (used during key change).
+    /// Create a new user with email/password and pre-verified status.
     pub async fn create_with_password_verified(
         &self,
         pubkey: &str,
@@ -235,16 +235,18 @@ impl UserRepository {
         email: &str,
         password_hash: &str,
         email_verified: bool,
+        email_verification_token: Option<&str>,
     ) -> Result<(), RepositoryError> {
         sqlx::query(
-            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, email_verification_token, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
         )
         .bind(pubkey)
         .bind(tenant_id)
         .bind(email)
         .bind(password_hash)
         .bind(email_verified)
+        .bind(email_verification_token)
         .bind(Utc::now())
         .bind(Utc::now())
         .execute(&self.pool)


### PR DESCRIPTION
## Summary

Fixes divinevideo/divine-mobile#1475 — email verification shows "Verify failed" after account creation.

Also fixes divinevideo/divine-mobile#1469 — Zendesk report of verification email link not registering on app.

Related: divinevideo/divine-mobile#939 — email verification redirects to App Store/Play Store instead of returning to app (this PR fixes the web page error, but the Play Store redirect on Android is a separate deep link issue in divine-mobile).

### Root cause

When a user taps the email verification link (`login.divine.video/verify-email?token=XXX`), Android App Links should open the diVine app directly to handle it. However, some email clients (e.g. Gmail) open links in in-app webviews/Chrome Custom Tabs that don't always trigger App Links. When this happens:

1. The web page at `login.divine.video/verify-email` calls `POST /api/auth/verify-email`
2. Meanwhile, the app may have already consumed the token via background polling or its own deep link handler
3. The `oauth_codes` entry is deleted after the first successful verification, and the token was never stored in the `users` table
4. The web page gets HTTP 401 → shows "Verification Failed"

This is a race condition between the app and the browser both processing the same verification URL.

### Fix

Store the `email_verification_token` in the `users` table when creating the user during OAuth email verification. Combined with the existing idempotent check (commit 71bf7d3), subsequent verification attempts find the token in the `users` table, see `email_verified = true`, and return success instead of 401.

- `auth.rs`: Both INSERT paths (auto-generated keys and BYOK) now include the token
- `user.rs`: `create_with_password_verified` accepts an optional `email_verification_token`

### Why this is safe

- The token is already stored in `users` for normal (non-OAuth) registration flows — this just makes OAuth consistent
- The `find_by_verification_token` + `email_verified` check (line 1337 in auth.rs) already handles the idempotent case correctly
- No schema changes needed — the `email_verification_token` column already exists

## Test plan

- [x] `cargo clippy` clean on all libraries
- [x] `oauth_deferred_registration_test` — 9/9 passed
- [x] Manually reproduced on Android emulator: verified the race condition causes "Verification Failed", confirmed fix resolves it