### PR TITLE
chore: Remove test environment from CI deploy dispatch

### DIFF
--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -221,9 +221,9 @@ jobs:
         id: envs
         run: |
           if [[ "${{ github.ref }}" == refs/tags/v* ]] || [[ "${{ inputs.include_production }}" == "true" ]]; then
-            echo 'environments=["poc","test","staging","production"]' >> $GITHUB_OUTPUT
+            echo 'environments=["poc","staging","production"]' >> $GITHUB_OUTPUT
           else
-            echo 'environments=["poc","test","staging"]' >> $GITHUB_OUTPUT
+            echo 'environments=["poc","staging"]' >> $GITHUB_OUTPUT
           fi
 
       - name: Generate GitHub App token


### PR DESCRIPTION
Closes #68

## Problem

Post-merge CI dispatches a `repository_dispatch` to `divine-iac-coreconfig` for each target environment, including `test`. The test environment's ArgoCD cluster (`argocd.test.dvines.org`) is unreachable, so the dispatch consistently fails and blocks promotion to production.

## Approach

Removed `test` from the environments array in the deploy job's "Determine environments" step. Both code paths (tag/production and non-production) now skip test, so the dispatch payload no longer includes an environment that can't be reached.

Root cause is the unreachable ArgoCD cluster, not the dispatch mechanism itself — removing test from the array is the minimal fix.

## Trade-offs

- The "Push to Test" Docker step and the summary step still reference test. This is intentional: pushing images to the test registry is harmless (just a Docker push with no downstream effect), and a separate IAC issue tracks broader removal of test from ApplicationSets and overlays.
- If the test cluster comes back online, test would need to be re-added here.

## Test plan

- Verify CI passes on this branch without dispatching to the test environment
- Confirm poc, staging, and production dispatches are unaffected