### PR TITLE
fix: tenant seed branding + centralize backend brand strings

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -14,6 +14,7 @@ use secrecy::{ExposeSecret, SecretString};
 use super::admin::{is_full_admin, is_support_admin};
 use crate::api::extractors::UcanAuth;
 use crate::bcrypt_queue::{BcryptJob, BcryptQueueError};
+use crate::brand::BRAND_NAME;
 use crate::nip98;
 use keycast_core::metrics::METRICS;
 use keycast_core::repositories::{
@@ -3414,8 +3415,7 @@ pub async fn delete_account(
             "Denied: not user-signed and not first-party"
         );
         return Err(AuthError::Forbidden(
-            "Account deletion requires the Divine app or web login with your private key"
-                .to_string(),
+            format!("Account deletion requires the {} app or web login with your private key", BRAND_NAME),
         ));
     }
 

--- a/api/src/api/http/claim.rs
+++ b/api/src/api/http/claim.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 
 use super::html_safety::escape_html;
 use super::routes::AuthState;
+use crate::brand::BRAND_NAME;
 use keycast_core::repositories::{ClaimTokenRepository, UserRepository};
 
 /// Get server keys from SERVER_NSEC environment variable
@@ -521,7 +522,7 @@ pub async fn claim_post(
                 <div class="step-num">1</div>
                 <div class="step-content">
                     <div class="step-title">Get the App</div>
-                    <div class="step-desc">Download Divine for the best experience.</div>
+                    <div class="step-desc">Download {brand} for the best experience.</div>
                     <div class="app-links">
                         <a class="app-link" href="https://apps.apple.com/app/divine-video/id6744577425" target="_blank">
                             &#63743; App Store
@@ -551,13 +552,14 @@ pub async fn claim_post(
         <div class="divider"></div>
 
         <a class="web-link" href="https://divine.video" target="_blank">
-            Open Divine on Web
+            Open {brand} on Web
         </a>
         <p class="note">You can also access your account at divine.video</p>
     </div>
 </body>
 </html>"#,
         display_name = escape_html(&display_name_str),
+        brand = BRAND_NAME,
     );
 
     Ok(([(header::SET_COOKIE, cookie_value)], Html(html)).into_response())

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 // Import constants and helpers from auth module
 use super::auth::{generate_secure_token, token_expiry_seconds, EMAIL_VERIFICATION_EXPIRY_HOURS};
 use super::html_safety::{escape_attr, escape_html, js_string_literal};
+use crate::brand::BRAND_NAME;
 
 /// Generate a 256-bit random authorization handle (64 hex characters)
 /// Used for silent re-authentication in OAuth flows
@@ -1222,7 +1223,7 @@ pub async fn authorize_get(
     <div class="container">
         <div class="header">
             <div class="logo">
-                <img src="/divine-logo.svg" alt="Divine" />
+                <img src="/divine-logo.svg" alt="{brand}" />
                 <span class="logo-sub">Login</span>
             </div>
             <h1>Authorize App</h1>
@@ -1253,7 +1254,7 @@ pub async fn authorize_get(
             </div>
 
             <p class="disclaimer">
-                By authorizing, you agree to Divine's <a href="https://divine.video/terms" target="_blank">terms</a> and <a href="https://divine.video/privacy" target="_blank">privacy policy</a>.
+                By authorizing, you agree to {brand}'s <a href="https://divine.video/terms" target="_blank">terms</a> and <a href="https://divine.video/privacy" target="_blank">privacy policy</a>.
             </p>
 
             <div class="buttons">
@@ -1499,6 +1500,7 @@ pub async fn authorize_get(
                 user_pubkey_js = js_string_literal(&pubkey),
                 user_email_js = js_string_literal(&user_email.as_deref().unwrap_or("")),
                 policy_info_json = policy_info_json, // already JSON-serialized
+                brand = BRAND_NAME,
             )
         }
     } else {
@@ -1510,7 +1512,7 @@ pub async fn authorize_get(
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <title>Sign in - Divine Login</title>
+    <title>Sign in - {brand} Login</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Bricolage+Grotesque:wght@600;700&display=swap" rel="stylesheet">
@@ -1820,7 +1822,7 @@ pub async fn authorize_get(
     <div class="container">
         <div class="header">
             <div class="logo">
-                <img src="/divine-logo.svg" alt="Divine" />
+                <img src="/divine-logo.svg" alt="{brand}" />
                 <span class="logo-sub">Login</span>
             </div>
             <h1>Sign in</h1>
@@ -1937,11 +1939,11 @@ pub async fn authorize_get(
             if (form === 'login') {{
                 document.getElementById('login_view').classList.add('active');
                 if (headerTitle) headerTitle.textContent = 'Sign in';
-                document.title = 'Sign in - Divine Login';
+                document.title = 'Sign in - {brand} Login';
             }} else {{
                 document.getElementById('register_view').classList.add('active');
                 if (headerTitle) headerTitle.textContent = 'Create account';
-                document.title = 'Create account - Divine Login';
+                document.title = 'Create account - {brand} Login';
             }}
 
             hideError();
@@ -2191,6 +2193,7 @@ pub async fn authorize_get(
             code_challenge_js = js_string_literal(&params.code_challenge.as_deref().unwrap_or("")),
             code_challenge_method_js =
                 js_string_literal(&params.code_challenge_method.as_deref().unwrap_or("")),
+            brand = BRAND_NAME,
         )
     };
 
@@ -3544,7 +3547,7 @@ pub async fn connect_get(
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <title>Authorize Connection - Divine Login</title>
+    <title>Authorize Connection - {brand} Login</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Bricolage+Grotesque:wght@600;700&display=swap" rel="stylesheet">
@@ -3766,7 +3769,7 @@ pub async fn connect_get(
     <div class="container">
         <div class="header">
             <div class="logo">
-                <img src="/divine-logo.svg" alt="Divine" />
+                <img src="/divine-logo.svg" alt="{brand}" />
                 <span class="logo-sub">Login</span>
             </div>
             <h1>Authorize Connection</h1>
@@ -3788,7 +3791,7 @@ pub async fn connect_get(
         </div>
 
         <div class="warning">
-            This will allow the app to sign events on your behalf using your Divine-managed keys.
+            This will allow the app to sign events on your behalf using your {brand}-managed keys.
         </div>
 
         <form method="POST" action="/api/oauth/connect">
@@ -3887,6 +3890,7 @@ pub async fn connect_get(
         secret_attr = escape_attr(&params.secret),
         perms_attr = escape_attr(params.perms.as_deref().unwrap_or("")),
         permissions_raw_js = js_string_literal(&permissions_raw),
+        brand = BRAND_NAME,
     );
 
     Ok(Html(html).into_response())

--- a/api/src/brand.rs
+++ b/api/src/brand.rs
@@ -1,0 +1,1 @@
+pub const BRAND_NAME: &str = "Divine";

--- a/api/src/email_service.rs
+++ b/api/src/email_service.rs
@@ -6,6 +6,8 @@ use serde::Serialize;
 use std::env;
 use std::sync::{Arc, Mutex};
 
+use crate::brand::BRAND_NAME;
+
 /// Captured email for testing/inspection
 #[derive(Debug, Clone)]
 pub struct CapturedEmail {
@@ -96,7 +98,7 @@ impl EmailSender for DevEmailSender {
         tracing::info!("  VERIFICATION EMAIL");
         tracing::info!("==================================================");
         tracing::info!("  To: {}", to_email);
-        tracing::info!("  Subject: Verify your Divine email address");
+        tracing::info!("  Subject: Verify your {} email address", BRAND_NAME);
         tracing::info!("");
         tracing::info!("  Click to verify:");
         tracing::info!("  {}", verification_url);
@@ -113,7 +115,7 @@ impl EmailSender for DevEmailSender {
         if let Ok(mut captured) = self.captured.lock() {
             captured.push(CapturedEmail {
                 to: to_email.to_string(),
-                subject: "Verify your Divine email address".to_string(),
+                subject: format!("Verify your {} email address", BRAND_NAME),
                 verification_url: Some(verification_url),
                 reset_url: None,
             });
@@ -134,7 +136,7 @@ impl EmailSender for DevEmailSender {
         tracing::info!("  PASSWORD RESET EMAIL");
         tracing::info!("==================================================");
         tracing::info!("  To: {}", to_email);
-        tracing::info!("  Subject: Reset your Divine password");
+        tracing::info!("  Subject: Reset your {} password", BRAND_NAME);
         tracing::info!("");
         tracing::info!("  Click to reset password:");
         tracing::info!("  {}", reset_url);
@@ -151,7 +153,7 @@ impl EmailSender for DevEmailSender {
         if let Ok(mut captured) = self.captured.lock() {
             captured.push(CapturedEmail {
                 to: to_email.to_string(),
-                subject: "Reset your Divine password".to_string(),
+                subject: format!("Reset your {} password", BRAND_NAME),
                 verification_url: None,
                 reset_url: Some(reset_url),
             });
@@ -166,7 +168,7 @@ impl EmailSender for DevEmailSender {
         tracing::info!("  VINE CLAIM EMAIL");
         tracing::info!("==================================================");
         tracing::info!("  To: {}", to_email);
-        tracing::info!("  Subject: Your Vine account on Divine is ready to claim");
+        tracing::info!("  Subject: Your Vine account on {} is ready to claim", BRAND_NAME);
         tracing::info!("");
         tracing::info!("  Claim link:");
         tracing::info!("  {}", claim_url);
@@ -181,7 +183,7 @@ impl EmailSender for DevEmailSender {
         if let Ok(mut captured) = self.captured.lock() {
             captured.push(CapturedEmail {
                 to: to_email.to_string(),
-                subject: "Your Vine account on Divine is ready to claim".to_string(),
+                subject: format!("Your Vine account on {} is ready to claim", BRAND_NAME),
                 verification_url: Some(claim_url.to_string()),
                 reset_url: None,
             });
@@ -261,7 +263,7 @@ impl SendGridEmailSender {
     pub fn new(api_key: String) -> Self {
         let from_email =
             env::var("FROM_EMAIL").unwrap_or_else(|_| "noreply@divine.video".to_string());
-        let from_name = env::var("FROM_NAME").unwrap_or_else(|_| "Divine".to_string());
+        let from_name = env::var("FROM_NAME").unwrap_or_else(|_| BRAND_NAME.to_string());
         let base_url = env::var("BASE_URL")
             .or_else(|_| env::var("APP_URL"))
             .unwrap_or_else(|_| "http://localhost:5173".to_string());
@@ -359,35 +361,35 @@ impl EmailSender for SendGridEmailSender {
             self.base_url, verification_token
         );
 
-        let subject = "Verify your Divine email address".to_string();
+        let subject = format!("Verify your {} email address", BRAND_NAME);
         let html_content = format!(
             r#"
             <html>
             <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-                <h1 style="color: #00B488;">Verify your Divine email</h1>
+                <h1 style="color: #00B488;">Verify your {brand} email</h1>
                 <p>Thanks for signing up! Please verify your email address by clicking the button below:</p>
                 <div style="margin: 30px 0;">
-                    <a href="{}"
+                    <a href="{url}"
                        style="background: #00B488; color: #fff; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block; font-weight: bold;">
                         Verify Email Address
                     </a>
                 </div>
                 <p style="color: #666; font-size: 14px;">
                     Or copy and paste this link into your browser:<br>
-                    <a href="{}" style="color: #00B488;">{}</a>
+                    <a href="{url}" style="color: #00B488;">{url}</a>
                 </p>
                 <p style="color: #666; font-size: 14px; margin-top: 30px;">
-                    If you didn't sign up for Divine, you can safely ignore this email.
+                    If you didn't sign up for {brand}, you can safely ignore this email.
                 </p>
             </body>
             </html>
             "#,
-            verification_url, verification_url, verification_url
+            url = verification_url, brand = BRAND_NAME
         );
 
         let text_content = format!(
-            "Thanks for signing up! Please verify your email address by clicking this link:\n\n{}\n\nIf you didn't sign up for Divine, you can safely ignore this email.",
-            verification_url
+            "Thanks for signing up! Please verify your email address by clicking this link:\n\n{url}\n\nIf you didn't sign up for {brand}, you can safely ignore this email.",
+            url = verification_url, brand = BRAND_NAME
         );
 
         self.send_email(to_email, &subject, &html_content, &text_content)
@@ -401,22 +403,22 @@ impl EmailSender for SendGridEmailSender {
     ) -> Result<(), String> {
         let reset_url = format!("{}/reset-password?token={}", self.base_url, reset_token);
 
-        let subject = "Reset your Divine password".to_string();
+        let subject = format!("Reset your {} password", BRAND_NAME);
         let html_content = format!(
             r#"
             <html>
             <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-                <h1 style="color: #00B488;">Reset your Divine password</h1>
+                <h1 style="color: #00B488;">Reset your {brand} password</h1>
                 <p>We received a request to reset your password. Click the button below to set a new password:</p>
                 <div style="margin: 30px 0;">
-                    <a href="{}"
+                    <a href="{url}"
                        style="background: #00B488; color: #fff; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block; font-weight: bold;">
                         Reset Password
                     </a>
                 </div>
                 <p style="color: #666; font-size: 14px;">
                     Or copy and paste this link into your browser:<br>
-                    <a href="{}" style="color: #00B488;">{}</a>
+                    <a href="{url}" style="color: #00B488;">{url}</a>
                 </p>
                 <p style="color: #666; font-size: 14px; margin-top: 30px;">
                     This link will expire in 1 hour. If you didn't request a password reset, you can safely ignore this email.
@@ -424,12 +426,12 @@ impl EmailSender for SendGridEmailSender {
             </body>
             </html>
             "#,
-            reset_url, reset_url, reset_url
+            url = reset_url, brand = BRAND_NAME
         );
 
         let text_content = format!(
-            "We received a request to reset your password. Click this link to set a new password:\n\n{}\n\nThis link will expire in 1 hour. If you didn't request a password reset, you can safely ignore this email.",
-            reset_url
+            "We received a request to reset your password. Click this link to set a new password:\n\n{url}\n\nThis link will expire in 1 hour. If you didn't request a password reset, you can safely ignore this email.",
+            url = reset_url
         );
 
         self.send_email(to_email, &subject, &html_content, &text_content)
@@ -437,22 +439,22 @@ impl EmailSender for SendGridEmailSender {
     }
 
     async fn send_claim_email(&self, to_email: &str, claim_url: &str) -> Result<(), String> {
-        let subject = "Your Vine account on Divine is ready to claim".to_string();
+        let subject = format!("Your Vine account on {} is ready to claim", BRAND_NAME);
         let html_content = format!(
             r#"
             <html>
             <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
                 <h1 style="color: #00B488;">Your Vine account is ready!</h1>
-                <p>Your Vine account has been migrated to Divine. Click the button below to claim it and set up your login:</p>
+                <p>Your Vine account has been migrated to {brand}. Click the button below to claim it and set up your login:</p>
                 <div style="margin: 30px 0;">
-                    <a href="{}"
+                    <a href="{url}"
                        style="background: #00B488; color: #fff; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block; font-weight: bold;">
                         Claim Your Account
                     </a>
                 </div>
                 <p style="color: #666; font-size: 14px;">
                     Or copy and paste this link into your browser:<br>
-                    <a href="{}" style="color: #00B488;">{}</a>
+                    <a href="{url}" style="color: #00B488;">{url}</a>
                 </p>
                 <p style="color: #666; font-size: 14px; margin-top: 30px;">
                     This link will expire in 14 days. If you didn't request this, you can safely ignore this email.
@@ -460,12 +462,12 @@ impl EmailSender for SendGridEmailSender {
             </body>
             </html>
             "#,
-            claim_url, claim_url, claim_url
+            url = claim_url, brand = BRAND_NAME
         );
 
         let text_content = format!(
-            "Your Vine account has been migrated to Divine. Click this link to claim it:\n\n{}\n\nThis link will expire in 14 days. If you didn't request this, you can safely ignore this email.",
-            claim_url
+            "Your Vine account has been migrated to {brand}. Click this link to claim it:\n\n{url}\n\nThis link will expire in 14 days. If you didn't request this, you can safely ignore this email.",
+            url = claim_url, brand = BRAND_NAME
         );
 
         self.send_email(to_email, &subject, &html_content, &text_content)

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod atproto_provisioning;
 pub mod bcrypt_queue;
+pub mod brand;
 pub mod divine_names;
 pub mod email_service;
 pub mod handlers;

--- a/database/migrations/20260423100000_update_tenant_seed_branding.sql
+++ b/database/migrations/20260423100000_update_tenant_seed_branding.sql
@@ -1,0 +1,3 @@
+-- Fix seed tenant branding: "diVine" → "Divine"
+-- Only updates the seed row (id=1). Non-seed tenant names are tenant-owned.
+UPDATE tenants SET name = 'Divine', updated_at = NOW() WHERE id = 1 AND name = 'diVine';


### PR DESCRIPTION
## Summary

- **Migration (#81):** Updates seed tenant row (id=1) from `diVine` to `Divine`. Idempotent — only fires when name still reads `diVine`. Non-seed tenant rows left as tenant-owned.
- **Brand constant (#82):** New `api/src/brand.rs` with `BRAND_NAME: &str = "Divine"`. Replaces 27 hardcoded brand strings across `email_service.rs`, `oauth.rs`, and `claim.rs` with format args referencing the constant. Future brand name changes are a one-line edit.

Closes #81, closes #82. Follow-ups from PR #73.

## Test plan

- [x] `cargo check` clean
- [x] `cargo clippy --all-targets` clean (zero warnings)
- [ ] Verify migration runs on staging (`sqlx migrate run`)
- [ ] Spot-check rendered email subjects and OAuth page titles after deploy