### PR TITLE
Fix verification notice layout and minor UI polish

### DIFF
--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -348,10 +348,8 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     );
 
     // Setup database
-    let database_url = env::var("DATABASE_URL")?; // Validated above
-
     let database = Database::new().await?;
-    tracing::info!("✔︎ Database initialized at {:?}", database_url);
+    tracing::info!("✔︎ Database initialized");
 
     // Initialize cluster coordination with Redis (Pub/Sub mode)
     // This handles instance registration, membership detection, and heartbeats

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -924,6 +924,9 @@ $effect(() => {
 	}
 
 	.identity-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem 1.25rem;
 		padding-top: 0.75rem;
 		margin-top: 0;
 	}

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -99,7 +99,7 @@
 				</div>
 				<h2>Check your email</h2>
 				<p>We've sent a verification link to <strong>{registeredEmail}</strong></p>
-				<p class="subtext">Click the link in the email to verify your account and sign in.</p>
+				<p class="subtext">Click the link in the email to verify your account and sign&nbsp;in.</p>
 				<a href="/login" class="btn-secondary">Go to Login</a>
 			</div>
 		{:else}
@@ -397,6 +397,8 @@
 	}
 
 	.verification-notice .notice-icon {
+		display: flex;
+		justify-content: center;
 		margin-bottom: 1rem;
 	}
 

--- a/web/src/routes/verify-email/+page.svelte
+++ b/web/src/routes/verify-email/+page.svelte
@@ -282,6 +282,8 @@
 	}
 
 	.status-icon {
+		display: flex;
+		justify-content: center;
 		margin-bottom: 1.25rem;
 	}
 


### PR DESCRIPTION
## Summary
- Center the envelope icon on the post-registration verification notice (was left-aligned)
- Fix orphaned "in." text wrapping on the verification subtext
- Center status icons on the verify-email page (loading, success, error states)
- Add proper spacing between dashboard identity action links

## Test plan
- [x] `cargo clippy` clean
- [x] `svelte-check` clean
- [x] Visual verification on desktop and mobile (iPhone 13)
- [ ] CI passes