### PR TITLE
fix: show success page after account claim

### DIFF
--- a/api/src/api/http/claim.rs
+++ b/api/src/api/http/claim.rs
@@ -541,11 +541,7 @@ pub async fn claim_post(
         display_name = html_escape(&display_name_str),
     );
 
-    Ok((
-        [(header::SET_COOKIE, cookie_value)],
-        Html(html),
-    )
-        .into_response())
+    Ok(([(header::SET_COOKIE, cookie_value)], Html(html)).into_response())
 }
 
 /// HTML-escape a string to prevent XSS


### PR DESCRIPTION
## Summary
- Replace the bare redirect to `APP_URL/` after claiming an account (which was a dead end — the API server doesn't serve a frontend) with an inline success page
- Success page shows: checkmark, "Account Claimed!" heading, user's display name, 3-step instructions (download app, sign in, your content is waiting), App Store + Google Play links, and an "Open diVine on Web" button linking to divine.video
- Session cookie is still set in the response so the user is authenticated if they navigate to the web app

## Test plan
- [ ] Visit a claim URL, fill in email/password, submit — verify success page renders with app links
- [ ] Verify session cookie is set after claim
- [ ] Verify App Store and Google Play links work
- [ ] Verify "Open diVine on Web" links to divine.video

🤖 Generated with [Claude Code](https://claude.com/claude-code)