### PR TITLE
style: cargo fmt after squash merge of #124

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -3414,9 +3414,10 @@ pub async fn delete_account(
             redirect_origin = %redirect_origin,
             "Denied: not user-signed and not first-party"
         );
-        return Err(AuthError::Forbidden(
-            format!("Account deletion requires the {} app or web login with your private key", BRAND_NAME),
-        ));
+        return Err(AuthError::Forbidden(format!(
+            "Account deletion requires the {} app or web login with your private key",
+            BRAND_NAME
+        )));
     }
 
     tracing::info!(

--- a/api/src/email_service.rs
+++ b/api/src/email_service.rs
@@ -168,7 +168,10 @@ impl EmailSender for DevEmailSender {
         tracing::info!("  VINE CLAIM EMAIL");
         tracing::info!("==================================================");
         tracing::info!("  To: {}", to_email);
-        tracing::info!("  Subject: Your Vine account on {} is ready to claim", BRAND_NAME);
+        tracing::info!(
+            "  Subject: Your Vine account on {} is ready to claim",
+            BRAND_NAME
+        );
         tracing::info!("");
         tracing::info!("  Claim link:");
         tracing::info!("  {}", claim_url);
@@ -384,7 +387,8 @@ impl EmailSender for SendGridEmailSender {
             </body>
             </html>
             "#,
-            url = verification_url, brand = BRAND_NAME
+            url = verification_url,
+            brand = BRAND_NAME
         );
 
         let text_content = format!(
@@ -426,7 +430,8 @@ impl EmailSender for SendGridEmailSender {
             </body>
             </html>
             "#,
-            url = reset_url, brand = BRAND_NAME
+            url = reset_url,
+            brand = BRAND_NAME
         );
 
         let text_content = format!(
@@ -462,7 +467,8 @@ impl EmailSender for SendGridEmailSender {
             </body>
             </html>
             "#,
-            url = claim_url, brand = BRAND_NAME
+            url = claim_url,
+            brand = BRAND_NAME
         );
 
         let text_content = format!(


### PR DESCRIPTION
## Summary

- `cargo fmt` fixup for `email_service.rs` and `auth.rs` after the squash merge of #124 introduced formatting that doesn't match rustfmt's multi-arg `format!()` preferences
- CI on main is failing due to the fmt check — this unblocks it