### PR TITLE
Claim flow: E2E tests, support-admin claim links, user lookup by username/vine_id

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -445,8 +445,64 @@ pub struct CreateClaimTokenResponse {
     pub expires_at: String,
 }
 
+// ============================================================================
+// GET /api/admin/claim-tokens?pubkey=... - Check existing valid claim token
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct GetClaimTokenQuery {
+    pub pubkey: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GetClaimTokenResponse {
+    pub has_token: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claim_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+}
+
+pub async fn get_claim_token(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    axum::extract::Query(query): axum::extract::Query<GetClaimTokenQuery>,
+) -> ApiResult<Json<GetClaimTokenResponse>> {
+    let tenant_id = tenant.0.id;
+    let pool = &auth_state.state.db;
+
+    if !is_support_admin(&auth).await {
+        return Err(ApiError::forbidden("Admin access required"));
+    }
+
+    let claim_token_repo = ClaimTokenRepository::new(pool.clone());
+    let token = claim_token_repo
+        .find_valid_by_user_pubkey(&query.pubkey, tenant_id)
+        .await?;
+
+    match token {
+        Some(ct) => {
+            let app_url =
+                std::env::var("APP_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
+            let claim_url = format!("{}/api/claim?token={}", app_url, ct.token);
+
+            Ok(Json(GetClaimTokenResponse {
+                has_token: true,
+                claim_url: Some(claim_url),
+                expires_at: Some(ct.expires_at.to_rfc3339()),
+            }))
+        }
+        None => Ok(Json(GetClaimTokenResponse {
+            has_token: false,
+            claim_url: None,
+            expires_at: None,
+        })),
+    }
+}
+
 /// Generate a claim link for a preloaded user.
-/// Requires admin authentication.
+/// Requires support admin or above.
 pub async fn create_claim_token(
     tenant: crate::api::tenant::TenantExtractor,
     State(auth_state): State<AuthState>,
@@ -456,7 +512,7 @@ pub async fn create_claim_token(
     let tenant_id = tenant.0.id;
     let pool = &auth_state.state.db;
 
-    if !is_full_admin(&auth) {
+    if !is_support_admin(&auth).await {
         tracing::warn!(
             "Claim token request denied for pubkey: {}",
             &auth.pubkey[..8]
@@ -529,7 +585,7 @@ pub struct UserLookupDetails {
     pub has_personal_key: bool,
     pub active_sessions: i64,
     pub created_at: String,
-    pub updated_at: String,
+    pub last_active: Option<String>,
 }
 
 /// Look up a user by email or pubkey. Available to support admins and above.
@@ -560,12 +616,18 @@ pub async fn get_user_lookup(
             user: None,
         })),
         Some(details) => {
-            // Count active sessions
+            // Count active sessions and find most recent activity
             let oauth_repo = OAuthAuthorizationRepository::new(pool.clone());
             let sessions = oauth_repo
                 .list_active_sessions(&details.pubkey, tenant_id)
                 .await
                 .unwrap_or_default();
+
+            let last_active = sessions
+                .iter()
+                .filter_map(|s| s.5.as_deref())
+                .max()
+                .map(String::from);
 
             Ok(Json(UserLookupResponse {
                 found: true,
@@ -579,7 +641,7 @@ pub async fn get_user_lookup(
                     has_personal_key: details.has_personal_key,
                     active_sessions: sessions.len() as i64,
                     created_at: details.created_at.to_rfc3339(),
-                    updated_at: details.updated_at.to_rfc3339(),
+                    last_active,
                 }),
             }))
         }

--- a/api/src/api/http/claim.rs
+++ b/api/src/api/http/claim.rs
@@ -75,8 +75,8 @@ pub async fn claim_get(
     <style>
         * {{ box-sizing: border-box; }}
         body {{
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+            font-family: 'Inter', system-ui, -apple-system, sans-serif;
+            background: #072218;
             min-height: 100vh;
             margin: 0;
             display: flex;
@@ -85,85 +85,100 @@ pub async fn claim_get(
             padding: 20px;
         }}
         .container {{
-            background: white;
+            background: #0F2E23;
+            border: 1px solid #1C4033;
             border-radius: 12px;
             padding: 40px;
             max-width: 400px;
             width: 100%;
-            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+            box-shadow: 0 8px 32px rgba(39, 197, 139, 0.08);
         }}
         h1 {{
-            margin: 0 0 10px 0;
-            color: #1a1a2e;
-            font-size: 24px;
+            margin: 0 0 8px 0;
+            color: #F9F7F6;
+            font-size: 22px;
+            font-weight: 600;
         }}
         .welcome {{
-            color: #666;
-            margin-bottom: 30px;
+            color: #BEB3A7;
+            font-size: 14px;
+            margin: 0 0 28px 0;
+            line-height: 1.5;
         }}
         .user-info {{
-            background: #f8f9fa;
+            background: #072218;
+            border: 1px solid #1C4033;
             border-radius: 8px;
-            padding: 15px;
-            margin-bottom: 25px;
+            padding: 14px 16px;
+            margin-bottom: 24px;
         }}
         .user-info .name {{
             font-weight: 600;
-            color: #1a1a2e;
-            font-size: 18px;
+            color: #F9F7F6;
+            font-size: 16px;
         }}
         .user-info .username {{
-            color: #666;
-            font-size: 14px;
+            color: #9CA3AF;
+            font-size: 13px;
+            margin-top: 2px;
         }}
         label {{
             display: block;
-            margin-bottom: 5px;
-            color: #333;
+            margin-bottom: 6px;
+            color: #BEB3A7;
+            font-size: 13px;
             font-weight: 500;
         }}
         input {{
             width: 100%;
-            padding: 12px;
-            border: 1px solid #ddd;
+            padding: 11px 14px;
+            background: #072218;
+            border: 1px solid #1C4033;
             border-radius: 8px;
-            font-size: 16px;
-            margin-bottom: 20px;
+            font-size: 15px;
+            color: #F9F7F6;
+            margin-bottom: 18px;
+            transition: border-color 0.2s;
+        }}
+        input::placeholder {{
+            color: #9CA3AF;
         }}
         input:focus {{
             outline: none;
-            border-color: #667eea;
-            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+            border-color: #27C58B;
+            box-shadow: 0 0 0 3px rgba(39, 197, 139, 0.1);
         }}
         button {{
             width: 100%;
-            padding: 14px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
+            padding: 12px;
+            background: #27C58B;
+            color: #072218;
             border: none;
             border-radius: 8px;
-            font-size: 16px;
+            font-size: 15px;
             font-weight: 600;
             cursor: pointer;
-            transition: transform 0.2s, box-shadow 0.2s;
+            transition: background 0.2s;
+            margin-top: 4px;
         }}
         button:hover {{
-            transform: translateY(-2px);
-            box-shadow: 0 5px 20px rgba(102, 126, 234, 0.4);
+            background: #1AA575;
         }}
         .error {{
-            background: #fee2e2;
-            color: #dc2626;
-            padding: 12px;
+            background: rgba(239, 68, 68, 0.1);
+            border: 1px solid rgba(239, 68, 68, 0.25);
+            color: #EF4444;
+            padding: 10px 14px;
             border-radius: 8px;
-            margin-bottom: 20px;
+            margin-bottom: 18px;
             display: none;
+            font-size: 14px;
         }}
         .requirements {{
             font-size: 12px;
-            color: #666;
-            margin-top: -15px;
-            margin-bottom: 20px;
+            color: #9CA3AF;
+            margin-top: -14px;
+            margin-bottom: 18px;
         }}
     </style>
 </head>
@@ -403,9 +418,10 @@ impl IntoResponse for ClaimError {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{title}</title>
     <style>
+        * {{ box-sizing: border-box; }}
         body {{
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+            font-family: 'Inter', system-ui, -apple-system, sans-serif;
+            background: #072218;
             min-height: 100vh;
             margin: 0;
             display: flex;
@@ -414,29 +430,37 @@ impl IntoResponse for ClaimError {
             padding: 20px;
         }}
         .container {{
-            background: white;
+            background: #0F2E23;
+            border: 1px solid #1C4033;
             border-radius: 12px;
             padding: 40px;
             max-width: 400px;
             text-align: center;
-            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+            box-shadow: 0 8px 32px rgba(39, 197, 139, 0.08);
         }}
         h1 {{
-            color: #dc2626;
-            margin: 0 0 15px 0;
+            color: #EF4444;
+            margin: 0 0 12px 0;
+            font-size: 20px;
+            font-weight: 600;
         }}
         p {{
-            color: #666;
+            color: #BEB3A7;
             line-height: 1.6;
+            font-size: 14px;
+            margin: 0;
         }}
         a {{
             display: inline-block;
-            margin-top: 20px;
-            color: #667eea;
+            margin-top: 24px;
+            color: #27C58B;
             text-decoration: none;
+            font-size: 14px;
+            font-weight: 500;
+            transition: color 0.2s;
         }}
         a:hover {{
-            text-decoration: underline;
+            color: #1AA575;
         }}
     </style>
 </head>
@@ -444,7 +468,7 @@ impl IntoResponse for ClaimError {
     <div class="container">
         <h1>{title}</h1>
         <p>{message}</p>
-        <a href="javascript:history.back()">← Go Back</a>
+        <a href="javascript:history.back()">Go Back</a>
     </div>
 </body>
 </html>"#,

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -153,7 +153,10 @@ pub fn api_routes(
         .route("/admin/token", get(admin::get_admin_token))
         .route("/admin/preload-user", post(admin::preload_user))
         .route("/admin/user-token", post(admin::get_user_token))
-        .route("/admin/claim-tokens", post(admin::create_claim_token))
+        .route(
+            "/admin/claim-tokens",
+            get(admin::get_claim_token).post(admin::create_claim_token),
+        )
         .route("/admin/user-lookup", get(admin::get_user_lookup))
         .route(
             "/admin/support-admins",

--- a/core/src/repositories/claim_token.rs
+++ b/core/src/repositories/claim_token.rs
@@ -75,6 +75,29 @@ impl ClaimTokenRepository {
         .map_err(Into::into)
     }
 
+    /// Find a valid (not expired, not used) claim token for a specific user.
+    /// Returns the most recently created valid token, if any.
+    pub async fn find_valid_by_user_pubkey(
+        &self,
+        user_pubkey: &str,
+        tenant_id: i64,
+    ) -> Result<Option<ClaimToken>, RepositoryError> {
+        sqlx::query_as::<_, ClaimToken>(
+            "SELECT * FROM account_claim_tokens
+             WHERE user_pubkey = $1
+               AND tenant_id = $2
+               AND expires_at > NOW()
+               AND used_at IS NULL
+             ORDER BY created_at DESC
+             LIMIT 1",
+        )
+        .bind(user_pubkey)
+        .bind(tenant_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
     /// Find all claim tokens for a user (for admin viewing).
     pub async fn find_by_user_pubkey(
         &self,

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1015,7 +1015,7 @@ impl UserRepository {
     }
 
     /// Look up a user for admin support tools.
-    /// Searches by email (if query contains @) or by hex/npub pubkey.
+    /// Searches by email (if query contains @), npub, username, vine_id, or hex pubkey.
     pub async fn find_user_for_admin(
         &self,
         query: &str,
@@ -1040,7 +1040,29 @@ impl UserRepository {
                 Err(_) => return Ok(None),
             }
         } else {
-            query.to_string()
+            // Try username, then vine_id, then fall through to hex pubkey
+            let by_username: Option<(String,)> =
+                sqlx::query_as("SELECT pubkey FROM users WHERE username = $1 AND tenant_id = $2")
+                    .bind(query)
+                    .bind(tenant_id)
+                    .fetch_optional(&self.pool)
+                    .await?;
+            if let Some((pk,)) = by_username {
+                pk
+            } else {
+                let by_vine_id: Option<(String,)> = sqlx::query_as(
+                    "SELECT pubkey FROM users WHERE vine_id = $1 AND tenant_id = $2",
+                )
+                .bind(query)
+                .bind(tenant_id)
+                .fetch_optional(&self.pool)
+                .await?;
+                if let Some((pk,)) = by_vine_id {
+                    pk
+                } else {
+                    query.to_string()
+                }
+            }
         };
 
         let row: Option<AdminUserDetails> = sqlx::query_as(

--- a/e2e/tests/claim.spec.ts
+++ b/e2e/tests/claim.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "@playwright/test";
+import { parseCookieValue } from "../helpers/auth";
+import { registerAdmin } from "../helpers/admin";
+
+test.describe("Account claim flow", () => {
+  test("preloaded user can claim via browser form", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(60000);
+
+    // 1. Register admin and get session cookie
+    const { cookie } = await registerAdmin(request);
+    const sessionCookie = `keycast_session=${parseCookieValue(cookie)}`;
+
+    // 2. Preload a user via admin API
+    const vineId = `e2e-vine-${Date.now()}`;
+    const username = `claimuser${Date.now()}`;
+    const displayName = "Test Claimer";
+
+    const preloadRes = await request.post("/api/admin/preload-user", {
+      headers: { Cookie: sessionCookie },
+      data: { vine_id: vineId, username, display_name: displayName },
+    });
+    expect(preloadRes.status()).toBe(200);
+    const preloadBody = await preloadRes.json();
+    expect(preloadBody.pubkey).toMatch(/^[0-9a-f]{64}$/);
+
+    // 3. Generate claim token via admin API
+    const claimRes = await request.post("/api/admin/claim-tokens", {
+      headers: { Cookie: sessionCookie },
+      data: { vine_id: vineId },
+    });
+    expect(claimRes.status()).toBe(200);
+    const claimBody = await claimRes.json();
+    expect(claimBody.claim_url).toContain("/api/claim?token=");
+    expect(claimBody.expires_at).toBeTruthy();
+
+    // 4. Navigate browser to the claim URL
+    await page.goto(claimBody.claim_url);
+
+    // 5. Verify the HTML form renders with display name and username
+    await expect(page.locator("h1")).toContainText("Claim Your Account", {
+      timeout: 10000,
+    });
+    await expect(page.locator(".name")).toContainText(displayName);
+    await expect(page.locator(".username")).toContainText(`@${username}`);
+
+    // 6. Fill email and password fields, submit
+    const claimEmail = `e2e-claimed-${Date.now()}@test.local`;
+    const claimPassword = "ClaimPass123!";
+
+    await page.fill('input[name="email"]', claimEmail);
+    await page.fill('input[name="password"]', claimPassword);
+    await page.fill('input[name="password_confirmation"]', claimPassword);
+    await page.click('button[type="submit"]');
+
+    // 7. Verify redirect to dashboard with session cookie set
+    await page.waitForURL("http://localhost:3000/", { timeout: 15000 });
+
+    const cookies = await page.context().cookies();
+    const kcCookie = cookies.find((c) => c.name === "keycast_session");
+    expect(kcCookie).toBeTruthy();
+
+    // 8. Verify the user can now log in with email/password
+    const loginRes = await request.post("/api/auth/login", {
+      data: { email: claimEmail, password: claimPassword },
+    });
+    expect(loginRes.status()).toBe(200);
+    const loginBody = await loginRes.json();
+    expect(loginBody.success).toBe(true);
+    expect(loginBody.pubkey).toBe(preloadBody.pubkey);
+  });
+
+  test("invalid claim token shows error page", async ({ page }) => {
+    await page.goto("http://localhost:3000/api/claim?token=invalid-token-abc");
+    await expect(page.locator("h1")).toContainText(
+      "Invalid or Expired Link",
+      { timeout: 10000 },
+    );
+  });
+
+  test("claim form rejects mismatched passwords", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(60000);
+
+    const { cookie } = await registerAdmin(request);
+    const sessionCookie = `keycast_session=${parseCookieValue(cookie)}`;
+
+    const vineId = `e2e-vine-mismatch-${Date.now()}`;
+    const preloadRes = await request.post("/api/admin/preload-user", {
+      headers: { Cookie: sessionCookie },
+      data: {
+        vine_id: vineId,
+        username: `mismatch${Date.now()}`,
+        display_name: "Mismatch Test",
+      },
+    });
+    expect(preloadRes.status()).toBe(200);
+
+    const claimRes = await request.post("/api/admin/claim-tokens", {
+      headers: { Cookie: sessionCookie },
+      data: { vine_id: vineId },
+    });
+    expect(claimRes.status()).toBe(200);
+    const claimBody = await claimRes.json();
+
+    await page.goto(claimBody.claim_url);
+    await expect(page.locator("h1")).toContainText("Claim Your Account", {
+      timeout: 10000,
+    });
+
+    await page.fill('input[name="email"]', `e2e-mismatch-${Date.now()}@test.local`);
+    await page.fill('input[name="password"]', "Password123!");
+    await page.fill('input[name="password_confirmation"]', "DifferentPass!");
+    await page.click('button[type="submit"]');
+
+    await expect(page.locator("#error")).toBeVisible({ timeout: 5000 });
+    await expect(page.locator("#error")).toContainText(
+      "Passwords do not match",
+    );
+  });
+});

--- a/web/src/routes/support-admin/+page.svelte
+++ b/web/src/routes/support-admin/+page.svelte
@@ -4,7 +4,7 @@
 	import { KeycastApi } from '$lib/keycast_api.svelte';
 	import { goto } from '$app/navigation';
 	import Loader from '$lib/components/Loader.svelte';
-	import { ShieldCheck, Warning, MagnifyingGlass, User, Key, Calendar, Globe, Copy, Check, CheckCircle, XCircle } from 'phosphor-svelte';
+	import { ShieldCheck, Warning, MagnifyingGlass, User, Key, Calendar, Globe, Copy, Check, CheckCircle, XCircle, Link } from 'phosphor-svelte';
 	import { nip19 } from 'nostr-tools';
 	import { toast } from 'svelte-hot-french-toast';
 
@@ -23,6 +23,12 @@
 	let pubkeyFormat = $state<'hex' | 'npub'>('npub');
 	let copiedPubkey = $state(false);
 
+	// Claim link state
+	let claimToken = $state<{ claim_url: string; expires_at: string } | null>(null);
+	let isLoadingClaimToken = $state(false);
+	let isGeneratingClaimToken = $state(false);
+	let copiedClaimUrl = $state(false);
+
 	interface UserDetails {
 		pubkey: string;
 		email: string | null;
@@ -33,7 +39,7 @@
 		has_personal_key: boolean;
 		active_sessions: number;
 		created_at: string;
-		updated_at: string;
+		last_active: string | null;
 	}
 
 	onMount(async () => {
@@ -110,6 +116,59 @@
 			toast.error('Failed to copy');
 		}
 	}
+
+	async function loadClaimToken(pubkey: string) {
+		isLoadingClaimToken = true;
+		claimToken = null;
+		try {
+			const result = await api.get<{ has_token: boolean; claim_url?: string; expires_at?: string }>(
+				`/admin/claim-tokens?pubkey=${encodeURIComponent(pubkey)}`
+			);
+			if (result.has_token && result.claim_url && result.expires_at) {
+				claimToken = { claim_url: result.claim_url, expires_at: result.expires_at };
+			}
+		} catch {
+			// Silently ignore - user may not have claim token access
+		} finally {
+			isLoadingClaimToken = false;
+		}
+	}
+
+	async function generateClaimToken(vineId: string) {
+		isGeneratingClaimToken = true;
+		try {
+			const result = await api.post<{ claim_url: string; expires_at: string }>(
+				'/admin/claim-tokens',
+				{ vine_id: vineId }
+			);
+			claimToken = result;
+			toast.success('Claim link generated');
+		} catch (err: any) {
+			toast.error(err.message || 'Failed to generate claim link');
+		} finally {
+			isGeneratingClaimToken = false;
+		}
+	}
+
+	async function copyClaimUrl() {
+		if (!claimToken) return;
+		try {
+			await navigator.clipboard.writeText(claimToken.claim_url);
+			copiedClaimUrl = true;
+			toast.success('Claim URL copied!');
+			setTimeout(() => (copiedClaimUrl = false), 2000);
+		} catch {
+			toast.error('Failed to copy');
+		}
+	}
+
+	$effect(() => {
+		if (searchResult?.found && searchResult.user?.vine_id && !searchResult.user?.email) {
+			loadClaimToken(searchResult.user.pubkey);
+		} else {
+			claimToken = null;
+		}
+	});
 </script>
 
 <svelte:head>
@@ -145,7 +204,7 @@
 					<input
 						type="text"
 						bind:value={searchQuery}
-						placeholder="Email address, hex pubkey, or npub..."
+						placeholder="Search for a user..."
 						class="search-input"
 						disabled={isSearching}
 					/>
@@ -154,6 +213,7 @@
 					{isSearching ? 'Searching...' : 'Search'}
 				</button>
 			</form>
+			<p class="search-hint">Search by email, Vine username, vine_id, hex pubkey, or npub</p>
 
 			{#if searchError}
 				<div class="search-error">
@@ -242,10 +302,51 @@
 							</div>
 
 							<div class="field">
-								<span class="field-label"><Calendar size={14} /> Updated</span>
-								<span class="field-value">{formatDate(u.updated_at)}</span>
+								<span class="field-label"><Calendar size={14} /> Last active</span>
+								<span class="field-value">{u.last_active ? formatDate(u.last_active) : 'Never'}</span>
 							</div>
 						</div>
+
+						{#if u.vine_id && !u.email}
+							<div class="claim-section">
+								<div class="claim-header">
+									<Link size={16} />
+									<span class="claim-title">Claim Link</span>
+								</div>
+								{#if isLoadingClaimToken}
+									<p class="claim-loading">Checking for existing claim link...</p>
+								{:else if claimToken}
+									<div class="claim-url-display">
+										<div class="claim-url-row">
+											<input
+												type="text"
+												value={claimToken.claim_url}
+												readonly
+												class="claim-url-input"
+											/>
+											<button class="icon-btn" onclick={copyClaimUrl} title="Copy claim URL">
+												{#if copiedClaimUrl}
+													<Check size={14} />
+												{:else}
+													<Copy size={14} />
+												{/if}
+											</button>
+										</div>
+										<span class="claim-expiry">
+											Expires {formatDate(claimToken.expires_at)}
+										</span>
+									</div>
+								{:else}
+									<button
+										class="btn-generate-claim"
+										onclick={() => generateClaimToken(u.vine_id!)}
+										disabled={isGeneratingClaimToken}
+									>
+										{isGeneratingClaimToken ? 'Generating...' : 'Generate Claim Link'}
+									</button>
+								{/if}
+							</div>
+						{/if}
 					</div>
 				{/if}
 			{/if}
@@ -385,6 +486,12 @@
 
 	.search-input::placeholder {
 		color: var(--color-divine-text-tertiary);
+	}
+
+	.search-hint {
+		font-size: 0.725rem;
+		color: var(--color-divine-text-tertiary);
+		margin: -0.5rem 0 1rem 0.25rem;
 	}
 
 	.btn-search {
@@ -590,6 +697,83 @@
 	.format-toggle:hover {
 		background: color-mix(in srgb, var(--color-divine-green) 15%, transparent);
 		color: var(--color-divine-green);
+	}
+
+	/* Claim link section */
+	.claim-section {
+		padding: 0.75rem 1.25rem;
+		border-top: 1px solid var(--color-divine-border);
+		background: color-mix(in srgb, var(--color-divine-green) 5%, var(--color-divine-surface));
+	}
+
+	.claim-header {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		color: var(--color-divine-green);
+		margin-bottom: 0.5rem;
+	}
+
+	.claim-title {
+		font-size: 0.825rem;
+		font-weight: 600;
+		color: var(--color-divine-text);
+	}
+
+	.claim-loading {
+		font-size: 0.8rem;
+		color: var(--color-divine-text-tertiary);
+		margin: 0;
+	}
+
+	.claim-url-display {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+	}
+
+	.claim-url-row {
+		display: flex;
+		gap: 0.375rem;
+		align-items: center;
+	}
+
+	.claim-url-input {
+		flex: 1;
+		padding: 0.5rem 0.625rem;
+		background: var(--color-divine-bg);
+		border: 1px solid var(--color-divine-border);
+		border-radius: 6px;
+		color: var(--color-divine-text);
+		font-family: var(--font-mono);
+		font-size: 0.725rem;
+		outline: none;
+	}
+
+	.claim-expiry {
+		font-size: 0.725rem;
+		color: var(--color-divine-text-tertiary);
+	}
+
+	.btn-generate-claim {
+		padding: 0.5rem 1rem;
+		background: var(--color-divine-green);
+		color: #fff;
+		border: none;
+		border-radius: 6px;
+		font-size: 0.825rem;
+		font-weight: 600;
+		cursor: pointer;
+		transition: opacity 0.2s;
+	}
+
+	.btn-generate-claim:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.btn-generate-claim:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 
 	.links-grid {


### PR DESCRIPTION
## Summary
- **User lookup by username/vine_id**: Support admins can now search for unclaimed Vine users by their username or vine_id (previously only email, hex pubkey, or npub worked)
- **Claim link generation from support-admin page**: When viewing an unclaimed Vine user, support admins see a "Claim Link" section to generate or view existing claim links with copy-to-clipboard
- **Claim token permissions relaxed**: `create_claim_token` now requires `is_support_admin` instead of `is_full_admin`, so support admins can generate claim links
- **Claim form redesigned**: The server-rendered claim form and error pages now match the app's dark theme (was white/purple, now dark green with brand colors)
- **E2E tests**: 3 new Playwright tests for the claim flow — happy path, invalid token, password mismatch

## Changes
| File | Change |
|------|--------|
| `core/src/repositories/claim_token.rs` | Add `find_valid_by_user_pubkey` method |
| `core/src/repositories/user.rs` | Extend `find_user_for_admin` with username/vine_id search |
| `api/src/api/http/admin.rs` | Add `get_claim_token` GET handler; relax `create_claim_token` to support admins |
| `api/src/api/http/claim.rs` | Redesign claim form + error page to match dark theme |
| `api/src/api/http/routes.rs` | Wire GET on `/admin/claim-tokens` |
| `web/src/routes/support-admin/+page.svelte` | Claim link UI section; search hint text below input |
| `e2e/tests/claim.spec.ts` | New — 3 E2E tests for claim flow |

## Test plan
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo test` in `api/` — all 162 tests pass
- [x] `npx svelte-check` — 0 errors
- [ ] Manual: start dev, go to `/support-admin`, search by username or vine_id
- [ ] Manual: for unclaimed Vine user, verify claim link section appears and works
- [ ] E2E: `cd e2e && npx playwright test tests/claim.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)