### PR TITLE
test: add permission loading failure coverage for signer policy validation

### DIFF
--- a/signer/tests/permission_validation_tests.rs
+++ b/signer/tests/permission_validation_tests.rs
@@ -528,6 +528,71 @@ async fn test_8_oauth_with_policy_enforces_restrictions() {
     assert!(result.is_err(), "OAuth with policy should deny kind 4");
 }
 
+#[tokio::test]
+async fn test_8b_permission_loading_failure_returns_error() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    // Start with a valid policy, then attach a malformed permission config row.
+    let (policy_id, _team_id) = create_policy_with_permissions(&pool, 1, vec![]).await;
+
+    let malformed_permission_id: i32 = sqlx::query_scalar(
+        "INSERT INTO permissions (identifier, config, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())
+         RETURNING id",
+    )
+    .bind("allowed_kinds")
+    .bind("{\"allowed_kinds\": [1]") // malformed JSON (missing closing brace)
+    .fetch_one(&pool)
+    .await
+    .expect("Failed to create malformed permission");
+
+    sqlx::query(
+        "INSERT INTO policy_permissions (policy_id, permission_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())",
+    )
+    .bind(policy_id)
+    .bind(malformed_permission_id)
+    .execute(&pool)
+    .await
+    .expect("Failed to attach malformed permission to policy");
+
+    let (oauth_auth, user_keys) =
+        create_oauth_authorization(&pool, 1, Some(policy_id), &key_manager).await;
+
+    let handler = Nip46Handler::new_for_test(
+        user_keys.clone(),
+        user_keys.clone(),
+        oauth_auth.secret_hash.clone(),
+        oauth_auth.id,
+        1,
+        true,
+        pool.clone(),
+    );
+
+    let unsigned = EventBuilder::text_note("Hello").build(user_keys.public_key());
+    let result = handler.sign_event_direct(unsigned).await;
+
+    assert!(
+        result.is_err(),
+        "Malformed permission config should fail during permission loading"
+    );
+
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Authorization error")
+            || err_msg.contains("Database error")
+            || err_msg.contains("config"),
+        "Error should indicate permission loading/parsing failure, got: {}",
+        err_msg
+    );
+    assert!(
+        !err_msg.contains("Blocked by"),
+        "Failure should happen during permission loading, not policy deny path: {}",
+        err_msg
+    );
+}
+
 // ============================================================================
 // EXPIRY TESTS
 // ============================================================================
@@ -1141,5 +1206,3 @@ async fn test_20_oauth_invalid_policy_id_allows_signing() {
         "OAuth authorization with invalid policy_id should follow current permissive behavior"
     );
 }
-
-// TODO: Add test for permission loading failure


### PR DESCRIPTION
Closes #130.

Adds `test_8b_permission_loading_failure_returns_error` to `signer/tests/permission_validation_tests.rs`, filling the TODO that #130 tracked.

## What it covers

Previous tests in this file exercise valid permissions (allow/deny paths) and missing policies, but nothing covered what happens when a stored `permissions.config` row is structurally unparseable. This test:

1. Creates a valid policy and OAuth authorization.
2. Inserts a `permissions` row with malformed JSON in `config` (`{"allowed_kinds": [1]` — missing closing brace) and attaches it to the policy.
3. Calls `sign_event_direct` and asserts:
   - The call returns `Err` (fails closed).
   - The error message points to permission loading/parsing (`Authorization error` / `Database error` / `config`), **not** the policy deny path (asserts the error does *not* contain `Blocked by`).

The negative assertion is the important one: it pins down that a malformed config can't be silently treated as "no permission matched → deny", which would mask data-corruption bugs as ordinary policy denies.