### PR TITLE
fix: dashboard copy and visual polish for newcomers

### DIFF
--- a/web/src/lib/components/CreateBunkerModal.svelte
+++ b/web/src/lib/components/CreateBunkerModal.svelte
@@ -109,27 +109,27 @@
 			{#if bunkerUrl}
 				<!-- Success state: Show bunker URL -->
 				<div class="modal-body">
-					<p class="success-message">Copy this bunker URL to your NIP-46 client:</p>
+					<p class="success-message">Copy this connection URL and paste it into your Nostr app:</p>
 
 					<div class="bunker-url-display">
 						<code>{bunkerUrl}</code>
 					</div>
 
 					<button class="btn-copy" onclick={copyBunkerUrl}>
-						{showCopySuccess ? '✓ Copied!' : 'Copy Bunker URL'}
+						{showCopySuccess ? '✓ Copied!' : 'Copy Connection URL'}
 					</button>
 
 					<div class="warning-box">
 						<strong>Save this URL now!</strong>
-						<p>This bunker URL acts like a password and is shown only once. Copy it now and paste it into your Nostr app. If you lose it, you can revoke this connection and create a new one.</p>
+						<p>This URL acts like a password and is shown only once. Copy it now and paste it into your Nostr app. If you lose it, revoke this connection and create a new one.</p>
 					</div>
 				</div>
 			{:else}
 				<!-- Form state: Create bunker -->
 				<div class="modal-body">
 					<div class="info-box">
-						<strong>Do you need this?</strong>
-						<p>If the app has a "Sign in with diVine" option, just use your email and password there. This is only for apps that accept a connection URL and don't have diVine Login integration (like Damus or Amethyst).</p>
+						<strong>You probably don't need this</strong>
+						<p>The diVine app and any app with "Sign in with diVine" already work with your email and password. This is only for Nostr apps that need a connection URL. Browse them at <a href="https://nostrapps.com" target="_blank" rel="noopener noreferrer">nostrapps.com</a>.</p>
 					</div>
 
 					<p class="description">
@@ -142,7 +142,7 @@
 							id="appName"
 							type="text"
 							bind:value={appName}
-							placeholder="e.g. Primal, Damus, Amethyst"
+							placeholder="e.g. Amethyst, YakiHonne, Habla"
 							required
 							disabled={isCreating}
 						/>
@@ -178,6 +178,16 @@
 {/if}
 
 <style>
+	@keyframes overlay-in {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+
+	@keyframes modal-in {
+		from { opacity: 0; transform: translateY(8px) scale(0.98); }
+		to { opacity: 1; transform: translateY(0) scale(1); }
+	}
+
 	.modal-overlay {
 		position: fixed;
 		top: 0;
@@ -190,6 +200,7 @@
 		justify-content: center;
 		z-index: 1000;
 		backdrop-filter: blur(4px);
+		animation: overlay-in 0.15s ease-out;
 	}
 
 	.modal {
@@ -200,7 +211,8 @@
 		width: 90%;
 		max-height: 90vh;
 		overflow-y: auto;
-		box-shadow: var(--shadow-lg);
+		box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+		animation: modal-in 0.2s ease-out;
 	}
 
 	.modal-header {
@@ -437,5 +449,36 @@
 		font-size: 0.875rem;
 		line-height: 1.5;
 		margin: 0;
+	}
+
+	.info-box {
+		background: color-mix(in srgb, var(--color-divine-green) 8%, transparent);
+		border: 1px solid color-mix(in srgb, var(--color-divine-green) 20%, transparent);
+		border-radius: 8px;
+		padding: 1rem;
+		margin-bottom: 1.25rem;
+	}
+
+	.info-box strong {
+		color: var(--color-divine-text);
+		display: block;
+		margin-bottom: 0.5rem;
+		font-size: 0.9rem;
+	}
+
+	.info-box p {
+		color: var(--color-divine-text-secondary);
+		font-size: 0.85rem;
+		line-height: 1.5;
+		margin: 0;
+	}
+
+	.info-box a {
+		color: var(--color-divine-green);
+		text-decoration: none;
+	}
+
+	.info-box a:hover {
+		text-decoration: underline;
 	}
 </style>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -336,24 +336,31 @@ onMount(async () => {
 						<div class="learn-block">
 							<h4><ShieldCheck size={16} weight="fill" /> Where Is Your Key?</h4>
 							<p>When you sign up with email and password, diVine generates a Nostr key for you and stores it on <a href="https://login.divine.video" target="_blank" rel="noopener noreferrer">login.divine.video</a>, encrypted using the same standards banks and password managers rely on (<a href="https://en.wikipedia.org/wiki/Advanced_Encryption_Standard" target="_blank" rel="noopener noreferrer">1</a>,<a href="https://cloud.google.com/security/products/security-key-management" target="_blank" rel="noopener noreferrer">2</a>). Your key is only decrypted in memory when an app needs to sign on your behalf, and is never stored in plain text.</p>
-							<p>Any Nostr app that supports diVine Login, like <a href="https://privdm.com" target="_blank" rel="noopener noreferrer">Priv DM <ArrowSquareOut size={12} /></a>, can use your identity with just your email and password. No copying keys between apps, no manual setup.</p>
+							<p>Any Nostr app that supports diVine Login, like <a href="https://privdm.com" target="_blank" rel="noopener noreferrer" class="inline-link">Priv DM <ArrowSquareOut size={12} /></a>, can use your identity with just your email and password. No copying keys between apps, no manual setup.</p>
+						</div>
 
-							<p class="learn-subtle"><strong>Already have a Nostr key?</strong></p>
+						<div class="learn-block">
+							<h4><Key size={16} weight="fill" /> Already Have a Nostr Key?</h4>
 							<p>You don't need a diVine account at all. Import your nsec into the diVine app and everything stays on your device.</p>
+						</div>
 
-							<p class="learn-subtle"><strong>Want to move your key to your own device?</strong></p>
+						<div class="learn-block">
+							<h4><Export size={16} weight="fill" /> Want Full Control of Your Key?</h4>
 							<p>If you started with email and password but want full control, export your nsec from <a href="/settings/security">Security Settings</a> and move it to:</p>
 							<ul class="learn-list">
-								<li><strong>Your phone:</strong> <a href="https://primal.net" target="_blank" rel="noopener noreferrer">Primal <ArrowSquareOut size={12} /></a> (iOS & Android), <a href="https://github.com/greenart7c3/Amber" target="_blank" rel="noopener noreferrer">Amber <ArrowSquareOut size={12} /></a> (Android), or <a href="https://nsec.app" target="_blank" rel="noopener noreferrer">nsec.app <ArrowSquareOut size={12} /></a> (any browser) turn your device into a personal signing server. When a Nostr app needs your signature, it asks your device and your key never leaves it.</li>
-								<li><strong>Your browser:</strong> Extensions like <a href="https://getalby.com" target="_blank" rel="noopener noreferrer">Alby <ArrowSquareOut size={12} /></a> or <a href="https://chromewebstore.google.com/detail/soapboxpub-signer/nnodjkgakfpkckcnbacpcjbpmlmbihdd" target="_blank" rel="noopener noreferrer">Soapbox Signer <ArrowSquareOut size={12} /></a> (Chrome, Firefox) keep your key in the browser itself. <a href="https://apps.apple.com/app/nostash/id6499558903" target="_blank" rel="noopener noreferrer">Nostash <ArrowSquareOut size={12} /></a> does the same for Safari on iOS.</li>
+								<li><strong>Your phone:</strong> <a href="https://primal.net" target="_blank" rel="noopener noreferrer" class="inline-link">Primal <ArrowSquareOut size={12} /></a> (iOS & Android), <a href="https://github.com/greenart7c3/Amber" target="_blank" rel="noopener noreferrer" class="inline-link">Amber <ArrowSquareOut size={12} /></a> (Android), or <a href="https://nsec.app" target="_blank" rel="noopener noreferrer" class="inline-link">nsec.app <ArrowSquareOut size={12} /></a> (any browser) turn your device into a personal signing server. When a Nostr app needs your signature, it asks your device and your key never leaves it.</li>
+								<li><strong>Your browser:</strong> Extensions like <a href="https://getalby.com" target="_blank" rel="noopener noreferrer" class="inline-link">Alby <ArrowSquareOut size={12} /></a> or <a href="https://chromewebstore.google.com/detail/soapboxpub-signer/nnodjkgakfpkckcnbacpcjbpmlmbihdd" target="_blank" rel="noopener noreferrer" class="inline-link">Soapbox Signer <ArrowSquareOut size={12} /></a> (Chrome, Firefox) keep your key in the browser itself. <a href="https://apps.apple.com/app/nostash/id6499558903" target="_blank" rel="noopener noreferrer" class="inline-link">Nostash <ArrowSquareOut size={12} /></a> does the same for Safari on iOS.</li>
 							</ul>
 							<p>With these options, each app that needs your signature must connect to your signer individually. diVine Login handles that for you automatically.</p>
 						</div>
 
 						<div class="learn-block highlight">
-							<h4><Export size={16} weight="fill" /> Why This Matters</h4>
+							<h4><ShieldCheck size={16} weight="fill" /> Why This Matters</h4>
 							<p>Unlike Twitter or Facebook, <strong>no company owns your Nostr identity</strong>. Even if diVine disappeared tomorrow, your identity and content would still exist on the network. Export your key and continue anywhere.</p>
 							<p class="learn-cta">That's the power of Nostr.</p>
+							<div class="learn-explore">
+								<a href="https://nostrapps.com" target="_blank" rel="noopener noreferrer">Explore Nostr apps at nostrapps.com <ArrowSquareOut size={12} /></a>
+							</div>
 						</div>
 					</div>
 				{/if}
@@ -375,7 +382,7 @@ onMount(async () => {
 					<div class="empty-state">
 						<p>No app connections yet.</p>
 						<p class="hint">
-							Apps that support diVine Login connect automatically when you sign in with your email and password. Use "Connect to Nostr App" only for apps that don't have diVine Login and accept a connection URL instead.
+							The diVine app and any app with "Sign in with diVine" already work with your email and password. Use this to connect to other Nostr apps. Browse them at <a href="https://nostrapps.com" target="_blank" rel="noopener noreferrer">nostrapps.com</a>.
 						</p>
 					</div>
 				{:else}
@@ -385,7 +392,14 @@ onMount(async () => {
 							<div class="app-card" class:expanded={isExpanded}>
 								<button class="app-header" onclick={() => toggleSession(session.bunker_pubkey)}>
 									<div class="app-info">
-										<p class="app-name">{session.application_name}</p>
+										<p class="app-name">
+											{session.application_name}
+											{#if session.redirect_origin?.trim()}
+												<span class="connection-badge oauth">diVine Login</span>
+											{:else}
+												<span class="connection-badge manual">Bunker</span>
+											{/if}
+										</p>
 										{#if session.redirect_origin}<p class="app-domain">{session.redirect_origin}</p>{/if}
 										<p class="app-meta">
 											{new Date(session.created_at).toLocaleDateString()}
@@ -904,10 +918,8 @@ onMount(async () => {
 		text-decoration: underline;
 	}
 
-	.learn-subtle {
-		color: var(--color-divine-text-tertiary) !important;
-		font-size: 0.8rem !important;
-		margin-top: 0.75rem !important;
+	.learn-block p strong {
+		color: var(--color-divine-text);
 	}
 
 	.learn-list {
@@ -919,13 +931,17 @@ onMount(async () => {
 	}
 
 	.learn-list li {
-		margin-bottom: 0.25rem;
+		margin-bottom: 0.5rem;
 	}
 
 	.learn-list a {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.25rem;
+	}
+
+	.inline-link {
+		white-space: nowrap;
 	}
 
 	.learn-block.highlight {
@@ -940,6 +956,26 @@ onMount(async () => {
 		color: var(--color-divine-green) !important;
 		font-weight: 500;
 		margin-top: 0.5rem !important;
+	}
+
+	.learn-explore {
+		margin-top: 0.75rem;
+		padding-top: 0.75rem;
+		border-top: 1px solid color-mix(in srgb, var(--color-divine-green) 15%, transparent);
+	}
+
+	.learn-explore a {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		color: var(--color-divine-green);
+		text-decoration: none;
+		font-size: 0.85rem;
+		font-weight: 500;
+	}
+
+	.learn-explore a:hover {
+		text-decoration: underline;
 	}
 
 	/* App Connections Section */
@@ -1044,6 +1080,29 @@ onMount(async () => {
 		color: var(--color-divine-text);
 		font-weight: 500;
 		margin: 0;
+	}
+
+	.connection-badge {
+		display: inline-block;
+		font-size: 0.65rem;
+		font-weight: 500;
+		padding: 0.125rem 0.5rem;
+		border-radius: 9999px;
+		margin-left: 0.5rem;
+		vertical-align: middle;
+		letter-spacing: 0.02em;
+	}
+
+	.connection-badge.oauth {
+		background: color-mix(in srgb, var(--color-divine-green) 15%, transparent);
+		color: var(--color-divine-green);
+		border: 1px solid color-mix(in srgb, var(--color-divine-green) 30%, transparent);
+	}
+
+	.connection-badge.manual {
+		background: color-mix(in srgb, var(--color-divine-text-tertiary) 10%, transparent);
+		color: var(--color-divine-text-secondary);
+		border: 1px solid color-mix(in srgb, var(--color-divine-text-tertiary) 25%, transparent);
 	}
 
 	.app-domain {


### PR DESCRIPTION
## Summary
- Improve onboarding copy to clarify diVine app vs diVine Login vs standalone Nostr apps
- Split monolithic "Where Is Your Key?" learn section into focused blocks (storage, nsec import, self-custody)
- Add connection type badges ("diVine Login" / "Bunker") to app cards based on redirect_origin
- Add guidance info-box to bunker creation modal with link to nostrapps.com
- Replace jargon (bunker URL, NIP-46 client) with plain language throughout

## Changes

**Dashboard (`+page.svelte`)**
- Learn section: 3 separate blocks for storage, nsec import, and self-custody signers
- Learn section: nostrapps.com explore link inside highlight block
- App cards: connection type badges detect OAuth vs manual bunker via `redirect_origin`
- Empty state: updated copy mentioning diVine app and nostrapps.com
- Removed em dashes from copy, improved list spacing

**Bunker modal (`CreateBunkerModal.svelte`)**
- Added info-box: "You probably don't need this" with nostrapps.com link
- Plain language: "connection URL" instead of "bunker URL"
- Modal entrance animation (fade + slide up)

## Test plan
- [ ] Verify learn-more section renders 5 blocks with correct icons
- [ ] Verify connection badges show "diVine Login" for OAuth sessions and "Bunker" for manual
- [ ] Verify bunker creation modal shows info-box with working nostrapps.com link
- [ ] Verify empty state copy when no sessions exist