### PR TITLE
Fix NIP-07 login for support admins

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -11,7 +11,7 @@ use bcrypt::{hash, verify, DEFAULT_COST};
 use chrono::{Duration, Utc};
 use secrecy::{ExposeSecret, SecretString};
 
-use super::admin::is_full_admin;
+use super::admin::{is_full_admin, is_support_admin};
 use crate::api::extractors::UcanAuth;
 use crate::bcrypt_queue::{BcryptJob, BcryptQueueError};
 use crate::nip98;
@@ -542,20 +542,24 @@ async fn nostr_auth_login(
 
     let pubkey_hex = nip98_auth.pubkey.to_hex();
 
-    // Check if pubkey is in ALLOWED_PUBKEYS whitelist
+    // Check if pubkey is a full admin or support admin (checks ALLOWED_PUBKEYS and Redis)
     let nip98_auth_check = UcanAuth {
         pubkey: pubkey_hex.clone(),
         admin_role: None,
     };
-    if !is_full_admin(&nip98_auth_check) {
+    let admin_role = if is_full_admin(&nip98_auth_check) {
+        "full"
+    } else if is_support_admin(&nip98_auth_check).await {
+        "support"
+    } else {
         tracing::warn!(
-            "NIP-98 login denied for non-whitelisted pubkey: {}",
+            "NIP-98 login denied for non-admin pubkey: {}",
             &pubkey_hex[..8]
         );
         return Err(AuthError::Forbidden(
             "Pubkey not authorized for admin access".to_string(),
         ));
-    }
+    };
 
     // Get redirect_origin from headers (required for UCAN)
     let redirect_origin = extract_origin_from_headers(headers)?;
@@ -570,7 +574,7 @@ async fn nostr_auth_login(
         None, // No bunker_pubkey for admin sessions
         &server_keys,
         false, // NIP-98 admin login is not first-party OAuth
-        Some("full"),
+        Some(admin_role),
     )
     .await?;
 

--- a/web/src/lib/utils/auth.ts
+++ b/web/src/lib/utils/auth.ts
@@ -2,16 +2,11 @@ import { browser } from "$app/environment";
 import { goto } from "$app/navigation";
 import { getCurrentUser, setCurrentUser } from "$lib/current_user.svelte";
 import toast from "svelte-hot-french-toast";
-import { getViteDomain, getAllowedPubkeys, isTeamsEnabled } from "$lib/utils/env";
+import { getViteDomain, isTeamsEnabled } from "$lib/utils/env";
 
 export enum SigninMethod {
     Nip07 = "nip07",
     NostrLogin = "nostr-login",
-}
-
-function isAllowedPubkey(pubkey: string) {
-    const allowedPubkeys = getAllowedPubkeys();
-    return allowedPubkeys && allowedPubkeys.includes(pubkey);
 }
 
 export async function signin(
@@ -26,7 +21,19 @@ export async function signin(
         if (!alreadySignedIn) {
             toast.success("Signed in successfully");
         }
-        const dest = method === SigninMethod.Nip07 ? "/admin" : (isTeamsEnabled() ? "/teams" : "/");
+        let dest = isTeamsEnabled() ? "/teams" : "/";
+        if (method === SigninMethod.Nip07) {
+            // Check actual admin role to redirect to the right page
+            try {
+                const statusRes = await fetch(`${getViteDomain()}/api/admin/status`, { credentials: 'include' });
+                if (statusRes.ok) {
+                    const status = await statusRes.json();
+                    dest = status.role === "full" ? "/admin" : "/support-admin";
+                }
+            } catch {
+                dest = "/admin";
+            }
+        }
         goto(dest);
     }
     return pubkey;
@@ -40,11 +47,6 @@ async function nip07Login(): Promise<string | null> {
 
     try {
         const pubkey = await window.nostr.getPublicKey();
-
-        if (!isAllowedPubkey(pubkey)) {
-            toast.error("Your pubkey is not authorized for admin access");
-            return null;
-        }
 
         const apiBase = getViteDomain();
         const url = `${apiBase}/api/auth/login`;


### PR DESCRIPTION
## Summary
- Backend `nostr_auth_login()` now checks Redis `support_admins` set via `is_support_admin()` instead of only checking `ALLOWED_PUBKEYS` via `is_full_admin()`
- UCAN token `admin_role` is set to the actual role ("full" or "support") instead of being hardcoded to "full"
- Frontend removes redundant `isAllowedPubkey()` gate that blocked support admins before the request reached the backend
- Frontend redirects to `/admin` or `/support-admin` based on actual role from `/api/admin/status`

## Test plan
- [ ] Add a support admin via `/admin` UI (npub only, not in `ALLOWED_PUBKEYS`)
- [ ] Verify that support admin can log in via NIP-07 extension and lands on `/support-admin`
- [ ] Verify that full admins still log in via NIP-07 and land on `/admin`
- [ ] Verify that a random pubkey (not in either list) still gets rejected with 403