### PR TITLE
feat(oauth): accept RFC 6761 .localhost subdomains as loopback

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1059,8 +1059,13 @@ fn validate_origin(origin: &str) -> Result<(), AuthError> {
         .host_str()
         .ok_or_else(|| AuthError::BadRequest("Origin must have a host".to_string()))?;
 
-    // Allow http:// only for localhost (development)
-    let is_localhost = host == "localhost" || host == "127.0.0.1";
+    // Allow http:// only for localhost (development). Accepts RFC 6761
+    // `.localhost` subdomains so multiple local dev services can coexist
+    // on distinct hostnames. The subdomain match requires a non-empty label
+    // before `.localhost`.
+    let is_localhost = host == "localhost"
+        || host == "127.0.0.1"
+        || (host.ends_with(".localhost") && host.len() > ".localhost".len());
     if url.scheme() != "https" && !is_localhost {
         return Err(AuthError::BadRequest("Origin must be HTTPS".to_string()));
     }
@@ -3474,6 +3479,37 @@ pub async fn delete_account(
 
 #[cfg(test)]
 mod tests {
+    use super::validate_origin;
+
+    #[test]
+    fn test_validate_origin_https() {
+        assert!(validate_origin("https://example.com").is_ok());
+        assert!(validate_origin("https://example.com:8080").is_ok());
+    }
+
+    #[test]
+    fn test_validate_origin_http_localhost() {
+        assert!(validate_origin("http://localhost").is_ok());
+        assert!(validate_origin("http://localhost:3000").is_ok());
+        assert!(validate_origin("http://127.0.0.1:3000").is_ok());
+    }
+
+    #[test]
+    fn test_validate_origin_http_localhost_subdomain() {
+        // RFC 6761 reserves *.localhost as loopback.
+        assert!(validate_origin("http://admin.localhost:8787").is_ok());
+        assert!(validate_origin("http://api.localhost").is_ok());
+        assert!(validate_origin("http://admin.app.localhost:8080").is_ok());
+    }
+
+    #[test]
+    fn test_validate_origin_http_non_localhost_rejected() {
+        assert!(validate_origin("http://example.com").is_err());
+        // Hosts that merely contain "localhost" must not be treated as loopback.
+        assert!(validate_origin("http://xxxlocalhost").is_err());
+        assert!(validate_origin("http://localhost.evil.com").is_err());
+    }
+
     #[cfg(feature = "integration-tests")]
     use super::{verify_email, VerifyEmailRequest};
     #[cfg(feature = "integration-tests")]

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1037,7 +1037,7 @@ pub async fn logout() -> Result<impl axum::response::IntoResponse, AuthError> {
 #[derive(Debug, Deserialize)]
 pub struct CreateBunkerRequest {
     pub app_name: String,            // Required: friendly display name
-    pub origin: Option<String>,      // Optional: the app's origin URL (must be HTTPS if provided)
+    pub origin: Option<String>,      // Optional: the app's origin URL (HTTPS, or http://localhost / *.localhost / 127.0.0.1 / [::1] for local dev)
     pub policy_slug: Option<String>, // Optional: null = full access
 }
 
@@ -1059,12 +1059,14 @@ fn validate_origin(origin: &str) -> Result<(), AuthError> {
         .host_str()
         .ok_or_else(|| AuthError::BadRequest("Origin must have a host".to_string()))?;
 
-    // Allow http:// only for localhost (development). Accepts RFC 6761
-    // `.localhost` subdomains so multiple local dev services can coexist
-    // on distinct hostnames. The subdomain match requires a non-empty label
-    // before `.localhost`.
+    // Allow http:// only for localhost (development). Accepts IPv4, IPv6, and
+    // RFC 6761 `.localhost` subdomains so multiple local dev services can
+    // coexist on distinct hostnames. The subdomain match requires a non-empty
+    // label before `.localhost`. Kept in sync with `extract_origin` in oauth.rs.
     let is_localhost = host == "localhost"
         || host == "127.0.0.1"
+        || host == "[::1]"
+        || host == "::1"
         || (host.ends_with(".localhost") && host.len() > ".localhost".len());
     if url.scheme() != "https" && !is_localhost {
         return Err(AuthError::BadRequest("Origin must be HTTPS".to_string()));
@@ -1087,7 +1089,7 @@ pub async fn create_bunker(
     let user_pubkey = extract_user_from_token(&headers, tenant_id).await?;
     let pool = &auth_state.state.db;
 
-    // Validate origin if provided (must be HTTPS)
+    // Validate origin if provided (HTTPS, or http:// for localhost variants)
     if let Some(ref origin) = req.origin {
         validate_origin(origin)?;
     }
@@ -3492,6 +3494,9 @@ mod tests {
         assert!(validate_origin("http://localhost").is_ok());
         assert!(validate_origin("http://localhost:3000").is_ok());
         assert!(validate_origin("http://127.0.0.1:3000").is_ok());
+        // IPv6 loopback, matching extract_origin in oauth.rs
+        assert!(validate_origin("http://[::1]").is_ok());
+        assert!(validate_origin("http://[::1]:3000").is_ok());
     }
 
     #[test]

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1037,7 +1037,7 @@ pub async fn logout() -> Result<impl axum::response::IntoResponse, AuthError> {
 #[derive(Debug, Deserialize)]
 pub struct CreateBunkerRequest {
     pub app_name: String,            // Required: friendly display name
-    pub origin: Option<String>,      // Optional: the app's origin URL (HTTPS, or http://localhost / *.localhost / 127.0.0.1 / [::1] for local dev)
+    pub origin: Option<String>, // Optional: the app's origin URL (HTTPS, or http://localhost / *.localhost / 127.0.0.1 / [::1] for local dev)
     pub policy_slug: Option<String>, // Optional: null = full access
 }
 

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -68,8 +68,17 @@ pub fn extract_origin(redirect_uri: &str) -> Result<String, OAuthError> {
 
     // For http/https schemes, apply web security rules
     if scheme == "http" || scheme == "https" {
-        let is_localhost =
-            host == "localhost" || host == "127.0.0.1" || host == "[::1]" || host == "::1";
+        // RFC 6761 reserves `localhost.` and every `*.localhost.` subdomain as
+        // loopback; browsers and OS resolvers honor this. Accepting `.localhost`
+        // subdomains here lets multiple local dev services coexist on distinct
+        // hostnames (e.g. admin.localhost, api.localhost) without each claiming
+        // the bare `localhost`. The subdomain match requires a non-empty label
+        // before `.localhost` so `xxxlocalhost` or the empty prefix are rejected.
+        let is_localhost = host == "localhost"
+            || host == "127.0.0.1"
+            || host == "[::1]"
+            || host == "::1"
+            || (host.ends_with(".localhost") && host.len() > ".localhost".len());
         if scheme == "http" && !is_localhost {
             return Err(OAuthError::InvalidRequest(
                 "HTTPS required for non-localhost redirect_uri".to_string(),
@@ -4169,9 +4178,47 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_origin_http_localhost_subdomain() {
+        // RFC 6761 reserves *.localhost as loopback; browsers resolve these to 127.0.0.1.
+        // Accepting them here lets multiple local dev services coexist on distinct hostnames.
+        assert_eq!(
+            extract_origin("http://admin.localhost:8787/callback").unwrap(),
+            "http://admin.localhost:8787"
+        );
+        assert_eq!(
+            extract_origin("http://api.localhost:3000/auth").unwrap(),
+            "http://api.localhost:3000"
+        );
+        // Nested subdomain
+        assert_eq!(
+            extract_origin("http://admin.app.localhost:8080/callback").unwrap(),
+            "http://admin.app.localhost:8080"
+        );
+    }
+
+    #[test]
     fn test_extract_origin_http_non_localhost_rejected() {
         let err = extract_origin("http://example.com/callback").unwrap_err();
         assert!(matches!(err, OAuthError::InvalidRequest(msg) if msg.contains("HTTPS required")));
+    }
+
+    #[test]
+    fn test_extract_origin_http_localhost_lookalike_rejected() {
+        // Hosts that merely contain "localhost" as a substring must not be treated as loopback.
+        // The subdomain match requires a `.` before `localhost`, so these are rejected.
+        for lookalike in [
+            "http://xxxlocalhost/callback",
+            "http://localhost.evil.com/callback",
+            "http://.localhost/callback", // empty label before .localhost
+        ] {
+            let err = extract_origin(lookalike).unwrap_err();
+            assert!(
+                matches!(&err, OAuthError::InvalidRequest(msg) if msg.contains("HTTPS required") || msg.contains("Invalid redirect_uri")),
+                "{} should be rejected, got {:?}",
+                lookalike,
+                err
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Extend `extract_origin` (oauth.rs) and `validate_origin` (auth.rs) to treat any `*.localhost` hostname as loopback in addition to the literal `localhost`, `127.0.0.1`, and `[::1]` strings.

## Why

RFC 6761 reserves `localhost.` and every `*.localhost.` subdomain as loopback. Browsers and modern OS resolvers honor this, so a request to `http://admin.localhost:8787` resolves to `127.0.0.1` with zero DNS or `/etc/hosts` configuration. Today Keycast rejects these with `HTTPS required for non-localhost redirect_uri`, which forces local-dev operators to either fall back to the bare `localhost` (colliding when multiple services want the same loopback name) or edit `/etc/hosts` for each service.

Accepting `.localhost` subdomains lets multiple local dev services coexist on distinct hostnames (`admin.localhost` for an admin UI, `api.localhost` for a public API, etc.) without losing the HTTPS requirement for real public hostnames. The match requires a **non-empty label before `.localhost`**, so substring lookalikes like `xxxlocalhost` or `localhost.evil.com` and the empty-label form `.localhost` are still rejected.

## Discovery context

Surfaced while bringing up a full local Keycast + Cloudflare Worker stack for `divine-name-server`, where the worker's admin UI lives at `admin.localhost:8787` and its public UI at `localhost:8787`. `divine-name-server`'s existing behavior of distinguishing admin vs public UI by hostname made the bare-localhost workaround structurally awkward. The same pattern is expected in other Divine apps (`divine-resurrection`, `divine-invite-darshan`) as they adopt the Keycast OAuth flow — this change stops every one of them from having to patch Keycast locally.

## What changed

| File | Change |
|------|--------|
| `api/src/api/http/oauth.rs` | `extract_origin` accepts `.localhost` subdomains with a non-empty label |
| `api/src/api/http/auth.rs` | `validate_origin` same treatment |

Both checks preserve the existing HTTPS-required semantics for any other hostname.

## Tests

- **`extract_origin`**: new `test_extract_origin_http_localhost_subdomain` covers `admin.localhost:8787`, `api.localhost:3000`, and nested `admin.app.localhost:8080`. New `test_extract_origin_http_localhost_lookalike_rejected` covers `xxxlocalhost`, `localhost.evil.com`, `.localhost`.
- **`validate_origin`**: added a plain unit-test block (the existing one was gated on `integration-tests`), covering HTTPS, `localhost`, `127.0.0.1`, `.localhost` subdomains, and rejection of lookalikes.
- `cargo test -p keycast_api --lib`: **96/96 pass**.

## Test plan

- [x] `cargo test -p keycast_api --lib` — 96/96
- [x] Manual end-to-end: local Keycast + divine-name-server wrangler dev against `http://admin.localhost:8787`, OAuth round-trip succeeds (previously blocked by this check)
- [ ] CI

## Notes for reviewers

- No behavior change for any real public hostname: `example.com`, `foo.bar.example.com`, etc. still require HTTPS.
- No behavior change for `localhost`, `127.0.0.1`, `[::1]`, `::1` — they continue to be accepted.
- The label-length check (`host.len() > ".localhost".len()`) exists specifically to reject `.localhost` with an empty prefix, which some parsers will accept.