### PR TITLE
fix(cloudbuild): retry CORS smoke tests + accept Any origin for headless

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -122,57 +122,62 @@ steps:
         echo "✅ Readiness check passed"
 
         PREVIEW_ORIGIN="https://preview.openvine-app.pages.dev"
+        HEADLESS_PUBLIC_ORIGIN="https://keycast-cors-smoke.invalid"
 
-        # Helper: read the Access-Control-Allow-Origin header from a CORS preflight.
+        # Helper: verify the Access-Control-Allow-Origin header from a CORS preflight.
         # Retries to ride out the brief warm-up window where requests can still land
         # on the previous revision after Cloud Run reports 100% traffic on the new one.
-        # First arg = endpoint path, prints the observed allow-origin value (or empty).
-        cors_preflight_allow_origin() {
+        # Args: endpoint path, request Origin, expected allow-origin.
+        # Prints the observed allow-origin value once it matches the expected value.
+        cors_preflight_expect_allow_origin() {
           local path="$$1"
+          local origin="$$2"
+          local expected_allow_origin="$$3"
           local headers
           local allow_origin=""
           for attempt in 1 2 3 4 5 6; do
+            allow_origin=""
             headers=$$(mktemp)
             local http_code
             http_code=$$(curl -s -D "$$headers" -o /dev/null -w "%{http_code}" \
-              -H "Origin: $$PREVIEW_ORIGIN" \
+              -H "Origin: $$origin" \
               -H "Access-Control-Request-Method: POST" \
               -H "Access-Control-Request-Headers: Content-Type" \
               -X OPTIONS \
               "$$SERVICE_URL$$path")
             if [ "$$http_code" = "200" ]; then
               allow_origin=$$(awk 'BEGIN{IGNORECASE=1}/^Access-Control-Allow-Origin:/ {print $$2}' "$$headers" | tr -d '\r')
-              if [ -n "$$allow_origin" ]; then
+              if [ "$$allow_origin" = "$$expected_allow_origin" ]; then
                 rm -f "$$headers"
                 echo "$$allow_origin"
                 return 0
               fi
             fi
             rm -f "$$headers"
-            echo "  attempt $$attempt: http=$$http_code allow_origin='$$allow_origin', retrying in 10s..." >&2
+            echo "  attempt $$attempt: http=$$http_code origin='$$origin' allow_origin='$$allow_origin' expected='$$expected_allow_origin', retrying in 10s..." >&2
             sleep 10
           done
-          echo ""
+          echo "$$allow_origin"
           return 1
         }
 
         echo "🔍 Testing CORS preflight for /api/auth/register from $$PREVIEW_ORIGIN..."
         # /api/auth/register uses the predicate-based CORS (auth_cors) and echoes the
         # specific request origin back when allowed.
-        REGISTER_ALLOW_ORIGIN=$$(cors_preflight_allow_origin "/api/auth/register")
+        REGISTER_ALLOW_ORIGIN=$$(cors_preflight_expect_allow_origin "/api/auth/register" "$$PREVIEW_ORIGIN" "$$PREVIEW_ORIGIN")
         if [ "$$REGISTER_ALLOW_ORIGIN" != "$$PREVIEW_ORIGIN" ]; then
           echo "❌ Register CORS preflight returned Access-Control-Allow-Origin='$$REGISTER_ALLOW_ORIGIN' (expected '$$PREVIEW_ORIGIN')"
           exit 1
         fi
         echo "✅ Register CORS preflight passed"
 
-        echo "🔍 Testing CORS preflight for /api/headless/login from $$PREVIEW_ORIGIN..."
+        echo "🔍 Testing CORS preflight for /api/headless/login from $$HEADLESS_PUBLIC_ORIGIN..."
         # /api/headless/login uses public_cors (allow_origin = Any) so the server
-        # responds with '*' rather than echoing the request origin. PKCE handles
-        # auth without cookies, so credentialed CORS isn't required here.
-        LOGIN_ALLOW_ORIGIN=$$(cors_preflight_allow_origin "/api/headless/login")
-        if [ "$$LOGIN_ALLOW_ORIGIN" != "*" ] && [ "$$LOGIN_ALLOW_ORIGIN" != "$$PREVIEW_ORIGIN" ]; then
-          echo "❌ Headless login CORS preflight returned Access-Control-Allow-Origin='$$LOGIN_ALLOW_ORIGIN' (expected '*' or '$$PREVIEW_ORIGIN')"
+        # responds with '*' for arbitrary origins. Using an unallowlisted origin here
+        # ensures a regression back to auth_cors cannot pass by echoing PREVIEW_ORIGIN.
+        LOGIN_ALLOW_ORIGIN=$$(cors_preflight_expect_allow_origin "/api/headless/login" "$$HEADLESS_PUBLIC_ORIGIN" "*")
+        if [ "$$LOGIN_ALLOW_ORIGIN" != "*" ]; then
+          echo "❌ Headless login CORS preflight returned Access-Control-Allow-Origin='$$LOGIN_ALLOW_ORIGIN' (expected '*')"
           exit 1
         fi
         echo "✅ Headless login CORS preflight passed (allow-origin='$$LOGIN_ALLOW_ORIGIN')"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -123,47 +123,59 @@ steps:
 
         PREVIEW_ORIGIN="https://preview.openvine-app.pages.dev"
 
+        # Helper: read the Access-Control-Allow-Origin header from a CORS preflight.
+        # Retries to ride out the brief warm-up window where requests can still land
+        # on the previous revision after Cloud Run reports 100% traffic on the new one.
+        # First arg = endpoint path, prints the observed allow-origin value (or empty).
+        cors_preflight_allow_origin() {
+          local path="$$1"
+          local headers
+          local allow_origin=""
+          for attempt in 1 2 3 4 5 6; do
+            headers=$$(mktemp)
+            local http_code
+            http_code=$$(curl -s -D "$$headers" -o /dev/null -w "%{http_code}" \
+              -H "Origin: $$PREVIEW_ORIGIN" \
+              -H "Access-Control-Request-Method: POST" \
+              -H "Access-Control-Request-Headers: Content-Type" \
+              -X OPTIONS \
+              "$$SERVICE_URL$$path")
+            if [ "$$http_code" = "200" ]; then
+              allow_origin=$$(awk 'BEGIN{IGNORECASE=1}/^Access-Control-Allow-Origin:/ {print $$2}' "$$headers" | tr -d '\r')
+              if [ -n "$$allow_origin" ]; then
+                rm -f "$$headers"
+                echo "$$allow_origin"
+                return 0
+              fi
+            fi
+            rm -f "$$headers"
+            echo "  attempt $$attempt: http=$$http_code allow_origin='$$allow_origin', retrying in 10s..." >&2
+            sleep 10
+          done
+          echo ""
+          return 1
+        }
+
         echo "🔍 Testing CORS preflight for /api/auth/register from $$PREVIEW_ORIGIN..."
-        REGISTER_HEADERS=$$(mktemp)
-        HTTP_CODE=$$(curl -s -D "$$REGISTER_HEADERS" -o /dev/null -w "%{http_code}" \
-          -H "Origin: $$PREVIEW_ORIGIN" \
-          -H "Access-Control-Request-Method: POST" \
-          -H "Access-Control-Request-Headers: Content-Type" \
-          -X OPTIONS \
-          "$$SERVICE_URL/api/auth/register")
-
-        if [ "$$HTTP_CODE" != "200" ]; then
-          echo "❌ Register CORS preflight failed with HTTP $$HTTP_CODE"
-          exit 1
-        fi
-
-        REGISTER_ALLOW_ORIGIN=$$(awk 'BEGIN{IGNORECASE=1}/^Access-Control-Allow-Origin:/ {print $$2}' "$$REGISTER_HEADERS" | tr -d '\r')
+        # /api/auth/register uses the predicate-based CORS (auth_cors) and echoes the
+        # specific request origin back when allowed.
+        REGISTER_ALLOW_ORIGIN=$$(cors_preflight_allow_origin "/api/auth/register")
         if [ "$$REGISTER_ALLOW_ORIGIN" != "$$PREVIEW_ORIGIN" ]; then
-          echo "❌ Register CORS preflight returned Access-Control-Allow-Origin=$$REGISTER_ALLOW_ORIGIN"
+          echo "❌ Register CORS preflight returned Access-Control-Allow-Origin='$$REGISTER_ALLOW_ORIGIN' (expected '$$PREVIEW_ORIGIN')"
           exit 1
         fi
         echo "✅ Register CORS preflight passed"
 
         echo "🔍 Testing CORS preflight for /api/headless/login from $$PREVIEW_ORIGIN..."
-        LOGIN_HEADERS=$$(mktemp)
-        HTTP_CODE=$$(curl -s -D "$$LOGIN_HEADERS" -o /dev/null -w "%{http_code}" \
-          -H "Origin: $$PREVIEW_ORIGIN" \
-          -H "Access-Control-Request-Method: POST" \
-          -H "Access-Control-Request-Headers: Content-Type" \
-          -X OPTIONS \
-          "$$SERVICE_URL/api/headless/login")
-
-        if [ "$$HTTP_CODE" != "200" ]; then
-          echo "❌ Headless login CORS preflight failed with HTTP $$HTTP_CODE"
+        # /api/headless/login uses public_cors (allow_origin = Any) so the server
+        # responds with '*' rather than echoing the request origin. PKCE handles
+        # auth without cookies, so credentialed CORS isn't required here.
+        LOGIN_ALLOW_ORIGIN=$$(cors_preflight_allow_origin "/api/headless/login")
+        if [ "$$LOGIN_ALLOW_ORIGIN" != "*" ] && [ "$$LOGIN_ALLOW_ORIGIN" != "$$PREVIEW_ORIGIN" ]; then
+          echo "❌ Headless login CORS preflight returned Access-Control-Allow-Origin='$$LOGIN_ALLOW_ORIGIN' (expected '*' or '$$PREVIEW_ORIGIN')"
           exit 1
         fi
-
-        LOGIN_ALLOW_ORIGIN=$$(awk 'BEGIN{IGNORECASE=1}/^Access-Control-Allow-Origin:/ {print $$2}' "$$LOGIN_HEADERS" | tr -d '\r')
-        if [ "$$LOGIN_ALLOW_ORIGIN" != "$$PREVIEW_ORIGIN" ]; then
-          echo "❌ Headless login CORS preflight returned Access-Control-Allow-Origin=$$LOGIN_ALLOW_ORIGIN"
-          exit 1
-        fi
-        echo "✅ Headless login CORS preflight passed"
+        echo "✅ Headless login CORS preflight passed (allow-origin='$$LOGIN_ALLOW_ORIGIN')"
 
         echo "🎉 All smoke tests passed!"
 


### PR DESCRIPTION
## Summary

Two related fixes for the post-deploy CORS smoke tests in `cloudbuild.yaml`:

1. **Retry warm-up race.** After Cloud Run reports 100% traffic on the new revision, in-flight requests can still land on the previous revision's process during the brief warm-up window. The current one-shot check after a fixed `sleep 30` flakes when it races that window. Now retries up to 6 times with 10s backoff.

2. **Accept `*` for headless login.** `/api/headless/login` uses `public_cors` (`allow_origin = Any`) so the server responds with `Access-Control-Allow-Origin: *` rather than echoing the request origin. The previous test compared the response to `PREVIEW_ORIGIN` exactly and would fail forever after that route's CORS layer was switched (which happened in #34 / `655fe9a`). The `/api/auth/register` test still requires the exact origin echo since that route uses the predicate-based `auth_cors`.

## Why this matters

The most recent production deploy (build `110b5ca2`) hit exactly this — image was built and Cloud Run revision 234 deployed and serving traffic, but the smoke test failed and marked the build FAILURE. False alarm masked a successful deploy. With this change the test catches real CORS regressions without false-failing on cutover races or design changes.

## Test plan

- [ ] Trigger Cloud Build on this branch (or merge then trigger on main)
- [ ] Confirm both smoke tests pass: `Register CORS preflight passed` and `Headless login CORS preflight passed (allow-origin='*')`
- [ ] Confirm a real regression is still caught (e.g. revert the public_cors swap on a throwaway branch and verify the headless test fails with a clear error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)