### PR TITLE
Add GHCR image push for mobile E2E testing

### DIFF
--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -156,6 +156,42 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # Push to GHCR (public, for E2E testing in divine-mobile)
+  push-ghcr:
+    name: Push to GHCR (public)
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push to GHCR
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/divinevideo/keycast:latest
+            ghcr.io/divinevideo/keycast:${{ github.sha }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   # Push to POC registry (always on push/PR)
   push-poc:
     name: Push to POC Registry


### PR DESCRIPTION
## Summary
- Adds a `push-ghcr` job to the CI workflow that pushes the keycast Docker image to `ghcr.io/divinevideo/keycast`
- Enables divine-mobile to pull keycast locally for E2E tests without needing GCP credentials
- Runs on push to master and manual dispatch (skips PRs), tagged with `latest` and commit SHA

## Notes
- GHCR package visibility must be set to public after the first push (Org → Packages → keycast → Package settings) if unauthenticated pulls are needed
- Uses `GITHUB_TOKEN` for auth — no additional secrets required

## Test plan
- [ ] Push to master triggers the `push-ghcr` job
- [ ] Image is available at `ghcr.io/divinevideo/keycast:latest`
- [ ] divine-mobile can pull and run the image for E2E tests