### PR TITLE
auth: enforce max NIP-05 username length boundary

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -33,6 +33,7 @@ const DEFAULT_TOKEN_EXPIRY_HOURS: i64 = 24;
 pub const EMAIL_VERIFICATION_EXPIRY_HOURS: i64 = 24;
 const PASSWORD_RESET_EXPIRY_HOURS: i64 = 1;
 const DEFAULT_NIP05_DOMAIN: &str = "divine.video";
+const MAX_NIP05_USERNAME_LENGTH: usize = 64;
 
 /// Get token expiry in seconds. Uses `TOKEN_EXPIRY_SECONDS` env var if set,
 /// otherwise defaults to 24 hours (86400 seconds).
@@ -90,6 +91,13 @@ fn normalize_nip05_username(raw_username: &str) -> Result<String, AuthError> {
         return Err(AuthError::Internal(
             "Username cannot start or end with a hyphen".to_string(),
         ));
+    }
+
+    if username.len() > MAX_NIP05_USERNAME_LENGTH {
+        return Err(AuthError::Internal(format!(
+            "Username must be at most {} characters",
+            MAX_NIP05_USERNAME_LENGTH
+        )));
     }
 
     Ok(username)
@@ -4143,5 +4151,20 @@ mod tests {
             super::resolve_nip05_domain("login.example.com"),
             "login.example.com"
         );
+    }
+
+    #[test]
+    fn test_normalize_nip05_username_accepts_max_length_boundary() {
+        let username = "a".repeat(super::MAX_NIP05_USERNAME_LENGTH);
+        let normalized = super::normalize_nip05_username(&username)
+            .expect("username with max allowed length should normalize");
+        assert_eq!(normalized, username);
+    }
+
+    #[test]
+    fn test_normalize_nip05_username_rejects_length_above_boundary() {
+        let username = "a".repeat(super::MAX_NIP05_USERNAME_LENGTH + 1);
+        let result = super::normalize_nip05_username(&username);
+        assert!(result.is_err(), "username longer than max boundary should be rejected");
     }
 }

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -4165,6 +4165,9 @@ mod tests {
     fn test_normalize_nip05_username_rejects_length_above_boundary() {
         let username = "a".repeat(super::MAX_NIP05_USERNAME_LENGTH + 1);
         let result = super::normalize_nip05_username(&username);
-        assert!(result.is_err(), "username longer than max boundary should be rejected");
+        assert!(
+            result.is_err(),
+            "username longer than max boundary should be rejected"
+        );
     }
 }


### PR DESCRIPTION
Closes #80.

This is a clean recut of the actual follow-up work from #99 on top of current `main`.

What it does:
- adds a max length boundary for normalized NIP-05 usernames
- adds unit coverage for the exact boundary and the first-over-boundary case

Why this exists as a fresh PR:
- the original #99 branch was stacked on pre-#72 NIP-05 work that is already merged
- this branch contains only the one unique follow-up commit on top of current `main`