### PR TITLE
signer: enforce encrypt/decrypt permissions and add coverage

### DIFF
--- a/signer/src/signer_daemon.rs
+++ b/signer/src/signer_daemon.rs
@@ -164,7 +164,8 @@ impl Nip46Handler {
     }
 
     /// Validate permissions before encrypting plaintext for a recipient.
-    async fn validate_permissions_for_encrypt(
+    #[doc(hidden)]
+    pub async fn validate_permissions_for_encrypt(
         &self,
         plaintext: &str,
         recipient_pubkey: &PublicKey,
@@ -208,7 +209,8 @@ impl Nip46Handler {
     }
 
     /// Validate permissions before decrypting ciphertext from a sender.
-    async fn validate_permissions_for_decrypt(
+    #[doc(hidden)]
+    pub async fn validate_permissions_for_decrypt(
         &self,
         ciphertext: &str,
         sender_pubkey: &PublicKey,
@@ -249,54 +251,6 @@ impl Nip46Handler {
         }
 
         Ok(())
-    }
-
-    /// Direct NIP-44 encryption helper for tests and in-process callers.
-    #[doc(hidden)]
-    pub async fn nip44_encrypt_direct(
-        &self,
-        recipient_pubkey: &PublicKey,
-        plaintext: &str,
-    ) -> SignerResult<String> {
-        self.validate_permissions_for_encrypt(plaintext, recipient_pubkey)
-            .await?;
-
-        let ciphertext = {
-            let secret = self.user_keys.secret_key().clone();
-            let pubkey = *recipient_pubkey;
-            let text = plaintext.to_string();
-            tokio::task::spawn_blocking(move || {
-                nip44::encrypt(&secret, &pubkey, &text, nip44::Version::V2)
-            })
-            .await
-            .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
-        };
-
-        Ok(ciphertext)
-    }
-
-    /// Direct NIP-44 decryption helper for tests and in-process callers.
-    #[doc(hidden)]
-    pub async fn nip44_decrypt_direct(
-        &self,
-        sender_pubkey: &PublicKey,
-        ciphertext: &str,
-    ) -> SignerResult<SecretString> {
-        self.validate_permissions_for_decrypt(ciphertext, sender_pubkey)
-            .await?;
-
-        let plaintext: SecretString = {
-            let secret = self.user_keys.secret_key().clone();
-            let pubkey = *sender_pubkey;
-            let text = ciphertext.to_string();
-            tokio::task::spawn_blocking(move || {
-                nip44::decrypt(&secret, &pubkey, &text).map(SecretString::from)
-            })
-            .await
-            .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
-        };
-
-        Ok(plaintext)
     }
 
     /// Process a NIP-46 connect request with client tracking.
@@ -1488,9 +1442,23 @@ impl UnifiedSigner {
 
                 let third_party_pubkey = PublicKey::from_hex(third_party_hex)
                     .map_err(|e| SignerError::invalid_key(e.to_string()))?;
-                let ciphertext = handler
-                    .nip44_encrypt_direct(&third_party_pubkey, plaintext)
+
+                // Validate policy before encryption
+                handler
+                    .validate_permissions_for_encrypt(plaintext, &third_party_pubkey)
                     .await?;
+
+                // CPU-bound crypto wrapped in spawn_blocking
+                let ciphertext = {
+                    let secret = handler.user_keys.secret_key().clone();
+                    let pubkey = third_party_pubkey;
+                    let text = plaintext.to_string();
+                    tokio::task::spawn_blocking(move || {
+                        nip44::encrypt(&secret, &pubkey, &text, nip44::Version::V2)
+                    })
+                    .await
+                    .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
+                };
 
                 // Log activity in background (non-blocking)
                 handler.spawn_update_activity();
@@ -1511,9 +1479,24 @@ impl UnifiedSigner {
 
                 let third_party_pubkey = PublicKey::from_hex(third_party_hex)
                     .map_err(|e| SignerError::invalid_key(e.to_string()))?;
-                let plaintext = handler
-                    .nip44_decrypt_direct(&third_party_pubkey, ciphertext)
+
+                // Validate policy before decryption
+                handler
+                    .validate_permissions_for_decrypt(ciphertext, &third_party_pubkey)
                     .await?;
+
+                // CPU-bound crypto wrapped in spawn_blocking
+                // Returns SecretString for automatic memory zeroization on drop
+                let plaintext: SecretString = {
+                    let secret = handler.user_keys.secret_key().clone();
+                    let pubkey = third_party_pubkey;
+                    let text = ciphertext.to_string();
+                    tokio::task::spawn_blocking(move || {
+                        nip44::decrypt(&secret, &pubkey, &text).map(SecretString::from)
+                    })
+                    .await
+                    .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
+                };
 
                 // Log activity in background (non-blocking)
                 handler.spawn_update_activity();

--- a/signer/src/signer_daemon.rs
+++ b/signer/src/signer_daemon.rs
@@ -163,6 +163,142 @@ impl Nip46Handler {
         Ok(())
     }
 
+    /// Validate permissions before encrypting plaintext for a recipient.
+    async fn validate_permissions_for_encrypt(
+        &self,
+        plaintext: &str,
+        recipient_pubkey: &PublicKey,
+    ) -> SignerResult<()> {
+        // Load permissions based on authorization type
+        let permissions = if self.is_oauth {
+            let oauth_auth =
+                OAuthAuthorization::find(&self.pool, self.tenant_id, self.authorization_id).await?;
+            oauth_auth.permissions(&self.pool, self.tenant_id).await?
+        } else {
+            let auth =
+                Authorization::find(&self.pool, self.tenant_id, self.authorization_id).await?;
+            auth.permissions(&self.pool, self.tenant_id).await?
+        };
+
+        // If no permissions configured, allow all (backward compatibility)
+        if permissions.is_empty() {
+            return Ok(());
+        }
+
+        let user_pubkey = self.user_keys.public_key();
+
+        // Convert and validate - ALL permissions must pass (AND logic)
+        for permission in &permissions {
+            let custom_permission = permission.to_custom_permission().map_err(|e| {
+                SignerError::invalid_permission(format!(
+                    "Failed to convert permission '{}': {}",
+                    permission.identifier, e
+                ))
+            })?;
+
+            if !custom_permission.can_encrypt(plaintext, &user_pubkey, recipient_pubkey) {
+                return Err(SignerError::permission_denied(format!(
+                    "Blocked by '{}' policy",
+                    custom_permission.identifier()
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate permissions before decrypting ciphertext from a sender.
+    async fn validate_permissions_for_decrypt(
+        &self,
+        ciphertext: &str,
+        sender_pubkey: &PublicKey,
+    ) -> SignerResult<()> {
+        // Load permissions based on authorization type
+        let permissions = if self.is_oauth {
+            let oauth_auth =
+                OAuthAuthorization::find(&self.pool, self.tenant_id, self.authorization_id).await?;
+            oauth_auth.permissions(&self.pool, self.tenant_id).await?
+        } else {
+            let auth =
+                Authorization::find(&self.pool, self.tenant_id, self.authorization_id).await?;
+            auth.permissions(&self.pool, self.tenant_id).await?
+        };
+
+        // If no permissions configured, allow all (backward compatibility)
+        if permissions.is_empty() {
+            return Ok(());
+        }
+
+        let user_pubkey = self.user_keys.public_key();
+
+        // Convert and validate - ALL permissions must pass (AND logic)
+        for permission in &permissions {
+            let custom_permission = permission.to_custom_permission().map_err(|e| {
+                SignerError::invalid_permission(format!(
+                    "Failed to convert permission '{}': {}",
+                    permission.identifier, e
+                ))
+            })?;
+
+            if !custom_permission.can_decrypt(ciphertext, sender_pubkey, &user_pubkey) {
+                return Err(SignerError::permission_denied(format!(
+                    "Blocked by '{}' policy",
+                    custom_permission.identifier()
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Direct NIP-44 encryption helper for tests and in-process callers.
+    #[doc(hidden)]
+    pub async fn nip44_encrypt_direct(
+        &self,
+        recipient_pubkey: &PublicKey,
+        plaintext: &str,
+    ) -> SignerResult<String> {
+        self.validate_permissions_for_encrypt(plaintext, recipient_pubkey)
+            .await?;
+
+        let ciphertext = {
+            let secret = self.user_keys.secret_key().clone();
+            let pubkey = *recipient_pubkey;
+            let text = plaintext.to_string();
+            tokio::task::spawn_blocking(move || {
+                nip44::encrypt(&secret, &pubkey, &text, nip44::Version::V2)
+            })
+            .await
+            .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
+        };
+
+        Ok(ciphertext)
+    }
+
+    /// Direct NIP-44 decryption helper for tests and in-process callers.
+    #[doc(hidden)]
+    pub async fn nip44_decrypt_direct(
+        &self,
+        sender_pubkey: &PublicKey,
+        ciphertext: &str,
+    ) -> SignerResult<SecretString> {
+        self.validate_permissions_for_decrypt(ciphertext, sender_pubkey)
+            .await?;
+
+        let plaintext: SecretString = {
+            let secret = self.user_keys.secret_key().clone();
+            let pubkey = *sender_pubkey;
+            let text = ciphertext.to_string();
+            tokio::task::spawn_blocking(move || {
+                nip44::decrypt(&secret, &pubkey, &text).map(SecretString::from)
+            })
+            .await
+            .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
+        };
+
+        Ok(plaintext)
+    }
+
     /// Process a NIP-46 connect request with client tracking.
     ///
     /// Validates the secret and stores the client pubkey for future request validation.
@@ -1352,18 +1488,9 @@ impl UnifiedSigner {
 
                 let third_party_pubkey = PublicKey::from_hex(third_party_hex)
                     .map_err(|e| SignerError::invalid_key(e.to_string()))?;
-
-                // CPU-bound crypto wrapped in spawn_blocking
-                let ciphertext = {
-                    let secret = handler.user_keys.secret_key().clone();
-                    let pubkey = third_party_pubkey;
-                    let text = plaintext.to_string();
-                    tokio::task::spawn_blocking(move || {
-                        nip44::encrypt(&secret, &pubkey, &text, nip44::Version::V2)
-                    })
-                    .await
-                    .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
-                };
+                let ciphertext = handler
+                    .nip44_encrypt_direct(&third_party_pubkey, plaintext)
+                    .await?;
 
                 // Log activity in background (non-blocking)
                 handler.spawn_update_activity();
@@ -1384,19 +1511,9 @@ impl UnifiedSigner {
 
                 let third_party_pubkey = PublicKey::from_hex(third_party_hex)
                     .map_err(|e| SignerError::invalid_key(e.to_string()))?;
-
-                // CPU-bound crypto wrapped in spawn_blocking
-                // Returns SecretString for automatic memory zeroization on drop
-                let plaintext: SecretString = {
-                    let secret = handler.user_keys.secret_key().clone();
-                    let pubkey = third_party_pubkey;
-                    let text = ciphertext.to_string();
-                    tokio::task::spawn_blocking(move || {
-                        nip44::decrypt(&secret, &pubkey, &text).map(SecretString::from)
-                    })
-                    .await
-                    .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
-                };
+                let plaintext = handler
+                    .nip44_decrypt_direct(&third_party_pubkey, ciphertext)
+                    .await?;
 
                 // Log activity in background (non-blocking)
                 handler.spawn_update_activity();
@@ -1418,6 +1535,11 @@ impl UnifiedSigner {
 
                 let third_party_pubkey = PublicKey::from_hex(third_party_hex)
                     .map_err(|e| SignerError::invalid_key(e.to_string()))?;
+
+                // Validate policy before encryption
+                handler
+                    .validate_permissions_for_encrypt(plaintext, &third_party_pubkey)
+                    .await?;
 
                 // CPU-bound crypto wrapped in spawn_blocking
                 let ciphertext = {
@@ -1450,6 +1572,11 @@ impl UnifiedSigner {
 
                 let third_party_pubkey = PublicKey::from_hex(third_party_hex)
                     .map_err(|e| SignerError::invalid_key(e.to_string()))?;
+
+                // Validate policy before decryption
+                handler
+                    .validate_permissions_for_decrypt(ciphertext, &third_party_pubkey)
+                    .await?;
 
                 // CPU-bound crypto wrapped in spawn_blocking
                 // Returns SecretString for automatic memory zeroization on drop

--- a/signer/tests/permission_validation_tests.rs
+++ b/signer/tests/permission_validation_tests.rs
@@ -10,6 +10,7 @@ use keycast_core::types::authorization::Authorization;
 use keycast_core::types::oauth_authorization::OAuthAuthorization;
 use keycast_signer::Nip46Handler;
 use nostr_sdk::prelude::*;
+use secrecy::ExposeSecret;
 use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -891,6 +892,105 @@ async fn test_15_null_expiry_team_authorization_loads() {
     );
 }
 
-// TODO: Add tests for encrypt/decrypt validation
+#[tokio::test]
+async fn test_16_decrypt_only_policy_denies_encrypt_allows_decrypt() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    // decrypt_only: can_decrypt=true, can_encrypt=false
+    let (policy_id, team_id) =
+        create_policy_with_permissions(&pool, 1, vec![("decrypt_only", json!({}))]).await;
+
+    let (auth, bunker_keys, user_keys) =
+        create_test_authorization(&pool, 1, team_id, policy_id, &key_manager).await;
+
+    let handler = Nip46Handler::new_for_test(
+        bunker_keys,
+        user_keys.clone(),
+        auth.secret_hash.clone(),
+        auth.id,
+        1,
+        false,
+        pool.clone(),
+    );
+
+    let recipient_keys = Keys::generate();
+    let encrypt_result = handler
+        .nip44_encrypt_direct(&recipient_keys.public_key(), "encrypted payload")
+        .await;
+    assert!(
+        matches!(
+            encrypt_result,
+            Err(keycast_signer::SignerError::PermissionDenied(_))
+        ),
+        "decrypt_only policy should deny encrypt operations"
+    );
+
+    let sender_keys = Keys::generate();
+    let ciphertext = nip44::encrypt(
+        sender_keys.secret_key(),
+        &user_keys.public_key(),
+        "message from sender",
+        nip44::Version::V2,
+    )
+    .expect("Failed to create test ciphertext");
+
+    let decrypt_result = handler
+        .nip44_decrypt_direct(&sender_keys.public_key(), &ciphertext)
+        .await;
+    assert!(
+        decrypt_result.is_ok(),
+        "decrypt_only policy should allow decrypt operations"
+    );
+    assert_eq!(
+        decrypt_result.unwrap().expose_secret(),
+        "message from sender",
+        "Decrypt result should match original plaintext"
+    );
+}
+
+#[tokio::test]
+async fn test_17_encrypt_to_self_policy_denies_decrypt_from_others() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    // encrypt_to_self requires sender_pubkey == recipient_pubkey
+    let (policy_id, team_id) =
+        create_policy_with_permissions(&pool, 1, vec![("encrypt_to_self", json!({}))]).await;
+
+    let (auth, bunker_keys, user_keys) =
+        create_test_authorization(&pool, 1, team_id, policy_id, &key_manager).await;
+
+    let handler = Nip46Handler::new_for_test(
+        bunker_keys,
+        user_keys.clone(),
+        auth.secret_hash.clone(),
+        auth.id,
+        1,
+        false,
+        pool.clone(),
+    );
+
+    let sender_keys = Keys::generate();
+    let ciphertext = nip44::encrypt(
+        sender_keys.secret_key(),
+        &user_keys.public_key(),
+        "message from other user",
+        nip44::Version::V2,
+    )
+    .expect("Failed to create test ciphertext");
+
+    let decrypt_result = handler
+        .nip44_decrypt_direct(&sender_keys.public_key(), &ciphertext)
+        .await;
+    assert!(
+        matches!(
+            decrypt_result,
+            Err(keycast_signer::SignerError::PermissionDenied(_))
+        ),
+        "encrypt_to_self should deny decrypt requests from other pubkeys"
+    );
+}
+
 // TODO: Add test for invalid policy_id handling
 // TODO: Add test for permission loading failure

--- a/signer/tests/permission_validation_tests.rs
+++ b/signer/tests/permission_validation_tests.rs
@@ -10,7 +10,6 @@ use keycast_core::types::authorization::Authorization;
 use keycast_core::types::oauth_authorization::OAuthAuthorization;
 use keycast_signer::Nip46Handler;
 use nostr_sdk::prelude::*;
-use secrecy::ExposeSecret;
 use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -916,7 +915,7 @@ async fn test_16_decrypt_only_policy_denies_encrypt_allows_decrypt() {
 
     let recipient_keys = Keys::generate();
     let encrypt_result = handler
-        .nip44_encrypt_direct(&recipient_keys.public_key(), "encrypted payload")
+        .validate_permissions_for_encrypt("encrypted payload", &recipient_keys.public_key())
         .await;
     assert!(
         matches!(
@@ -927,25 +926,12 @@ async fn test_16_decrypt_only_policy_denies_encrypt_allows_decrypt() {
     );
 
     let sender_keys = Keys::generate();
-    let ciphertext = nip44::encrypt(
-        sender_keys.secret_key(),
-        &user_keys.public_key(),
-        "message from sender",
-        nip44::Version::V2,
-    )
-    .expect("Failed to create test ciphertext");
-
     let decrypt_result = handler
-        .nip44_decrypt_direct(&sender_keys.public_key(), &ciphertext)
+        .validate_permissions_for_decrypt("any-ciphertext", &sender_keys.public_key())
         .await;
     assert!(
         decrypt_result.is_ok(),
         "decrypt_only policy should allow decrypt operations"
-    );
-    assert_eq!(
-        decrypt_result.unwrap().expose_secret(),
-        "message from sender",
-        "Decrypt result should match original plaintext"
     );
 }
 
@@ -972,16 +958,8 @@ async fn test_17_encrypt_to_self_policy_denies_decrypt_from_others() {
     );
 
     let sender_keys = Keys::generate();
-    let ciphertext = nip44::encrypt(
-        sender_keys.secret_key(),
-        &user_keys.public_key(),
-        "message from other user",
-        nip44::Version::V2,
-    )
-    .expect("Failed to create test ciphertext");
-
     let decrypt_result = handler
-        .nip44_decrypt_direct(&sender_keys.public_key(), &ciphertext)
+        .validate_permissions_for_decrypt("any-ciphertext", &sender_keys.public_key())
         .await;
     assert!(
         matches!(

--- a/signer/tests/permission_validation_tests.rs
+++ b/signer/tests/permission_validation_tests.rs
@@ -935,6 +935,51 @@ async fn test_16_decrypt_only_policy_denies_encrypt_allows_decrypt() {
     );
 }
 
+/// OAuth-authorization branch of validate_permissions_for_*.
+/// Mirrors test_16 but exercises the `is_oauth=true` path that loads via OAuthAuthorization::find.
+#[tokio::test]
+async fn test_16b_oauth_decrypt_only_policy_denies_encrypt_allows_decrypt() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    let (policy_id, _team_id) =
+        create_policy_with_permissions(&pool, 1, vec![("decrypt_only", json!({}))]).await;
+
+    let (oauth_auth, user_keys) =
+        create_oauth_authorization(&pool, 1, Some(policy_id), &key_manager).await;
+
+    let handler = Nip46Handler::new_for_test(
+        user_keys.clone(),
+        user_keys.clone(),
+        oauth_auth.secret_hash.clone(),
+        oauth_auth.id,
+        1,
+        true,
+        pool.clone(),
+    );
+
+    let recipient_keys = Keys::generate();
+    let encrypt_result = handler
+        .validate_permissions_for_encrypt("encrypted payload", &recipient_keys.public_key())
+        .await;
+    assert!(
+        matches!(
+            encrypt_result,
+            Err(keycast_signer::SignerError::PermissionDenied(_))
+        ),
+        "OAuth decrypt_only policy should deny encrypt operations"
+    );
+
+    let sender_keys = Keys::generate();
+    let decrypt_result = handler
+        .validate_permissions_for_decrypt("any-ciphertext", &sender_keys.public_key())
+        .await;
+    assert!(
+        decrypt_result.is_ok(),
+        "OAuth decrypt_only policy should allow decrypt operations"
+    );
+}
+
 #[tokio::test]
 async fn test_17_encrypt_to_self_policy_denies_decrypt_from_others() {
     let pool = setup_test_db().await;
@@ -967,6 +1012,102 @@ async fn test_17_encrypt_to_self_policy_denies_decrypt_from_others() {
             Err(keycast_signer::SignerError::PermissionDenied(_))
         ),
         "encrypt_to_self should deny decrypt requests from other pubkeys"
+    );
+}
+
+/// Backward-compat: when a policy has no permissions linked, encrypt/decrypt validation must
+/// allow the operation. Locks in the `permissions.is_empty() → Ok(())` fallback branch.
+#[tokio::test]
+async fn test_18_no_permissions_allows_encrypt_and_decrypt() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    // Policy with zero linked permissions.
+    let (policy_id, team_id) = create_policy_with_permissions(&pool, 1, vec![]).await;
+
+    let (auth, bunker_keys, user_keys) =
+        create_test_authorization(&pool, 1, team_id, policy_id, &key_manager).await;
+
+    let handler = Nip46Handler::new_for_test(
+        bunker_keys,
+        user_keys.clone(),
+        auth.secret_hash.clone(),
+        auth.id,
+        1,
+        false,
+        pool.clone(),
+    );
+
+    let counterparty = Keys::generate();
+    assert!(
+        handler
+            .validate_permissions_for_encrypt("anything", &counterparty.public_key())
+            .await
+            .is_ok(),
+        "Empty permission set must not block encrypt (backward compatibility)"
+    );
+    assert!(
+        handler
+            .validate_permissions_for_decrypt("anything", &counterparty.public_key())
+            .await
+            .is_ok(),
+        "Empty permission set must not block decrypt (backward compatibility)"
+    );
+}
+
+/// Behavior change: enforcing encrypt/decrypt now applies content_filter to plaintext.
+/// Customers using content_filter for sign-time policy will see encrypts of plaintext
+/// containing blocked words denied. This test pins the behavior.
+#[tokio::test]
+async fn test_19_content_filter_blocks_encrypt_of_blocked_plaintext() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    let (policy_id, team_id) = create_policy_with_permissions(
+        &pool,
+        1,
+        vec![(
+            "content_filter",
+            json!({ "blocked_words": ["forbidden"] }),
+        )],
+    )
+    .await;
+
+    let (auth, bunker_keys, user_keys) =
+        create_test_authorization(&pool, 1, team_id, policy_id, &key_manager).await;
+
+    let handler = Nip46Handler::new_for_test(
+        bunker_keys,
+        user_keys.clone(),
+        auth.secret_hash.clone(),
+        auth.id,
+        1,
+        false,
+        pool.clone(),
+    );
+
+    let recipient = Keys::generate();
+
+    let blocked = handler
+        .validate_permissions_for_encrypt(
+            "this message contains forbidden text",
+            &recipient.public_key(),
+        )
+        .await;
+    assert!(
+        matches!(
+            blocked,
+            Err(keycast_signer::SignerError::PermissionDenied(_))
+        ),
+        "content_filter must deny encrypt when plaintext contains a blocked word"
+    );
+
+    let allowed = handler
+        .validate_permissions_for_encrypt("clean message body", &recipient.public_key())
+        .await;
+    assert!(
+        allowed.is_ok(),
+        "content_filter must allow encrypt when plaintext contains no blocked words"
     );
 }
 

--- a/signer/tests/permission_validation_tests.rs
+++ b/signer/tests/permission_validation_tests.rs
@@ -1066,10 +1066,7 @@ async fn test_19_content_filter_blocks_encrypt_of_blocked_plaintext() {
     let (policy_id, team_id) = create_policy_with_permissions(
         &pool,
         1,
-        vec![(
-            "content_filter",
-            json!({ "blocked_words": ["forbidden"] }),
-        )],
+        vec![("content_filter", json!({ "blocked_words": ["forbidden"] }))],
     )
     .await;
 


### PR DESCRIPTION
  ## Summary

  Addresses #128 and fixes a latent signer permission-enforcement gap.

  This PR does two things:
  1. adds the missing encrypt/decrypt permission coverage originally called out in #128
  2. wires the existing `CustomPermission::can_encrypt` / `can_decrypt` methods into the signer's `nip04_*` and `nip44_*` encrypt/decrypt dispatch arms

  On `main`, `validate_permissions_for_sign` exists, but no analogous validation runs before encrypt/decrypt. This PR closes that production gap and adds coverage for the newly enforced behavior.

  ## Behavior change — read this

  This is a real, customer-visible behavior change. Existing custom permissions behave as follows after this PR:

  | Permission        | Pre-PR (encrypt/decrypt) | Post-PR                                     |
  |-------------------|--------------------------|---------------------------------------------|
  | `allowed_kinds`   | not enforced             | unchanged — `can_encrypt`/`can_decrypt` always return `true` |
  | `encrypt_to_self` | not enforced (inert)     | now enforced — restricts encrypt/decrypt to user's own pubkey (intended) |
  | `decrypt_only`    | not enforced (inert)     | now enforced — denies encrypt, allows decrypt (intended) |
  | `content_filter`  | not enforced             | **now blocks encrypt of plaintext containing blocked words** |

  The `content_filter` row is the one to flag for ops/support: customers who configured `content_filter` for sign-time policy may now see encrypt requests denied when the plaintext contains a blocked word. They did not previously opt into encrypt-time blocking.

  - **Backward-compatible default preserved:** if no permissions are linked, encrypt/decrypt continue to succeed.

  ## Implementation

  - `validate_permissions_for_encrypt` and `validate_permissions_for_decrypt` added to `Nip46Handler`, mirroring `validate_permissions_for_sign`. Marked `pub + #[doc(hidden)]` to follow the existing test-seam convention used by `new_for_test`.
  - All four dispatch arms (`nip04_encrypt`, `nip04_decrypt`, `nip44_encrypt`, `nip44_decrypt`) now call the appropriate validate method before performing crypto. Both arms have identical structure.

  ## Tests

  - `test_16` `decrypt_only` denies encrypt, allows decrypt (team auth path)
  - `test_16b` same coverage on OAuth auth path
  - `test_17` `encrypt_to_self` denies decrypt from third party
  - `test_18` no-permissions fallback for both encrypt and decrypt
  - `test_19` `content_filter` blocked-encrypt + clean-encrypt

  ## Follow-up

  Dispatcher-level end-to-end coverage for `handle_nip46_request` is intentionally out of scope for this PR. Exercising that path requires heavier relay/cache/coordinator test scaffolding. This PR instead covers the shared permission-enforcement logic and the key behavior cases introduced by the new enforcement.