### PR TITLE
feat: add auth observability tooling

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -1,17 +1,18 @@
 // ABOUTME: Admin endpoints for preloaded accounts, claim token generation, and support admin management
 // ABOUTME: Used for Vine import and support workflows
 
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::Json;
 use chrono::{Duration, Utc};
 use nostr_sdk::{FromBech32, Keys};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use super::routes::AuthState;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extractors::UcanAuth;
 use keycast_core::repositories::{
-    ClaimTokenRepository, OAuthAuthorizationRepository, UserRepository,
+    AuthEventRepository, ClaimTokenRepository, OAuthAuthorizationRepository, UserRepository,
 };
 use keycast_core::types::claim_token::generate_claim_token;
 
@@ -895,6 +896,331 @@ pub async fn get_user_lookup(
     }
 
     Ok(Json(UserLookupResponse { results, total }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AuthDebugQuery {
+    pub email: Option<String>,
+    pub pubkey: Option<String>,
+    pub npub: Option<String>,
+    pub request_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuthDebugAccount {
+    pub pubkey: String,
+    pub email: Option<String>,
+    pub email_verified: Option<bool>,
+    pub password_hash_present: bool,
+    pub password_reset_pending: bool,
+    pub active_sessions: i64,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuthDebugDuplicate {
+    pub pubkey: String,
+    pub email: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuthDebugEvent {
+    pub occurred_at: String,
+    pub request_id: String,
+    pub endpoint: String,
+    pub event_type: String,
+    pub outcome: String,
+    pub reason_code: Option<String>,
+    pub http_status: Option<i32>,
+    pub email: Option<String>,
+    pub pubkey: Option<String>,
+    pub client_id: Option<String>,
+    pub redirect_origin: Option<String>,
+    pub user_agent: Option<String>,
+    pub metadata_json: Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuthDebugResponse {
+    pub diagnosis: String,
+    pub account: Option<AuthDebugAccount>,
+    pub duplicates: Vec<AuthDebugDuplicate>,
+    pub events: Vec<AuthDebugEvent>,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct AuthDebugAccountRow {
+    pub pubkey: String,
+    pub email: Option<String>,
+    pub email_verified: Option<bool>,
+    pub password_hash_present: bool,
+    pub password_reset_pending: bool,
+    pub created_at: chrono::DateTime<Utc>,
+    pub updated_at: chrono::DateTime<Utc>,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct AuthDebugDuplicateRow {
+    pub pubkey: String,
+    pub email: Option<String>,
+    pub created_at: chrono::DateTime<Utc>,
+}
+
+/// Engineer-facing auth debugging endpoint. Support admin or above.
+pub async fn get_auth_debug(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    Query(query): Query<AuthDebugQuery>,
+) -> ApiResult<Json<AuthDebugResponse>> {
+    if !is_support_admin(&auth).await {
+        return Err(ApiError::forbidden("Admin access required"));
+    }
+
+    if query.email.as_deref().is_none_or(str::is_empty)
+        && query.pubkey.as_deref().is_none_or(str::is_empty)
+        && query.npub.as_deref().is_none_or(str::is_empty)
+        && query.request_id.as_deref().is_none_or(str::is_empty)
+    {
+        return Err(ApiError::bad_request(
+            "Provide email, pubkey, npub, or request_id",
+        ));
+    }
+
+    let tenant_id = tenant.0.id;
+    let pool = &auth_state.state.db;
+    let auth_event_repo = AuthEventRepository::new(pool.clone());
+
+    let mut target_email = query
+        .email
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(|email| email.trim().to_lowercase());
+    let mut target_pubkey = match query.pubkey.as_deref() {
+        Some(pubkey) if !pubkey.trim().is_empty() => Some(
+            nostr_sdk::PublicKey::from_hex(pubkey.trim())
+                .map_err(|e| ApiError::bad_request(format!("Invalid pubkey: {}", e)))?
+                .to_hex(),
+        ),
+        _ => None,
+    };
+
+    if target_pubkey.is_none() {
+        if let Some(npub) = query
+            .npub
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            target_pubkey = Some(
+                nostr_sdk::PublicKey::from_bech32(npub.trim())
+                    .map_err(|e| ApiError::bad_request(format!("Invalid npub: {}", e)))?
+                    .to_hex(),
+            );
+        }
+    }
+
+    let mut auth_events = if let Some(request_id) = query.request_id.as_deref() {
+        auth_event_repo
+            .list_recent_by_request_id(tenant_id, request_id.trim(), 50)
+            .await
+            .map_err(|e| ApiError::Internal(format!("Database error: {}", e)))?
+    } else {
+        Vec::new()
+    };
+
+    if target_email.is_none() {
+        target_email = auth_events.iter().find_map(|event| event.email.clone());
+    }
+    if target_pubkey.is_none() {
+        target_pubkey = auth_events.iter().find_map(|event| event.pubkey.clone());
+    }
+
+    if auth_events.is_empty() {
+        if let Some(email) = target_email.as_deref() {
+            auth_events = auth_event_repo
+                .list_recent_by_email(tenant_id, email, 50)
+                .await
+                .map_err(|e| ApiError::Internal(format!("Database error: {}", e)))?;
+        } else if let Some(pubkey) = target_pubkey.as_deref() {
+            auth_events = auth_event_repo
+                .list_recent_by_pubkey(tenant_id, pubkey, 50)
+                .await
+                .map_err(|e| ApiError::Internal(format!("Database error: {}", e)))?;
+        }
+    }
+
+    if target_pubkey.is_none() {
+        if let Some(email) = target_email.as_deref() {
+            let user_repo = UserRepository::new(pool.clone());
+            target_pubkey = user_repo
+                .find_pubkey_by_email(email, tenant_id)
+                .await
+                .map_err(|e| ApiError::Internal(format!("Database error: {}", e)))?;
+        }
+    }
+
+    if target_email.is_none() {
+        if let Some(pubkey) = target_pubkey.as_deref() {
+            target_email = sqlx::query_scalar::<_, String>(
+                "SELECT email FROM users WHERE tenant_id = $1 AND pubkey = $2",
+            )
+            .bind(tenant_id)
+            .bind(pubkey)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| ApiError::Internal(format!("Database error: {}", e)))?;
+        }
+    }
+
+    let account = if let Some(pubkey) = target_pubkey.as_deref() {
+        let row = sqlx::query_as::<_, AuthDebugAccountRow>(
+            "SELECT
+                pubkey,
+                email,
+                email_verified,
+                password_hash IS NOT NULL AS password_hash_present,
+                password_reset_token IS NOT NULL
+                    AND (password_reset_expires_at IS NULL OR password_reset_expires_at > NOW())
+                    AS password_reset_pending,
+                created_at,
+                updated_at
+             FROM users
+             WHERE tenant_id = $1 AND pubkey = $2",
+        )
+        .bind(tenant_id)
+        .bind(pubkey)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {}", e)))?;
+
+        match row {
+            Some(row) => {
+                let active_sessions = OAuthAuthorizationRepository::new(pool.clone())
+                    .list_active_sessions(&row.pubkey, tenant_id)
+                    .await
+                    .unwrap_or_default()
+                    .len() as i64;
+                Some(AuthDebugAccount {
+                    pubkey: row.pubkey,
+                    email: row.email,
+                    email_verified: row.email_verified,
+                    password_hash_present: row.password_hash_present,
+                    password_reset_pending: row.password_reset_pending,
+                    active_sessions,
+                    created_at: row.created_at.to_rfc3339(),
+                    updated_at: row.updated_at.to_rfc3339(),
+                })
+            }
+            None => None,
+        }
+    } else {
+        None
+    };
+
+    let duplicates = if let Some(email) = target_email.as_deref() {
+        sqlx::query_as::<_, AuthDebugDuplicateRow>(
+            "SELECT pubkey, email, created_at
+             FROM users
+             WHERE tenant_id = $1
+               AND LOWER(TRIM(email)) = LOWER(TRIM($2))
+             ORDER BY created_at DESC",
+        )
+        .bind(tenant_id)
+        .bind(email)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {}", e)))?
+        .into_iter()
+        .map(|row| AuthDebugDuplicate {
+            pubkey: row.pubkey,
+            email: row.email,
+            created_at: row.created_at.to_rfc3339(),
+        })
+        .collect()
+    } else {
+        Vec::new()
+    };
+
+    let events = auth_events
+        .into_iter()
+        .map(|row| AuthDebugEvent {
+            occurred_at: row.occurred_at.to_rfc3339(),
+            request_id: row.request_id,
+            endpoint: row.endpoint,
+            event_type: row.event_type,
+            outcome: row.outcome,
+            reason_code: row.reason_code,
+            http_status: row.http_status,
+            email: row.email,
+            pubkey: row.pubkey,
+            client_id: row.client_id,
+            redirect_origin: row.redirect_origin,
+            user_agent: row.user_agent,
+            metadata_json: row.metadata_json,
+        })
+        .collect::<Vec<_>>();
+
+    let diagnosis = diagnose_auth_debug(account.as_ref(), &duplicates, &events);
+
+    Ok(Json(AuthDebugResponse {
+        diagnosis,
+        account,
+        duplicates,
+        events,
+    }))
+}
+
+fn diagnose_auth_debug(
+    account: Option<&AuthDebugAccount>,
+    duplicates: &[AuthDebugDuplicate],
+    events: &[AuthDebugEvent],
+) -> String {
+    if duplicates.len() > 1 {
+        return "multiple_normalized_email_rows".to_string();
+    }
+
+    if let Some(reset_success) = events.iter().find(|event| {
+        event.endpoint == "/api/auth/reset-password"
+            && event.outcome == "success"
+            && event.reason_code.as_deref() == Some("password_hash_updated")
+    }) {
+        if events.iter().any(|event| {
+            event.occurred_at > reset_success.occurred_at
+                && event.event_type == "login"
+                && event.outcome == "failure"
+                && event.reason_code.as_deref() == Some("invalid_password")
+        }) {
+            return "password_reset_persisted_but_login_failed_invalid_password".to_string();
+        }
+    }
+
+    if account.is_none() {
+        return "no_users_row_found".to_string();
+    }
+
+    if account.is_some_and(|account| account.email_verified == Some(false))
+        || events
+            .iter()
+            .any(|event| event.reason_code.as_deref() == Some("email_not_verified"))
+    {
+        return "email_not_verified".to_string();
+    }
+
+    if account.is_some_and(|account| !account.password_hash_present) {
+        return "password_not_set".to_string();
+    }
+
+    if let Some(reason_code) = events
+        .iter()
+        .find(|event| event.outcome == "failure")
+        .and_then(|event| event.reason_code.clone())
+    {
+        return reason_code;
+    }
+
+    "no_obvious_auth_gate".to_string()
 }
 
 // ============================================================================

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -784,6 +784,7 @@ pub async fn login(
     body: String,
 ) -> Result<Response, AuthError> {
     let tenant_id = tenant.0.id;
+    let endpoint = "/api/auth/login";
 
     // Check for NIP-98 Authorization header first
     if let Some(auth_header) = headers.get("Authorization") {
@@ -802,7 +803,35 @@ pub async fn login(
     let pool = &auth_state.state.db;
 
     // Extract redirect_origin from HTTP Origin header (required for UCAN)
-    let redirect_origin = extract_origin_from_headers(&headers)?;
+    let redirect_origin = match extract_origin_from_headers(&headers) {
+        Ok(origin) => origin,
+        Err(error) => {
+            let message = match &error {
+                AuthError::BadRequest(message) => message.clone(),
+                _ => "Invalid origin".to_string(),
+            };
+            super::auth_observability::record_auth_event_and_log(
+                &auth_state.state.db,
+                &headers,
+                None,
+                super::auth_observability::AuthEvent {
+                    tenant_id,
+                    endpoint,
+                    event_type: "login",
+                    outcome: "failure",
+                    reason_code: Some("invalid_request"),
+                    http_status: 400,
+                    email: None,
+                    pubkey: None,
+                    client_id: None,
+                    redirect_origin: None,
+                    metadata_json: serde_json::json!({ "error": message }),
+                },
+            )
+            .await;
+            return Err(error);
+        }
+    };
 
     tracing::info!(
         event = "login_attempt",
@@ -818,6 +847,25 @@ pub async fn login(
     let (public_key, password_hash, email_verified) = match user {
         Some(u) => u,
         None => {
+            super::auth_observability::record_auth_event_and_log(
+                pool,
+                &headers,
+                None,
+                super::auth_observability::AuthEvent {
+                    tenant_id,
+                    endpoint,
+                    event_type: "login",
+                    outcome: "failure",
+                    reason_code: Some("user_not_found"),
+                    http_status: 401,
+                    email: Some(&req.email),
+                    pubkey: None,
+                    client_id: None,
+                    redirect_origin: Some(&redirect_origin),
+                    metadata_json: serde_json::json!({}),
+                },
+            )
+            .await;
             tracing::warn!(
                 event = "login",
                 tenant_id = tenant_id,
@@ -836,6 +884,25 @@ pub async fn login(
         .await
         .map_err(|e| AuthError::Internal(format!("Task join error: {}", e)))??;
     if !valid {
+        super::auth_observability::record_auth_event_and_log(
+            pool,
+            &headers,
+            None,
+            super::auth_observability::AuthEvent {
+                tenant_id,
+                endpoint,
+                event_type: "login",
+                outcome: "failure",
+                reason_code: Some("invalid_password"),
+                http_status: 401,
+                email: Some(&req.email),
+                pubkey: Some(&public_key),
+                client_id: None,
+                redirect_origin: Some(&redirect_origin),
+                metadata_json: serde_json::json!({}),
+            },
+        )
+        .await;
         tracing::warn!(
             event = "login",
             tenant_id = tenant_id,
@@ -849,6 +916,25 @@ pub async fn login(
 
     // Check if email is verified
     if !email_verified {
+        super::auth_observability::record_auth_event_and_log(
+            pool,
+            &headers,
+            None,
+            super::auth_observability::AuthEvent {
+                tenant_id,
+                endpoint,
+                event_type: "login",
+                outcome: "failure",
+                reason_code: Some("email_not_verified"),
+                http_status: 403,
+                email: Some(&req.email),
+                pubkey: Some(&public_key),
+                client_id: None,
+                redirect_origin: Some(&redirect_origin),
+                metadata_json: serde_json::json!({}),
+            },
+        )
+        .await;
         tracing::warn!(
             event = "login",
             tenant_id = tenant_id,
@@ -889,6 +975,26 @@ pub async fn login(
         success = true,
         "User logged in successfully"
     );
+
+    super::auth_observability::record_auth_event_and_log(
+        pool,
+        &headers,
+        None,
+        super::auth_observability::AuthEvent {
+            tenant_id,
+            endpoint,
+            event_type: "login",
+            outcome: "success",
+            reason_code: None,
+            http_status: 200,
+            email: Some(&req.email),
+            pubkey: Some(&public_key),
+            client_id: None,
+            redirect_origin: Some(&redirect_origin),
+            metadata_json: serde_json::json!({}),
+        },
+    )
+    .await;
 
     // Create response with UCAN session cookie
     let cookie = format!(
@@ -1709,9 +1815,11 @@ pub async fn resend_verification(
 pub async fn forgot_password(
     tenant: crate::api::tenant::TenantExtractor,
     State(pool): State<PgPool>,
+    headers: HeaderMap,
     Json(mut req): Json<ForgotPasswordRequest>,
 ) -> Result<Json<ForgotPasswordResponse>, AuthError> {
     let tenant_id = tenant.0.id;
+    let endpoint = "/api/auth/forgot-password";
     req.email = req.email.to_lowercase();
     tracing::info!(
         "Password reset requested for email: {} in tenant: {}",
@@ -1729,6 +1837,25 @@ pub async fn forgot_password(
     let public_key = match user_pubkey {
         Some(pubkey) => pubkey,
         None => {
+            super::auth_observability::record_auth_event_and_log(
+                &pool,
+                &headers,
+                None,
+                super::auth_observability::AuthEvent {
+                    tenant_id,
+                    endpoint,
+                    event_type: "password_reset_request",
+                    outcome: "accepted",
+                    reason_code: Some("user_not_found"),
+                    http_status: 200,
+                    email: Some(&req.email),
+                    pubkey: None,
+                    client_id: None,
+                    redirect_origin: None,
+                    metadata_json: serde_json::json!({}),
+                },
+            )
+            .await;
             tracing::info!(
                 "Password reset requested for non-existent email: {}",
                 req.email
@@ -1741,6 +1868,8 @@ pub async fn forgot_password(
             }));
         }
     };
+
+    let mut reason_code = None;
 
     // Generate reset token
     let reset_token = generate_secure_token();
@@ -1758,6 +1887,8 @@ pub async fn forgot_password(
                 .send_password_reset_email(&req.email, &reset_token)
                 .await
             {
+                METRICS.inc_auth_email_send_failure("password_reset");
+                reason_code = Some("email_send_failed");
                 tracing::error!(
                     "Failed to send password reset email to {}: {}",
                     req.email,
@@ -1768,12 +1899,34 @@ pub async fn forgot_password(
             }
         }
         Err(e) => {
+            METRICS.inc_auth_email_send_failure("password_reset");
+            reason_code = Some("email_send_failed");
             tracing::warn!(
                 "Email service unavailable, skipping password reset email: {}",
                 e
             );
         }
     }
+
+    super::auth_observability::record_auth_event_and_log(
+        &pool,
+        &headers,
+        None,
+        super::auth_observability::AuthEvent {
+            tenant_id,
+            endpoint,
+            event_type: "password_reset_request",
+            outcome: "accepted",
+            reason_code,
+            http_status: 200,
+            email: Some(&req.email),
+            pubkey: Some(&public_key),
+            client_id: None,
+            redirect_origin: None,
+            metadata_json: serde_json::json!({}),
+        },
+    )
+    .await;
 
     Ok(Json(ForgotPasswordResponse {
         success: true,
@@ -1786,9 +1939,11 @@ pub async fn forgot_password(
 pub async fn reset_password(
     tenant: crate::api::tenant::TenantExtractor,
     State(pool): State<PgPool>,
+    headers: HeaderMap,
     Json(req): Json<ResetPasswordRequest>,
 ) -> Result<Json<ResetPasswordResponse>, AuthError> {
     let tenant_id = tenant.0.id;
+    let endpoint = "/api/auth/reset-password";
     tracing::info!(
         "Password reset attempt with token: {}... for tenant: {}",
         &req.token[..10],
@@ -1797,14 +1952,64 @@ pub async fn reset_password(
 
     // Find user with this reset token in this tenant
     let user_repo = UserRepository::new(pool.clone());
-    let (public_key, expires_at) = user_repo
-        .find_by_reset_token(&req.token, tenant_id)
-        .await?
-        .ok_or(AuthError::InvalidToken)?;
+    let (public_key, expires_at) =
+        match user_repo.find_by_reset_token(&req.token, tenant_id).await? {
+            Some(data) => data,
+            None => {
+                super::auth_observability::record_auth_event_and_log(
+                    &pool,
+                    &headers,
+                    None,
+                    super::auth_observability::AuthEvent {
+                        tenant_id,
+                        endpoint,
+                        event_type: "password_reset",
+                        outcome: "failure",
+                        reason_code: Some("invalid_token"),
+                        http_status: 401,
+                        email: None,
+                        pubkey: None,
+                        client_id: None,
+                        redirect_origin: None,
+                        metadata_json: serde_json::json!({}),
+                    },
+                )
+                .await;
+                return Err(AuthError::InvalidToken);
+            }
+        };
+    let account_email: Option<String> = sqlx::query_scalar::<_, String>(
+        "SELECT email FROM users WHERE pubkey = $1 AND tenant_id = $2",
+    )
+    .bind(&public_key)
+    .bind(tenant_id)
+    .fetch_optional(&pool)
+    .await
+    .ok()
+    .flatten();
 
     // Check if token is expired
     if let Some(expires) = expires_at {
         if expires < Utc::now() {
+            super::auth_observability::record_auth_event_and_log(
+                &pool,
+                &headers,
+                None,
+                super::auth_observability::AuthEvent {
+                    tenant_id,
+                    endpoint,
+                    event_type: "password_reset",
+                    outcome: "failure",
+                    reason_code: Some("token_expired"),
+                    http_status: 200,
+                    email: account_email.as_deref(),
+                    pubkey: Some(&public_key),
+                    client_id: None,
+                    redirect_origin: None,
+                    metadata_json: serde_json::json!({}),
+                },
+            )
+            .await;
             return Ok(Json(ResetPasswordResponse {
                 success: false,
                 message: "Password reset link has expired. Please request a new one.".to_string(),
@@ -1824,6 +2029,26 @@ pub async fn reset_password(
     user_repo
         .reset_password(&public_key, tenant_id, &password_hash)
         .await?;
+
+    super::auth_observability::record_auth_event_and_log(
+        &pool,
+        &headers,
+        None,
+        super::auth_observability::AuthEvent {
+            tenant_id,
+            endpoint,
+            event_type: "password_reset",
+            outcome: "success",
+            reason_code: Some("password_hash_updated"),
+            http_status: 200,
+            email: account_email.as_deref(),
+            pubkey: Some(&public_key),
+            client_id: None,
+            redirect_origin: None,
+            metadata_json: serde_json::json!({}),
+        },
+    )
+    .await;
 
     tracing::info!(
         event = "password_reset",

--- a/api/src/api/http/auth_observability.rs
+++ b/api/src/api/http/auth_observability.rs
@@ -1,0 +1,231 @@
+use axum::{
+    body::Body,
+    http::{
+        header::{HeaderName, HeaderValue},
+        HeaderMap, Request,
+    },
+    middleware::Next,
+    response::Response,
+};
+use keycast_core::{
+    metrics::METRICS,
+    repositories::{AuthEventRecord, AuthEventRepository},
+};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use sqlx::PgPool;
+use std::time::Instant;
+use uuid::Uuid;
+
+pub const REQUEST_ID_HEADER: &str = "x-request-id";
+pub const TRACE_ID_HEADER: &str = "x-trace-id";
+
+#[derive(Clone, Debug)]
+pub struct RequestContext {
+    pub request_id: String,
+    pub started_at: Instant,
+}
+
+impl RequestContext {
+    pub fn new(request_id: String) -> Self {
+        Self {
+            request_id,
+            started_at: Instant::now(),
+        }
+    }
+}
+
+pub fn request_context(request: &Request<Body>) -> Option<&RequestContext> {
+    request.extensions().get::<RequestContext>()
+}
+
+pub fn request_id_from_headers(headers: &HeaderMap) -> Option<String> {
+    for header_name in [REQUEST_ID_HEADER, TRACE_ID_HEADER] {
+        let Some(value) = headers.get(header_name) else {
+            continue;
+        };
+
+        let Ok(value) = value.to_str() else {
+            continue;
+        };
+
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+
+    None
+}
+
+pub fn generate_request_id() -> String {
+    Uuid::new_v4().to_string()
+}
+
+pub fn hash_email(email: Option<&str>) -> String {
+    let Some(email) = email else {
+        return "none".to_string();
+    };
+
+    let normalized = email.trim().to_lowercase();
+    if normalized.is_empty() {
+        return "none".to_string();
+    }
+
+    hex::encode(Sha256::digest(normalized.as_bytes()))
+}
+
+pub fn pubkey_prefix(pubkey: Option<&str>) -> Option<String> {
+    pubkey.map(|value| value.chars().take(12).collect::<String>())
+}
+
+fn user_agent(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("user-agent")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+pub struct AuthEvent<'a> {
+    pub tenant_id: i64,
+    pub endpoint: &'static str,
+    pub event_type: &'static str,
+    pub outcome: &'static str,
+    pub reason_code: Option<&'a str>,
+    pub http_status: i32,
+    pub email: Option<&'a str>,
+    pub pubkey: Option<&'a str>,
+    pub client_id: Option<&'a str>,
+    pub redirect_origin: Option<&'a str>,
+    pub metadata_json: Value,
+}
+
+pub async fn record_auth_event_and_log(
+    pool: &PgPool,
+    headers: &HeaderMap,
+    request_context: Option<&RequestContext>,
+    event: AuthEvent<'_>,
+) {
+    let request_id = request_context
+        .map(|context| context.request_id.clone())
+        .or_else(|| request_id_from_headers(headers))
+        .unwrap_or_else(generate_request_id);
+    let latency = request_context
+        .map(|context| context.started_at.elapsed())
+        .unwrap_or_default();
+    let email_hash = hash_email(event.email);
+    let pubkey_prefix = pubkey_prefix(event.pubkey);
+    let user_agent = user_agent(headers);
+
+    METRICS.observe_auth_request(event.endpoint, event.outcome, event.reason_code, latency);
+
+    match event.outcome {
+        "success" | "accepted" => tracing::info!(
+            event = "auth_event",
+            endpoint = event.endpoint,
+            event_type = event.event_type,
+            outcome = event.outcome,
+            reason_code = event.reason_code.unwrap_or("none"),
+            http_status = event.http_status,
+            tenant_id = event.tenant_id,
+            request_id = %request_id,
+            email_hash = %email_hash,
+            pubkey_prefix = pubkey_prefix.as_deref().unwrap_or("none"),
+            client_id = event.client_id.unwrap_or("none"),
+            redirect_origin = event.redirect_origin.unwrap_or("none"),
+            latency_ms = latency.as_millis() as u64,
+            "Auth event"
+        ),
+        "failure" => tracing::warn!(
+            event = "auth_event",
+            endpoint = event.endpoint,
+            event_type = event.event_type,
+            outcome = event.outcome,
+            reason_code = event.reason_code.unwrap_or("none"),
+            http_status = event.http_status,
+            tenant_id = event.tenant_id,
+            request_id = %request_id,
+            email_hash = %email_hash,
+            pubkey_prefix = pubkey_prefix.as_deref().unwrap_or("none"),
+            client_id = event.client_id.unwrap_or("none"),
+            redirect_origin = event.redirect_origin.unwrap_or("none"),
+            latency_ms = latency.as_millis() as u64,
+            "Auth event"
+        ),
+        _ => tracing::error!(
+            event = "auth_event",
+            endpoint = event.endpoint,
+            event_type = event.event_type,
+            outcome = event.outcome,
+            reason_code = event.reason_code.unwrap_or("none"),
+            http_status = event.http_status,
+            tenant_id = event.tenant_id,
+            request_id = %request_id,
+            email_hash = %email_hash,
+            pubkey_prefix = pubkey_prefix.as_deref().unwrap_or("none"),
+            client_id = event.client_id.unwrap_or("none"),
+            redirect_origin = event.redirect_origin.unwrap_or("none"),
+            latency_ms = latency.as_millis() as u64,
+            "Auth event"
+        ),
+    }
+
+    let repo = AuthEventRepository::new(pool.clone());
+    if let Err(error) = repo
+        .record(AuthEventRecord {
+            tenant_id: event.tenant_id,
+            request_id,
+            endpoint: event.endpoint.to_string(),
+            event_type: event.event_type.to_string(),
+            outcome: event.outcome.to_string(),
+            reason_code: event.reason_code.map(str::to_string),
+            http_status: Some(event.http_status),
+            email: event.email.map(str::to_string),
+            email_hash,
+            pubkey: event.pubkey.map(str::to_string),
+            pubkey_prefix,
+            client_id: event.client_id.map(str::to_string),
+            redirect_origin: event.redirect_origin.map(str::to_string),
+            user_agent,
+            metadata_json: event.metadata_json,
+        })
+        .await
+    {
+        METRICS.inc_auth_audit_write_failure(event.endpoint);
+        tracing::error!(
+            endpoint = event.endpoint,
+            tenant_id = event.tenant_id,
+            error = %error,
+            "Failed to write auth audit event"
+        );
+    }
+}
+
+pub async fn request_id_middleware(mut request: Request<Body>, next: Next) -> Response {
+    let request_id = request_id_from_headers(request.headers()).unwrap_or_else(generate_request_id);
+    let request_context = RequestContext::new(request_id.clone());
+    let request_id_value =
+        HeaderValue::from_str(&request_id).expect("generated request id must be ASCII");
+
+    request.headers_mut().insert(
+        HeaderName::from_static(REQUEST_ID_HEADER),
+        request_id_value.clone(),
+    );
+    request.headers_mut().insert(
+        HeaderName::from_static(TRACE_ID_HEADER),
+        request_id_value.clone(),
+    );
+    request.extensions_mut().insert(request_context);
+
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+    headers.insert(
+        HeaderName::from_static(REQUEST_ID_HEADER),
+        request_id_value.clone(),
+    );
+    headers.insert(HeaderName::from_static(TRACE_ID_HEADER), request_id_value);
+
+    response
+}

--- a/api/src/api/http/auth_observability.rs
+++ b/api/src/api/http/auth_observability.rs
@@ -14,11 +14,12 @@ use keycast_core::{
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
-use std::time::Instant;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 pub const REQUEST_ID_HEADER: &str = "x-request-id";
 pub const TRACE_ID_HEADER: &str = "x-trace-id";
+pub const REQUEST_START_HEADER: &str = "x-keycast-request-start-ms";
 
 #[derive(Clone, Debug)]
 pub struct RequestContext {
@@ -88,6 +89,15 @@ fn user_agent(headers: &HeaderMap) -> Option<String> {
         .map(str::to_string)
 }
 
+fn latency_from_headers(headers: &HeaderMap) -> Option<Duration> {
+    let started_at_ms = headers
+        .get(REQUEST_START_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())?;
+    let started_at = UNIX_EPOCH.checked_add(Duration::from_millis(started_at_ms))?;
+    SystemTime::now().duration_since(started_at).ok()
+}
+
 pub struct AuthEvent<'a> {
     pub tenant_id: i64,
     pub endpoint: &'static str,
@@ -114,6 +124,7 @@ pub async fn record_auth_event_and_log(
         .unwrap_or_else(generate_request_id);
     let latency = request_context
         .map(|context| context.started_at.elapsed())
+        .or_else(|| latency_from_headers(headers))
         .unwrap_or_default();
     let email_hash = hash_email(event.email);
     let pubkey_prefix = pubkey_prefix(event.pubkey);
@@ -208,6 +219,13 @@ pub async fn request_id_middleware(mut request: Request<Body>, next: Next) -> Re
     let request_context = RequestContext::new(request_id.clone());
     let request_id_value =
         HeaderValue::from_str(&request_id).expect("generated request id must be ASCII");
+    let started_at_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_millis()
+        .to_string();
+    let started_at_value =
+        HeaderValue::from_str(&started_at_ms).expect("request start header must be ASCII digits");
 
     request.headers_mut().insert(
         HeaderName::from_static(REQUEST_ID_HEADER),
@@ -216,6 +234,10 @@ pub async fn request_id_middleware(mut request: Request<Body>, next: Next) -> Re
     request.headers_mut().insert(
         HeaderName::from_static(TRACE_ID_HEADER),
         request_id_value.clone(),
+    );
+    request.headers_mut().insert(
+        HeaderName::from_static(REQUEST_START_HEADER),
+        started_at_value,
     );
     request.extensions_mut().insert(request_context);
 
@@ -228,4 +250,87 @@ pub async fn request_id_middleware(mut request: Request<Body>, next: Next) -> Re
     headers.insert(HeaderName::from_static(TRACE_ID_HEADER), request_id_value);
 
     response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::postgres::PgPoolOptions;
+
+    fn metric_value(output: &str, metric: &str) -> u64 {
+        output
+            .lines()
+            .find(|line| line.starts_with(metric))
+            .and_then(|line| line.split_whitespace().last())
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0)
+    }
+
+    #[tokio::test]
+    async fn test_record_auth_event_uses_request_start_header_for_latency_metrics() {
+        let pool = PgPoolOptions::new()
+            .acquire_timeout(Duration::from_millis(25))
+            .connect_lazy("postgres://postgres:postgres@127.0.0.1:1/keycast_test")
+            .expect("lazy pool should parse");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static(REQUEST_ID_HEADER),
+            HeaderValue::from_static("req-latency-test"),
+        );
+
+        let started_at_ms = SystemTime::now()
+            .checked_sub(Duration::from_millis(120))
+            .expect("system time should support subtraction")
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_millis()
+            .to_string();
+        headers.insert(
+            HeaderName::from_static(REQUEST_START_HEADER),
+            HeaderValue::from_str(&started_at_ms).expect("request start header should be valid"),
+        );
+
+        let before = METRICS.to_prometheus();
+        let before_small_bucket = metric_value(
+            &before,
+            "keycast_auth_request_duration_seconds_bucket{endpoint=\"/api/admin/auth-debug\",outcome=\"success\",le=\"0.05\"}",
+        );
+        let before_medium_bucket = metric_value(
+            &before,
+            "keycast_auth_request_duration_seconds_bucket{endpoint=\"/api/admin/auth-debug\",outcome=\"success\",le=\"0.25\"}",
+        );
+
+        record_auth_event_and_log(
+            &pool,
+            &headers,
+            None,
+            AuthEvent {
+                tenant_id: 1,
+                endpoint: "/api/admin/auth-debug",
+                event_type: "debug_lookup",
+                outcome: "success",
+                reason_code: None,
+                http_status: 200,
+                email: None,
+                pubkey: None,
+                client_id: None,
+                redirect_origin: None,
+                metadata_json: serde_json::json!({}),
+            },
+        )
+        .await;
+
+        let after = METRICS.to_prometheus();
+        let after_small_bucket = metric_value(
+            &after,
+            "keycast_auth_request_duration_seconds_bucket{endpoint=\"/api/admin/auth-debug\",outcome=\"success\",le=\"0.05\"}",
+        );
+        let after_medium_bucket = metric_value(
+            &after,
+            "keycast_auth_request_duration_seconds_bucket{endpoint=\"/api/admin/auth-debug\",outcome=\"success\",le=\"0.25\"}",
+        );
+
+        assert_eq!(after_small_bucket - before_small_bucket, 0);
+        assert_eq!(after_medium_bucket - before_medium_bucket, 1);
+    }
 }

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -3,7 +3,7 @@
 
 use axum::{
     extract::State,
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -289,10 +289,12 @@ pub struct HeadlessLoginResponse {
 pub async fn headless_login(
     tenant: crate::api::tenant::TenantExtractor,
     State(auth_state): State<super::routes::AuthState>,
+    headers: HeaderMap,
     Json(mut req): Json<HeadlessLoginRequest>,
 ) -> Result<impl IntoResponse, HeadlessError> {
     let pool = &auth_state.state.db;
     let tenant_id = tenant.0.id;
+    let endpoint = "/api/headless/login";
 
     req.email = req.email.to_lowercase();
 
@@ -304,8 +306,36 @@ pub async fn headless_login(
     );
 
     // Validate redirect_uri
-    let _redirect_origin = extract_origin(&req.redirect_uri)
-        .map_err(|e| HeadlessError::InvalidRequest(format!("Invalid redirect_uri: {:?}", e)))?;
+    let redirect_origin = match extract_origin(&req.redirect_uri) {
+        Ok(origin) => origin,
+        Err(e) => {
+            super::auth_observability::record_auth_event_and_log(
+                pool,
+                &headers,
+                None,
+                super::auth_observability::AuthEvent {
+                    tenant_id,
+                    endpoint,
+                    event_type: "login",
+                    outcome: "failure",
+                    reason_code: Some("invalid_request"),
+                    http_status: 400,
+                    email: Some(&req.email),
+                    pubkey: None,
+                    client_id: Some(&req.client_id),
+                    redirect_origin: None,
+                    metadata_json: serde_json::json!({
+                        "error": format!("Invalid redirect_uri: {:?}", e),
+                    }),
+                },
+            )
+            .await;
+            return Err(HeadlessError::InvalidRequest(format!(
+                "Invalid redirect_uri: {:?}",
+                e
+            )));
+        }
+    };
 
     // Fetch user with password hash
     let user_repo = UserRepository::new(pool.clone());
@@ -314,6 +344,25 @@ pub async fn headless_login(
     let (public_key, password_hash, email_verified) = match user {
         Some(u) => u,
         None => {
+            super::auth_observability::record_auth_event_and_log(
+                pool,
+                &headers,
+                None,
+                super::auth_observability::AuthEvent {
+                    tenant_id,
+                    endpoint,
+                    event_type: "login",
+                    outcome: "failure",
+                    reason_code: Some("user_not_found"),
+                    http_status: 401,
+                    email: Some(&req.email),
+                    pubkey: None,
+                    client_id: Some(&req.client_id),
+                    redirect_origin: Some(&redirect_origin),
+                    metadata_json: serde_json::json!({}),
+                },
+            )
+            .await;
             tracing::warn!(
                 event = "headless_login",
                 tenant_id = tenant_id,
@@ -334,6 +383,25 @@ pub async fn headless_login(
         .map_err(|_| HeadlessError::Internal("Password verification failed".to_string()))?;
 
     if !valid {
+        super::auth_observability::record_auth_event_and_log(
+            pool,
+            &headers,
+            None,
+            super::auth_observability::AuthEvent {
+                tenant_id,
+                endpoint,
+                event_type: "login",
+                outcome: "failure",
+                reason_code: Some("invalid_password"),
+                http_status: 401,
+                email: Some(&req.email),
+                pubkey: Some(&public_key),
+                client_id: Some(&req.client_id),
+                redirect_origin: Some(&redirect_origin),
+                metadata_json: serde_json::json!({}),
+            },
+        )
+        .await;
         tracing::warn!(
             event = "headless_login",
             tenant_id = tenant_id,
@@ -347,6 +415,25 @@ pub async fn headless_login(
 
     // Check if email is verified
     if !email_verified {
+        super::auth_observability::record_auth_event_and_log(
+            pool,
+            &headers,
+            None,
+            super::auth_observability::AuthEvent {
+                tenant_id,
+                endpoint,
+                event_type: "login",
+                outcome: "failure",
+                reason_code: Some("email_not_verified"),
+                http_status: 403,
+                email: Some(&req.email),
+                pubkey: Some(&public_key),
+                client_id: Some(&req.client_id),
+                redirect_origin: Some(&redirect_origin),
+                metadata_json: serde_json::json!({}),
+            },
+        )
+        .await;
         tracing::warn!(
             event = "headless_login",
             tenant_id = tenant_id,
@@ -395,6 +482,26 @@ pub async fn headless_login(
         success = true,
         "Headless login successful"
     );
+
+    super::auth_observability::record_auth_event_and_log(
+        pool,
+        &headers,
+        None,
+        super::auth_observability::AuthEvent {
+            tenant_id,
+            endpoint,
+            event_type: "login",
+            outcome: "success",
+            reason_code: None,
+            http_status: 200,
+            email: Some(&req.email),
+            pubkey: Some(&public_key),
+            client_id: Some(&req.client_id),
+            redirect_origin: Some(&redirect_origin),
+            metadata_json: serde_json::json!({}),
+        },
+    )
+    .await;
 
     Ok(Json(HeadlessLoginResponse {
         success: true,

--- a/api/src/api/http/mod.rs
+++ b/api/src/api/http/mod.rs
@@ -3,6 +3,7 @@ pub mod atproto;
 pub mod atproto_oauth;
 pub mod atproto_oauth_metadata;
 pub mod auth;
+pub mod auth_observability;
 pub mod claim;
 pub mod headless;
 pub mod html_safety;

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -2986,12 +2986,14 @@ pub struct OAuthLoginRequest {
 pub async fn oauth_login(
     tenant: crate::api::tenant::TenantExtractor,
     State(auth_state): State<super::routes::AuthState>,
+    headers: HeaderMap,
     Json(mut req): Json<OAuthLoginRequest>,
 ) -> Result<impl IntoResponse, OAuthError> {
     use super::auth::generate_ucan_token;
     let pool = &auth_state.state.db;
     let key_manager = auth_state.state.key_manager.as_ref();
     let tenant_id = tenant.0.id;
+    let endpoint = "/api/oauth/login";
 
     req.email = req.email.to_lowercase();
 
@@ -3003,10 +3005,32 @@ pub async fn oauth_login(
 
     // Validate credentials
     let user_repo = UserRepository::new(pool.clone());
-    let (public_key, password_hash, email_verified) = user_repo
-        .find_with_password(&req.email, tenant_id)
-        .await?
-        .ok_or(OAuthError::Unauthorized)?;
+    let (public_key, password_hash, email_verified) =
+        match user_repo.find_with_password(&req.email, tenant_id).await? {
+            Some(user) => user,
+            None => {
+                super::auth_observability::record_auth_event_and_log(
+                    pool,
+                    &headers,
+                    None,
+                    super::auth_observability::AuthEvent {
+                        tenant_id,
+                        endpoint,
+                        event_type: "login",
+                        outcome: "failure",
+                        reason_code: Some("user_not_found"),
+                        http_status: 401,
+                        email: Some(&req.email),
+                        pubkey: None,
+                        client_id: Some(&req.client_id),
+                        redirect_origin: None,
+                        metadata_json: serde_json::json!({}),
+                    },
+                )
+                .await;
+                return Err(OAuthError::Unauthorized);
+            }
+        };
 
     // Verify password (spawn_blocking to avoid blocking async runtime)
     let password = req.password.clone();
@@ -3017,11 +3041,49 @@ pub async fn oauth_login(
         .map_err(|_| OAuthError::InvalidRequest("Password verification failed".to_string()))?;
 
     if !valid {
+        super::auth_observability::record_auth_event_and_log(
+            pool,
+            &headers,
+            None,
+            super::auth_observability::AuthEvent {
+                tenant_id,
+                endpoint,
+                event_type: "login",
+                outcome: "failure",
+                reason_code: Some("invalid_password"),
+                http_status: 401,
+                email: Some(&req.email),
+                pubkey: Some(&public_key),
+                client_id: Some(&req.client_id),
+                redirect_origin: None,
+                metadata_json: serde_json::json!({}),
+            },
+        )
+        .await;
         return Err(OAuthError::Unauthorized);
     }
 
     // Check if email is verified
     if !email_verified {
+        super::auth_observability::record_auth_event_and_log(
+            pool,
+            &headers,
+            None,
+            super::auth_observability::AuthEvent {
+                tenant_id,
+                endpoint,
+                event_type: "login",
+                outcome: "failure",
+                reason_code: Some("email_not_verified"),
+                http_status: 400,
+                email: Some(&req.email),
+                pubkey: Some(&public_key),
+                client_id: Some(&req.client_id),
+                redirect_origin: None,
+                metadata_json: serde_json::json!({}),
+            },
+        )
+        .await;
         tracing::warn!("OAuth login failed: email not verified for {}", req.email);
         return Err(OAuthError::InvalidRequest(
             "Please verify your email address before signing in. Check your inbox for the verification link.".to_string(),
@@ -3048,7 +3110,33 @@ pub async fn oauth_login(
     let keys = Keys::new(secret_key.into());
 
     // Extract redirect_origin from redirect_uri for UCAN
-    let redirect_origin = extract_origin(&req.redirect_uri)?;
+    let redirect_origin = match extract_origin(&req.redirect_uri) {
+        Ok(origin) => origin,
+        Err(error) => {
+            super::auth_observability::record_auth_event_and_log(
+                pool,
+                &headers,
+                None,
+                super::auth_observability::AuthEvent {
+                    tenant_id,
+                    endpoint,
+                    event_type: "login",
+                    outcome: "failure",
+                    reason_code: Some("invalid_request"),
+                    http_status: 400,
+                    email: Some(&req.email),
+                    pubkey: Some(&public_key),
+                    client_id: Some(&req.client_id),
+                    redirect_origin: None,
+                    metadata_json: serde_json::json!({
+                        "error": format!("{:?}", error),
+                    }),
+                },
+            )
+            .await;
+            return Err(error);
+        }
+    };
 
     // Generate UCAN token with redirect_origin
     let ucan_token = generate_ucan_token(&keys, tenant_id, &req.email, &redirect_origin, None)
@@ -3058,6 +3146,26 @@ pub async fn oauth_login(
     // OAuth popup login: bunker authorization will be created manually by user if needed
 
     tracing::info!("OAuth popup login successful for user: {}", public_key);
+
+    super::auth_observability::record_auth_event_and_log(
+        pool,
+        &headers,
+        None,
+        super::auth_observability::AuthEvent {
+            tenant_id,
+            endpoint,
+            event_type: "login",
+            outcome: "success",
+            reason_code: None,
+            http_status: 200,
+            email: Some(&req.email),
+            pubkey: Some(&public_key),
+            client_id: Some(&req.client_id),
+            redirect_origin: Some(&redirect_origin),
+            metadata_json: serde_json::json!({}),
+        },
+    )
+    .await;
 
     // Set cookie and return success - page will reload to show approval
     let cookie = format!(

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -198,6 +198,7 @@ pub fn api_routes(
             "/admin/claim-tokens/stats",
             get(admin::get_claim_token_stats),
         )
+        .route("/admin/auth-debug", get(admin::get_auth_debug))
         .route("/admin/user-lookup", get(admin::get_user_lookup))
         .route(
             "/admin/support-admins",

--- a/api/tests/auth_debug_test.rs
+++ b/api/tests/auth_debug_test.rs
@@ -1,0 +1,196 @@
+#![cfg(feature = "integration-tests")]
+
+use bcrypt::hash;
+use chrono::Utc;
+use keycast_api::{
+    api::{
+        extractors::UcanAuth,
+        http::admin::{get_auth_debug, AuthDebugQuery},
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    repositories::{AuthEventRecord, AuthEventRepository},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use std::sync::Arc;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+mod common;
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    keycast_api::api::http::routes::AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+fn create_test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: 1,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+async fn cleanup_by_email(pool: &PgPool, email: &str) {
+    let _ = sqlx::query("DELETE FROM auth_events WHERE email = $1")
+        .bind(email)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM users WHERE email = $1")
+        .bind(email)
+        .execute(pool)
+        .await;
+}
+
+#[tokio::test]
+async fn test_auth_debug_returns_account_state_and_recent_events_for_email() {
+    let pool = setup_pool().await;
+    let auth_state = create_test_auth_state(pool.clone());
+    let email = format!("auth-debug-{}@example.com", Uuid::new_v4());
+    let pubkey = Keys::generate().public_key().to_hex();
+    let request_id = format!("req-{}", Uuid::new_v4());
+    let password_hash = hash("secret-password", 4).unwrap();
+
+    cleanup_by_email(&pool, &email).await;
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+         VALUES ($1, 1, $2, $3, false, NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .bind(&email)
+    .bind(&password_hash)
+    .execute(&pool)
+    .await
+    .expect("Should create test user");
+
+    let auth_event_repo = AuthEventRepository::new(pool.clone());
+    auth_event_repo
+        .record(AuthEventRecord {
+            tenant_id: 1,
+            request_id,
+            endpoint: "/api/headless/login".to_string(),
+            event_type: "login".to_string(),
+            outcome: "failure".to_string(),
+            reason_code: Some("email_not_verified".to_string()),
+            http_status: Some(403),
+            email: Some(email.clone()),
+            email_hash: keycast_api::api::http::auth_observability::hash_email(Some(&email)),
+            pubkey: Some(pubkey.clone()),
+            pubkey_prefix: Some(pubkey.chars().take(12).collect()),
+            client_id: Some("DivineMobileTest".to_string()),
+            redirect_origin: Some("https://app.divine.video".to_string()),
+            user_agent: Some("integration-test".to_string()),
+            metadata_json: serde_json::json!({}),
+        })
+        .await
+        .expect("Should create auth event");
+
+    let response = get_auth_debug(
+        create_test_tenant(),
+        axum::extract::State(auth_state),
+        UcanAuth {
+            pubkey: Keys::generate().public_key().to_hex(),
+            admin_role: Some("support".to_string()),
+        },
+        axum::extract::Query(AuthDebugQuery {
+            email: Some(email.clone()),
+            pubkey: None,
+            npub: None,
+            request_id: None,
+        }),
+    )
+    .await
+    .expect("auth debug should succeed")
+    .0;
+
+    assert_eq!(response.diagnosis, "email_not_verified");
+    assert_eq!(
+        response
+            .account
+            .as_ref()
+            .and_then(|account| account.email.as_deref()),
+        Some(email.as_str())
+    );
+    assert_eq!(
+        response
+            .account
+            .as_ref()
+            .map(|account| account.email_verified),
+        Some(Some(false))
+    );
+    assert_eq!(
+        response
+            .account
+            .as_ref()
+            .map(|account| account.password_hash_present),
+        Some(true)
+    );
+    assert_eq!(response.events.len(), 1);
+    assert_eq!(
+        response.events[0].reason_code.as_deref(),
+        Some("email_not_verified")
+    );
+
+    cleanup_by_email(&pool, &email).await;
+}

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -3,6 +3,9 @@
 
 use sqlx::PgPool;
 
+#[allow(dead_code)]
+pub type AuthEventRow = (String, String, String, Option<String>, String, Option<i32>);
+
 /// CRITICAL: Validates that DATABASE_URL points to a local/dev database only.
 /// This prevents accidental execution of tests against production databases.
 ///

--- a/api/tests/headless_auth_test.rs
+++ b/api/tests/headless_auth_test.rs
@@ -368,18 +368,17 @@ async fn test_headless_login_records_auth_event_and_echoes_request_id_on_failure
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     assert_eq!(response.headers().get("x-request-id").unwrap(), &request_id);
 
-    let event: Option<(String, String, String, Option<String>, String, Option<i32>)> =
-        sqlx::query_as(
-            "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
+    let event: Option<common::AuthEventRow> = sqlx::query_as(
+        "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
              FROM auth_events
              WHERE tenant_id = 1 AND email = $1
              ORDER BY occurred_at DESC, id DESC
              LIMIT 1",
-        )
-        .bind(&test_email)
-        .fetch_optional(&pool)
-        .await
-        .expect("auth event query should succeed");
+    )
+    .bind(&test_email)
+    .fetch_optional(&pool)
+    .await
+    .expect("auth event query should succeed");
 
     assert_eq!(
         event,

--- a/api/tests/headless_auth_test.rs
+++ b/api/tests/headless_auth_test.rs
@@ -3,10 +3,38 @@
 // ABOUTME: Integration tests for headless authentication endpoints
 // ABOUTME: Tests the pure JSON API flow for native mobile apps (Flutter, etc.)
 
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    middleware,
+    routing::post,
+    Json, Router,
+};
 use chrono::{Duration, Utc};
+use keycast_api::{
+    api::{
+        http::{
+            auth_observability::request_id_middleware,
+            headless::{headless_login, HeadlessLoginRequest},
+        },
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
 use nostr_sdk::Keys;
 use sqlx::PgPool;
+use std::sync::Arc;
+use tower::ServiceExt;
 use uuid::Uuid;
+use zeroize::Zeroizing;
 
 mod common;
 
@@ -21,6 +49,10 @@ async fn setup_pool() -> PgPool {
 
 /// Clean up test data
 async fn cleanup_test_user(pool: &PgPool, pubkey: &str) {
+    let _ = sqlx::query("DELETE FROM auth_events WHERE pubkey = $1")
+        .bind(pubkey)
+        .execute(pool)
+        .await;
     let _ = sqlx::query("DELETE FROM oauth_authorizations WHERE user_pubkey = $1")
         .bind(pubkey)
         .execute(pool)
@@ -37,6 +69,55 @@ async fn cleanup_test_user(pool: &PgPool, pubkey: &str) {
         .bind(pubkey)
         .execute(pool)
         .await;
+}
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    keycast_api::api::http::routes::AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+fn create_test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: 1,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
 }
 
 // ============================================================================
@@ -225,6 +306,97 @@ async fn test_headless_login_fails_unverified_email() {
 
     // Cleanup
     cleanup_test_user(&pool, &pubkey).await;
+}
+
+#[tokio::test]
+async fn test_headless_login_records_auth_event_and_echoes_request_id_on_failure() {
+    let pool = setup_pool().await;
+    let auth_state = create_test_auth_state(pool.clone());
+    let test_email = format!("headless-missing-{}@example.com", Uuid::new_v4());
+    let request_id = format!("trace-{}", Uuid::new_v4());
+
+    let _ = sqlx::query("DELETE FROM auth_events WHERE email = $1")
+        .bind(&test_email)
+        .execute(&pool)
+        .await;
+
+    let app = {
+        let auth_state = auth_state.clone();
+        Router::new()
+            .route(
+                "/headless/login",
+                post(
+                    move |headers: axum::http::HeaderMap, Json(req): Json<HeadlessLoginRequest>| {
+                        let auth_state = auth_state.clone();
+                        async move {
+                            headless_login(
+                                create_test_tenant(),
+                                State(auth_state),
+                                headers,
+                                Json(req),
+                            )
+                            .await
+                        }
+                    },
+                ),
+            )
+            .layer(middleware::from_fn(request_id_middleware))
+    };
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/headless/login")
+                .header("host", "localhost")
+                .header("content-type", "application/json")
+                .header("x-trace-id", &request_id)
+                .body(Body::from(
+                    serde_json::json!({
+                        "email": test_email,
+                        "password": "wrong-password",
+                        "client_id": "DivineMobileTest",
+                        "redirect_uri": "https://app.divine.video/callback"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(response.headers().get("x-request-id").unwrap(), &request_id);
+
+    let event: Option<(String, String, String, Option<String>, String, Option<i32>)> =
+        sqlx::query_as(
+            "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
+             FROM auth_events
+             WHERE tenant_id = 1 AND email = $1
+             ORDER BY occurred_at DESC, id DESC
+             LIMIT 1",
+        )
+        .bind(&test_email)
+        .fetch_optional(&pool)
+        .await
+        .expect("auth event query should succeed");
+
+    assert_eq!(
+        event,
+        Some((
+            "/api/headless/login".to_string(),
+            "login".to_string(),
+            "failure".to_string(),
+            Some("user_not_found".to_string()),
+            request_id,
+            Some(401),
+        ))
+    );
+
+    let _ = sqlx::query("DELETE FROM auth_events WHERE email = $1")
+        .bind(&test_email)
+        .execute(&pool)
+        .await;
 }
 
 // ============================================================================

--- a/api/tests/login_observability_test.rs
+++ b/api/tests/login_observability_test.rs
@@ -158,18 +158,17 @@ async fn test_login_records_auth_event_for_missing_user() {
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     assert_eq!(response.headers().get("x-request-id").unwrap(), &request_id);
 
-    let event: Option<(String, String, String, Option<String>, String, Option<i32>)> =
-        sqlx::query_as(
-            "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
+    let event: Option<common::AuthEventRow> = sqlx::query_as(
+        "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
              FROM auth_events
              WHERE tenant_id = 1 AND email = $1
              ORDER BY occurred_at DESC, id DESC
              LIMIT 1",
-        )
-        .bind(&email)
-        .fetch_optional(&pool)
-        .await
-        .expect("auth event query should succeed");
+    )
+    .bind(&email)
+    .fetch_optional(&pool)
+    .await
+    .expect("auth event query should succeed");
 
     assert_eq!(
         event,
@@ -251,18 +250,17 @@ async fn test_oauth_login_records_auth_event_for_unverified_user() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(response.headers().get("x-request-id").unwrap(), &request_id);
 
-    let event: Option<(String, String, String, Option<String>, String, Option<i32>)> =
-        sqlx::query_as(
-            "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
+    let event: Option<common::AuthEventRow> = sqlx::query_as(
+        "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
              FROM auth_events
              WHERE tenant_id = 1 AND email = $1
              ORDER BY occurred_at DESC, id DESC
              LIMIT 1",
-        )
-        .bind(&email)
-        .fetch_optional(&pool)
-        .await
-        .expect("auth event query should succeed");
+    )
+    .bind(&email)
+    .fetch_optional(&pool)
+    .await
+    .expect("auth event query should succeed");
 
     assert_eq!(
         event,

--- a/api/tests/login_observability_test.rs
+++ b/api/tests/login_observability_test.rs
@@ -1,0 +1,280 @@
+#![cfg(feature = "integration-tests")]
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{HeaderMap, Request, StatusCode},
+    middleware,
+    routing::post,
+    Json, Router,
+};
+use bcrypt::hash;
+use chrono::Utc;
+use keycast_api::{
+    api::{
+        http::{
+            auth::login,
+            auth_observability::request_id_middleware,
+            oauth::{oauth_login, OAuthLoginRequest},
+        },
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tower::ServiceExt;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+mod common;
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    keycast_api::api::http::routes::AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+fn create_test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: 1,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+async fn cleanup_by_email(pool: &PgPool, email: &str) {
+    let _ = sqlx::query("DELETE FROM auth_events WHERE email = $1")
+        .bind(email)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM users WHERE email = $1")
+        .bind(email)
+        .execute(pool)
+        .await;
+}
+
+#[tokio::test]
+async fn test_login_records_auth_event_for_missing_user() {
+    let pool = setup_pool().await;
+    let auth_state = create_test_auth_state(pool.clone());
+    let email = format!("missing-login-{}@example.com", Uuid::new_v4());
+    let request_id = format!("trace-{}", Uuid::new_v4());
+
+    cleanup_by_email(&pool, &email).await;
+
+    let app = {
+        let auth_state = auth_state.clone();
+        Router::new()
+            .route(
+                "/auth/login",
+                post(move |headers: HeaderMap, body: String| {
+                    let auth_state = auth_state.clone();
+                    async move { login(create_test_tenant(), State(auth_state), headers, body).await }
+                }),
+            )
+            .layer(middleware::from_fn(request_id_middleware))
+    };
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/login")
+                .header("content-type", "application/json")
+                .header("origin", "https://app.divine.video")
+                .header("x-trace-id", &request_id)
+                .body(Body::from(
+                    serde_json::json!({
+                        "email": email,
+                        "password": "wrong-password"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(response.headers().get("x-request-id").unwrap(), &request_id);
+
+    let event: Option<(String, String, String, Option<String>, String, Option<i32>)> =
+        sqlx::query_as(
+            "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
+             FROM auth_events
+             WHERE tenant_id = 1 AND email = $1
+             ORDER BY occurred_at DESC, id DESC
+             LIMIT 1",
+        )
+        .bind(&email)
+        .fetch_optional(&pool)
+        .await
+        .expect("auth event query should succeed");
+
+    assert_eq!(
+        event,
+        Some((
+            "/api/auth/login".to_string(),
+            "login".to_string(),
+            "failure".to_string(),
+            Some("user_not_found".to_string()),
+            request_id,
+            Some(401),
+        ))
+    );
+
+    cleanup_by_email(&pool, &email).await;
+}
+
+#[tokio::test]
+async fn test_oauth_login_records_auth_event_for_unverified_user() {
+    let pool = setup_pool().await;
+    let auth_state = create_test_auth_state(pool.clone());
+    let email = format!("oauth-unverified-{}@example.com", Uuid::new_v4());
+    let request_id = format!("trace-{}", Uuid::new_v4());
+    let pubkey = Keys::generate().public_key().to_hex();
+    let password_hash = hash("test-password", 4).unwrap();
+
+    cleanup_by_email(&pool, &email).await;
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+         VALUES ($1, 1, $2, $3, false, NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .bind(&email)
+    .bind(&password_hash)
+    .execute(&pool)
+    .await
+    .expect("Should create user");
+
+    let app = {
+        let auth_state = auth_state.clone();
+        Router::new()
+            .route(
+                "/oauth/login",
+                post(
+                    move |headers: HeaderMap, Json(req): Json<OAuthLoginRequest>| {
+                        let auth_state = auth_state.clone();
+                        async move {
+                            oauth_login(create_test_tenant(), State(auth_state), headers, Json(req))
+                                .await
+                        }
+                    },
+                ),
+            )
+            .layer(middleware::from_fn(request_id_middleware))
+    };
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/oauth/login")
+                .header("content-type", "application/json")
+                .header("x-trace-id", &request_id)
+                .body(Body::from(
+                    serde_json::json!({
+                        "email": email,
+                        "password": "test-password",
+                        "client_id": "WebPopupTest",
+                        "redirect_uri": "https://app.divine.video/callback",
+                        "scope": "policy:full"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.headers().get("x-request-id").unwrap(), &request_id);
+
+    let event: Option<(String, String, String, Option<String>, String, Option<i32>)> =
+        sqlx::query_as(
+            "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
+             FROM auth_events
+             WHERE tenant_id = 1 AND email = $1
+             ORDER BY occurred_at DESC, id DESC
+             LIMIT 1",
+        )
+        .bind(&email)
+        .fetch_optional(&pool)
+        .await
+        .expect("auth event query should succeed");
+
+    assert_eq!(
+        event,
+        Some((
+            "/api/oauth/login".to_string(),
+            "login".to_string(),
+            "failure".to_string(),
+            Some("email_not_verified".to_string()),
+            request_id,
+            Some(400),
+        ))
+    );
+
+    cleanup_by_email(&pool, &email).await;
+}

--- a/api/tests/password_reset_observability_test.rs
+++ b/api/tests/password_reset_observability_test.rs
@@ -1,0 +1,245 @@
+#![cfg(feature = "integration-tests")]
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{HeaderMap, Request, StatusCode},
+    middleware,
+    routing::post,
+    Json, Router,
+};
+use bcrypt::{hash, verify};
+use chrono::{Duration, Utc};
+use keycast_api::api::{
+    http::{
+        auth::{forgot_password, reset_password, ForgotPasswordRequest, ResetPasswordRequest},
+        auth_observability::request_id_middleware,
+    },
+    tenant::{Tenant, TenantExtractor},
+};
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+mod common;
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+fn create_test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: 1,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+async fn cleanup_by_email(pool: &PgPool, email: &str) {
+    let _ = sqlx::query("DELETE FROM auth_events WHERE email = $1")
+        .bind(email)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM users WHERE email = $1")
+        .bind(email)
+        .execute(pool)
+        .await;
+}
+
+#[tokio::test]
+async fn test_forgot_password_records_accepted_event_for_missing_email() {
+    let pool = setup_pool().await;
+    let email = format!("missing-reset-{}@example.com", Uuid::new_v4());
+    let request_id = format!("trace-{}", Uuid::new_v4());
+
+    cleanup_by_email(&pool, &email).await;
+
+    let app = {
+        let pool = pool.clone();
+        Router::new()
+            .route(
+                "/auth/forgot-password",
+                post(
+                    move |headers: HeaderMap, Json(req): Json<ForgotPasswordRequest>| {
+                        let pool = pool.clone();
+                        async move {
+                            forgot_password(create_test_tenant(), State(pool), headers, Json(req))
+                                .await
+                        }
+                    },
+                ),
+            )
+            .layer(middleware::from_fn(request_id_middleware))
+    };
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/forgot-password")
+                .header("content-type", "application/json")
+                .header("x-trace-id", &request_id)
+                .body(Body::from(
+                    serde_json::json!({ "email": email }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers().get("x-request-id").unwrap(), &request_id);
+
+    let event: Option<(String, String, String, Option<String>, String, Option<i32>)> =
+        sqlx::query_as(
+            "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
+             FROM auth_events
+             WHERE tenant_id = 1 AND email = $1
+             ORDER BY occurred_at DESC, id DESC
+             LIMIT 1",
+        )
+        .bind(&email)
+        .fetch_optional(&pool)
+        .await
+        .expect("auth event query should succeed");
+
+    assert_eq!(
+        event,
+        Some((
+            "/api/auth/forgot-password".to_string(),
+            "password_reset_request".to_string(),
+            "accepted".to_string(),
+            Some("user_not_found".to_string()),
+            request_id,
+            Some(200),
+        ))
+    );
+
+    cleanup_by_email(&pool, &email).await;
+}
+
+#[tokio::test]
+async fn test_reset_password_records_success_event_and_updates_hash() {
+    let pool = setup_pool().await;
+    let email = format!("reset-success-{}@example.com", Uuid::new_v4());
+    let pubkey = Keys::generate().public_key().to_hex();
+    let request_id = format!("trace-{}", Uuid::new_v4());
+    let reset_token = format!("reset-{}", Uuid::new_v4());
+    let new_password = "new-password-123!";
+    let old_password_hash = hash("old-password-123!", 4).unwrap();
+
+    cleanup_by_email(&pool, &email).await;
+
+    sqlx::query(
+        "INSERT INTO users (
+            pubkey, tenant_id, email, password_hash, email_verified,
+            password_reset_token, password_reset_expires_at, created_at, updated_at
+         ) VALUES ($1, 1, $2, $3, false, $4, $5, NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .bind(&email)
+    .bind(&old_password_hash)
+    .bind(&reset_token)
+    .bind(Utc::now() + Duration::hours(1))
+    .execute(&pool)
+    .await
+    .expect("Should create resettable user");
+
+    let app = {
+        let pool = pool.clone();
+        Router::new()
+            .route(
+                "/auth/reset-password",
+                post(
+                    move |headers: HeaderMap, Json(req): Json<ResetPasswordRequest>| {
+                        let pool = pool.clone();
+                        async move {
+                            reset_password(create_test_tenant(), State(pool), headers, Json(req))
+                                .await
+                        }
+                    },
+                ),
+            )
+            .layer(middleware::from_fn(request_id_middleware))
+    };
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/reset-password")
+                .header("content-type", "application/json")
+                .header("x-trace-id", &request_id)
+                .body(Body::from(
+                    serde_json::json!({
+                        "token": reset_token,
+                        "new_password": new_password
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers().get("x-request-id").unwrap(), &request_id);
+
+    let user_row: (String, bool, Option<String>) = sqlx::query_as(
+        "SELECT password_hash, email_verified, password_reset_token
+         FROM users
+         WHERE pubkey = $1 AND tenant_id = 1",
+    )
+    .bind(&pubkey)
+    .fetch_one(&pool)
+    .await
+    .expect("updated user row should exist");
+
+    assert!(verify(new_password, &user_row.0).unwrap());
+    assert!(user_row.1);
+    assert!(user_row.2.is_none());
+
+    let event: Option<(String, String, String, Option<String>, String, Option<i32>)> =
+        sqlx::query_as(
+            "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
+             FROM auth_events
+             WHERE tenant_id = 1 AND email = $1
+             ORDER BY occurred_at DESC, id DESC
+             LIMIT 1",
+        )
+        .bind(&email)
+        .fetch_optional(&pool)
+        .await
+        .expect("auth event query should succeed");
+
+    assert_eq!(
+        event,
+        Some((
+            "/api/auth/reset-password".to_string(),
+            "password_reset".to_string(),
+            "success".to_string(),
+            Some("password_hash_updated".to_string()),
+            request_id,
+            Some(200),
+        ))
+    );
+
+    cleanup_by_email(&pool, &email).await;
+}

--- a/api/tests/password_reset_observability_test.rs
+++ b/api/tests/password_reset_observability_test.rs
@@ -107,18 +107,17 @@ async fn test_forgot_password_records_accepted_event_for_missing_email() {
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.headers().get("x-request-id").unwrap(), &request_id);
 
-    let event: Option<(String, String, String, Option<String>, String, Option<i32>)> =
-        sqlx::query_as(
-            "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
+    let event: Option<common::AuthEventRow> = sqlx::query_as(
+        "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
              FROM auth_events
              WHERE tenant_id = 1 AND email = $1
              ORDER BY occurred_at DESC, id DESC
              LIMIT 1",
-        )
-        .bind(&email)
-        .fetch_optional(&pool)
-        .await
-        .expect("auth event query should succeed");
+    )
+    .bind(&email)
+    .fetch_optional(&pool)
+    .await
+    .expect("auth event query should succeed");
 
     assert_eq!(
         event,
@@ -216,18 +215,17 @@ async fn test_reset_password_records_success_event_and_updates_hash() {
     assert!(user_row.1);
     assert!(user_row.2.is_none());
 
-    let event: Option<(String, String, String, Option<String>, String, Option<i32>)> =
-        sqlx::query_as(
-            "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
+    let event: Option<common::AuthEventRow> = sqlx::query_as(
+        "SELECT endpoint, event_type, outcome, reason_code, request_id, http_status
              FROM auth_events
              WHERE tenant_id = 1 AND email = $1
              ORDER BY occurred_at DESC, id DESC
              LIMIT 1",
-        )
-        .bind(&email)
-        .fetch_optional(&pool)
-        .await
-        .expect("auth event query should succeed");
+    )
+    .bind(&email)
+    .fetch_optional(&pool)
+    .await
+    .expect("auth event query should succeed");
 
     assert_eq!(
         event,

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -2,7 +2,36 @@
 // ABOUTME: Uses atomic counters that can be incremented from signer and read from API
 
 use once_cell::sync::Lazy;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+    collections::BTreeMap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Mutex,
+    },
+    time::Duration,
+};
+
+const AUTH_DURATION_BUCKETS: [f64; 8] = [0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0];
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct AuthRequestKey {
+    endpoint: String,
+    outcome: String,
+    reason_code: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct AuthDurationKey {
+    endpoint: String,
+    outcome: String,
+}
+
+#[derive(Clone, Debug, Default)]
+struct AuthDurationMetric {
+    buckets: [u64; AUTH_DURATION_BUCKETS.len()],
+    count: u64,
+    sum: f64,
+}
 
 /// Global metrics counters accessible from any crate
 pub struct Metrics {
@@ -55,10 +84,16 @@ pub struct Metrics {
     pub oauth_authorizations_created: AtomicU64,
     /// Total OAuth authorizations revoked
     pub oauth_authorizations_revoked: AtomicU64,
+
+    // === Labeled Auth Metrics ===
+    auth_requests_total: Mutex<BTreeMap<AuthRequestKey, u64>>,
+    auth_request_durations: Mutex<BTreeMap<AuthDurationKey, AuthDurationMetric>>,
+    auth_audit_write_failures_total: Mutex<BTreeMap<String, u64>>,
+    auth_email_send_failures_total: Mutex<BTreeMap<String, u64>>,
 }
 
 impl Metrics {
-    const fn new() -> Self {
+    fn new() -> Self {
         Self {
             // NIP-46 metrics
             cache_hits: AtomicU64::new(0),
@@ -85,6 +120,11 @@ impl Metrics {
             // OAuth metrics
             oauth_authorizations_created: AtomicU64::new(0),
             oauth_authorizations_revoked: AtomicU64::new(0),
+            // Labeled auth metrics
+            auth_requests_total: Mutex::new(BTreeMap::new()),
+            auth_request_durations: Mutex::new(BTreeMap::new()),
+            auth_audit_write_failures_total: Mutex::new(BTreeMap::new()),
+            auth_email_send_failures_total: Mutex::new(BTreeMap::new()),
         }
     }
 
@@ -183,6 +223,65 @@ impl Metrics {
     pub fn inc_oauth_revoked(&self) {
         self.oauth_authorizations_revoked
             .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn observe_auth_request(
+        &self,
+        endpoint: &str,
+        outcome: &str,
+        reason_code: Option<&str>,
+        duration: Duration,
+    ) {
+        let endpoint = normalize_auth_endpoint(endpoint).to_string();
+        let outcome = normalize_auth_outcome(outcome).to_string();
+        let reason_code = normalize_auth_reason(reason_code).to_string();
+
+        let mut request_totals = self
+            .auth_requests_total
+            .lock()
+            .expect("auth request totals lock poisoned");
+        *request_totals
+            .entry(AuthRequestKey {
+                endpoint: endpoint.clone(),
+                outcome: outcome.clone(),
+                reason_code,
+            })
+            .or_insert(0) += 1;
+        drop(request_totals);
+
+        let seconds = duration.as_secs_f64();
+        let mut duration_metrics = self
+            .auth_request_durations
+            .lock()
+            .expect("auth duration metrics lock poisoned");
+        let metric = duration_metrics
+            .entry(AuthDurationKey { endpoint, outcome })
+            .or_default();
+        metric.count += 1;
+        metric.sum += seconds;
+        for (index, bucket) in AUTH_DURATION_BUCKETS.iter().enumerate() {
+            if seconds <= *bucket {
+                metric.buckets[index] += 1;
+            }
+        }
+    }
+
+    pub fn inc_auth_audit_write_failure(&self, endpoint: &str) {
+        let endpoint = normalize_auth_endpoint(endpoint).to_string();
+        let mut failures = self
+            .auth_audit_write_failures_total
+            .lock()
+            .expect("auth audit failures lock poisoned");
+        *failures.entry(endpoint).or_insert(0) += 1;
+    }
+
+    pub fn inc_auth_email_send_failure(&self, template: &str) {
+        let template = normalize_email_template(template).to_string();
+        let mut failures = self
+            .auth_email_send_failures_total
+            .lock()
+            .expect("auth email failures lock poisoned");
+        *failures.entry(template).or_insert(0) += 1;
     }
 
     /// Format all metrics as Prometheus text
@@ -359,9 +458,188 @@ impl Metrics {
             self.oauth_authorizations_revoked.load(Ordering::Relaxed)
         ));
 
+        output.push_str(
+            "\n# HELP keycast_auth_requests_total Auth request outcomes by endpoint and reason\n",
+        );
+        output.push_str("# TYPE keycast_auth_requests_total counter\n");
+        for (key, count) in self
+            .auth_requests_total
+            .lock()
+            .expect("auth request totals lock poisoned")
+            .iter()
+        {
+            output.push_str(&format!(
+                "keycast_auth_requests_total{{endpoint=\"{}\",outcome=\"{}\",reason_code=\"{}\"}} {}\n",
+                key.endpoint, key.outcome, key.reason_code, count
+            ));
+        }
+
+        output.push_str(
+            "\n# HELP keycast_auth_request_duration_seconds Auth request latency by endpoint and outcome\n",
+        );
+        output.push_str("# TYPE keycast_auth_request_duration_seconds histogram\n");
+        for (key, metric) in self
+            .auth_request_durations
+            .lock()
+            .expect("auth duration metrics lock poisoned")
+            .iter()
+        {
+            for (index, bucket) in AUTH_DURATION_BUCKETS.iter().enumerate() {
+                output.push_str(&format!(
+                    "keycast_auth_request_duration_seconds_bucket{{endpoint=\"{}\",outcome=\"{}\",le=\"{}\"}} {}\n",
+                    key.endpoint, key.outcome, bucket, metric.buckets[index]
+                ));
+            }
+            output.push_str(&format!(
+                "keycast_auth_request_duration_seconds_bucket{{endpoint=\"{}\",outcome=\"{}\",le=\"+Inf\"}} {}\n",
+                key.endpoint, key.outcome, metric.count
+            ));
+            output.push_str(&format!(
+                "keycast_auth_request_duration_seconds_sum{{endpoint=\"{}\",outcome=\"{}\"}} {}\n",
+                key.endpoint, key.outcome, metric.sum
+            ));
+            output.push_str(&format!(
+                "keycast_auth_request_duration_seconds_count{{endpoint=\"{}\",outcome=\"{}\"}} {}\n",
+                key.endpoint, key.outcome, metric.count
+            ));
+        }
+
+        output.push_str(
+            "\n# HELP keycast_auth_audit_write_failures_total Auth audit writes that failed but did not fail the user request\n",
+        );
+        output.push_str("# TYPE keycast_auth_audit_write_failures_total counter\n");
+        for (endpoint, count) in self
+            .auth_audit_write_failures_total
+            .lock()
+            .expect("auth audit failures lock poisoned")
+            .iter()
+        {
+            output.push_str(&format!(
+                "keycast_auth_audit_write_failures_total{{endpoint=\"{}\"}} {}\n",
+                endpoint, count
+            ));
+        }
+
+        output.push_str(
+            "\n# HELP keycast_auth_email_send_failures_total Auth email send failures by template\n",
+        );
+        output.push_str("# TYPE keycast_auth_email_send_failures_total counter\n");
+        for (template, count) in self
+            .auth_email_send_failures_total
+            .lock()
+            .expect("auth email failures lock poisoned")
+            .iter()
+        {
+            output.push_str(&format!(
+                "keycast_auth_email_send_failures_total{{template=\"{}\"}} {}\n",
+                template, count
+            ));
+        }
+
         output
+    }
+}
+
+fn normalize_auth_endpoint(endpoint: &str) -> &'static str {
+    match endpoint {
+        "/api/auth/register" => "/api/auth/register",
+        "/api/auth/login" => "/api/auth/login",
+        "/api/auth/verify-email" => "/api/auth/verify-email",
+        "/api/auth/forgot-password" => "/api/auth/forgot-password",
+        "/api/auth/reset-password" => "/api/auth/reset-password",
+        "/api/auth/resend-verification" => "/api/auth/resend-verification",
+        "/api/oauth/login" => "/api/oauth/login",
+        "/api/oauth/register" => "/api/oauth/register",
+        "/api/oauth/authorize" => "/api/oauth/authorize",
+        "/api/oauth/token" => "/api/oauth/token",
+        "/api/oauth/poll" => "/api/oauth/poll",
+        "/api/oauth/connect" => "/api/oauth/connect",
+        "/api/headless/register" => "/api/headless/register",
+        "/api/headless/login" => "/api/headless/login",
+        "/api/headless/authorize" => "/api/headless/authorize",
+        "/api/claim" => "/api/claim",
+        "/api/admin/auth-debug" => "/api/admin/auth-debug",
+        _ => "other",
+    }
+}
+
+fn normalize_auth_outcome(outcome: &str) -> &'static str {
+    match outcome {
+        "success" => "success",
+        "failure" => "failure",
+        "accepted" => "accepted",
+        "error" => "error",
+        _ => "other",
+    }
+}
+
+fn normalize_auth_reason(reason_code: Option<&str>) -> &'static str {
+    match reason_code.unwrap_or("none") {
+        "none" => "none",
+        "user_not_found" => "user_not_found",
+        "invalid_password" => "invalid_password",
+        "invalid_credentials" => "invalid_credentials",
+        "email_not_verified" => "email_not_verified",
+        "invalid_request" => "invalid_request",
+        "invalid_token" => "invalid_token",
+        "token_expired" => "token_expired",
+        "conflict" => "conflict",
+        "email_send_failed" => "email_send_failed",
+        "service_unavailable" => "service_unavailable",
+        "account_setup_incomplete" => "account_setup_incomplete",
+        "missing_personal_key" => "missing_personal_key",
+        "password_hash_updated" => "password_hash_updated",
+        "unsupported_client" => "unsupported_client",
+        "authorization_not_found" => "authorization_not_found",
+        _ => "other",
+    }
+}
+
+fn normalize_email_template(template: &str) -> &'static str {
+    match template {
+        "verification" => "verification",
+        "password_reset" => "password_reset",
+        "resend_verification" => "resend_verification",
+        _ => "other",
     }
 }
 
 /// Global metrics instance
 pub static METRICS: Lazy<Metrics> = Lazy::new(Metrics::new);
+
+#[cfg(test)]
+mod tests {
+    use super::Metrics;
+    use std::time::Duration;
+
+    #[test]
+    fn test_auth_labeled_metrics_render_prometheus_series() {
+        let metrics = Metrics::new();
+
+        metrics.observe_auth_request(
+            "/api/headless/login",
+            "failure",
+            Some("user_not_found"),
+            Duration::from_millis(120),
+        );
+        metrics.inc_auth_audit_write_failure("/api/headless/login");
+        metrics.inc_auth_email_send_failure("password_reset");
+
+        let output = metrics.to_prometheus();
+
+        assert!(output.contains(
+            "keycast_auth_requests_total{endpoint=\"/api/headless/login\",outcome=\"failure\",reason_code=\"user_not_found\"} 1"
+        ));
+        assert!(output.contains(
+            "keycast_auth_request_duration_seconds_bucket{endpoint=\"/api/headless/login\",outcome=\"failure\",le=\"0.25\"} 1"
+        ));
+        assert!(output.contains(
+            "keycast_auth_request_duration_seconds_count{endpoint=\"/api/headless/login\",outcome=\"failure\"} 1"
+        ));
+        assert!(output.contains(
+            "keycast_auth_audit_write_failures_total{endpoint=\"/api/headless/login\"} 1"
+        ));
+        assert!(output
+            .contains("keycast_auth_email_send_failures_total{template=\"password_reset\"} 1"));
+    }
+}

--- a/core/src/repositories/auth_event.rs
+++ b/core/src/repositories/auth_event.rs
@@ -1,0 +1,241 @@
+// ABOUTME: Repository for engineer-facing authentication audit events
+// ABOUTME: Stores append-only auth history for support and debugging workflows
+
+use crate::repositories::RepositoryError;
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use sqlx::{FromRow, PgPool};
+
+#[derive(Debug, Clone)]
+pub struct AuthEventRecord {
+    pub tenant_id: i64,
+    pub request_id: String,
+    pub endpoint: String,
+    pub event_type: String,
+    pub outcome: String,
+    pub reason_code: Option<String>,
+    pub http_status: Option<i32>,
+    pub email: Option<String>,
+    pub email_hash: String,
+    pub pubkey: Option<String>,
+    pub pubkey_prefix: Option<String>,
+    pub client_id: Option<String>,
+    pub redirect_origin: Option<String>,
+    pub user_agent: Option<String>,
+    pub metadata_json: Value,
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct AuthEventRow {
+    pub id: i64,
+    pub occurred_at: DateTime<Utc>,
+    pub request_id: String,
+    pub tenant_id: i64,
+    pub endpoint: String,
+    pub event_type: String,
+    pub outcome: String,
+    pub reason_code: Option<String>,
+    pub http_status: Option<i32>,
+    pub email: Option<String>,
+    pub email_hash: String,
+    pub pubkey: Option<String>,
+    pub pubkey_prefix: Option<String>,
+    pub client_id: Option<String>,
+    pub redirect_origin: Option<String>,
+    pub user_agent: Option<String>,
+    pub metadata_json: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthEventRepository {
+    pool: PgPool,
+}
+
+impl AuthEventRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn record(&self, record: AuthEventRecord) -> Result<AuthEventRow, RepositoryError> {
+        sqlx::query_as::<_, AuthEventRow>(
+            "INSERT INTO auth_events (
+                request_id,
+                tenant_id,
+                endpoint,
+                event_type,
+                outcome,
+                reason_code,
+                http_status,
+                email,
+                email_hash,
+                pubkey,
+                pubkey_prefix,
+                client_id,
+                redirect_origin,
+                user_agent,
+                metadata_json
+             ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+             )
+             RETURNING
+                id,
+                occurred_at,
+                request_id,
+                tenant_id,
+                endpoint,
+                event_type,
+                outcome,
+                reason_code,
+                http_status,
+                email,
+                email_hash,
+                pubkey,
+                pubkey_prefix,
+                client_id,
+                redirect_origin,
+                user_agent,
+                metadata_json",
+        )
+        .bind(record.request_id)
+        .bind(record.tenant_id)
+        .bind(record.endpoint)
+        .bind(record.event_type)
+        .bind(record.outcome)
+        .bind(record.reason_code)
+        .bind(record.http_status)
+        .bind(record.email)
+        .bind(record.email_hash)
+        .bind(record.pubkey)
+        .bind(record.pubkey_prefix)
+        .bind(record.client_id)
+        .bind(record.redirect_origin)
+        .bind(record.user_agent)
+        .bind(record.metadata_json)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    pub async fn list_recent_by_email(
+        &self,
+        tenant_id: i64,
+        email: &str,
+        limit: i64,
+    ) -> Result<Vec<AuthEventRow>, RepositoryError> {
+        sqlx::query_as::<_, AuthEventRow>(
+            "SELECT
+                id,
+                occurred_at,
+                request_id,
+                tenant_id,
+                endpoint,
+                event_type,
+                outcome,
+                reason_code,
+                http_status,
+                email,
+                email_hash,
+                pubkey,
+                pubkey_prefix,
+                client_id,
+                redirect_origin,
+                user_agent,
+                metadata_json
+             FROM auth_events
+             WHERE tenant_id = $1 AND email = $2
+             ORDER BY occurred_at DESC, id DESC
+             LIMIT $3",
+        )
+        .bind(tenant_id)
+        .bind(email)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    pub async fn list_recent_by_pubkey(
+        &self,
+        tenant_id: i64,
+        pubkey: &str,
+        limit: i64,
+    ) -> Result<Vec<AuthEventRow>, RepositoryError> {
+        sqlx::query_as::<_, AuthEventRow>(
+            "SELECT
+                id,
+                occurred_at,
+                request_id,
+                tenant_id,
+                endpoint,
+                event_type,
+                outcome,
+                reason_code,
+                http_status,
+                email,
+                email_hash,
+                pubkey,
+                pubkey_prefix,
+                client_id,
+                redirect_origin,
+                user_agent,
+                metadata_json
+             FROM auth_events
+             WHERE tenant_id = $1 AND pubkey = $2
+             ORDER BY occurred_at DESC, id DESC
+             LIMIT $3",
+        )
+        .bind(tenant_id)
+        .bind(pubkey)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    pub async fn list_recent_by_request_id(
+        &self,
+        tenant_id: i64,
+        request_id: &str,
+        limit: i64,
+    ) -> Result<Vec<AuthEventRow>, RepositoryError> {
+        sqlx::query_as::<_, AuthEventRow>(
+            "SELECT
+                id,
+                occurred_at,
+                request_id,
+                tenant_id,
+                endpoint,
+                event_type,
+                outcome,
+                reason_code,
+                http_status,
+                email,
+                email_hash,
+                pubkey,
+                pubkey_prefix,
+                client_id,
+                redirect_origin,
+                user_agent,
+                metadata_json
+             FROM auth_events
+             WHERE tenant_id = $1 AND request_id = $2
+             ORDER BY occurred_at DESC, id DESC
+             LIMIT $3",
+        )
+        .bind(tenant_id)
+        .bind(request_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    pub async fn delete_older_than(&self, cutoff: DateTime<Utc>) -> Result<u64, RepositoryError> {
+        let result = sqlx::query("DELETE FROM auth_events WHERE occurred_at < $1")
+            .bind(cutoff)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(result.rows_affected())
+    }
+}

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -2,6 +2,7 @@
 // ABOUTME: Provides abstraction layer between handlers and database
 
 mod atproto_oauth_session;
+mod auth_event;
 mod authorization;
 mod claim_token;
 mod error;
@@ -19,6 +20,7 @@ pub use atproto_oauth_session::{
     AtprotoOAuthSession, AtprotoOAuthSessionRepository, CreateAtprotoOAuthSessionParams,
     IssueAtprotoTokensParams,
 };
+pub use auth_event::{AuthEventRecord, AuthEventRepository, AuthEventRow};
 pub use authorization::AuthorizationRepository;
 pub use claim_token::ClaimTokenRepository;
 pub use error::RepositoryError;

--- a/core/tests/auth_event_repository_test.rs
+++ b/core/tests/auth_event_repository_test.rs
@@ -1,0 +1,71 @@
+use keycast_core::repositories::{AuthEventRecord, AuthEventRepository};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn assert_test_database_url() {
+    let url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+
+    assert!(
+        url.contains("localhost") || url.contains("127.0.0.1"),
+        "Tests must run against localhost database"
+    );
+}
+
+async fn setup_pool() -> PgPool {
+    assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+#[tokio::test]
+async fn records_and_queries_auth_events() {
+    let pool = setup_pool().await;
+    let repo = AuthEventRepository::new(pool.clone());
+    let suffix = Uuid::new_v4().to_string();
+    let email = format!("auth-event-{}@example.com", suffix);
+    let pubkey = format!("{:0>64}", suffix.replace('-', ""));
+    let request_id = format!("req-{}", &suffix[..8]);
+
+    repo.record(AuthEventRecord {
+        tenant_id: 1,
+        request_id: request_id.clone(),
+        endpoint: "/api/headless/login".to_string(),
+        event_type: "request_completed".to_string(),
+        outcome: "failure".to_string(),
+        reason_code: Some("user_not_found".to_string()),
+        http_status: Some(401),
+        email: Some(email.clone()),
+        email_hash: "hash".to_string(),
+        pubkey: Some(pubkey.clone()),
+        pubkey_prefix: Some(pubkey[..8].to_string()),
+        client_id: Some("test-client".to_string()),
+        redirect_origin: Some("https://example.com".to_string()),
+        user_agent: Some("integration-test".to_string()),
+        metadata_json: json!({"flow": "headless"}),
+    })
+    .await
+    .unwrap();
+
+    let by_email = repo.list_recent_by_email(1, &email, 10).await.unwrap();
+    assert_eq!(by_email.len(), 1);
+    assert_eq!(by_email[0].request_id, request_id);
+
+    let by_request = repo
+        .list_recent_by_request_id(1, &request_id, 10)
+        .await
+        .unwrap();
+    assert_eq!(by_request.len(), 1);
+    assert_eq!(by_request[0].reason_code.as_deref(), Some("user_not_found"));
+}

--- a/database/migrations/20260418100000_add_auth_events.sql
+++ b/database/migrations/20260418100000_add_auth_events.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS auth_events (
+    id BIGSERIAL PRIMARY KEY,
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    request_id TEXT NOT NULL,
+    tenant_id BIGINT NOT NULL,
+    endpoint TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    outcome TEXT NOT NULL,
+    reason_code TEXT,
+    http_status INTEGER,
+    email TEXT,
+    email_hash TEXT NOT NULL,
+    pubkey TEXT,
+    pubkey_prefix TEXT,
+    client_id TEXT,
+    redirect_origin TEXT,
+    user_agent TEXT,
+    metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_events_occurred_at
+    ON auth_events (occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_auth_events_request_id
+    ON auth_events (request_id);
+
+CREATE INDEX IF NOT EXISTS idx_auth_events_tenant_email
+    ON auth_events (tenant_id, email, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_auth_events_tenant_pubkey
+    ON auth_events (tenant_id, pubkey, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_auth_events_tenant_endpoint_occurred_at
+    ON auth_events (tenant_id, endpoint, occurred_at DESC);

--- a/docs/superpowers/plans/2026-04-18-keycast-auth-observability.md
+++ b/docs/superpowers/plans/2026-04-18-keycast-auth-observability.md
@@ -1,0 +1,399 @@
+# Keycast Auth Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add durable auth auditing, request correlation, engineer lookup tooling, and production monitoring so engineers can diagnose Keycast auth failures with user-level evidence.
+
+**Architecture:** Add an append-only `auth_events` table in Keycast Postgres, instrument auth handlers through a shared observability helper, expose an engineer-only debug endpoint and CLI wrapper, and add Keycast-specific alerts, dashboard panels, and retention automation in `divine-iac-coreconfig`.
+
+**Tech Stack:** Rust, Axum, SQLx/Postgres, Prometheus/VictoriaMetrics, Grafana, Kubernetes CronJob, Kustomize
+
+---
+
+## Chunk 1: Keycast Persistence And Runtime Instrumentation
+
+### Task 1: Add `auth_events` persistence and repository support
+
+**Files:**
+- Create: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/database/migrations/20260418100000_add_auth_events.sql`
+- Create: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/core/src/repositories/auth_event.rs`
+- Modify: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/core/src/repositories/mod.rs`
+- Test: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/core/src/repositories/auth_event.rs`
+
+- [ ] **Step 1: Write repository tests first**
+
+Add unit tests around insert and query helpers in `auth_event.rs` using the existing repository test style:
+
+```rust
+#[tokio::test]
+async fn records_auth_event_with_lookup_fields() {
+    let repo = AuthEventRepository::new(pool.clone());
+    repo.record(AuthEventRecord { /* ... */ }).await.unwrap();
+
+    let rows = repo.list_recent_by_email(tenant_id, "user@example.com", 10).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].reason_code.as_deref(), Some("user_not_found"));
+}
+```
+
+- [ ] **Step 2: Run the repository test to confirm it fails**
+
+Run: `cargo test -p keycast_core auth_event --quiet`
+
+Expected: FAIL because `AuthEventRepository` and the migration do not exist yet.
+
+- [ ] **Step 3: Add the SQL migration**
+
+Create `20260418100000_add_auth_events.sql` with:
+
+- `auth_events` table
+- indexes on `occurred_at`, `request_id`, `(tenant_id, email)`, `(tenant_id, pubkey)`, `(tenant_id, endpoint, occurred_at)`
+- text fields for `endpoint`, `event_type`, `outcome`, `reason_code`
+- JSONB `metadata_json default '{}'::jsonb`
+
+- [ ] **Step 4: Add the repository implementation**
+
+Implement:
+
+- `AuthEventRecord`
+- `AuthEventRow`
+- `AuthEventRepository::record`
+- `AuthEventRepository::list_recent_by_email`
+- `AuthEventRepository::list_recent_by_pubkey`
+- `AuthEventRepository::list_recent_by_request_id`
+- `AuthEventRepository::delete_older_than`
+
+- [ ] **Step 5: Re-export the repository**
+
+Update `core/src/repositories/mod.rs` so API/admin code can import the new repository cleanly.
+
+- [ ] **Step 6: Re-run the repository test**
+
+Run: `cargo test -p keycast_core auth_event --quiet`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git -C /Users/rabble/code/divine/keycast/.worktrees/auth-observability add \
+  database/migrations/20260418100000_add_auth_events.sql \
+  core/src/repositories/auth_event.rs \
+  core/src/repositories/mod.rs
+git -C /Users/rabble/code/divine/keycast/.worktrees/auth-observability commit -m "feat: add auth event persistence"
+```
+
+### Task 2: Add request IDs and canonical auth observability helpers
+
+**Files:**
+- Create: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/api/src/api/http/auth_observability.rs`
+- Modify: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/api/src/api/http/mod.rs`
+- Modify: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/keycast/src/main.rs`
+- Modify: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/core/src/metrics.rs`
+- Test: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/api/tests/headless_auth_test.rs`
+
+- [ ] **Step 1: Write a failing request-ID propagation test**
+
+Extend `headless_auth_test.rs` with a case that sends `x-trace-id` and asserts `x-request-id` is echoed back on failure.
+
+```rust
+assert_eq!(response.headers()["x-request-id"], "test-trace-id");
+```
+
+- [ ] **Step 2: Run the new test to confirm it fails**
+
+Run: `cargo test -p keycast_api --test headless_auth_test --quiet`
+
+Expected: FAIL because responses do not yet set `x-request-id`.
+
+- [ ] **Step 3: Add shared request-context helpers**
+
+Implement `auth_observability.rs` with:
+
+- request ID extraction/generation
+- stable email hashing helper
+- pubkey prefix helper
+- `record_auth_event_and_log(...)`
+- latency timing support
+
+- [ ] **Step 4: Thread request IDs through the HTTP stack**
+
+Update `keycast/src/main.rs` so the request trace span continues to exist, but responses also expose `x-request-id`. Keep the existing `x-trace-id` compatibility behavior.
+
+- [ ] **Step 5: Add richer auth metrics**
+
+Extend `core/src/metrics.rs` to emit:
+
+- `keycast_auth_requests_total{endpoint,outcome,reason_code}`
+- `keycast_auth_request_duration_seconds{endpoint,outcome}`
+- `keycast_auth_audit_write_failures_total{endpoint}`
+- `keycast_auth_email_send_failures_total{template}`
+
+Use bounded labels only.
+
+- [ ] **Step 6: Instrument representative auth handlers first**
+
+Update:
+
+- `api/src/api/http/auth.rs`
+- `api/src/api/http/headless.rs`
+- `api/src/api/http/claim.rs`
+- `api/src/api/http/oauth.rs`
+
+to call the shared helper for canonical outcome logging and auth event recording.
+
+- [ ] **Step 7: Re-run the request-ID/auth tests**
+
+Run: `cargo test -p keycast_api --test headless_auth_test --quiet`
+
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git -C /Users/rabble/code/divine/keycast/.worktrees/auth-observability add \
+  api/src/api/http/auth_observability.rs \
+  api/src/api/http/mod.rs \
+  api/src/api/http/auth.rs \
+  api/src/api/http/headless.rs \
+  api/src/api/http/claim.rs \
+  api/src/api/http/oauth.rs \
+  core/src/metrics.rs \
+  keycast/src/main.rs \
+  api/tests/headless_auth_test.rs
+git -C /Users/rabble/code/divine/keycast/.worktrees/auth-observability commit -m "feat: instrument auth requests and outcomes"
+```
+
+### Task 3: Add engineer lookup surface and CLI wrapper
+
+**Files:**
+- Modify: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/api/src/api/http/admin.rs`
+- Modify: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/api/src/api/http/routes.rs`
+- Create: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/scripts/auth-debug.sh`
+- Test: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/api/tests/admin_token_test.rs`
+- Test: `/Users/rabble/code/divine/keycast/.worktrees/auth-observability/api/tests/admin_preload_test.rs`
+
+- [ ] **Step 1: Write a failing admin lookup test**
+
+Add a test for a new support-admin endpoint such as `/api/admin/auth-debug` that returns:
+
+- current user/account state
+- recent auth events
+- derived login diagnosis
+
+- [ ] **Step 2: Run the admin test to confirm it fails**
+
+Run: `cargo test -p keycast_api --test admin_token_test --quiet`
+
+Expected: FAIL because the route and response type do not exist yet.
+
+- [ ] **Step 3: Add the admin endpoint**
+
+In `admin.rs`:
+
+- define query params for `email`, `pubkey`, `npub`, or `request_id`
+- require support-admin or full-admin auth
+- query `UserRepository`, `OAuthAuthorizationRepository`, and `AuthEventRepository`
+- build a compact diagnosis string such as `"no users row found"` or `"email_not_verified"`
+
+In `routes.rs`:
+
+- mount `GET /admin/auth-debug`
+
+- [ ] **Step 4: Add the engineer CLI wrapper**
+
+Create `scripts/auth-debug.sh` that:
+
+- accepts `--email`, `--pubkey`, `--npub`, or `--request-id`
+- calls the new admin endpoint with an existing admin token
+- prints compact JSON for engineers
+
+- [ ] **Step 5: Re-run the admin tests**
+
+Run:
+
+```bash
+cargo test -p keycast_api --test admin_token_test --quiet
+cargo test -p keycast_api --test admin_preload_test --quiet
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git -C /Users/rabble/code/divine/keycast/.worktrees/auth-observability add \
+  api/src/api/http/admin.rs \
+  api/src/api/http/routes.rs \
+  scripts/auth-debug.sh \
+  api/tests/admin_token_test.rs \
+  api/tests/admin_preload_test.rs
+git -C /Users/rabble/code/divine/keycast/.worktrees/auth-observability commit -m "feat: add engineer auth debug surface"
+```
+
+## Chunk 2: Infrastructure Monitoring And Retention
+
+### Task 4: Add retention CronJob to Keycast Kubernetes manifests
+
+**Files:**
+- Create: `/Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability/k8s/applications/keycast/base/auth-events-retention-cronjob.yaml`
+- Modify: `/Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability/k8s/applications/keycast/base/kustomization.yaml`
+
+- [ ] **Step 1: Add the retention job manifest**
+
+Create a CronJob that:
+
+- runs in `identity`
+- uses `postgres:16-alpine`
+- reads `DATABASE_URL` from `keycast-db-credentials`
+- executes `DELETE FROM auth_events WHERE occurred_at < NOW() - INTERVAL '30 days'`
+
+- [ ] **Step 2: Include it in the base kustomization**
+
+Update the Keycast base kustomization so every environment gets the retention job.
+
+- [ ] **Step 3: Validate the manifest**
+
+Run:
+
+```bash
+kubeconform -strict \
+  /Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability/k8s/applications/keycast/base/auth-events-retention-cronjob.yaml
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git -C /Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability add \
+  k8s/applications/keycast/base/auth-events-retention-cronjob.yaml \
+  k8s/applications/keycast/base/kustomization.yaml
+git -C /Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability commit -m "feat: retain keycast auth events for 30 days"
+```
+
+### Task 5: Add Keycast alerts and dashboard
+
+**Files:**
+- Create: `/Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability/k8s/victoria-metrics/base/vmrule-keycast.yaml`
+- Create: `/Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability/k8s/victoria-metrics/base/dashboard-keycast.yaml`
+- Modify: `/Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability/k8s/victoria-metrics/base/kustomization.yaml`
+
+- [ ] **Step 1: Add Keycast VMRule alerts**
+
+Create alerts for:
+
+- high auth failure rate
+- auth audit write failures
+- reset email send failures
+- auth 5xx spikes
+- root-route 5xx spikes
+
+- [ ] **Step 2: Add Keycast Grafana dashboard**
+
+Create panels for:
+
+- auth request rate by endpoint
+- success/failure ratio
+- failure reasons
+- forgot-password/reset funnel
+- auth latency
+- audit write failures
+
+- [ ] **Step 3: Register both resources**
+
+Update the VictoriaMetrics base kustomization to include the new VMRule and dashboard ConfigMap.
+
+- [ ] **Step 4: Validate the manifests**
+
+Run:
+
+```bash
+kubeconform -strict \
+  /Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability/k8s/victoria-metrics/base/vmrule-keycast.yaml \
+  /Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability/k8s/victoria-metrics/base/dashboard-keycast.yaml
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git -C /Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability add \
+  k8s/victoria-metrics/base/vmrule-keycast.yaml \
+  k8s/victoria-metrics/base/dashboard-keycast.yaml \
+  k8s/victoria-metrics/base/kustomization.yaml
+git -C /Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability commit -m "feat: monitor keycast auth health"
+```
+
+### Task 6: Final verification and handoff
+
+**Files:**
+- Modify as needed: both worktrees
+
+- [ ] **Step 1: Run focused Rust tests**
+
+Run:
+
+```bash
+cargo test -p keycast_core auth_event --quiet
+cargo test -p keycast_api --test headless_auth_test --quiet
+cargo test -p keycast_api --test admin_token_test --quiet
+cargo test -p keycast_api --test admin_preload_test --quiet
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Run formatter and lints**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Validate the K8s manifests**
+
+Run:
+
+```bash
+kubeconform -strict \
+  /Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability/k8s/applications/keycast/base/auth-events-retention-cronjob.yaml \
+  /Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability/k8s/victoria-metrics/base/vmrule-keycast.yaml \
+  /Users/rabble/code/divine/divine-iac-coreconfig/.worktrees/keycast-auth-observability/k8s/victoria-metrics/base/dashboard-keycast.yaml
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Smoke-test the engineer lookup**
+
+Run the new script against staging or a local admin token once deployed:
+
+```bash
+/Users/rabble/code/divine/keycast/.worktrees/auth-observability/scripts/auth-debug.sh --email user@example.com
+```
+
+Expected: JSON summary with account state and recent auth events.
+
+- [ ] **Step 5: Prepare rollout notes**
+
+Document:
+
+- migration requirement
+- staging-first deployment
+- post-deploy smoke checks
+- expected Grafana and alert names
+

--- a/docs/superpowers/specs/2026-04-18-keycast-auth-observability-design.md
+++ b/docs/superpowers/specs/2026-04-18-keycast-auth-observability-design.md
@@ -1,0 +1,268 @@
+# Keycast Auth Observability Design
+
+Date: 2026-04-18
+
+## Goal
+
+Make Keycast supportable for authentication incidents by adding a durable engineer-facing auth audit trail, consistent request correlation, structured auth outcome logs, actionable metrics, and production alerts/dashboard coverage.
+
+## Problem
+
+Recent production debugging showed three operational gaps:
+
+1. Auth request logs are inconsistent and difficult to query by user or request.
+2. Metrics are global counters with little breakdown by endpoint, outcome, or reason.
+3. There is no persistent per-user auth history once logs are missing, sparse, or aged out.
+
+The result is that engineers cannot reliably answer basic incident questions such as:
+
+- Did the password reset request hit the server?
+- Did a reset token get stored and later consumed?
+- Did the password hash change?
+- Why did login fail for this user at this time?
+- Is the client failing before it reaches the auth endpoint?
+
+## Design Summary
+
+The first implementation uses Postgres as the system of record for hot auth history. Keycast will write append-only `auth_events` rows for all auth-related flows, return a stable request identifier to clients, emit canonical structured auth outcome logs, and expose richer Prometheus metrics. Engineers will get a CLI lookup tool that joins current account state with recent auth events. Infrastructure will gain Keycast-specific alert rules, a Grafana dashboard, and a retention job that deletes auth events older than 30 days.
+
+ClickHouse remains a good follow-up for longer retention and aggregate analysis, but it is not part of the first ship.
+
+## Architecture
+
+### Request correlation
+
+Every auth request gets a `request_id`:
+
+- Accept incoming `x-trace-id` if present.
+- Otherwise generate a new UUID-derived ID.
+- Attach it to the request context and current tracing span.
+- Return it to the client in an `x-request-id` response header.
+
+This ID becomes the join key across:
+
+- HTTP responses
+- structured logs
+- `auth_events`
+- engineer lookup output
+
+### Audit trail
+
+Add a new append-only `auth_events` table in Keycast Postgres. This is the engineer-facing source of truth for user-level auth history.
+
+The table stores:
+
+- `id`
+- `occurred_at`
+- `request_id`
+- `tenant_id`
+- `endpoint`
+- `event_type`
+- `outcome`
+- `reason_code`
+- `http_status`
+- `email`
+- `email_hash`
+- `pubkey`
+- `pubkey_prefix`
+- `client_id`
+- `redirect_origin`
+- `user_agent`
+- `metadata_json`
+
+Raw `email` and `pubkey` are allowed in the table because the table is for engineer support workflows. Logs and metrics will not expose raw identifiers.
+
+`metadata_json` stores flow-specific details without adding table churn for each new auth path. Examples:
+
+- reset token fingerprint
+- OAuth client metadata
+- claim token ID
+- admin role
+- verification method
+
+Secrets and credentials are never stored:
+
+- no raw passwords
+- no raw reset tokens
+- no bearer tokens
+- no cookies
+- no decrypted secrets
+
+### Event coverage
+
+The audit trail covers broader auth flows, not only password reset:
+
+- login
+- headless login
+- register
+- forgot password
+- reset password
+- verify email
+- logout
+- OAuth authorize/token/poll flows where auth state changes or rejects occur
+- claim flows
+- admin/support auth flows
+
+Each flow writes lifecycle events such as:
+
+- request received
+- token or authorization created
+- state transition completed
+- external side effect attempted or failed
+- request rejected with reason
+- response completed
+
+### Logging
+
+Add a canonical structured auth outcome log shape with consistent field names:
+
+- `request_id`
+- `endpoint`
+- `event_type`
+- `outcome`
+- `reason_code`
+- `http_status`
+- `tenant_id`
+- `email_hash`
+- `pubkey_prefix`
+- `latency_ms`
+
+Handlers should stop hand-rolling inconsistent auth logs. Instead, they provide outcome data to a shared helper which emits the final structured log and writes the audit event.
+
+### Metrics
+
+Keep existing global counters, but add auth-specific labeled metrics:
+
+- `keycast_auth_requests_total{endpoint,outcome,reason_code}`
+- `keycast_auth_request_duration_seconds{endpoint,outcome}`
+- `keycast_auth_audit_write_failures_total{endpoint}`
+- `keycast_auth_email_send_failures_total{template}`
+
+Label cardinality must stay bounded:
+
+- no raw email
+- no raw pubkey
+- no request IDs
+
+### Engineer tooling
+
+Add engineer-facing lookup tooling in the Keycast repo. The first pass is CLI-only.
+
+The lookup script should support:
+
+- email
+- pubkey
+- npub
+- request ID
+
+It should output:
+
+- matching user row(s)
+- current account state
+- recent `auth_events`
+- a short derived summary of why login would fail right now
+
+### Retention
+
+Retain auth events for 30 days in Postgres.
+
+Retention will be enforced by a cleanup job that deletes rows older than 30 days. The initial implementation will use Kubernetes CronJob infrastructure in `divine-iac-coreconfig`.
+
+## Failure handling
+
+Auth observability must not make auth less reliable.
+
+- If the main auth transaction fails, auth still fails as normal.
+- If the audit write fails independently, the request should fail open from the user perspective.
+- On audit write failure, Keycast must:
+  - emit an error log
+  - increment `keycast_auth_audit_write_failures_total`
+
+This keeps supportability from becoming an auth availability dependency.
+
+## Data model details
+
+### `auth_events` constraints and indexes
+
+Required indexes:
+
+- `occurred_at`
+- `request_id`
+- `(tenant_id, email)`
+- `(tenant_id, pubkey)`
+- `(tenant_id, endpoint, occurred_at)`
+
+Recommended conventions:
+
+- `event_type` and `outcome` should be stored as constrained text values
+- `reason_code` should be machine-oriented and stable
+- `metadata_json` should default to empty JSON
+
+### Normalization rules
+
+Keycast currently lowercases emails for login and forgot-password lookup, but does not trim whitespace. This implementation should not silently redesign auth semantics. It should record current behavior and make failures visible.
+
+Follow-up work can tighten canonical-email normalization and uniqueness constraints once the support signal is in place.
+
+## Infra and monitoring
+
+`divine-iac-coreconfig` will add:
+
+- a dedicated Keycast VMRule
+- a dedicated Keycast Grafana dashboard
+- an auth event retention CronJob
+
+Initial alerts:
+
+- high auth failure rate
+- audit write failures
+- password reset email send failures
+- auth 5xx spikes
+- root-route 5xx spikes
+
+Initial dashboard views:
+
+- auth request volume by endpoint
+- auth success and failure rates
+- failure reason breakdown
+- forgot-password and reset funnel
+- login funnel
+- audit write failure count
+- auth latency
+
+## Verification strategy
+
+Staging verification must cover:
+
+- forgot-password for existing and nonexistent emails
+- reset-password success
+- reset-password invalid token
+- login success
+- login invalid password
+- login user not found
+- login email not verified
+- headless login success and failure reasons
+- at least one representative OAuth, claim, and admin flow
+- response headers include `x-request-id`
+- corresponding log rows and `auth_events` rows exist
+- retention cleanup works on expired sample rows
+
+## Rollout
+
+1. Ship schema and code to staging.
+2. Run migrations.
+3. Exercise representative auth flows in staging.
+4. Confirm dashboard panels and alerts populate.
+5. Deploy to production during a low-risk window.
+6. Run one real engineer lookup in production to confirm the support path.
+
+## Non-goals
+
+- no end-user support UI
+- no ClickHouse pipeline yet
+- no permanent retention/archive design
+- no broad client rewrite in this change
+
+## Follow-up
+
+After the Postgres-backed hot path is working, mirror `auth_events` into ClickHouse for longer retention, aggregate analysis, and historical auth-funnel reporting.

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -35,7 +35,6 @@ use tower_http::services::ServeDir;
 use tower_http::trace::TraceLayer;
 use tracing::Level;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-use uuid::Uuid;
 use zeroize::Zeroizing;
 
 async fn health_check() -> impl IntoResponse {
@@ -784,13 +783,14 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     // All logs within the request will automatically include these fields
     let app = app.layer(
         TraceLayer::new_for_http().make_span_with(|request: &Request<Body>| {
-            // Use incoming x-trace-id header or generate new 8-char UUID
-            let trace_id = request
-                .headers()
-                .get("x-trace-id")
-                .and_then(|v| v.to_str().ok())
-                .map(String::from)
-                .unwrap_or_else(|| Uuid::new_v4().to_string()[..8].to_string());
+            let trace_id = keycast_api::api::http::auth_observability::request_context(request)
+                .map(|context| context.request_id.clone())
+                .or_else(|| {
+                    keycast_api::api::http::auth_observability::request_id_from_headers(
+                        request.headers(),
+                    )
+                })
+                .unwrap_or_else(|| "missing-request-id".to_string());
 
             tracing::span!(
                 Level::INFO,
@@ -801,6 +801,10 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
             )
         }),
     );
+
+    let app = app.layer(middleware::from_fn(
+        keycast_api::api::http::auth_observability::request_id_middleware,
+    ));
 
     // Add Cache-Control headers for browser caching
     let app = app.layer(middleware::from_fn(cache_control_middleware));
@@ -946,7 +950,10 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{body::Body, http::Request, routing::get, Router};
+    use keycast_api::api::http::auth_observability::request_id_middleware;
     use serial_test::serial;
+    use tower::ServiceExt;
 
     #[test]
     #[serial]
@@ -1080,5 +1087,43 @@ mod tests {
             "https://evil.pages.dev",
             "https://login.divine.video,https://*.openvine-app.pages.dev"
         ));
+    }
+
+    #[tokio::test]
+    async fn test_request_id_middleware_echoes_trace_header() {
+        let app = Router::new()
+            .route("/ok", get(|| async { "ok" }))
+            .layer(middleware::from_fn(request_id_middleware));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ok")
+                    .header("x-trace-id", "trace-1234")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.headers().get("x-request-id").unwrap(),
+            "trace-1234"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_request_id_middleware_generates_request_id() {
+        let app = Router::new()
+            .route("/ok", get(|| async { "ok" }))
+            .layer(middleware::from_fn(request_id_middleware));
+
+        let response = app
+            .oneshot(Request::builder().uri("/ok").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let request_id = response.headers().get("x-request-id").unwrap();
+        assert!(!request_id.is_empty());
     }
 }

--- a/scripts/auth-debug.sh
+++ b/scripts/auth-debug.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage:
+  auth-debug.sh --base-url https://login.divine.video --token <admin-token> [--email <email> | --pubkey <hex> | --npub <npub> | --request-id <id>]
+
+Options:
+  --base-url     Keycast base URL, defaults to https://login.divine.video
+  --token        Support-admin or full-admin bearer token
+  --email        Email address to inspect
+  --pubkey       Hex pubkey to inspect
+  --npub         npub to inspect
+  --request-id   Request ID to inspect
+EOF
+}
+
+base_url="https://login.divine.video"
+token=""
+email=""
+pubkey=""
+npub=""
+request_id=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base-url)
+      base_url="$2"
+      shift 2
+      ;;
+    --token)
+      token="$2"
+      shift 2
+      ;;
+    --email)
+      email="$2"
+      shift 2
+      ;;
+    --pubkey)
+      pubkey="$2"
+      shift 2
+      ;;
+    --npub)
+      npub="$2"
+      shift 2
+      ;;
+    --request-id)
+      request_id="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$token" ]; then
+  echo "--token is required" >&2
+  usage >&2
+  exit 1
+fi
+
+query_count=0
+[ -n "$email" ] && query_count=$((query_count + 1))
+[ -n "$pubkey" ] && query_count=$((query_count + 1))
+[ -n "$npub" ] && query_count=$((query_count + 1))
+[ -n "$request_id" ] && query_count=$((query_count + 1))
+
+if [ "$query_count" -eq 0 ]; then
+  echo "Provide at least one of --email, --pubkey, --npub, or --request-id" >&2
+  usage >&2
+  exit 1
+fi
+
+query=""
+append_query() {
+  key="$1"
+  value="$2"
+  if [ -n "$query" ]; then
+    query="${query}&"
+  fi
+  query="${query}${key}=$(printf '%s' "$value" | jq -sRr @uri)"
+}
+
+[ -n "$email" ] && append_query "email" "$email"
+[ -n "$pubkey" ] && append_query "pubkey" "$pubkey"
+[ -n "$npub" ] && append_query "npub" "$npub"
+[ -n "$request_id" ] && append_query "request_id" "$request_id"
+
+curl --fail --silent --show-error \
+  -H "Authorization: Bearer ${token}" \
+  "${base_url%/}/api/admin/auth-debug?${query}"


### PR DESCRIPTION
## Summary
- add durable auth event persistence, request ID propagation, and labeled auth metrics for engineer-facing diagnosis
- instrument login and password reset flows, add a support-admin `/api/admin/auth-debug` endpoint, and ship an `auth-debug.sh` wrapper
- add the design and implementation docs plus integration and repository coverage for auth audit rows and support lookup behavior

## Test Plan
- [x] `cargo fmt --all`
- [x] `cargo test -p keycast_core --quiet`
- [x] `cargo test -p keycast --quiet`
- [x] `DATABASE_URL=postgres://postgres:password@localhost:5432/keycast_test MASTER_KEY_PATH=./master.key cargo test -p keycast_api --features integration-tests --quiet`
