### PR TITLE
e2e: prevent process leaks and add OAuth/DPoP security regression coverage

### DIFF
--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -78,3 +78,64 @@ export async function getVerificationToken(email: string): Promise<string> {
 
   throw new Error(`Could not find verification token for ${email}`);
 }
+
+export async function markUserAtprotoReady(
+  pubkey: string,
+  did: string,
+  tenantId?: number,
+): Promise<void> {
+  await withDb(async (db) => {
+    if (tenantId === undefined) {
+      await db.query(
+        `UPDATE users
+         SET atproto_enabled = true,
+             atproto_state = 'ready',
+             atproto_did = $1,
+             updated_at = NOW()
+         WHERE pubkey = $2`,
+        [did, pubkey],
+      );
+      return;
+    }
+
+    await db.query(
+      `UPDATE users
+       SET atproto_enabled = true,
+           atproto_state = 'ready',
+           atproto_did = $1,
+           updated_at = NOW()
+       WHERE pubkey = $2
+         AND tenant_id = $3`,
+      [did, pubkey, tenantId],
+    );
+  });
+}
+
+export async function addRegisteredClient(
+  clientId: string,
+  redirectUris: string[],
+  tenantId = 1,
+): Promise<void> {
+  await withDb(async (db) => {
+    await db.query(
+      `INSERT INTO registered_clients (client_id, allowed_redirect_uris, tenant_id, created_at, updated_at)
+       VALUES ($1, $2::text[], $3, NOW(), NOW())
+       ON CONFLICT (client_id, tenant_id)
+       DO UPDATE SET allowed_redirect_uris = EXCLUDED.allowed_redirect_uris,
+                     updated_at = NOW()`,
+      [clientId, redirectUris, tenantId],
+    );
+  });
+}
+
+export async function deleteRegisteredClient(
+  clientId: string,
+  tenantId = 1,
+): Promise<void> {
+  await withDb(async (db) => {
+    await db.query(
+      "DELETE FROM registered_clients WHERE client_id = $1 AND tenant_id = $2",
+      [clientId, tenantId],
+    );
+  });
+}

--- a/e2e/helpers/keycast-process.ts
+++ b/e2e/helpers/keycast-process.ts
@@ -1,0 +1,139 @@
+import net from "node:net";
+import path from "node:path";
+import { spawn, ChildProcess } from "node:child_process";
+
+const DEFAULT_DATABASE_URL = "postgres://postgres:password@localhost/keycast";
+const DEFAULT_REDIS_URL = "redis://localhost:16379";
+
+function isPortReachable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once("error", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+function waitForPort(port: number, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const tryConnect = () => {
+      const socket = net.createConnection({ host: "127.0.0.1", port });
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.once("error", () => {
+        socket.destroy();
+        if (Date.now() - start > timeoutMs) {
+          reject(new Error(`Port ${port} not reachable after ${timeoutMs}ms`));
+          return;
+        }
+        setTimeout(tryConnect, 200);
+      });
+    };
+    tryConnect();
+  });
+}
+
+function waitForExit(processHandle: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (processHandle.exitCode !== null) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise((resolve) => {
+    const onExit = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      processHandle.off("exit", onExit);
+      resolve(false);
+    }, timeoutMs);
+    processHandle.once("exit", onExit);
+  });
+}
+
+function defaultEnv(port: number): Record<string, string> {
+  const workspaceRoot = path.resolve(__dirname, "..", "..");
+  return {
+    DATABASE_URL: process.env.DATABASE_URL || DEFAULT_DATABASE_URL,
+    REDIS_URL: process.env.REDIS_URL || DEFAULT_REDIS_URL,
+    MASTER_KEY_PATH: process.env.MASTER_KEY_PATH || `${workspaceRoot}/master.key`,
+    SERVER_NSEC:
+      process.env.SERVER_NSEC ||
+      "0000000000000000000000000000000000000000000000000000000000000001",
+    BUNKER_RELAYS: process.env.BUNKER_RELAYS || "ws://localhost:8080",
+    ALLOWED_ORIGINS:
+      process.env.ALLOWED_ORIGINS ||
+      "http://localhost:3000,http://localhost:5173,http://localhost:5174",
+    ALLOWED_TENANT_DOMAINS:
+      process.env.ALLOWED_TENANT_DOMAINS ||
+      "localhost,tenant-a.localhost,tenant-b.localhost",
+    ATPROTO_OAUTH_JWT_PRIVATE_KEY_HEX:
+      process.env.ATPROTO_OAUTH_JWT_PRIVATE_KEY_HEX ||
+      "8f2a55949068468ad5d670dfd0c0a33d5b9e7e1a2c0d2059f0f8f8779d4d078d",
+    ATPROTO_OAUTH_PDS_DID:
+      process.env.ATPROTO_OAUTH_PDS_DID || "did:web:pds.divine.test",
+    APP_URL: process.env.APP_URL || `http://localhost:${port}`,
+    BASE_URL: process.env.BASE_URL || `http://localhost:${port}`,
+    PORT: String(port),
+  };
+}
+
+export async function startKeycastProcess(opts: {
+  port: number;
+  env?: Record<string, string>;
+  timeoutMs?: number;
+}): Promise<ChildProcess> {
+  if (await isPortReachable(opts.port)) {
+    throw new Error(`Port ${opts.port} is already in use before starting keycast`);
+  }
+
+  const workspaceRoot = path.resolve(__dirname, "..", "..");
+  const binaryPath =
+    process.env.KEYCAST_BINARY || path.join(workspaceRoot, "target", "debug", "keycast");
+
+  const child = spawn(binaryPath, [], {
+    cwd: workspaceRoot,
+    env: {
+      ...process.env,
+      ...defaultEnv(opts.port),
+      ...(opts.env || {}),
+    },
+    stdio: "pipe",
+  });
+
+  const exitedBeforeReady = new Promise<never>((_, reject) => {
+    child.once("exit", (code, signal) => {
+      reject(
+        new Error(
+          `keycast exited before becoming ready (code=${String(code)}, signal=${String(signal)})`,
+        ),
+      );
+    });
+  });
+
+  await Promise.race([waitForPort(opts.port, opts.timeoutMs ?? 30_000), exitedBeforeReady]);
+  return child;
+}
+
+export async function stopKeycastProcess(
+  processHandle: ChildProcess | null | undefined,
+): Promise<void> {
+  if (!processHandle || processHandle.exitCode !== null) {
+    return;
+  }
+
+  processHandle.kill("SIGTERM");
+  const exited = await waitForExit(processHandle, 2_000);
+  if (!exited && processHandle.exitCode === null) {
+    processHandle.kill("SIGKILL");
+    await waitForExit(processHandle, 1_000);
+  }
+}

--- a/e2e/helpers/oauth.ts
+++ b/e2e/helpers/oauth.ts
@@ -1,4 +1,11 @@
-import { createHash, randomBytes } from "node:crypto";
+import {
+  createHash,
+  createSign,
+  generateKeyPairSync,
+  KeyObject,
+  randomBytes,
+  randomUUID,
+} from "node:crypto";
 import { APIRequestContext } from "@playwright/test";
 
 export interface PKCEChallenge {
@@ -51,6 +58,276 @@ export async function exchangeCode(
 export interface AuthorizeResponse {
   code: string;
   redirect_uri: string;
+}
+
+export interface DpopKeyMaterial {
+  privateKey: KeyObject;
+  jwk: {
+    kty: string;
+    crv: string;
+    x: string;
+    y: string;
+  };
+  jkt: string;
+}
+
+export interface AtprotoParResponse {
+  request_uri: string;
+  expires_in: number;
+}
+
+export interface AtprotoTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token: string;
+  scope: string;
+  sub: string;
+}
+
+function apiOrigin(): string {
+  return new URL(process.env.API_URL || "http://localhost:3000").origin;
+}
+
+function canonicalDpopThumbprintInput(jwk: DpopKeyMaterial["jwk"]): string {
+  return `{"crv":"${jwk.crv}","kty":"${jwk.kty}","x":"${jwk.x}","y":"${jwk.y}"}`;
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function derToJose(signatureDer: Buffer, joseSize: number): string {
+  let offset = 0;
+  if (signatureDer[offset++] !== 0x30) {
+    throw new Error("Invalid DER signature (missing sequence)");
+  }
+
+  const sequenceLength = signatureDer[offset++];
+  if (sequenceLength + 2 !== signatureDer.length) {
+    throw new Error("Invalid DER signature length");
+  }
+
+  if (signatureDer[offset++] !== 0x02) {
+    throw new Error("Invalid DER signature (missing r)");
+  }
+  const rLength = signatureDer[offset++];
+  const r = signatureDer.slice(offset, offset + rLength);
+  offset += rLength;
+
+  if (signatureDer[offset++] !== 0x02) {
+    throw new Error("Invalid DER signature (missing s)");
+  }
+  const sLength = signatureDer[offset++];
+  const s = signatureDer.slice(offset, offset + sLength);
+
+  const componentSize = joseSize / 2;
+  const paddedR = Buffer.concat([Buffer.alloc(componentSize), r]).slice(
+    -componentSize,
+  );
+  const paddedS = Buffer.concat([Buffer.alloc(componentSize), s]).slice(
+    -componentSize,
+  );
+
+  return Buffer.concat([paddedR, paddedS]).toString("base64url");
+}
+
+export function generateDpopKeyMaterial(): DpopKeyMaterial {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", {
+    namedCurve: "prime256v1",
+  });
+  const exported = publicKey.export({ format: "jwk" }) as {
+    kty?: string;
+    crv?: string;
+    x?: string;
+    y?: string;
+  };
+
+  if (
+    exported.kty !== "EC" ||
+    exported.crv !== "P-256" ||
+    !exported.x ||
+    !exported.y
+  ) {
+    throw new Error("Unexpected EC key export for DPoP");
+  }
+
+  const jwk = {
+    kty: exported.kty,
+    crv: exported.crv,
+    x: exported.x,
+    y: exported.y,
+  };
+  const jkt = createHash("sha256")
+    .update(canonicalDpopThumbprintInput(jwk))
+    .digest("base64url");
+
+  return { privateKey, jwk, jkt };
+}
+
+export function createDpopProof(
+  material: DpopKeyMaterial,
+  opts: {
+    method: "POST" | "GET";
+    htu: string;
+    nonce?: string;
+    ath?: string;
+    iat?: number;
+    jti?: string;
+  },
+): string {
+  const header = {
+    typ: "dpop+jwt",
+    alg: "ES256",
+    jwk: material.jwk,
+  };
+  const payload: Record<string, string | number> = {
+    jti: opts.jti || `dpop-${randomUUID()}`,
+    htm: opts.method,
+    htu: opts.htu,
+    iat: opts.iat ?? Math.floor(Date.now() / 1000),
+  };
+  if (opts.nonce) payload.nonce = opts.nonce;
+  if (opts.ath) payload.ath = opts.ath;
+
+  const encodedHeader = base64UrlJson(header);
+  const encodedPayload = base64UrlJson(payload);
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  const signer = createSign("SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const derSignature = signer.sign(material.privateKey);
+  const joseSignature = derToJose(derSignature, 64);
+
+  return `${signingInput}.${joseSignature}`;
+}
+
+export async function atprotoPar(
+  request: APIRequestContext,
+  opts: {
+    dpopKey: DpopKeyMaterial;
+    clientId: string;
+    redirectUri: string;
+    scope?: string;
+    state?: string;
+    codeChallenge: string;
+    codeChallengeMethod?: "S256";
+    host?: string;
+    proofJti?: string;
+  },
+): Promise<{ body: AtprotoParResponse; nonce: string }> {
+  const htu = `${apiOrigin()}/api/atproto/oauth/par`;
+  const proof = createDpopProof(opts.dpopKey, {
+    method: "POST",
+    htu,
+    jti: opts.proofJti,
+  });
+
+  const body = new URLSearchParams({
+    client_id: opts.clientId,
+    redirect_uri: opts.redirectUri,
+    scope: opts.scope || "atproto",
+    state: opts.state || `state-${Date.now()}`,
+    code_challenge: opts.codeChallenge,
+    code_challenge_method: opts.codeChallengeMethod || "S256",
+  });
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    DPoP: proof,
+  };
+  if (opts.host) headers.Host = opts.host;
+
+  const res = await request.post("/api/atproto/oauth/par", {
+    headers,
+    data: body.toString(),
+  });
+  if (!res.ok()) {
+    throw new Error(`PAR failed (${res.status()}): ${await res.text()}`);
+  }
+
+  const nonce = res.headers()["dpop-nonce"];
+  if (!nonce) {
+    throw new Error("Missing DPoP-Nonce on PAR response");
+  }
+
+  return { body: await res.json(), nonce };
+}
+
+export async function atprotoAuthorize(
+  request: APIRequestContext,
+  opts: { cookie: string; requestUri: string; host?: string },
+): Promise<{ location: string; code: string }> {
+  const headers: Record<string, string> = { Cookie: opts.cookie };
+  if (opts.host) headers.Host = opts.host;
+
+  const res = await request.get(
+    `/api/atproto/oauth/authorize?request_uri=${encodeURIComponent(opts.requestUri)}`,
+    { headers, maxRedirects: 0 },
+  );
+  if (res.status() !== 303 && res.status() !== 302) {
+    throw new Error(`ATProto authorize failed (${res.status()}): ${await res.text()}`);
+  }
+
+  const location = res.headers()["location"] || "";
+  const url = new URL(location);
+  const code = url.searchParams.get("code");
+  if (!code) {
+    throw new Error(`Missing code in authorize redirect: ${location}`);
+  }
+  return { location, code };
+}
+
+export async function atprotoExchangeCode(
+  request: APIRequestContext,
+  opts: {
+    dpopKey: DpopKeyMaterial;
+    nonce: string;
+    code: string;
+    clientId: string;
+    redirectUri: string;
+    codeVerifier: string;
+    host?: string;
+    proofJti?: string;
+  },
+): Promise<{ body: AtprotoTokenResponse; nonce: string }> {
+  const htu = `${apiOrigin()}/api/atproto/oauth/token`;
+  const proof = createDpopProof(opts.dpopKey, {
+    method: "POST",
+    htu,
+    nonce: opts.nonce,
+    jti: opts.proofJti,
+  });
+
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: opts.code,
+    client_id: opts.clientId,
+    redirect_uri: opts.redirectUri,
+    code_verifier: opts.codeVerifier,
+  });
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    DPoP: proof,
+  };
+  if (opts.host) headers.Host = opts.host;
+
+  const res = await request.post("/api/atproto/oauth/token", {
+    headers,
+    data: body.toString(),
+  });
+  if (!res.ok()) {
+    throw new Error(`ATProto token failed (${res.status()}): ${await res.text()}`);
+  }
+
+  const nextNonce = res.headers()["dpop-nonce"];
+  if (!nextNonce) {
+    throw new Error("Missing DPoP-Nonce on ATProto token response");
+  }
+
+  return { body: await res.json(), nonce: nextNonce };
 }
 
 export async function apiAuthorize(

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -65,13 +65,19 @@ test.describe("Authentication flows", () => {
     });
     expect(registerRes.ok()).toBe(true);
 
-    // Wait for bcrypt
-    await new Promise((r) => setTimeout(r, 1500));
-
-    const loginRes = await request.post("/api/auth/login", {
-      data: { email, password },
-    });
-    expect(loginRes.status()).toBe(403);
+    // Wait for async bcrypt queue to settle enough for deterministic auth-state checks.
+    let status = 0;
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const loginRes = await request.post("/api/auth/login", {
+        data: { email, password },
+      });
+      status = loginRes.status();
+      if (status === 403) {
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 300));
+    }
+    expect(status).toBe(403);
   });
 
   test("logout clears session cookie", async ({ request }) => {

--- a/e2e/tests/oauth-security.spec.ts
+++ b/e2e/tests/oauth-security.spec.ts
@@ -1,0 +1,256 @@
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { expect, request as playwrightRequest, test } from "@playwright/test";
+import { parseCookieValue, registerAndVerify } from "../helpers/auth";
+import {
+  atprotoAuthorize,
+  atprotoExchangeCode,
+  atprotoPar,
+  completeOAuthFlow,
+  createDpopProof,
+  generateDpopKeyMaterial,
+  generatePKCE,
+} from "../helpers/oauth";
+import { markUserAtprotoReady } from "../helpers/db";
+import { startKeycastProcess, stopKeycastProcess } from "../helpers/keycast-process";
+
+async function setupAtprotoReadyUser(requestCtx: any): Promise<{ cookie: string }> {
+  const email = `e2e-atproto-${Date.now()}-${Math.random().toString(36).slice(2, 7)}@test.local`;
+  const { cookie } = await registerAndVerify(requestCtx, email, "TestPass123!");
+  const sessionCookie = `keycast_session=${parseCookieValue(cookie)}`;
+
+  const accountRes = await requestCtx.get("/api/user/account", {
+    headers: { Cookie: sessionCookie },
+  });
+  if (!accountRes.ok()) {
+    throw new Error(
+      `Failed to fetch account for ATProto setup (${accountRes.status()}): ${await accountRes.text()}`,
+    );
+  }
+  const account = await accountRes.json();
+  await markUserAtprotoReady(account.public_key, `did:plc:${Date.now()}atproto`);
+
+  return { cookie: sessionCookie };
+}
+
+function decodeJwtPayload(token: string): Record<string, any> {
+  const payload = token.split(".")[1];
+  return JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+}
+
+test.describe("OAuth security regressions", () => {
+  let atprotoServer: any;
+  let atprotoApi: any;
+
+  test.beforeAll(async () => {
+    atprotoServer = await startKeycastProcess({
+      port: 3410,
+      env: {
+        ENABLE_TENANT_AUTO_PROVISIONING: "true",
+      },
+    });
+    atprotoApi = await playwrightRequest.newContext({
+      baseURL: "http://localhost:3410",
+    });
+  });
+
+  test.afterAll(async () => {
+    await atprotoApi?.dispose();
+    await stopKeycastProcess(atprotoServer);
+  });
+
+  test("ATProto OAuth code exchange returns DPoP-bound tokens", async () => {
+    const { cookie } = await setupAtprotoReadyUser(atprotoApi);
+    const pkce = generatePKCE();
+    const dpopKey = generateDpopKeyMaterial();
+    const clientId = "https://client.example";
+    const redirectUri = "https://client.example/callback";
+
+    const par = await atprotoPar(atprotoApi, {
+      dpopKey,
+      clientId,
+      redirectUri,
+      codeChallenge: pkce.challenge,
+      codeChallengeMethod: pkce.method,
+    });
+
+    const authorized = await atprotoAuthorize(atprotoApi, {
+      cookie,
+      requestUri: par.body.request_uri,
+    });
+
+    const token = await atprotoExchangeCode(atprotoApi, {
+      dpopKey,
+      nonce: par.nonce,
+      code: authorized.code,
+      clientId,
+      redirectUri,
+      codeVerifier: pkce.verifier,
+    });
+
+    expect(token.body.token_type).toBe("DPoP");
+    expect(token.body.scope).toBe("atproto");
+    const payload = decodeJwtPayload(token.body.access_token);
+    expect(payload.cnf?.jkt).toBe(dpopKey.jkt);
+  });
+
+  test("ATProto OAuth rejects missing and replayed DPoP proofs", async () => {
+    const pkce = generatePKCE();
+    const formBody = new URLSearchParams({
+      client_id: "https://client.example",
+      redirect_uri: "https://client.example/callback",
+      scope: "atproto",
+      state: "state-replay",
+      code_challenge: pkce.challenge,
+      code_challenge_method: pkce.method,
+    }).toString();
+
+    const missingProof = await atprotoApi.post("/api/atproto/oauth/par", {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      data: formBody,
+    });
+    expect(missingProof.status()).toBe(400);
+
+    const dpopKey = generateDpopKeyMaterial();
+    const fixedJti = `dpop-fixed-${Date.now()}`;
+    const firstProof = createDpopProof(dpopKey, {
+      method: "POST",
+      htu: `${new URL(process.env.API_URL || "http://localhost:3000").origin}/api/atproto/oauth/par`,
+      jti: fixedJti,
+      iat: Math.floor(Date.now() / 1000),
+    });
+
+    const first = await atprotoApi.post("/api/atproto/oauth/par", {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        DPoP: firstProof,
+      },
+      data: formBody,
+    });
+    expect(first.status()).toBe(200);
+
+    const replay = await atprotoApi.post("/api/atproto/oauth/par", {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        DPoP: firstProof,
+      },
+      data: formBody,
+    });
+    expect(replay.status()).toBe(400);
+    expect(await replay.text()).toContain("already been used");
+  });
+
+  test("Cross-tenant resource access is rejected for OAuth tokens", async () => {
+    const isolatedPort = 3411;
+    const server = await startKeycastProcess({
+      port: isolatedPort,
+      env: {
+        ENABLE_TENANT_AUTO_PROVISIONING: "false",
+      },
+    });
+
+    try {
+      const isolatedApi = await playwrightRequest.newContext({
+        baseURL: `http://localhost:${isolatedPort}`,
+      });
+
+      const email = `e2e-cross-tenant-${Date.now()}@test.local`;
+      const { cookie } = await registerAndVerify(isolatedApi, email, "TestPass123!");
+      const sessionCookie = `keycast_session=${parseCookieValue(cookie)}`;
+      const token = await completeOAuthFlow(isolatedApi, sessionCookie, {
+        clientId: `e2e-cross-tenant-client-${Date.now()}`,
+      });
+
+      const crossTenant = await isolatedApi.post("/api/nostr", {
+        headers: {
+          Authorization: `Bearer ${token.access_token}`,
+          Host: "tenant-b.localhost",
+        },
+        data: { method: "get_public_key", params: [] },
+      });
+
+      expect([400, 401, 403]).toContain(crossTenant.status());
+    } finally {
+      await stopKeycastProcess(server);
+    }
+  });
+
+  test("Strict mode rejects unknown OAuth clients", async () => {
+    const isolatedPort = 3412;
+    const server = await startKeycastProcess({
+      port: isolatedPort,
+      env: {
+        REQUIRE_REGISTERED_OAUTH_CLIENTS: "true",
+      },
+    });
+
+    try {
+      const isolatedApi = await playwrightRequest.newContext({
+        baseURL: `http://localhost:${isolatedPort}`,
+      });
+      const res = await isolatedApi.get(
+        `/api/oauth/authorize?client_id=unknown-security-client&redirect_uri=${encodeURIComponent(
+          "http://localhost:3456/callback.html",
+        )}&scope=policy:full`,
+      );
+      expect(res.status()).toBe(400);
+      expect(await res.text()).toContain("Unregistered client");
+    } finally {
+      await stopKeycastProcess(server);
+    }
+  });
+
+  test("Production mode fails closed when email provider is missing", async () => {
+    const workspaceRoot = path.resolve(__dirname, "..", "..");
+    const binaryPath =
+      process.env.KEYCAST_BINARY || path.join(workspaceRoot, "target", "debug", "keycast");
+
+    let child: ReturnType<typeof spawn> | null = null;
+    let output = "";
+
+    try {
+      child = spawn(binaryPath, [], {
+        cwd: workspaceRoot,
+        env: {
+          ...process.env,
+          DATABASE_URL:
+            process.env.DATABASE_URL || "postgres://postgres:password@localhost/keycast",
+          REDIS_URL: process.env.REDIS_URL || "redis://localhost:16379",
+          MASTER_KEY_PATH: process.env.MASTER_KEY_PATH || path.join(workspaceRoot, "master.key"),
+          SERVER_NSEC:
+            process.env.SERVER_NSEC ||
+            "0000000000000000000000000000000000000000000000000000000000000001",
+          BUNKER_RELAYS: process.env.BUNKER_RELAYS || "ws://localhost:8080",
+          ALLOWED_ORIGINS:
+            process.env.ALLOWED_ORIGINS || "http://localhost:3000,http://localhost:5173",
+          ALLOWED_TENANT_DOMAINS: process.env.ALLOWED_TENANT_DOMAINS || "localhost",
+          RUST_ENV: "production",
+          SENDGRID_API_KEY: "",
+          DISABLE_EMAILS: "",
+          PORT: "3413",
+        },
+        stdio: "pipe",
+      });
+
+      child.stdout.on("data", (chunk) => {
+        output += chunk.toString();
+      });
+      child.stderr.on("data", (chunk) => {
+        output += chunk.toString();
+      });
+
+      const exitCode = await Promise.race<number | null>([
+        new Promise<number | null>((resolve) => {
+          child?.once("close", resolve);
+        }),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 15_000)),
+      ]);
+
+      expect(exitCode).not.toBeNull();
+      expect(exitCode).not.toBe(0);
+      expect(output).toContain("SENDGRID_API_KEY required in production");
+    } finally {
+      await stopKeycastProcess(child);
+    }
+  });
+});

--- a/e2e/tests/oauth.spec.ts
+++ b/e2e/tests/oauth.spec.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { test, expect } from "@playwright/test";
 import { registerAndVerify, parseCookieValue } from "../helpers/auth";
 import {
@@ -21,90 +20,8 @@ async function setupUser(request: any) {
 
 async function setupBrowserUser(request: any) {
   const email = `e2e-oauth-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
-  const registerRes = await request.post("/api/auth/register", {
-    data: { email, password: PASSWORD },
-  });
-  if (!registerRes.ok()) {
-    const body = await registerRes.text();
-    throw new Error(`Registration failed (${registerRes.status()}): ${body}`);
-  }
-
-  let token = "";
-  for (let attempt = 0; attempt < 10; attempt++) {
-    token = execFileSync(
-      "docker",
-      [
-        "exec",
-        "keycast-postgres",
-        "psql",
-        "-U",
-        "postgres",
-        "-d",
-        "keycast_chooser",
-        "-t",
-        "-A",
-        "-c",
-        `SELECT email_verification_token FROM users WHERE email = '${email}'`,
-      ],
-      { encoding: "utf8" },
-    ).trim();
-
-    if (token) {
-      break;
-    }
-
-    await new Promise((r) => setTimeout(r, 300));
-  }
-
-  if (!token) {
-    throw new Error(`Could not find verification token for ${email}`);
-  }
-
-  const apiUrl = process.env.API_URL || "http://localhost:3000";
-  let setCookie: string | null = null;
-
-  for (let attempt = 0; attempt < 10; attempt++) {
-    const response = execFileSync(
-      "curl",
-      [
-        "-sS",
-        "-D",
-        "-",
-        "-H",
-        "Content-Type: application/json",
-        "-H",
-        `Origin: ${apiUrl}`,
-        "-X",
-        "POST",
-        `${apiUrl}/api/auth/verify-email`,
-        "--data",
-        JSON.stringify({ token }),
-      ],
-      { encoding: "utf8" },
-    );
-
-    const headerEnd = response.indexOf("\r\n\r\n");
-    const headers = headerEnd === -1 ? response : response.slice(0, headerEnd);
-    const body = headerEnd === -1 ? "" : response.slice(headerEnd + 4);
-
-    const cookieMatch = headers.match(/^set-cookie:\s*(.+)$/im);
-    if (cookieMatch?.[1]?.includes("keycast_session=")) {
-      setCookie = cookieMatch[1];
-      break;
-    }
-
-    if (!body.includes('"status":"processing"')) {
-      throw new Error(`Email verification did not return a session cookie: ${body}`);
-    }
-
-    await new Promise((r) => setTimeout(r, 500));
-  }
-
-  if (!setCookie || !setCookie.includes("keycast_session=")) {
-    throw new Error("No keycast_session cookie in verify-email response");
-  }
-
-  return { email, cookie: `keycast_session=${parseCookieValue(setCookie)}` };
+  const { cookie } = await registerAndVerify(request, email, PASSWORD);
+  return { email, cookie: `keycast_session=${parseCookieValue(cookie)}` };
 }
 
 test.describe("OAuth consent flow", () => {


### PR DESCRIPTION
## Summary

Closes #83. Delivers the Playwright OAuth security regression suite that was deferred from PR #67, plus the harness improvements that made it possible.

## What's new

**Test infrastructure (`e2e/helpers/`)**
- `keycast-process.ts` (new): spawn/kill the keycast binary with port-already-in-use guarding and SIGTERM → SIGKILL cleanup. Closes the stated process-leak / stale-port problem.
- `oauth.ts`: DPoP key material generation, DER→JOSE signature conversion, atproto OAuth client (`atprotoPar`, `atprotoAuthorize`, `atprotoExchangeCode`).
- `db.ts`: `markUserAtprotoReady`, `addRegisteredClient`, `deleteRegisteredClient`.

**Test cleanup**
- `oauth.spec.ts`: removes ~80 lines of `docker exec psql` + raw `curl` invocations; uses the existing `registerAndVerify` helper.
- `auth.spec.ts`: replaces a fixed 1500ms bcrypt-settling wait with a poll-with-retry loop.

**Security regression coverage (`oauth-security.spec.ts`, new) — five tests delivering #83**
1. ATProto OAuth code exchange returns DPoP-bound tokens
2. ATProto OAuth rejects missing and replayed DPoP proofs
3. Cross-tenant resource access is rejected for OAuth tokens
4. Strict mode rejects unknown OAuth clients (`REQUIRE_REGISTERED_OAUTH_CLIENTS=true`)
5. Production mode fails closed when email provider is missing

## Scope

`e2e/` only — no production code changes.

## CI note

`.github/workflows/build-test-push.yaml` currently runs only `cargo test`, `cargo clippy`, and `cargo fmt`. The new TypeScript regression suite is **not** executed in GitHub checks. The five tests above were validated locally; gating them in CI is tracked as #145.

## Follow-ups

- #142 — rename or comment hardcoded secret defaults in `keycast-process.ts` as test-only
- #143 — document or enforce sequential execution for shared-DB e2e suite
- #144 — scope the DER→JOSE helper to ES256/P-256 with a doc comment
- #145 — run the Playwright OAuth security suite in CI