### PR TITLE
fix: skip browser redirect for headless email verification

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1296,7 +1296,33 @@ pub async fn verify_email(
             .delete_by_verification_token(&req.token, tenant_id)
             .await?;
 
-        // Build redirect URL
+        // For headless flows (mobile app), don't redirect — the app is polling
+        // via device_code/Redis and will pick up the code automatically.
+        // The browser just shows a success page.
+        if oauth_data.is_headless {
+            tracing::info!(
+                event = "email_verification",
+                tenant_id = tenant_id,
+                flow = "oauth_headless",
+                success = true,
+                "Email verified (headless), app will pick up code via polling"
+            );
+
+            return Ok((
+                axum::http::StatusCode::OK,
+                axum::Json(VerifyEmailResponse {
+                    success: true,
+                    message: "Email verified! Open the app to continue.".to_string(),
+                    redirect_to: None,
+                    authenticated: None,
+                    status: Some("headless".to_string()),
+                    retry_after: None,
+                }),
+            )
+                .into_response());
+        }
+
+        // Non-headless: redirect to OAuth client's callback URL
         let mut redirect_url = format!("{}?code={}", oauth_data.redirect_uri, new_code);
         if let Some(ref state) = oauth_data.state {
             redirect_url = format!("{}&state={}", redirect_url, state);

--- a/web/src/routes/verify-email/+page.svelte
+++ b/web/src/routes/verify-email/+page.svelte
@@ -8,7 +8,7 @@
 
 	const api = new KeycastApi();
 
-	let status = $state<'loading' | 'processing' | 'success' | 'oauth_redirect' | 'error' | 'no-token'>('loading');
+	let status = $state<'loading' | 'processing' | 'success' | 'oauth_redirect' | 'headless_verified' | 'error' | 'no-token'>('loading');
 	let message = $state('');
 	let redirectUrl = $state('');
 
@@ -44,6 +44,14 @@
 				}
 
 				if (response.success) {
+					// Headless flow (mobile app) — app is polling, just show success
+					if (response.status === 'headless') {
+						status = 'headless_verified';
+						message = response.message || 'Email verified! Open the app to continue.';
+						toast.success('Email verified!');
+						return;
+					}
+
 					// Check if this is an OAuth flow (has redirect_to)
 					if (response.redirect_to) {
 						status = 'oauth_redirect';
@@ -177,6 +185,15 @@
 			<h1>Email Verified!</h1>
 			<p class="subtitle">{message}</p>
 			<p class="redirect-notice">Redirecting to application...</p>
+
+		{:else if status === 'headless_verified'}
+			<div class="status-icon success">
+				<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="currentColor" viewBox="0 0 256 256">
+					<path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm45.66,85.66-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35a8,8,0,0,1,11.32,11.32Z"></path>
+				</svg>
+			</div>
+			<h1>Email Verified!</h1>
+			<p class="subtitle">{message}</p>
 
 		{:else if status === 'success'}
 			<div class="status-icon success">


### PR DESCRIPTION
## Summary
- For headless OAuth flows (mobile app), the verify-email web page no longer redirects to the OAuth callback URL
- Instead, it shows a success page ("Open the app to continue") since the app is polling via `device_code`
- This prevents the Play Store redirect on Android when App Links fail to intercept the verification link

## Root cause
When a headless-registered user's verification link opens in the browser (instead of being intercepted by App Links), the server returns `redirect_to: "https://divine.video/app/callback?code=XXX"`. The Svelte page wraps this in an `intent://` URL on Android, but `/app/callback` is not in the AndroidManifest intent filters, so Chrome sends the user to the Play Store.

## Fix
When `is_headless` is true on the oauth_codes entry, return `status: "headless"` with no `redirect_to`. The Svelte page shows a static success page. The mobile app picks up the authorization code via its existing device_code polling mechanism.

Non-headless web OAuth flows are unchanged.

## Reproduction
Reproduced on Android emulator:
1. `POST /api/headless/register` with test email
2. Opened `login.divine.video/verify-email?token=XXX` directly in Chrome (bypassing App Links)
3. Observed Play Store "Item not found" page

## Test plan
- [x] Reproduced bug on Android emulator
- [x] Verified poll endpoint returns code after browser verification
- [x] `cargo clippy` and all tests pass
- [ ] Deploy and verify success page shown instead of Play Store redirect

Ref: divinevideo/divine-mobile#939