### PR TITLE
fix: re-add origin-based auto-approve fallback for OAuth consent

### DIFF
--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -580,8 +580,7 @@ pub async fn authorize_get(
         (None, false)
     };
 
-    // Check for silent re-authentication via authorization_handle
-    // This replaces the buggy origin-based auto-approve check
+    // Check for silent re-authentication via authorization_handle (primary mechanism)
     if let Some(ref pubkey) = user_pubkey {
         let previous_auth_id: Option<i32> = if let Some(ref handle) = params.authorization_handle {
             tracing::info!(
@@ -644,6 +643,57 @@ pub async fn authorize_get(
             return Ok(Redirect::to(&redirect_url).into_response());
         } else if previous_auth_id.is_some() && force_consent {
             tracing::info!("prompt=consent: skipping auto-approve, showing approval screen");
+        }
+    }
+
+    // Origin-based auto-approve fallback: if no handle was provided (or handle was invalid),
+    // check if the user already has an active authorization for this origin.
+    if let Some(ref pubkey) = user_pubkey {
+        if !force_consent {
+            let redirect_origin = extract_origin(&params.redirect_uri)?;
+            let repo = OAuthAuthorizationRepository::new(pool.clone());
+            if repo
+                .has_active_for_origin(pubkey, &redirect_origin, tenant_id)
+                .await?
+            {
+                tracing::info!(
+                    "Auto-approving via active origin authorization for user {} origin {}",
+                    pubkey,
+                    redirect_origin
+                );
+
+                let code: String = rand::thread_rng()
+                    .sample_iter(&rand::distributions::Alphanumeric)
+                    .take(32)
+                    .map(char::from)
+                    .collect();
+
+                let expires_at = Utc::now() + Duration::minutes(10);
+                let scope = params.scope.as_deref().unwrap_or("sign_event");
+
+                store_oauth_code(
+                    pool,
+                    tenant_id,
+                    &code,
+                    pubkey,
+                    &params.client_id,
+                    &params.redirect_uri,
+                    scope,
+                    params.code_challenge.as_deref(),
+                    params.code_challenge_method.as_deref(),
+                    expires_at,
+                    None,
+                    params.state.as_deref(),
+                )
+                .await?;
+
+                let redirect_url = if let Some(ref state) = params.state {
+                    format!("{}?code={}&state={}", params.redirect_uri, code, state)
+                } else {
+                    format!("{}?code={}", params.redirect_uri, code)
+                };
+                return Ok(Redirect::to(&redirect_url).into_response());
+            }
         }
     }
 

--- a/core/src/repositories/oauth_authorization.rs
+++ b/core/src/repositories/oauth_authorization.rs
@@ -314,6 +314,29 @@ impl OAuthAuthorizationRepository {
         .map_err(Into::into)
     }
 
+    /// Check if any active (non-revoked) authorization exists for a user+origin.
+    pub async fn has_active_for_origin(
+        &self,
+        user_pubkey: &str,
+        redirect_origin: &str,
+        tenant_id: i64,
+    ) -> Result<bool, RepositoryError> {
+        let exists: Option<(i32,)> = sqlx::query_as(
+            "SELECT 1 FROM oauth_authorizations
+             WHERE user_pubkey = $1
+               AND redirect_origin = $2
+               AND tenant_id = $3
+               AND revoked_at IS NULL
+             LIMIT 1",
+        )
+        .bind(user_pubkey)
+        .bind(redirect_origin)
+        .bind(tenant_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(exists.is_some())
+    }
+
     /// Find the most recent bunker pubkey for a user.
     pub async fn find_latest_bunker_pubkey(
         &self,


### PR DESCRIPTION
## Summary

- Re-adds origin-based auto-approve as a fallback when the client's `authorization_handle` is missing (e.g., after logout clears localStorage)
- Adds `has_active_for_origin` repository method that checks for non-revoked authorizations with `revoked_at IS NULL` (fixing the bug that caused the original origin-based check to be removed)
- Handle-based auto-approve remains the primary mechanism; origin check only runs if handle lookup didn't already approve

## Problem

When a user logs out of an OAuth client app and logs back in, keycast shows the consent screen again even though the user already approved this app. This happens because:

1. The current auto-approve relies solely on `authorization_handle` — a server-generated token stored client-side
2. On logout, client apps clear the handle
3. Without the handle, keycast has no way to detect the prior approval
4. The old origin-based check was removed due to a bug (missing `AND revoked_at IS NULL`)

## Test plan

- [x] First login (no prior auth) — consent screen shown
- [x] Re-login after logout (handle cleared, active auth exists) — auto-approved via origin fallback, no consent screen
- [x] Re-login after revocation (all auths revoked) — consent screen shown again
- [x] `prompt=consent` still forces consent screen regardless
- [x] `cargo clippy` clean, 306 tests pass