### PR TITLE
feat(claim-token): extend default claim-link lifetime from 7 to 14 days

### DIFF
--- a/api/src/email_service.rs
+++ b/api/src/email_service.rs
@@ -455,7 +455,7 @@ impl EmailSender for SendGridEmailSender {
                     <a href="{}" style="color: #00B488;">{}</a>
                 </p>
                 <p style="color: #666; font-size: 14px; margin-top: 30px;">
-                    This link will expire in 7 days. If you didn't request this, you can safely ignore this email.
+                    This link will expire in 14 days. If you didn't request this, you can safely ignore this email.
                 </p>
             </body>
             </html>
@@ -464,7 +464,7 @@ impl EmailSender for SendGridEmailSender {
         );
 
         let text_content = format!(
-            "Your Vine account has been migrated to Divine. Click this link to claim it:\n\n{}\n\nThis link will expire in 7 days. If you didn't request this, you can safely ignore this email.",
+            "Your Vine account has been migrated to Divine. Click this link to claim it:\n\n{}\n\nThis link will expire in 14 days. If you didn't request this, you can safely ignore this email.",
             claim_url
         );
 

--- a/core/src/types/claim_token.rs
+++ b/core/src/types/claim_token.rs
@@ -3,8 +3,15 @@ use chrono::{DateTime, Utc};
 use rand::Rng;
 use sqlx::FromRow;
 
-/// Claim token expiry in days (7 days)
-pub const CLAIM_TOKEN_EXPIRY_DAYS: i64 = 7;
+/// Claim token expiry in days (14 days).
+///
+/// Extended from 7 to 14 days in response to marketing/support feedback
+/// from early onboarding conversations with OG Vine creators: the original
+/// 7-day window frequently expired before the creator actually tried to
+/// claim (travel, busy weeks, missed email). 14 days more realistically
+/// matches the rhythm of those handoffs without extending credential
+/// exposure unreasonably.
+pub const CLAIM_TOKEN_EXPIRY_DAYS: i64 = 14;
 
 /// Account claim token for preloaded users to claim their accounts
 #[derive(Debug, FromRow)]

--- a/web/src/routes/admin/+page.svelte
+++ b/web/src/routes/admin/+page.svelte
@@ -487,7 +487,7 @@
 						<table class="params-table">
 							<tbody>
 								<tr><td><code>claim_url</code></td><td>URL to send to the user</td></tr>
-								<tr><td><code>expires_at</code></td><td>Link expiration (7 days)</td></tr>
+								<tr><td><code>expires_at</code></td><td>Link expiration (14 days)</td></tr>
 							</tbody>
 						</table>
 
@@ -495,7 +495,7 @@
 						<pre class="code-block">{claimTokenExample}</pre>
 
 						<p class="doc-note">
-							Claim links are single-use and expire after 7 days. You can generate new links for the same user if needed.
+							Claim links are single-use and expire after 14 days. You can generate new links for the same user if needed.
 						</p>
 					</div>
 				{/if}


### PR DESCRIPTION
## Summary

Extend the default claim-link lifetime from 7 to 14 days, driven by marketing/support feedback from early onboarding conversations with OG Vine creators.

The existing 7-day window frequently expires before the creator actually tries to claim — travel, busy weeks, missed first email. 14 days better matches the realistic rhythm of those handoffs without meaningfully widening credential exposure, especially now that admin-initiated regenerate (#122) and invalidate are available if a link needs to be rotated or killed.

## Changes

- `core/src/types/claim_token.rs`: `CLAIM_TOKEN_EXPIRY_DAYS` 7 → 14, with a doc comment explaining the rationale.
- `api/src/email_service.rs`: both claim-invite email templates (HTML + text) updated from "expire in 7 days" to "14 days".
- `web/src/routes/admin/+page.svelte`: admin docs page references updated from 7 to 14 days.

## Not changed (intentionally)

- The 7-day session-cookie `Max-Age` in `api/src/api/http/claim.rs` (after a successful claim) — that's the post-claim session, unrelated to the claim-link expiry.
- Log-retention references in `docs/SIGNER_RELIABILITY_GUIDE.md` — unrelated.

## Test plan

- [x] `cargo check --all-targets` clean
- [x] No tests assert against `CLAIM_TOKEN_EXPIRY_DAYS` directly; test data that uses `Duration::days(7)` constructs specific rows and is unaffected by the constant change
- [ ] CI integration tests pass on PR
- [ ] Manual smoke: generate a claim link post-deploy, confirm `expires_at` is ~14 days out

## Coordination

PR #122 (regenerate + invalidate + state-specific error pages) is in flight and also touches the claim-link surface. When #122 merges first, this PR will need a trivial conflict resolution: updating the TokenExpired error-page copy from "Claim links are valid for 7 days" to "14 days" in `api/src/api/http/claim.rs`. Noting it here so whoever merges second doesn't miss it.