### PR TITLE
test(auth): add NIP-05 domain resolution precedence coverage

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -3583,6 +3583,7 @@ mod tests {
     #[cfg(feature = "integration-tests")]
     use moka::future::Cache;
     use nostr_sdk::{Keys, Kind, Timestamp, UnsignedEvent};
+    use serial_test::serial;
     #[cfg(feature = "integration-tests")]
     use sqlx::PgPool;
     #[cfg(feature = "integration-tests")]
@@ -3591,6 +3592,35 @@ mod tests {
     use uuid::Uuid;
     #[cfg(feature = "integration-tests")]
     use zeroize::Zeroizing;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(original) = &self.original {
+                std::env::set_var(self.key, original);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
 
     /// Helper to create test database connection
     /// Uses DATABASE_URL env var or defaults to localhost
@@ -4104,6 +4134,58 @@ mod tests {
         // NOTE: Content length validation not implemented yet (would need new permission type)
         // Current permissions: allowed_kinds, content_filter (word blocking), encrypt_to_self
         println!("✅ Content length validation tested");
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_nip05_domain_prefers_nip05_domain_env() {
+        let _nip05_domain_guard = EnvVarGuard::set("NIP05_DOMAIN", "nip05.example");
+        let _domain_guard = EnvVarGuard::set("DOMAIN", "domain.example");
+
+        let resolved = super::resolve_nip05_domain("tenant.example");
+        assert_eq!(resolved, "nip05.example");
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_nip05_domain_falls_back_to_domain_env() {
+        let _nip05_domain_guard = EnvVarGuard::remove("NIP05_DOMAIN");
+        let _domain_guard = EnvVarGuard::set("DOMAIN", "domain.example");
+
+        let resolved = super::resolve_nip05_domain("tenant.example");
+        assert_eq!(resolved, "domain.example");
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_nip05_domain_uses_default_for_localhost() {
+        let _nip05_domain_guard = EnvVarGuard::remove("NIP05_DOMAIN");
+        let _domain_guard = EnvVarGuard::remove("DOMAIN");
+
+        let resolved_localhost = super::resolve_nip05_domain("localhost");
+        let resolved_loopback = super::resolve_nip05_domain("127.0.0.1");
+        assert_eq!(resolved_localhost, super::DEFAULT_NIP05_DOMAIN);
+        assert_eq!(resolved_loopback, super::DEFAULT_NIP05_DOMAIN);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_nip05_domain_passthroughs_tenant_domain() {
+        let _nip05_domain_guard = EnvVarGuard::remove("NIP05_DOMAIN");
+        let _domain_guard = EnvVarGuard::remove("DOMAIN");
+
+        let resolved = super::resolve_nip05_domain("tenant.example");
+        assert_eq!(resolved, "tenant.example");
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_nip05_domain_ignores_empty_env_values() {
+        let _nip05_domain_guard = EnvVarGuard::set("NIP05_DOMAIN", "   ");
+        let _domain_guard = EnvVarGuard::set("DOMAIN", "");
+
+        let resolved = super::resolve_nip05_domain("tenant.example");
+        assert_eq!(resolved, "tenant.example");
     }
 
     #[test]


### PR DESCRIPTION
Closes #75.

This is a clean recut of the actual follow-up work from #109 on top of current `main`.

What it does:
- adds coverage for NIP-05 domain resolution precedence
- verifies tenant/public-host precedence stays locked down after #72

Why this exists as a fresh PR:
- the original #109 branch was stacked on pre-#72 NIP-05 work that is already merged
- this branch contains only the one unique follow-up commit on top of current `main`