### PR TITLE
feat(claim-token): regenerate and invalidate from Support Admin

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -775,6 +775,69 @@ pub async fn batch_create_claim_tokens(
 }
 
 // ============================================================================
+// POST /api/admin/claim-tokens/invalidate - Invalidate claim token without replacement
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct InvalidateClaimTokenRequest {
+    pub vine_id: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InvalidateClaimTokenResponse {
+    pub invalidated_count: u64,
+    pub invalidated_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Invalidate all valid claim tokens for a preloaded user without issuing a
+/// replacement. Requires support admin. Idempotent: returns count=0 when
+/// nothing is currently valid.
+pub async fn invalidate_claim_token(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    Json(req): Json<InvalidateClaimTokenRequest>,
+) -> ApiResult<Json<InvalidateClaimTokenResponse>> {
+    let tenant_id = tenant.0.id;
+    let pool = &auth_state.state.db;
+
+    if !is_support_admin(&auth).await {
+        tracing::warn!("Claim token invalidate denied (not support admin)");
+        return Err(ApiError::forbidden("Admin access required"));
+    }
+
+    let user_repo = UserRepository::new(pool.clone());
+    let user_pubkey = user_repo
+        .find_pubkey_by_vine_id(&req.vine_id, tenant_id)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(format!("User with vine_id {} not found", req.vine_id))
+        })?;
+
+    let claim_token_repo = ClaimTokenRepository::new(pool.clone());
+    let count = claim_token_repo
+        .invalidate_valid_for_user(&user_pubkey, tenant_id, &auth.pubkey, req.reason.as_deref())
+        .await?;
+
+    tracing::info!(
+        "Claim token invalidated: vine_id={} count={} reason={:?}",
+        req.vine_id,
+        count,
+        req.reason,
+    );
+
+    Ok(Json(InvalidateClaimTokenResponse {
+        invalidated_count: count,
+        invalidated_at: if count > 0 {
+            Some(chrono::Utc::now())
+        } else {
+            None
+        },
+    }))
+}
+
+// ============================================================================
 // GET /api/admin/claim-tokens/stats - Aggregate claim token statistics
 // ============================================================================
 

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -531,12 +531,22 @@ pub async fn create_claim_token(
         return Err(ApiError::conflict("User has already claimed their account"));
     }
 
-    // Generate claim token
+    // Generate claim token. Invalidates prior valid tokens for the user in
+    // the same transaction so Regenerate replaces cleanly and doesn't leave
+    // stale credentials in circulation.
     let token = generate_claim_token();
     let claim_token_repo = ClaimTokenRepository::new(pool.clone());
-    let claim_token = claim_token_repo
-        .create(&token, &user_pubkey, Some(&auth.pubkey), tenant_id)
+    let (claim_token, invalidated_prior) = claim_token_repo
+        .create_with_prior_invalidation(&token, &user_pubkey, Some(&auth.pubkey), tenant_id)
         .await?;
+
+    if invalidated_prior > 0 {
+        tracing::info!(
+            "Claim token regenerate: {} prior token(s) invalidated for vine_id={}",
+            invalidated_prior,
+            req.vine_id,
+        );
+    }
 
     // Build claim URL
     let app_url = std::env::var("APP_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());

--- a/api/src/api/http/claim.rs
+++ b/api/src/api/http/claim.rs
@@ -698,8 +698,14 @@ impl IntoResponse for ClaimError {
     </div>
 </body>
 </html>"#,
-            title = title,
-            message = message,
+            // All current title/message values are hardcoded string literals,
+            // but route every interpolation through escape_html() to match the
+            // escape-everywhere pattern established in PR #67 and applied in
+            // claim_get's success-page template above. This defends against a
+            // future dev adding dynamic content to a ClaimError variant
+            // without remembering to escape it at the call site.
+            title = escape_html(title),
+            message = escape_html(message),
         );
 
         (axum::http::StatusCode::BAD_REQUEST, Html(html)).into_response()

--- a/api/src/api/http/claim.rs
+++ b/api/src/api/http/claim.rs
@@ -47,13 +47,22 @@ pub async fn claim_get(
     let tenant_id = tenant.0.id;
     let pool = &auth_state.state.db;
 
-    // Validate token
+    // Classify token into one of the five terminal states so we can render a
+    // state-specific error page when it's not valid.
+    use keycast_core::types::claim_token::ClaimTokenState;
     let claim_token_repo = ClaimTokenRepository::new(pool.clone());
-    let claim_token = claim_token_repo
-        .find_valid(&params.token)
+    let claim_token = match claim_token_repo
+        .classify(&params.token, tenant_id)
         .await
         .map_err(|e| ClaimError::Internal(format!("Database error: {}", e)))?
-        .ok_or(ClaimError::InvalidToken)?;
+    {
+        ClaimTokenState::Valid(ct) => ct,
+        ClaimTokenState::Unrecognized => return Err(ClaimError::TokenUnrecognized),
+        ClaimTokenState::AlreadyClaimed(_) => return Err(ClaimError::TokenAlreadyClaimed),
+        ClaimTokenState::AdminInvalidated(_) => return Err(ClaimError::TokenAdminInvalidated),
+        ClaimTokenState::Replaced { .. } => return Err(ClaimError::TokenReplaced),
+        ClaimTokenState::Expired(_) => return Err(ClaimError::TokenExpired),
+    };
 
     // Get user info (username, display_name)
     let user_repo = UserRepository::new(pool.clone());
@@ -255,13 +264,22 @@ pub async fn claim_post(
 
     form.email = form.email.to_lowercase();
 
-    // Validate token
+    // Classify token into one of the five terminal states; on anything but
+    // Valid, bail with the state-specific error page.
+    use keycast_core::types::claim_token::ClaimTokenState;
     let claim_token_repo = ClaimTokenRepository::new(pool.clone());
-    let claim_token = claim_token_repo
-        .find_valid(&form.token)
+    let claim_token = match claim_token_repo
+        .classify(&form.token, tenant_id)
         .await
         .map_err(|e| ClaimError::Internal(format!("Database error: {}", e)))?
-        .ok_or(ClaimError::InvalidToken)?;
+    {
+        ClaimTokenState::Valid(ct) => ct,
+        ClaimTokenState::Unrecognized => return Err(ClaimError::TokenUnrecognized),
+        ClaimTokenState::AlreadyClaimed(_) => return Err(ClaimError::TokenAlreadyClaimed),
+        ClaimTokenState::AdminInvalidated(_) => return Err(ClaimError::TokenAdminInvalidated),
+        ClaimTokenState::Replaced { .. } => return Err(ClaimError::TokenReplaced),
+        ClaimTokenState::Expired(_) => return Err(ClaimError::TokenExpired),
+    };
 
     // Validate passwords match
     if form.password != form.password_confirmation {
@@ -548,7 +566,16 @@ pub async fn claim_post(
 /// Claim-specific errors
 #[derive(Debug)]
 pub enum ClaimError {
-    InvalidToken,
+    /// No row matches the token string.
+    TokenUnrecognized,
+    /// Token row exists and `used_at IS NOT NULL`.
+    TokenAlreadyClaimed,
+    /// Token row exists and `invalidated_at IS NOT NULL` (admin-killed).
+    TokenAdminInvalidated,
+    /// Token is past `expires_at` and a newer valid token exists for same user.
+    TokenReplaced,
+    /// Token is past `expires_at`, no newer valid token, no admin invalidation.
+    TokenExpired,
     UserNotFound,
     PasswordMismatch,
     WeakPassword,
@@ -560,9 +587,25 @@ pub enum ClaimError {
 impl IntoResponse for ClaimError {
     fn into_response(self) -> Response {
         let (title, message) = match self {
-            ClaimError::InvalidToken => (
-                "Invalid or Expired Link",
-                "This claim link is invalid or has already been used. Please contact support for a new link.",
+            ClaimError::TokenUnrecognized => (
+                "Link not recognized",
+                "We don't recognize this claim link. Double-check the URL you received, or contact the person who sent it for help.",
+            ),
+            ClaimError::TokenAlreadyClaimed => (
+                "Account already claimed",
+                "This account has already been claimed. If you set it up, sign in at divine.video. If you didn't, contact support — someone else may have used this link.",
+            ),
+            ClaimError::TokenAdminInvalidated => (
+                "Link has been deactivated",
+                "This claim link was deactivated by Divine support. Contact the person who sent it, or email support@divine.video, to learn more.",
+            ),
+            ClaimError::TokenReplaced => (
+                "Link has been replaced",
+                "A newer claim link has been issued for this account. Check your email for the most recent message from Divine support, or contact the person who sent it for the current link.",
+            ),
+            ClaimError::TokenExpired => (
+                "Link has expired",
+                "Claim links are valid for 7 days. This one is past its expiration. Contact the person who sent it, or email support@divine.video, for a fresh link.",
             ),
             ClaimError::UserNotFound => (
                 "Account Not Found",

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -195,6 +195,10 @@ pub fn api_routes(
             post(admin::batch_create_claim_tokens),
         )
         .route(
+            "/admin/claim-tokens/invalidate",
+            post(admin::invalidate_claim_token),
+        )
+        .route(
             "/admin/claim-tokens/stats",
             get(admin::get_claim_token_stats),
         )

--- a/api/tests/claim_token_classify_test.rs
+++ b/api/tests/claim_token_classify_test.rs
@@ -1,0 +1,226 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration tests for ClaimTokenRepository::classify
+// ABOUTME: Verifies the five discriminated ClaimTokenState variants
+
+use chrono::{DateTime, Duration, Utc};
+use keycast_core::repositories::ClaimTokenRepository;
+use keycast_core::types::claim_token::ClaimTokenState;
+use sqlx::PgPool;
+
+mod common;
+
+/// Pad a label into a 64-char pubkey-shaped string so users.pubkey (CHAR(64)) accepts it.
+fn pk64(label: &str) -> String {
+    let mut s = label.to_string();
+    while s.len() < 64 {
+        s.push('0');
+    }
+    s.truncate(64);
+    s
+}
+
+/// Ensure a user row exists for the given pubkey so FK constraints on
+/// account_claim_tokens.user_pubkey are satisfied.
+async fn ensure_user(pool: &PgPool, pubkey: &str, tenant_id: i64) {
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id) VALUES ($1, $2)
+         ON CONFLICT (pubkey) DO NOTHING",
+    )
+    .bind(pubkey)
+    .bind(tenant_id)
+    .execute(pool)
+    .await
+    .expect("ensure_user failed");
+}
+
+async fn insert_raw_token(
+    pool: &PgPool,
+    token: &str,
+    user_pubkey: &str,
+    tenant_id: i64,
+    expires_at: DateTime<Utc>,
+    used_at: Option<DateTime<Utc>>,
+    invalidated_at: Option<DateTime<Utc>>,
+) {
+    ensure_user(pool, user_pubkey, tenant_id).await;
+    sqlx::query(
+        "INSERT INTO account_claim_tokens
+         (token, user_pubkey, expires_at, created_at, tenant_id, used_at, invalidated_at)
+         VALUES ($1, $2, $3, NOW(), $4, $5, $6)",
+    )
+    .bind(token)
+    .bind(user_pubkey)
+    .bind(expires_at)
+    .bind(tenant_id)
+    .bind(used_at)
+    .bind(invalidated_at)
+    .execute(pool)
+    .await
+    .expect("insert failed");
+}
+
+async fn cleanup(pool: &PgPool, user_pubkey: &str) {
+    sqlx::query("DELETE FROM account_claim_tokens WHERE user_pubkey = $1")
+        .bind(user_pubkey)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM users WHERE pubkey = $1")
+        .bind(user_pubkey)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+async fn classify_returns_unrecognized_for_missing_token() {
+    let pool = common::setup_test_db().await;
+    let repo = ClaimTokenRepository::new(pool.clone());
+    let state = repo
+        .classify("nope-does-not-exist", 1)
+        .await
+        .expect("query ok");
+    assert!(matches!(state, ClaimTokenState::Unrecognized));
+}
+
+#[tokio::test]
+async fn classify_returns_valid_for_fresh_token() {
+    let pool = common::setup_test_db().await;
+    let repo = ClaimTokenRepository::new(pool.clone());
+    let token = "t_classify_valid";
+    let pk = pk64("pk_classify_valid");
+    let pk = pk.as_str();
+    cleanup(&pool, pk).await;
+    insert_raw_token(
+        &pool,
+        token,
+        pk,
+        1,
+        Utc::now() + Duration::days(7),
+        None,
+        None,
+    )
+    .await;
+    let state = repo.classify(token, 1).await.expect("query ok");
+    assert!(
+        matches!(state, ClaimTokenState::Valid(_)),
+        "expected Valid, got {:?}",
+        state
+    );
+    cleanup(&pool, pk).await;
+}
+
+#[tokio::test]
+async fn classify_returns_already_claimed_when_used_at_set() {
+    let pool = common::setup_test_db().await;
+    let repo = ClaimTokenRepository::new(pool.clone());
+    let token = "t_classify_used";
+    let pk = pk64("pk_classify_used");
+    let pk = pk.as_str();
+    cleanup(&pool, pk).await;
+    insert_raw_token(
+        &pool,
+        token,
+        pk,
+        1,
+        Utc::now() + Duration::days(7),
+        Some(Utc::now()),
+        None,
+    )
+    .await;
+    let state = repo.classify(token, 1).await.expect("query ok");
+    assert!(
+        matches!(state, ClaimTokenState::AlreadyClaimed(_)),
+        "expected AlreadyClaimed, got {:?}",
+        state
+    );
+    cleanup(&pool, pk).await;
+}
+
+#[tokio::test]
+async fn classify_returns_admin_invalidated_when_invalidated_at_set() {
+    let pool = common::setup_test_db().await;
+    let repo = ClaimTokenRepository::new(pool.clone());
+    let token = "t_classify_inv";
+    let pk = pk64("pk_classify_inv");
+    let pk = pk.as_str();
+    cleanup(&pool, pk).await;
+    insert_raw_token(&pool, token, pk, 1, Utc::now(), None, Some(Utc::now())).await;
+    let state = repo.classify(token, 1).await.expect("query ok");
+    assert!(
+        matches!(state, ClaimTokenState::AdminInvalidated(_)),
+        "expected AdminInvalidated, got {:?}",
+        state
+    );
+    cleanup(&pool, pk).await;
+}
+
+#[tokio::test]
+async fn classify_returns_expired_when_past_with_no_newer() {
+    let pool = common::setup_test_db().await;
+    let repo = ClaimTokenRepository::new(pool.clone());
+    let token = "t_classify_exp";
+    let pk = pk64("pk_classify_exp");
+    let pk = pk.as_str();
+    cleanup(&pool, pk).await;
+    insert_raw_token(
+        &pool,
+        token,
+        pk,
+        1,
+        Utc::now() - Duration::hours(1),
+        None,
+        None,
+    )
+    .await;
+    let state = repo.classify(token, 1).await.expect("query ok");
+    assert!(
+        matches!(state, ClaimTokenState::Expired(_)),
+        "expected Expired, got {:?}",
+        state
+    );
+    cleanup(&pool, pk).await;
+}
+
+#[tokio::test]
+async fn classify_returns_replaced_when_newer_valid_token_exists() {
+    let pool = common::setup_test_db().await;
+    let repo = ClaimTokenRepository::new(pool.clone());
+    let old_token = "t_classify_replaced_old";
+    let new_token = "t_classify_replaced_new";
+    let pk = pk64("pk_classify_replaced");
+    let pk = pk.as_str();
+    cleanup(&pool, pk).await;
+    // Old, expired
+    insert_raw_token(
+        &pool,
+        old_token,
+        pk,
+        1,
+        Utc::now() - Duration::hours(1),
+        None,
+        None,
+    )
+    .await;
+    // Small sleep so created_at differs (NOW() resolution)
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    // New, valid
+    insert_raw_token(
+        &pool,
+        new_token,
+        pk,
+        1,
+        Utc::now() + Duration::days(7),
+        None,
+        None,
+    )
+    .await;
+    let state = repo.classify(old_token, 1).await.expect("query ok");
+    assert!(
+        matches!(state, ClaimTokenState::Replaced { .. }),
+        "expected Replaced, got {:?}",
+        state
+    );
+    cleanup(&pool, pk).await;
+}

--- a/api/tests/claim_token_create_with_invalidation_test.rs
+++ b/api/tests/claim_token_create_with_invalidation_test.rs
@@ -1,0 +1,106 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration tests for ClaimTokenRepository::create_with_prior_invalidation
+// ABOUTME: Regenerate path — transactional insert + invalidate priors
+
+use chrono::{Duration, Utc};
+use keycast_core::repositories::ClaimTokenRepository;
+use sqlx::PgPool;
+
+mod common;
+
+fn pk64(label: &str) -> String {
+    let mut s = label.to_string();
+    while s.len() < 64 {
+        s.push('0');
+    }
+    s.truncate(64);
+    s
+}
+
+async fn ensure_user(pool: &PgPool, pubkey: &str, tenant_id: i64) {
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id) VALUES ($1, $2)
+         ON CONFLICT (pubkey) DO NOTHING",
+    )
+    .bind(pubkey)
+    .bind(tenant_id)
+    .execute(pool)
+    .await
+    .expect("ensure_user failed");
+}
+
+async fn cleanup(pool: &PgPool, user_pubkey: &str) {
+    sqlx::query("DELETE FROM account_claim_tokens WHERE user_pubkey = $1")
+        .bind(user_pubkey)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM users WHERE pubkey = $1")
+        .bind(user_pubkey)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+async fn create_with_prior_invalidation_invalidates_existing_and_inserts_new() {
+    let pool = common::setup_test_db().await;
+    let repo = ClaimTokenRepository::new(pool.clone());
+    let pk = pk64("pk_regen_1");
+    let pk = pk.as_str();
+    cleanup(&pool, pk).await;
+    ensure_user(&pool, pk, 1).await;
+
+    let original = repo
+        .create("tok_v1_regen", pk, Some("admin1"), 1)
+        .await
+        .expect("create");
+    assert_eq!(original.invalidated_at, None);
+
+    let (new_tok, invalidated_count) = repo
+        .create_with_prior_invalidation("tok_v2_regen", pk, Some("admin2"), 1)
+        .await
+        .expect("create_with_prior_invalidation");
+
+    assert_eq!(invalidated_count, 1);
+    assert_eq!(new_tok.token, "tok_v2_regen");
+    assert!(new_tok.expires_at > Utc::now() + Duration::days(6));
+    assert_eq!(new_tok.invalidated_at, None);
+
+    let v1 = sqlx::query_as::<_, keycast_core::types::claim_token::ClaimToken>(
+        "SELECT * FROM account_claim_tokens WHERE token = $1",
+    )
+    .bind("tok_v1_regen")
+    .fetch_one(&pool)
+    .await
+    .expect("fetch v1");
+    assert!(v1.invalidated_at.is_some());
+    assert_eq!(v1.invalidated_by.as_deref(), Some("admin2"));
+    assert_eq!(
+        v1.invalidation_reason.as_deref(),
+        Some("replaced_by_regenerate")
+    );
+
+    cleanup(&pool, pk).await;
+}
+
+#[tokio::test]
+async fn create_with_prior_invalidation_noops_when_no_priors() {
+    let pool = common::setup_test_db().await;
+    let repo = ClaimTokenRepository::new(pool.clone());
+    let pk = pk64("pk_regen_2");
+    let pk = pk.as_str();
+    cleanup(&pool, pk).await;
+    ensure_user(&pool, pk, 1).await;
+
+    let (new_tok, invalidated_count) = repo
+        .create_with_prior_invalidation("tok_fresh_regen", pk, Some("admin1"), 1)
+        .await
+        .expect("create_with_prior_invalidation");
+
+    assert_eq!(invalidated_count, 0);
+    assert_eq!(new_tok.token, "tok_fresh_regen");
+
+    cleanup(&pool, pk).await;
+}

--- a/api/tests/claim_token_invalidate_repo_test.rs
+++ b/api/tests/claim_token_invalidate_repo_test.rs
@@ -1,0 +1,143 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration tests for ClaimTokenRepository::invalidate_valid_for_user
+// ABOUTME: Happy path, idempotent no-op, skips used/already-invalidated tokens
+
+use chrono::{Duration, Utc};
+use keycast_core::repositories::ClaimTokenRepository;
+use sqlx::PgPool;
+
+mod common;
+
+fn pk64(label: &str) -> String {
+    let mut s = label.to_string();
+    while s.len() < 64 {
+        s.push('0');
+    }
+    s.truncate(64);
+    s
+}
+
+async fn ensure_user(pool: &PgPool, pubkey: &str, tenant_id: i64) {
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id) VALUES ($1, $2)
+         ON CONFLICT (pubkey) DO NOTHING",
+    )
+    .bind(pubkey)
+    .bind(tenant_id)
+    .execute(pool)
+    .await
+    .expect("ensure_user failed");
+}
+
+async fn cleanup(pool: &PgPool, user_pubkey: &str) {
+    sqlx::query("DELETE FROM account_claim_tokens WHERE user_pubkey = $1")
+        .bind(user_pubkey)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM users WHERE pubkey = $1")
+        .bind(user_pubkey)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+async fn invalidate_valid_for_user_marks_single_valid_token() {
+    let pool = common::setup_test_db().await;
+    let repo = ClaimTokenRepository::new(pool.clone());
+    let pk = pk64("pk_inv_repo_1");
+    let pk = pk.as_str();
+    cleanup(&pool, pk).await;
+    ensure_user(&pool, pk, 1).await;
+
+    let created = repo
+        .create("tok_live_inv", pk, Some("admin1"), 1)
+        .await
+        .expect("create");
+    assert_eq!(created.invalidated_at, None);
+
+    let count = repo
+        .invalidate_valid_for_user(pk, 1, "admin2", Some("security"))
+        .await
+        .expect("invalidate");
+    assert_eq!(count, 1);
+
+    let after = sqlx::query_as::<_, keycast_core::types::claim_token::ClaimToken>(
+        "SELECT * FROM account_claim_tokens WHERE token = $1",
+    )
+    .bind("tok_live_inv")
+    .fetch_one(&pool)
+    .await
+    .expect("fetch");
+    assert!(after.invalidated_at.is_some());
+    assert_eq!(after.invalidated_by.as_deref(), Some("admin2"));
+    assert_eq!(after.invalidation_reason.as_deref(), Some("security"));
+    assert!(after.expires_at <= Utc::now() + Duration::seconds(5));
+
+    cleanup(&pool, pk).await;
+}
+
+#[tokio::test]
+async fn invalidate_valid_for_user_is_idempotent_when_no_valid_token() {
+    let pool = common::setup_test_db().await;
+    let repo = ClaimTokenRepository::new(pool.clone());
+    let pk = pk64("pk_inv_repo_2");
+    let pk = pk.as_str();
+    cleanup(&pool, pk).await;
+    ensure_user(&pool, pk, 1).await;
+
+    let count = repo
+        .invalidate_valid_for_user(pk, 1, "admin1", None)
+        .await
+        .expect("invalidate");
+    assert_eq!(count, 0);
+
+    cleanup(&pool, pk).await;
+}
+
+#[tokio::test]
+async fn invalidate_valid_for_user_skips_used_and_already_invalidated() {
+    let pool = common::setup_test_db().await;
+    let repo = ClaimTokenRepository::new(pool.clone());
+    let pk = pk64("pk_inv_repo_3");
+    let pk = pk.as_str();
+    cleanup(&pool, pk).await;
+    ensure_user(&pool, pk, 1).await;
+
+    // Used token (should be skipped)
+    sqlx::query(
+        "INSERT INTO account_claim_tokens
+         (token, user_pubkey, expires_at, created_at, tenant_id, used_at)
+         VALUES ($1, $2, $3, NOW(), 1, NOW())",
+    )
+    .bind("tok_used_skip")
+    .bind(pk)
+    .bind(Utc::now() + Duration::days(7))
+    .execute(&pool)
+    .await
+    .expect("insert used");
+
+    // Already-invalidated token (should be skipped)
+    sqlx::query(
+        "INSERT INTO account_claim_tokens
+         (token, user_pubkey, expires_at, created_at, tenant_id, invalidated_at, invalidated_by)
+         VALUES ($1, $2, $3, NOW(), 1, NOW(), $4)",
+    )
+    .bind("tok_already_inv_skip")
+    .bind(pk)
+    .bind(Utc::now() + Duration::days(7))
+    .bind("prior_admin")
+    .execute(&pool)
+    .await
+    .expect("insert inv");
+
+    let count = repo
+        .invalidate_valid_for_user(pk, 1, "admin_new", Some("explicit"))
+        .await
+        .expect("invalidate");
+    assert_eq!(count, 0);
+
+    cleanup(&pool, pk).await;
+}

--- a/core/src/repositories/claim_token.rs
+++ b/core/src/repositories/claim_token.rs
@@ -2,7 +2,9 @@ use chrono::{Duration, Utc};
 use sqlx::PgPool;
 
 use crate::repositories::RepositoryError;
-use crate::types::claim_token::{ClaimToken, ClaimTokenStats, CLAIM_TOKEN_EXPIRY_DAYS};
+use crate::types::claim_token::{
+    ClaimToken, ClaimTokenState, ClaimTokenStats, CLAIM_TOKEN_EXPIRY_DAYS,
+};
 
 /// Repository for account claim token operations.
 /// Used for preloaded users to claim their accounts by setting email/password.
@@ -153,5 +155,65 @@ impl ClaimTokenRepository {
         .await?;
 
         Ok(result.rows_affected())
+    }
+
+    /// Classify a token string into one of the ClaimTokenState variants by
+    /// inspecting the row and, for expired rows, checking for a newer valid
+    /// replacement. Used by the `/claim` HTTP handler to pick the right
+    /// error page.
+    pub async fn classify(
+        &self,
+        token: &str,
+        tenant_id: i64,
+    ) -> Result<ClaimTokenState, RepositoryError> {
+        let ct = sqlx::query_as::<_, ClaimToken>(
+            "SELECT * FROM account_claim_tokens
+             WHERE token = $1 AND tenant_id = $2",
+        )
+        .bind(token)
+        .bind(tenant_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let ct = match ct {
+            None => return Ok(ClaimTokenState::Unrecognized),
+            Some(t) => t,
+        };
+
+        if ct.used_at.is_some() {
+            return Ok(ClaimTokenState::AlreadyClaimed(ct));
+        }
+        if ct.invalidated_at.is_some() {
+            return Ok(ClaimTokenState::AdminInvalidated(ct));
+        }
+        if ct.expires_at > Utc::now() {
+            return Ok(ClaimTokenState::Valid(ct));
+        }
+
+        // Expired, not admin-invalidated; check for newer valid token for same user.
+        let newer = sqlx::query_as::<_, ClaimToken>(
+            "SELECT * FROM account_claim_tokens
+             WHERE user_pubkey = $1
+               AND tenant_id = $2
+               AND created_at > $3
+               AND used_at IS NULL
+               AND invalidated_at IS NULL
+               AND expires_at > NOW()
+             ORDER BY created_at DESC
+             LIMIT 1",
+        )
+        .bind(&ct.user_pubkey)
+        .bind(tenant_id)
+        .bind(ct.created_at)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(match newer {
+            Some(n) => ClaimTokenState::Replaced {
+                current: ct,
+                newer: n,
+            },
+            None => ClaimTokenState::Expired(ct),
+        })
     }
 }

--- a/core/src/repositories/claim_token.rs
+++ b/core/src/repositories/claim_token.rs
@@ -46,14 +46,23 @@ impl ClaimTokenRepository {
         .map_err(Into::into)
     }
 
-    /// Find a valid (not expired, not used) claim token.
-    /// Returns None if token doesn't exist, is expired, or already used.
+    /// Find a valid (not expired, not used, not admin-invalidated) claim token.
+    /// Returns None if token doesn't exist, is expired, already used, or has
+    /// been administratively invalidated.
+    ///
+    /// Note: this filters on `invalidated_at IS NULL` as defense-in-depth even
+    /// though `invalidate_valid_for_user` and `create_with_prior_invalidation`
+    /// both also set `expires_at = NOW()` (which the `expires_at > NOW()`
+    /// predicate would catch). The explicit `invalidated_at IS NULL` check
+    /// prevents a future code path that sets `invalidated_at` without also
+    /// clamping `expires_at` from surfacing invalidated tokens.
     pub async fn find_valid(&self, token: &str) -> Result<Option<ClaimToken>, RepositoryError> {
         sqlx::query_as::<_, ClaimToken>(
             "SELECT * FROM account_claim_tokens
              WHERE token = $1
                AND expires_at > NOW()
-               AND used_at IS NULL",
+               AND used_at IS NULL
+               AND invalidated_at IS NULL",
         )
         .bind(token)
         .fetch_optional(&self.pool)
@@ -77,8 +86,9 @@ impl ClaimTokenRepository {
         .map_err(Into::into)
     }
 
-    /// Find a valid (not expired, not used) claim token for a specific user.
-    /// Returns the most recently created valid token, if any.
+    /// Find a valid (not expired, not used, not admin-invalidated) claim token
+    /// for a specific user. Returns the most recently created valid token, if
+    /// any. Same defense-in-depth filter as `find_valid`.
     pub async fn find_valid_by_user_pubkey(
         &self,
         user_pubkey: &str,
@@ -90,6 +100,7 @@ impl ClaimTokenRepository {
                AND tenant_id = $2
                AND expires_at > NOW()
                AND used_at IS NULL
+               AND invalidated_at IS NULL
              ORDER BY created_at DESC
              LIMIT 1",
         )
@@ -160,6 +171,13 @@ impl ClaimTokenRepository {
     /// Create a new claim token and, in the same transaction, invalidate any
     /// prior valid token for the same user. Used by the Regenerate admin
     /// action. Returns (new_token, count_of_priors_invalidated).
+    ///
+    /// The invalidation UPDATE's WHERE clause (`used_at IS NULL AND
+    /// invalidated_at IS NULL AND expires_at > NOW()`) is the safety guard:
+    /// it won't clobber an already-claimed, already-invalidated, or
+    /// already-expired row's timestamps. Wrapping the UPDATE and the INSERT
+    /// in one transaction means a Regenerate either swaps both (old dead,
+    /// new alive) or neither — no "neither valid" window.
     pub async fn create_with_prior_invalidation(
         &self,
         token: &str,
@@ -214,6 +232,13 @@ impl ClaimTokenRepository {
     /// tokens for a user. Sets expires_at = NOW() and invalidated_at = NOW(),
     /// records admin pubkey and optional reason. Returns the count of rows
     /// updated. Idempotent: returns 0 when nothing valid exists.
+    ///
+    /// The WHERE clause (`used_at IS NULL AND invalidated_at IS NULL AND
+    /// expires_at > NOW()`) is the safety guard: it atomically excludes
+    /// already-claimed, already-invalidated, and already-expired rows.
+    /// Callers do not need a separate pre-flight check against races with
+    /// concurrent claim / invalidate / expiry transitions — the update either
+    /// matches a valid row or is a no-op.
     pub async fn invalidate_valid_for_user(
         &self,
         user_pubkey: &str,

--- a/core/src/repositories/claim_token.rs
+++ b/core/src/repositories/claim_token.rs
@@ -157,6 +157,38 @@ impl ClaimTokenRepository {
         Ok(result.rows_affected())
     }
 
+    /// Invalidate all valid (unused, unexpired, not-already-invalidated) claim
+    /// tokens for a user. Sets expires_at = NOW() and invalidated_at = NOW(),
+    /// records admin pubkey and optional reason. Returns the count of rows
+    /// updated. Idempotent: returns 0 when nothing valid exists.
+    pub async fn invalidate_valid_for_user(
+        &self,
+        user_pubkey: &str,
+        tenant_id: i64,
+        invalidated_by: &str,
+        reason: Option<&str>,
+    ) -> Result<u64, RepositoryError> {
+        let result = sqlx::query(
+            "UPDATE account_claim_tokens
+             SET expires_at = NOW(),
+                 invalidated_at = NOW(),
+                 invalidated_by = $3,
+                 invalidation_reason = $4
+             WHERE user_pubkey = $1
+               AND tenant_id = $2
+               AND used_at IS NULL
+               AND invalidated_at IS NULL
+               AND expires_at > NOW()",
+        )
+        .bind(user_pubkey)
+        .bind(tenant_id)
+        .bind(invalidated_by)
+        .bind(reason)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
     /// Classify a token string into one of the ClaimTokenState variants by
     /// inspecting the row and, for expired rows, checking for a newer valid
     /// replacement. Used by the `/claim` HTTP handler to pick the right

--- a/core/src/repositories/claim_token.rs
+++ b/core/src/repositories/claim_token.rs
@@ -157,6 +157,59 @@ impl ClaimTokenRepository {
         Ok(result.rows_affected())
     }
 
+    /// Create a new claim token and, in the same transaction, invalidate any
+    /// prior valid token for the same user. Used by the Regenerate admin
+    /// action. Returns (new_token, count_of_priors_invalidated).
+    pub async fn create_with_prior_invalidation(
+        &self,
+        token: &str,
+        user_pubkey: &str,
+        created_by_pubkey: Option<&str>,
+        tenant_id: i64,
+    ) -> Result<(ClaimToken, u64), RepositoryError> {
+        let now = Utc::now();
+        let expires_at = now + Duration::days(CLAIM_TOKEN_EXPIRY_DAYS);
+
+        let mut tx = self.pool.begin().await?;
+
+        let invalidated_count = sqlx::query(
+            "UPDATE account_claim_tokens
+             SET expires_at = NOW(),
+                 invalidated_at = NOW(),
+                 invalidated_by = $1,
+                 invalidation_reason = 'replaced_by_regenerate'
+             WHERE user_pubkey = $2
+               AND tenant_id = $3
+               AND used_at IS NULL
+               AND invalidated_at IS NULL
+               AND expires_at > NOW()",
+        )
+        .bind(created_by_pubkey)
+        .bind(user_pubkey)
+        .bind(tenant_id)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+
+        let new_token = sqlx::query_as::<_, ClaimToken>(
+            "INSERT INTO account_claim_tokens
+             (token, user_pubkey, expires_at, created_at, created_by_pubkey, tenant_id)
+             VALUES ($1, $2, $3, $4, $5, $6)
+             RETURNING *",
+        )
+        .bind(token)
+        .bind(user_pubkey)
+        .bind(expires_at)
+        .bind(now)
+        .bind(created_by_pubkey)
+        .bind(tenant_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok((new_token, invalidated_count))
+    }
+
     /// Invalidate all valid (unused, unexpired, not-already-invalidated) claim
     /// tokens for a user. Sets expires_at = NOW() and invalidated_at = NOW(),
     /// records admin pubkey and optional reason. Returns the count of rows

--- a/core/src/types/claim_token.rs
+++ b/core/src/types/claim_token.rs
@@ -17,6 +17,37 @@ pub struct ClaimToken {
     pub created_at: DateTime<Utc>,
     pub created_by_pubkey: Option<String>,
     pub tenant_id: i64,
+    // Set by admin Invalidate or by Regenerate when it replaces prior tokens.
+    // When set, the claim handler treats the token as AdminInvalidated rather
+    // than Expired.
+    pub invalidated_at: Option<DateTime<Utc>>,
+    pub invalidated_by: Option<String>,
+    pub invalidation_reason: Option<String>,
+}
+
+/// Discriminated state of a claim token, derived from its row + peers.
+/// Used by the claim HTTP handler to choose the correct error page when a
+/// token string doesn't validate on first pass.
+#[derive(Debug)]
+pub enum ClaimTokenState {
+    /// Token exists, is unused, is not admin-invalidated, and has not yet expired.
+    Valid(ClaimToken),
+    /// No row matches the token string.
+    Unrecognized,
+    /// Token row exists and `used_at IS NOT NULL`.
+    AlreadyClaimed(ClaimToken),
+    /// Token row exists and `invalidated_at IS NOT NULL` (set by admin
+    /// Invalidate or by Regenerate replacing the token).
+    AdminInvalidated(ClaimToken),
+    /// Token is past `expires_at`, was not admin-invalidated, and a newer
+    /// valid token exists for the same user.
+    Replaced {
+        current: ClaimToken,
+        newer: ClaimToken,
+    },
+    /// Token is past `expires_at`, was not admin-invalidated, and no newer
+    /// valid token exists.
+    Expired(ClaimToken),
 }
 
 /// Aggregate statistics for claim tokens in a tenant

--- a/database/migrations/20260422120000_claim_token_invalidation.sql
+++ b/database/migrations/20260422120000_claim_token_invalidation.sql
@@ -1,0 +1,8 @@
+ALTER TABLE account_claim_tokens
+  ADD COLUMN IF NOT EXISTS invalidated_at       TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS invalidated_by       TEXT,
+  ADD COLUMN IF NOT EXISTS invalidation_reason  TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_claim_tokens_invalidated_at
+  ON account_claim_tokens (invalidated_at)
+  WHERE invalidated_at IS NOT NULL;

--- a/web/src/lib/components/InvalidateClaimTokenModal.svelte
+++ b/web/src/lib/components/InvalidateClaimTokenModal.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+	import { toast } from 'svelte-hot-french-toast';
+	import { KeycastApi } from '$lib/keycast_api.svelte';
+
+	const api = new KeycastApi();
+
+	interface Props {
+		show: boolean;
+		vineId: string;
+		userDisplayName: string;
+		onClose: () => void;
+		onSuccess: () => void;
+	}
+
+	let {
+		show = $bindable(false),
+		vineId,
+		userDisplayName,
+		onClose,
+		onSuccess
+	}: Props = $props();
+
+	let reason = $state('');
+	let isInvalidating = $state(false);
+
+	async function handleInvalidate() {
+		try {
+			isInvalidating = true;
+			const body: { vine_id: string; reason?: string } = { vine_id: vineId };
+			if (reason.trim()) body.reason = reason.trim();
+
+			const res = await api.post<{
+				invalidated_count: number;
+				invalidated_at: string | null;
+			}>('/admin/claim-tokens/invalidate', body);
+
+			if (res.invalidated_count === 0) {
+				toast.success('No active claim link to invalidate.');
+			} else {
+				toast.success('Claim link invalidated.');
+			}
+			reason = '';
+			onSuccess();
+			onClose();
+		} catch (err: any) {
+			toast.error(err?.message || 'Failed to invalidate claim link');
+		} finally {
+			isInvalidating = false;
+		}
+	}
+
+	function handleCancel() {
+		reason = '';
+		onClose();
+	}
+</script>
+
+{#if show}
+	<div class="modal-overlay" role="dialog" aria-modal="true">
+		<div class="modal-content">
+			<h2>Invalidate claim link for {userDisplayName}?</h2>
+			<p>
+				This link will stop working immediately. The account stays unclaimed;
+				you can issue a new link later with "Generate Claim Link" or
+				"Regenerate."
+			</p>
+
+			<label for="invalidate-reason">Reason (optional)</label>
+			<textarea
+				id="invalidate-reason"
+				bind:value={reason}
+				rows="3"
+				placeholder="e.g. credential suspected compromised; link sent to wrong person"
+				disabled={isInvalidating}
+			></textarea>
+
+			<div class="modal-actions">
+				<button class="btn-secondary" onclick={handleCancel} disabled={isInvalidating}>
+					Cancel
+				</button>
+				<button
+					class="btn-destructive"
+					onclick={handleInvalidate}
+					disabled={isInvalidating}
+				>
+					{isInvalidating ? 'Invalidating...' : 'Invalidate'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.modal-overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+	}
+	.modal-content {
+		background: #0f2e23;
+		border: 1px solid #1c4033;
+		border-radius: 12px;
+		padding: 24px;
+		max-width: 480px;
+		width: 90%;
+		color: #f9f7f6;
+	}
+	.modal-content h2 {
+		margin: 0 0 12px 0;
+		font-size: 18px;
+	}
+	.modal-content p {
+		color: #beb3a7;
+		font-size: 14px;
+		line-height: 1.5;
+		margin: 0 0 16px 0;
+	}
+	.modal-content label {
+		display: block;
+		font-size: 13px;
+		color: #beb3a7;
+		margin-bottom: 6px;
+	}
+	.modal-content textarea {
+		width: 100%;
+		background: #072218;
+		border: 1px solid #1c4033;
+		border-radius: 6px;
+		color: #f9f7f6;
+		padding: 8px 10px;
+		font-size: 14px;
+		font-family: inherit;
+		resize: vertical;
+		box-sizing: border-box;
+	}
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		margin-top: 20px;
+	}
+	.btn-secondary,
+	.btn-destructive {
+		padding: 8px 14px;
+		border-radius: 6px;
+		font-size: 14px;
+		cursor: pointer;
+		border: 1px solid transparent;
+	}
+	.btn-secondary {
+		background: transparent;
+		border-color: #1c4033;
+		color: #beb3a7;
+	}
+	.btn-destructive {
+		background: #7f1d1d;
+		color: #fee2e2;
+	}
+	.btn-destructive:hover {
+		background: #991b1b;
+	}
+	.btn-secondary:hover {
+		background: #1c4033;
+		color: #f9f7f6;
+	}
+</style>

--- a/web/src/routes/support-admin/+page.svelte
+++ b/web/src/routes/support-admin/+page.svelte
@@ -4,6 +4,7 @@
 	import { KeycastApi } from '$lib/keycast_api.svelte';
 	import { goto } from '$app/navigation';
 	import Loader from '$lib/components/Loader.svelte';
+	import InvalidateClaimTokenModal from '$lib/components/InvalidateClaimTokenModal.svelte';
 	import { ShieldCheck, Warning, MagnifyingGlass, User, Key, Calendar, Globe, Copy, Check, CheckCircle, XCircle, Link, CaretDown, CaretRight } from 'phosphor-svelte';
 	import { nip19 } from 'nostr-tools';
 	import { toast } from 'svelte-hot-french-toast';
@@ -31,6 +32,23 @@
 	let isLoadingClaimToken = $state(false);
 	let isGeneratingClaimToken = $state(false);
 	let copiedClaimUrl = $state(false);
+
+	// Invalidate modal state
+	let showInvalidateModal = $state(false);
+	let invalidateModalVineId = $state('');
+	let invalidateModalUserName = $state('');
+
+	function openInvalidateModal(vineId: string, userName: string) {
+		invalidateModalVineId = vineId;
+		invalidateModalUserName = userName;
+		showInvalidateModal = true;
+	}
+
+	function handleInvalidateSuccess() {
+		// Clear displayed claim link; the {:else} branch will render
+		// "Generate Claim Link" on the next render cycle.
+		claimToken = null;
+	}
 
 	interface UserDetails {
 		pubkey: string;
@@ -400,6 +418,13 @@
 															>
 																{isGeneratingClaimToken ? 'Regenerating...' : 'Regenerate'}
 															</button>
+															<button
+																class="btn-destructive-inline"
+																onclick={() => openInvalidateModal(u.vine_id!, u.display_name || u.username || u.vine_id!)}
+																disabled={isGeneratingClaimToken}
+															>
+																Invalidate
+															</button>
 														</div>
 													</div>
 												{:else}
@@ -435,6 +460,14 @@
 		{/if}
 	{/if}
 </div>
+
+<InvalidateClaimTokenModal
+	bind:show={showInvalidateModal}
+	vineId={invalidateModalVineId}
+	userDisplayName={invalidateModalUserName}
+	onClose={() => (showInvalidateModal = false)}
+	onSuccess={handleInvalidateSuccess}
+/>
 
 <style>
 	.support-page {
@@ -905,6 +938,24 @@
 		display: flex;
 		gap: 0.5rem;
 		margin-top: 0.75rem;
+	}
+
+	.btn-destructive-inline {
+		padding: 0.5rem 0.875rem;
+		background: transparent;
+		border: 1px solid #7f1d1d;
+		color: #fca5a5;
+		border-radius: 6px;
+		font-size: 0.875rem;
+		cursor: pointer;
+	}
+	.btn-destructive-inline:hover:not(:disabled) {
+		background: #7f1d1d;
+		color: #fee2e2;
+	}
+	.btn-destructive-inline:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 
 	.links-grid {

--- a/web/src/routes/support-admin/+page.svelte
+++ b/web/src/routes/support-admin/+page.svelte
@@ -157,6 +157,22 @@
 		}
 	}
 
+	async function regenerateClaimToken(vineId: string) {
+		isGeneratingClaimToken = true;
+		try {
+			const result = await api.post<{ claim_url: string; expires_at: string }>(
+				'/admin/claim-tokens',
+				{ vine_id: vineId }
+			);
+			claimToken = result;
+			toast.success('Claim link regenerated. Prior link is now invalidated.');
+		} catch (err: any) {
+			toast.error(err.message || 'Failed to regenerate claim link');
+		} finally {
+			isGeneratingClaimToken = false;
+		}
+	}
+
 	async function copyClaimUrl() {
 		if (!claimToken) return;
 		try {
@@ -376,6 +392,15 @@
 														<span class="claim-expiry">
 															Expires {formatDate(claimToken.expires_at)}
 														</span>
+														<div class="claim-actions">
+															<button
+																class="btn-generate-claim"
+																onclick={() => regenerateClaimToken(u.vine_id!)}
+																disabled={isGeneratingClaimToken}
+															>
+																{isGeneratingClaimToken ? 'Regenerating...' : 'Regenerate'}
+															</button>
+														</div>
 													</div>
 												{:else}
 													<button
@@ -874,6 +899,12 @@
 	.btn-generate-claim:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+	}
+
+	.claim-actions {
+		display: flex;
+		gap: 0.5rem;
+		margin-top: 0.75rem;
 	}
 
 	.links-grid {


### PR DESCRIPTION
## Summary

Implements the spec at `docs/superpowers/specs/2026-04-22-claim-token-regenerate-invalidate.md`.

- Adds `invalidated_at`, `invalidated_by`, `invalidation_reason` audit columns to `account_claim_tokens` plus a partial index on `invalidated_at`.
- New `ClaimTokenState` enum + `ClaimTokenRepository::classify()` distinguishes Valid / Unrecognized / AlreadyClaimed / AdminInvalidated / Replaced / Expired.
- **Regenerate**: `POST /api/admin/claim-tokens` (existing endpoint) now invalidates prior valid tokens for the user atomically with the new insert, via `create_with_prior_invalidation`. Invalidation reason is `'replaced_by_regenerate'`. Response shape unchanged.
- **Invalidate**: new `POST /api/admin/claim-tokens/invalidate` kills the current valid token without replacement. Takes `{vine_id, reason?}`. Support-admin-gated. Idempotent.
- Claim-page error copy now distinguishes each terminal state with actionable user-facing messages instead of the prior generic "invalid or already used." See spec table.
- Support Admin UI: Regenerate and Invalidate buttons added next to the existing claim-link display. Invalidate opens a confirmation modal with an optional reason field.

No grace window on invalidation, by design (see spec "Non-goals"). The confirmation modal on Invalidate is the guardrail.

## Test plan

- [x] Repo-level integration tests for `classify` (six tests covering every state variant)
- [x] Repo-level integration tests for `invalidate_valid_for_user` (happy path, idempotent no-op, skips used/already-invalidated)
- [x] Repo-level integration tests for `create_with_prior_invalidation` (transactional regenerate, no-op when no priors)
- [x] `cargo check --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `bun run check` / biome in CI (no local bun available tonight; CI will cover)
- [ ] Manual end-to-end smoke through the Support Admin UI (blocked on local web stack tonight; plan Task 10 Step 3 spells out the flow for PR validation)

## Files

- `database/migrations/20260422120000_claim_token_invalidation.sql`
- `core/src/types/claim_token.rs` (+ClaimTokenState enum, +3 fields)
- `core/src/repositories/claim_token.rs` (+classify, +invalidate_valid_for_user, +create_with_prior_invalidation)
- `api/src/api/http/admin.rs` (existing create handler rewired; new invalidate handler)
- `api/src/api/http/routes.rs` (+invalidate route)
- `api/src/api/http/claim.rs` (ClaimError variants + state-specific error pages)
- `web/src/routes/support-admin/+page.svelte` (Regenerate + Invalidate buttons)
- `web/src/lib/components/InvalidateClaimTokenModal.svelte` (new)
- `api/tests/claim_token_classify_test.rs` (new)
- `api/tests/claim_token_invalidate_repo_test.rs` (new)
- `api/tests/claim_token_create_with_invalidation_test.rs` (new)