### PR TITLE
feat(auth): include email in password-reset URL for password-manager pairing

### DIFF
--- a/api/src/email_service.rs
+++ b/api/src/email_service.rs
@@ -127,7 +127,12 @@ impl EmailSender for DevEmailSender {
         to_email: &str,
         reset_token: &str,
     ) -> Result<(), String> {
-        let reset_url = format!("{}/reset-password?token={}", self.base_url, reset_token);
+        let reset_url = format!(
+            "{}/reset-password?token={}&email={}",
+            self.base_url,
+            reset_token,
+            urlencoding::encode(to_email),
+        );
 
         tracing::info!("");
         tracing::info!("==================================================");
@@ -399,7 +404,12 @@ impl EmailSender for SendGridEmailSender {
         to_email: &str,
         reset_token: &str,
     ) -> Result<(), String> {
-        let reset_url = format!("{}/reset-password?token={}", self.base_url, reset_token);
+        let reset_url = format!(
+            "{}/reset-password?token={}&email={}",
+            self.base_url,
+            reset_token,
+            urlencoding::encode(to_email),
+        );
 
         let subject = "Reset your diVine password".to_string();
         let html_content = format!(


### PR DESCRIPTION
## Summary
- Adds `&email=<url-encoded>` to the password-reset URL emitted in both the dev logger and SendGrid/SMTP email paths (`api/src/email_service.rs`).
- Token remains the sole authenticator for `POST /api/auth/reset-password`; the email is only a hint so mobile password managers can pair the new password with the existing saved credential instead of saving a duplicate entry.

## Why
iCloud Keychain (iOS) and Google Password Manager (Android) will only *update* an existing saved credential when they see the same account identifier alongside the new password. Without the email on the reset URL, the mobile app (`divine-mobile`) has to create a new credential — producing duplicate entries for the same Divine account. Users then hit autofill with the stale entry, fail to sign in, and contact support.

Cross-repo dependency: divinevideo/divine-mobile#3156 — client-side fix is ready to ship once this lands.

## Security note
Reset tokens are short-lived and are still the only thing that authorizes the reset. Putting the account email in the URL during that window is a conscious trade against the UX cost of duplicate password-manager entries. If there's a standing policy against any PII in URLs for reset flows, flag it and we'll switch to Option B in issue #3156 (a `GET /api/auth/reset-password/inspect?token=XYZ` endpoint that returns `{email}` without state change).

## What is unchanged
- No route/endpoint changes — `POST /api/auth/reset-password` still validates the token exactly as before.
- AASA file untouched (PR #23 already added `/reset-password`).
- Account-claim and admin-reset flows untouched.

## Test plan
- [x] `cargo build --lib` on the `api` crate passes.
- [x] `cargo clippy --lib` is clean.
- [x] Library unit tests that don't require a live Postgres all pass (50/50). 3 failing tests in `api::http::auth::tests::test_*_path_components` are pre-existing — they fail on `master` without a local Postgres (`VersionMissing(9)` during `sqlx::migrate!`) and are unrelated to this change.
- [ ] Manual verification in dev: trigger password reset and confirm the logged URL contains `&email=<encoded>` with `+`, `@`, `.` correctly escaped.
- [ ] Mobile QA with divinevideo/divine-mobile#3156: reset password end-to-end on iOS and Android, confirm password manager *updates* the existing entry rather than creating a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)