### PR TITLE
fix: Dockerfile GLIBC mismatch, migration job limits, and tools credential handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage for Rust API
-FROM rust:1.93-slim AS rust-builder
+FROM rust:1.93-slim-bookworm AS rust-builder
 
 RUN apt-get update && apt-get install -y \
     pkg-config \

--- a/k8s/migrations/migrate-vine-users-production.yaml
+++ b/k8s/migrations/migrate-vine-users-production.yaml
@@ -21,8 +21,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: migrate
-          # TODO: update tag once CI production push is fixed
-          image: us-central1-docker.pkg.dev/dv-platform-prod/containers-production/keycast:IMAGE_TAG
+          image: us-central1-docker.pkg.dev/dv-platform-prod/containers-production/keycast:a5d3261
           command: ["./migrate-vine-users"]
           env:
             # Source: openvine-co Cloud SQL via proxy sidecar (IAM auth, no password)
@@ -61,11 +60,11 @@ spec:
               value: "10"
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "100m"
+              memory: "512Mi"
+              cpu: "200m"
             limits:
-              memory: "256Mi"
-              cpu: "500m"
+              memory: "1Gi"
+              cpu: "1000m"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/tools/run-migrations.sh
+++ b/tools/run-migrations.sh
@@ -14,7 +14,7 @@ CONNECTION_NAME="$PROJECT_ID:$REGION:$INSTANCE_NAME"
 
 DB_USER="postgres"
 DB_NAME="keycast"
-DB_PORT="15432"  # Non-standard port to avoid conflicts with local PostgreSQL
+DB_PORT="${DB_PORT:-15432}"  # Non-standard port to avoid conflicts with local PostgreSQL
 # ---------------------
 
 # Find cloud-sql-proxy binary
@@ -25,17 +25,18 @@ if [ ! -x "$PROXY_BIN" ]; then
     exit 1
 fi
 
-# 1. Auto-Detect Password from Secret Manager
-if [ -z "$DB_PASS" ]; then
+# 1. Auto-Detect DATABASE_URL from Secret Manager
+# Use the full URL (rewritten to proxy host) instead of extracting password,
+# which avoids shell escaping issues with special characters in passwords.
+if [ -z "$DB_URL" ]; then
     echo "🔍 Auto-detecting database credentials..."
 
     DB_URL=$(gcloud secrets versions access latest --secret="keycast-database-url" --project=$PROJECT_ID 2>/dev/null || true)
 
-    if [[ "$DB_URL" =~ ://[^:]+:([^@]+)@ ]]; then
-        DB_PASS="${BASH_REMATCH[1]}"
-        echo "✅ Found password from Secret Manager!"
+    if [ -n "$DB_URL" ]; then
+        echo "✅ Found DATABASE_URL from Secret Manager!"
     else
-        echo "⚠️  Could not auto-detect password."
+        echo "⚠️  Could not auto-detect credentials."
         read -s -p "🔑 Enter DB Password manually: " DB_PASS
         echo ""
     fi
@@ -44,7 +45,7 @@ fi
 # 2. Start Cloud SQL Auth Proxy in the background
 echo "🔌 Starting Cloud SQL Auth Proxy for [$CONNECTION_NAME]..."
 
-"$PROXY_BIN" "$CONNECTION_NAME" --port $DB_PORT --gcloud-auth --quiet 2>&1 >&2 &
+"$PROXY_BIN" "$CONNECTION_NAME" --port $DB_PORT --quiet 2>&1 >&2 &
 PROXY_PID=$!
 
 # Cleanup function to stop proxy on exit
@@ -67,7 +68,12 @@ done
 # 4. Run the SQLx Migration
 echo "🚀 Running SQLx Migrations..."
 
-export DATABASE_URL="postgres://$DB_USER:$DB_PASS@127.0.0.1:$DB_PORT/$DB_NAME?sslmode=disable"
+if [ -n "$DB_URL" ]; then
+    # Rewrite host in DATABASE_URL to point at the local proxy
+    export DATABASE_URL=$(echo "$DB_URL" | sed -E "s/@[^/]+\//@127.0.0.1:$DB_PORT\//")
+else
+    export DATABASE_URL="postgres://$DB_USER:$DB_PASS@127.0.0.1:$DB_PORT/$DB_NAME?sslmode=disable"
+fi
 
 # Change to project root to find migrations
 cd "$(dirname "$0")/.."

--- a/tools/run-sql.sh
+++ b/tools/run-sql.sh
@@ -23,7 +23,7 @@ CONNECTION_NAME="$PROJECT_ID:$REGION:$INSTANCE_NAME"
 
 DB_USER="postgres"
 DB_NAME="keycast"
-DB_PORT="15432"  # Non-standard port to avoid conflicts with local PostgreSQL
+DB_PORT="${DB_PORT:-15432}"  # Non-standard port to avoid conflicts with local PostgreSQL
 # ---------------------
 
 # Find cloud-sql-proxy binary
@@ -34,17 +34,18 @@ if [ ! -x "$PROXY_BIN" ]; then
     exit 1
 fi
 
-# 1. Auto-Detect Password from Secret Manager
-if [ -z "$DB_PASS" ]; then
+# 1. Auto-Detect DATABASE_URL from Secret Manager
+# Use the full URL (rewritten to proxy host) instead of extracting password,
+# which avoids shell escaping issues with special characters in passwords.
+if [ -z "$DB_URL" ]; then
     echo "🔍 Auto-detecting database credentials..." >&2
 
     DB_URL=$(gcloud secrets versions access latest --secret="keycast-database-url" --project=$PROJECT_ID 2>/dev/null || true)
 
-    if [[ "$DB_URL" =~ ://[^:]+:([^@]+)@ ]]; then
-        DB_PASS="${BASH_REMATCH[1]}"
-        echo "✅ Found password from Secret Manager!" >&2
+    if [ -n "$DB_URL" ]; then
+        echo "✅ Found DATABASE_URL from Secret Manager!" >&2
     else
-        echo "⚠️  Could not auto-detect password." >&2
+        echo "⚠️  Could not auto-detect credentials." >&2
         read -s -p "🔑 Enter DB Password manually: " DB_PASS
         echo "" >&2
     fi
@@ -69,7 +70,7 @@ fi
 # 3. Start Cloud SQL Auth Proxy in the background
 echo "🔌 Starting Cloud SQL Auth Proxy..." >&2
 
-"$PROXY_BIN" "$CONNECTION_NAME" --port $DB_PORT --gcloud-auth --quiet 2>&1 >&2 &
+"$PROXY_BIN" "$CONNECTION_NAME" --port $DB_PORT --quiet 2>&1 >&2 &
 PROXY_PID=$!
 
 # Cleanup function to stop proxy on exit
@@ -90,7 +91,13 @@ done
 
 # 5. Execute SQL
 echo "🚀 Executing SQL..." >&2
-export PGPASSWORD="$DB_PASS"
-echo "$SQL_QUERY" | psql -h 127.0.0.1 -p $DB_PORT -U $DB_USER -d $DB_NAME -f -
+if [ -n "$DB_URL" ]; then
+    # Rewrite host in DATABASE_URL to point at the local proxy
+    PROXY_URL=$(echo "$DB_URL" | sed -E "s/@[^/]+\//@127.0.0.1:$DB_PORT\//")
+    echo "$SQL_QUERY" | psql "$PROXY_URL" -f -
+else
+    export PGPASSWORD="$DB_PASS"
+    echo "$SQL_QUERY" | psql -h 127.0.0.1 -p $DB_PORT -U $DB_USER -d $DB_NAME -f -
+fi
 
 echo "✨ Done!" >&2


### PR DESCRIPTION
## Description

Fix three operational issues: (1) Dockerfile build stage uses `rust:1.93-slim` (Debian Trixie, GLIBC 2.39) but runtime stage is `debian:bookworm-slim` (GLIBC 2.36), causing `GLIBC_2.39 not found` crashes on GKE pods — pin build stage to bookworm. (2) Production migration Job had a placeholder image tag and memory limits (256Mi) that OOMKilled at 98k users — pin to a5d3261 and bump to 1Gi. (3) `run-sql.sh` and `run-migrations.sh` extracted the DB password from DATABASE_URL via regex, which mangled special characters — use the full URL with host rewrite instead.

## Type of Change

- [x] Bug fix
- [x] Build configuration change

## Test plan

- [ ] `docker build .` succeeds with `rust:1.93-slim-bookworm` base
- [ ] GKE pods start without GLIBC errors after image rebuild
- [ ] `tools/run-sql.sh "SELECT 1;"` works against Cloud SQL
- [ ] Migration Job manifest reflects the 2026-04-11 successful run config