### PR TITLE
fix(deploy): set ALLOWED_TENANT_DOMAINS in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -100,7 +100,7 @@ steps:
       - '--subnet=default'
       - '--vpc-egress=private-ranges-only'
       - '--set-secrets=DATABASE_URL=keycast-database-url:latest,SERVER_NSEC=keycast-ucan-secret:latest,SENDGRID_API_KEY=keycast-sendgrid-api-key:latest,REDIS_URL=keycast-redis-url:latest'
-      - '--set-env-vars=^;^NODE_ENV=production;USE_GCP_KMS=true;GCP_PROJECT_ID=${PROJECT_ID};ALLOWED_ORIGINS=https://login.divine.video,https://divine.video,https://*.openvine-app.pages.dev;APP_URL=https://login.divine.video;FROM_EMAIL=noreply@divine.video;RUST_LOG=info;ENABLE_EXAMPLES=true;SQLX_STATEMENT_CACHE=100;SQLX_POOL_SIZE=50;ALLOWED_PUBKEYS=89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5,76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa;BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol;ENABLE_DIVINE_NAMES=true'
+      - '--set-env-vars=^;^NODE_ENV=production;USE_GCP_KMS=true;GCP_PROJECT_ID=${PROJECT_ID};ALLOWED_ORIGINS=https://login.divine.video,https://divine.video,https://*.openvine-app.pages.dev;ALLOWED_TENANT_DOMAINS=login.divine.video;APP_URL=https://login.divine.video;FROM_EMAIL=noreply@divine.video;RUST_LOG=info;ENABLE_EXAMPLES=true;SQLX_STATEMENT_CACHE=100;SQLX_POOL_SIZE=50;ALLOWED_PUBKEYS=89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5,76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa;BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol;ENABLE_DIVINE_NAMES=true'
 
   # Smoke tests - verify deployment
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'


### PR DESCRIPTION
## Summary

Adds `ALLOWED_TENANT_DOMAINS=login.divine.video` to the Cloud Run deploy in `cloudbuild.yaml` so future revisions don't regress account creation.

## Background

Production was returning `Invalid domain: login.divine.video` because the tenant validator (made fail-closed in #67) rejects all domains unless `ALLOWED_TENANT_DOMAINS` or `ENABLE_TENANT_AUTO_PROVISIONING` is set, and neither was being passed to Cloud Run. Already applied as a live hotfix via \`gcloud run services update\`; this PR makes the change survive subsequent deploys.

## Test plan

- [x] Verified hotfix on live service: \`POST https://login.divine.video/api/auth/register\` → 200
- [x] Confirmed env var present on revision \`keycast-00235-8v5\`
- [ ] Cloud Build smoke tests pass on this PR's deploy