### PR TITLE
fix: update branding from diVine to Divine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,7 @@ SENDGRID_API_KEY=
 FROM_EMAIL=noreply@keycast.example.com
 
 # Optional: From name for email notifications
-FROM_NAME=diVine
+FROM_NAME=Divine
 
 # Optional: Base URL for email verification links (used in email templates)
 # Should match your frontend URL

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ See [DEVELOPMENT.md](./docs/DEVELOPMENT.md) for local development setup.
 |----------|---------|-------------|
 | `SENDGRID_API_KEY` | *(none)* | If set, uses SendGrid; otherwise logs emails to console |
 | `FROM_EMAIL` | `noreply@keycast.app` | Sender email address |
-| `FROM_NAME` | `diVine` | Sender display name |
+| `FROM_NAME` | `Divine` | Sender display name |
 | `BASE_URL` | `https://login.divine.video` | Base URL for email verification links |
 | `DISABLE_EMAILS` | *(none)* | If set (any value), skips sending emails |
 

--- a/api/src/api/http/claim.rs
+++ b/api/src/api/http/claim.rs
@@ -502,7 +502,7 @@ pub async fn claim_post(
                 <div class="step-num">1</div>
                 <div class="step-content">
                     <div class="step-title">Get the App</div>
-                    <div class="step-desc">Download diVine for the best experience.</div>
+                    <div class="step-desc">Download Divine for the best experience.</div>
                     <div class="app-links">
                         <a class="app-link" href="https://apps.apple.com/app/divine-video/id6744577425" target="_blank">
                             &#63743; App Store
@@ -532,7 +532,7 @@ pub async fn claim_post(
         <div class="divider"></div>
 
         <a class="web-link" href="https://divine.video" target="_blank">
-            Open diVine on Web
+            Open Divine on Web
         </a>
         <p class="note">You can also access your account at divine.video</p>
     </div>

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -1193,7 +1193,7 @@ pub async fn authorize_get(
     <div class="container">
         <div class="header">
             <div class="logo">
-                <img src="/divine-logo.svg" alt="diVine" />
+                <img src="/divine-logo.svg" alt="Divine" />
                 <span class="logo-sub">Login</span>
             </div>
             <h1>Authorize App</h1>
@@ -1224,7 +1224,7 @@ pub async fn authorize_get(
             </div>
 
             <p class="disclaimer">
-                By authorizing, you agree to diVine's <a href="https://divine.video/terms" target="_blank">terms</a> and <a href="https://divine.video/privacy" target="_blank">privacy policy</a>.
+                By authorizing, you agree to Divine's <a href="https://divine.video/terms" target="_blank">terms</a> and <a href="https://divine.video/privacy" target="_blank">privacy policy</a>.
             </p>
 
             <div class="buttons">
@@ -1476,7 +1476,7 @@ pub async fn authorize_get(
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <title>Sign in - diVine Login</title>
+    <title>Sign in - Divine Login</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Bricolage+Grotesque:wght@600;700&display=swap" rel="stylesheet">
@@ -1786,7 +1786,7 @@ pub async fn authorize_get(
     <div class="container">
         <div class="header">
             <div class="logo">
-                <img src="/divine-logo.svg" alt="diVine" />
+                <img src="/divine-logo.svg" alt="Divine" />
                 <span class="logo-sub">Login</span>
             </div>
             <h1>Sign in</h1>
@@ -1903,11 +1903,11 @@ pub async fn authorize_get(
             if (form === 'login') {{
                 document.getElementById('login_view').classList.add('active');
                 if (headerTitle) headerTitle.textContent = 'Sign in';
-                document.title = 'Sign in - diVine Login';
+                document.title = 'Sign in - Divine Login';
             }} else {{
                 document.getElementById('register_view').classList.add('active');
                 if (headerTitle) headerTitle.textContent = 'Create account';
-                document.title = 'Create account - diVine Login';
+                document.title = 'Create account - Divine Login';
             }}
 
             hideError();
@@ -3375,7 +3375,7 @@ pub async fn connect_get(
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <title>Authorize Connection - diVine Login</title>
+    <title>Authorize Connection - Divine Login</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Bricolage+Grotesque:wght@600;700&display=swap" rel="stylesheet">
@@ -3597,7 +3597,7 @@ pub async fn connect_get(
     <div class="container">
         <div class="header">
             <div class="logo">
-                <img src="/divine-logo.svg" alt="diVine" />
+                <img src="/divine-logo.svg" alt="Divine" />
                 <span class="logo-sub">Login</span>
             </div>
             <h1>Authorize Connection</h1>
@@ -3619,7 +3619,7 @@ pub async fn connect_get(
         </div>
 
         <div class="warning">
-            This will allow the app to sign events on your behalf using your diVine-managed keys.
+            This will allow the app to sign events on your behalf using your Divine-managed keys.
         </div>
 
         <form method="POST" action="/api/oauth/connect">

--- a/api/src/email_service.rs
+++ b/api/src/email_service.rs
@@ -96,7 +96,7 @@ impl EmailSender for DevEmailSender {
         tracing::info!("  VERIFICATION EMAIL");
         tracing::info!("==================================================");
         tracing::info!("  To: {}", to_email);
-        tracing::info!("  Subject: Verify your diVine email address");
+        tracing::info!("  Subject: Verify your Divine email address");
         tracing::info!("");
         tracing::info!("  Click to verify:");
         tracing::info!("  {}", verification_url);
@@ -113,7 +113,7 @@ impl EmailSender for DevEmailSender {
         if let Ok(mut captured) = self.captured.lock() {
             captured.push(CapturedEmail {
                 to: to_email.to_string(),
-                subject: "Verify your diVine email address".to_string(),
+                subject: "Verify your Divine email address".to_string(),
                 verification_url: Some(verification_url),
                 reset_url: None,
             });
@@ -134,7 +134,7 @@ impl EmailSender for DevEmailSender {
         tracing::info!("  PASSWORD RESET EMAIL");
         tracing::info!("==================================================");
         tracing::info!("  To: {}", to_email);
-        tracing::info!("  Subject: Reset your diVine password");
+        tracing::info!("  Subject: Reset your Divine password");
         tracing::info!("");
         tracing::info!("  Click to reset password:");
         tracing::info!("  {}", reset_url);
@@ -151,7 +151,7 @@ impl EmailSender for DevEmailSender {
         if let Ok(mut captured) = self.captured.lock() {
             captured.push(CapturedEmail {
                 to: to_email.to_string(),
-                subject: "Reset your diVine password".to_string(),
+                subject: "Reset your Divine password".to_string(),
                 verification_url: None,
                 reset_url: Some(reset_url),
             });
@@ -166,7 +166,7 @@ impl EmailSender for DevEmailSender {
         tracing::info!("  VINE CLAIM EMAIL");
         tracing::info!("==================================================");
         tracing::info!("  To: {}", to_email);
-        tracing::info!("  Subject: Your Vine account on diVine is ready to claim");
+        tracing::info!("  Subject: Your Vine account on Divine is ready to claim");
         tracing::info!("");
         tracing::info!("  Claim link:");
         tracing::info!("  {}", claim_url);
@@ -181,7 +181,7 @@ impl EmailSender for DevEmailSender {
         if let Ok(mut captured) = self.captured.lock() {
             captured.push(CapturedEmail {
                 to: to_email.to_string(),
-                subject: "Your Vine account on diVine is ready to claim".to_string(),
+                subject: "Your Vine account on Divine is ready to claim".to_string(),
                 verification_url: Some(claim_url.to_string()),
                 reset_url: None,
             });
@@ -261,7 +261,7 @@ impl SendGridEmailSender {
     pub fn new(api_key: String) -> Self {
         let from_email =
             env::var("FROM_EMAIL").unwrap_or_else(|_| "noreply@divine.video".to_string());
-        let from_name = env::var("FROM_NAME").unwrap_or_else(|_| "diVine".to_string());
+        let from_name = env::var("FROM_NAME").unwrap_or_else(|_| "Divine".to_string());
         let base_url = env::var("BASE_URL")
             .or_else(|_| env::var("APP_URL"))
             .unwrap_or_else(|_| "http://localhost:5173".to_string());
@@ -359,12 +359,12 @@ impl EmailSender for SendGridEmailSender {
             self.base_url, verification_token
         );
 
-        let subject = "Verify your diVine email address".to_string();
+        let subject = "Verify your Divine email address".to_string();
         let html_content = format!(
             r#"
             <html>
             <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-                <h1 style="color: #00B488;">Verify your diVine email</h1>
+                <h1 style="color: #00B488;">Verify your Divine email</h1>
                 <p>Thanks for signing up! Please verify your email address by clicking the button below:</p>
                 <div style="margin: 30px 0;">
                     <a href="{}"
@@ -377,7 +377,7 @@ impl EmailSender for SendGridEmailSender {
                     <a href="{}" style="color: #00B488;">{}</a>
                 </p>
                 <p style="color: #666; font-size: 14px; margin-top: 30px;">
-                    If you didn't sign up for diVine, you can safely ignore this email.
+                    If you didn't sign up for Divine, you can safely ignore this email.
                 </p>
             </body>
             </html>
@@ -386,7 +386,7 @@ impl EmailSender for SendGridEmailSender {
         );
 
         let text_content = format!(
-            "Thanks for signing up! Please verify your email address by clicking this link:\n\n{}\n\nIf you didn't sign up for diVine, you can safely ignore this email.",
+            "Thanks for signing up! Please verify your email address by clicking this link:\n\n{}\n\nIf you didn't sign up for Divine, you can safely ignore this email.",
             verification_url
         );
 
@@ -401,12 +401,12 @@ impl EmailSender for SendGridEmailSender {
     ) -> Result<(), String> {
         let reset_url = format!("{}/reset-password?token={}", self.base_url, reset_token);
 
-        let subject = "Reset your diVine password".to_string();
+        let subject = "Reset your Divine password".to_string();
         let html_content = format!(
             r#"
             <html>
             <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-                <h1 style="color: #00B488;">Reset your diVine password</h1>
+                <h1 style="color: #00B488;">Reset your Divine password</h1>
                 <p>We received a request to reset your password. Click the button below to set a new password:</p>
                 <div style="margin: 30px 0;">
                     <a href="{}"
@@ -437,13 +437,13 @@ impl EmailSender for SendGridEmailSender {
     }
 
     async fn send_claim_email(&self, to_email: &str, claim_url: &str) -> Result<(), String> {
-        let subject = "Your Vine account on diVine is ready to claim".to_string();
+        let subject = "Your Vine account on Divine is ready to claim".to_string();
         let html_content = format!(
             r#"
             <html>
             <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
                 <h1 style="color: #00B488;">Your Vine account is ready!</h1>
-                <p>Your Vine account has been migrated to diVine. Click the button below to claim it and set up your login:</p>
+                <p>Your Vine account has been migrated to Divine. Click the button below to claim it and set up your login:</p>
                 <div style="margin: 30px 0;">
                     <a href="{}"
                        style="background: #00B488; color: #fff; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block; font-weight: bold;">
@@ -464,7 +464,7 @@ impl EmailSender for SendGridEmailSender {
         );
 
         let text_content = format!(
-            "Your Vine account has been migrated to diVine. Click this link to claim it:\n\n{}\n\nThis link will expire in 7 days. If you didn't request this, you can safely ignore this email.",
+            "Your Vine account has been migrated to Divine. Click this link to claim it:\n\n{}\n\nThis link will expire in 7 days. If you didn't request this, you can safely ignore this email.",
             claim_url
         );
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       # Email configuration
       SENDGRID_API_KEY: ${SENDGRID_API_KEY:-}
       FROM_EMAIL: ${FROM_EMAIL:-noreply@divine.video}
-      FROM_NAME: ${FROM_NAME:-diVine}
+      FROM_NAME: ${FROM_NAME:-Divine}
       BASE_URL: ${BASE_URL:-http://localhost:5173}
       # DISABLE_EMAILS: ${DISABLE_EMAILS:-}
       # Server configuration

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -6,13 +6,13 @@
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="shortcut icon" href="/favicon.ico" />
 		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-		<meta name="apple-mobile-web-app-title" content="diVine Login" />
+		<meta name="apple-mobile-web-app-title" content="Divine Login" />
 		<link rel="manifest" href="/site.webmanifest" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="preconnect" href="https://fonts.googleapis.com">
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 		<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@600;700;800&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-		<title>diVine Login</title>
+		<title>Divine Login</title>
 		<meta name="description" content="Manage your Nostr identity" />
 		%sveltekit.head%
 	</head>

--- a/web/src/lib/brand.ts
+++ b/web/src/lib/brand.ts
@@ -1,5 +1,5 @@
 export const BRAND = {
-  name: 'diVine Login',
-  shortName: 'diVine',
+  name: 'Divine Login',
+  shortName: 'Divine',
   tagline: 'Sign in to Nostr apps with your email',
 } as const;

--- a/web/src/lib/components/CreateBunkerModal.svelte
+++ b/web/src/lib/components/CreateBunkerModal.svelte
@@ -129,7 +129,7 @@
 				<div class="modal-body">
 					<div class="info-box">
 						<strong>You probably don't need this</strong>
-						<p>The diVine app and any app with "Sign in with diVine" already work with your email and password. This is only for Nostr apps that need a connection URL. Browse them at <a href="https://nostrapps.com" target="_blank" rel="noopener noreferrer">nostrapps.com</a>.</p>
+						<p>The Divine app and any app with "Sign in with Divine" already work with your email and password. This is only for Nostr apps that need a connection URL. Browse them at <a href="https://nostrapps.com" target="_blank" rel="noopener noreferrer">nostrapps.com</a>.</p>
 					</div>
 
 					<p class="description">

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -418,13 +418,13 @@ $effect(() => {
 
 						<div class="learn-block">
 							<h4><ShieldCheck size={16} weight="fill" /> Where Is Your Key?</h4>
-							<p>When you sign up with email and password, diVine generates a Nostr key for you and stores it on <a href="https://login.divine.video" target="_blank" rel="noopener noreferrer">login.divine.video</a>, encrypted using the same standards banks and password managers rely on (<a href="https://en.wikipedia.org/wiki/Advanced_Encryption_Standard" target="_blank" rel="noopener noreferrer">1</a>,<a href="https://cloud.google.com/security/products/security-key-management" target="_blank" rel="noopener noreferrer">2</a>). Your key is only decrypted in memory when an app needs to sign on your behalf, and is never stored in plain text.</p>
-							<p>Any Nostr app that supports diVine Login, like <a href="https://privdm.com" target="_blank" rel="noopener noreferrer" class="inline-link">Priv DM <ArrowSquareOut size={12} /></a>, can use your identity with just your email and password. No copying keys between apps, no manual setup.</p>
+							<p>When you sign up with email and password, Divine generates a Nostr key for you and stores it on <a href="https://login.divine.video" target="_blank" rel="noopener noreferrer">login.divine.video</a>, encrypted using the same standards banks and password managers rely on (<a href="https://en.wikipedia.org/wiki/Advanced_Encryption_Standard" target="_blank" rel="noopener noreferrer">1</a>,<a href="https://cloud.google.com/security/products/security-key-management" target="_blank" rel="noopener noreferrer">2</a>). Your key is only decrypted in memory when an app needs to sign on your behalf, and is never stored in plain text.</p>
+							<p>Any Nostr app that supports Divine Login, like <a href="https://privdm.com" target="_blank" rel="noopener noreferrer" class="inline-link">Priv DM <ArrowSquareOut size={12} /></a>, can use your identity with just your email and password. No copying keys between apps, no manual setup.</p>
 						</div>
 
 						<div class="learn-block">
 							<h4><Key size={16} weight="fill" /> Already Have a Nostr Key?</h4>
-							<p>You don't need a diVine account at all. Import your nsec into the diVine app and everything stays on your device.</p>
+							<p>You don't need a Divine account at all. Import your nsec into the Divine app and everything stays on your device.</p>
 						</div>
 
 						<div class="learn-block">
@@ -434,12 +434,12 @@ $effect(() => {
 								<li><strong>Your phone:</strong> <a href="https://primal.net" target="_blank" rel="noopener noreferrer" class="inline-link">Primal <ArrowSquareOut size={12} /></a> (iOS & Android), <a href="https://github.com/greenart7c3/Amber" target="_blank" rel="noopener noreferrer" class="inline-link">Amber <ArrowSquareOut size={12} /></a> (Android), or <a href="https://nsec.app" target="_blank" rel="noopener noreferrer" class="inline-link">nsec.app <ArrowSquareOut size={12} /></a> (any browser) turn your device into a personal signing server. When a Nostr app needs your signature, it asks your device and your key never leaves it.</li>
 								<li><strong>Your browser:</strong> Extensions like <a href="https://getalby.com" target="_blank" rel="noopener noreferrer" class="inline-link">Alby <ArrowSquareOut size={12} /></a> or <a href="https://chromewebstore.google.com/detail/soapboxpub-signer/nnodjkgakfpkckcnbacpcjbpmlmbihdd" target="_blank" rel="noopener noreferrer" class="inline-link">Soapbox Signer <ArrowSquareOut size={12} /></a> (Chrome, Firefox) keep your key in the browser itself. <a href="https://apps.apple.com/app/nostash/id6499558903" target="_blank" rel="noopener noreferrer" class="inline-link">Nostash <ArrowSquareOut size={12} /></a> does the same for Safari on iOS.</li>
 							</ul>
-							<p>With these options, each app that needs your signature must connect to your signer individually. diVine Login handles that for you automatically.</p>
+							<p>With these options, each app that needs your signature must connect to your signer individually. Divine Login handles that for you automatically.</p>
 						</div>
 
 						<div class="learn-block highlight">
 							<h4><ShieldCheck size={16} weight="fill" /> Why This Matters</h4>
-							<p>Unlike Twitter or Facebook, <strong>no company owns your Nostr identity</strong>. Even if diVine disappeared tomorrow, your identity and content would still exist on the network. Export your key and continue anywhere.</p>
+							<p>Unlike Twitter or Facebook, <strong>no company owns your Nostr identity</strong>. Even if Divine disappeared tomorrow, your identity and content would still exist on the network. Export your key and continue anywhere.</p>
 							<p class="learn-cta">That's the power of Nostr.</p>
 							<div class="learn-explore">
 								<a href="https://nostrapps.com" target="_blank" rel="noopener noreferrer">Explore Nostr apps at nostrapps.com <ArrowSquareOut size={12} /></a>
@@ -465,7 +465,7 @@ $effect(() => {
 					<div class="empty-state">
 						<p>No app connections yet.</p>
 						<p class="hint">
-							The diVine app and any app with "Sign in with diVine" already work with your email and password. Use this to connect to other Nostr apps. Browse them at <a href="https://nostrapps.com" target="_blank" rel="noopener noreferrer">nostrapps.com</a>.
+							The Divine app and any app with "Sign in with Divine" already work with your email and password. Use this to connect to other Nostr apps. Browse them at <a href="https://nostrapps.com" target="_blank" rel="noopener noreferrer">nostrapps.com</a>.
 						</p>
 					</div>
 				{:else}
@@ -478,7 +478,7 @@ $effect(() => {
 										<p class="app-name">
 											{group.application_name}
 											{#if group.isOAuth}
-												<span class="connection-badge oauth">diVine Login</span>
+												<span class="connection-badge oauth">Divine Login</span>
 											{:else}
 												<span class="connection-badge manual">Bunker</span>
 											{/if}
@@ -735,7 +735,7 @@ $effect(() => {
 						<PlugsConnected size={24} weight="fill" />
 					</div>
 					<h3>Works across apps</h3>
-					<p>Sign in to any Nostr app that supports diVine Login. One account, everywhere.</p>
+					<p>Sign in to any Nostr app that supports Divine Login. One account, everywhere.</p>
 				</div>
 
 				<div class="feature-card">

--- a/web/src/routes/app/callback/+page.svelte
+++ b/web/src/routes/app/callback/+page.svelte
@@ -8,7 +8,7 @@ const currentUrl = $derived(browser ? $page.url.href : "");
 </script>
 
 <svelte:head>
-    <title>Returning to App - diVine Login</title>
+    <title>Returning to App - Divine Login</title>
     <meta name="robots" content="noindex">
 </svelte:head>
 

--- a/web/src/routes/demo/+page.svelte
+++ b/web/src/routes/demo/+page.svelte
@@ -22,7 +22,7 @@
 
   // Configuration
   const SERVER_URL = getViteDomain();
-  const CLIENT_ID = "diVine Login Demo";
+  const CLIENT_ID = "Divine Login Demo";
   console.log(
     "SERVER_URL:",
     SERVER_URL,
@@ -437,7 +437,7 @@
       <p class="hint-text">
         To test the OAuth approval flow again, first <a
           href="/"
-          class="text-link">revoke the "diVine Login Demo" authorization</a
+          class="text-link">revoke the "Divine Login Demo" authorization</a
         > in your dashboard, then click Disconnect above.
       </p>
 

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -163,7 +163,7 @@
 						autocomplete="off"
 						disabled={isLoading}
 					/>
-					<p class="field-hint">Import your existing key to use it with diVine Login. Leave empty to create a new one.</p>
+					<p class="field-hint">Import your existing key to use it with Divine Login. Leave empty to create a new one.</p>
 				</div>
 			</div>
 			{/if}

--- a/web/static/site.webmanifest
+++ b/web/static/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "diVine Login",
-  "short_name": "diVine",
+  "name": "Divine Login",
+  "short_name": "Divine",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",


### PR DESCRIPTION
## Summary

Updates all user-facing instances of "diVine" to "Divine" to match the current brand spelling. Changes are split into four commits for cherry-pickability:

- **Email templates** -- subjects, headings, and body text in verification, password reset, and Vine claim emails
- **Email config defaults** -- FROM_NAME default in .env.example, docker-compose.yml, README
- **Server-side UI** -- OAuth consent pages, sign-in/register titles, claim success page
- **Web frontend** -- brand.ts, app.html, site.webmanifest, all Svelte components

Does not touch the database migration seed value (tenants table) -- that would need a separate migration.

## Test plan

- [ ] Trigger a password reset or verification email and confirm "Divine" appears (not "diVine")
- [ ] Check login.divine.video sign-in page title
- [ ] Check OAuth consent screen text
- [ ] Verify web manifest shows "Divine"