### PR TITLE
fix(oauth): register Divine invite admin client

### DIFF
--- a/api/tests/registered_clients_migration_test.rs
+++ b/api/tests/registered_clients_migration_test.rs
@@ -1,0 +1,37 @@
+mod common;
+
+use keycast_core::repositories::RegisteredClientRepository;
+
+#[tokio::test]
+async fn migrations_register_divine_invite_admin_oauth_client() {
+    let pool = common::setup_test_db().await;
+    let repo = RegisteredClientRepository::new(pool);
+
+    let allowed_redirects = repo
+        .get_allowed_redirect_uris("divine-invite-admin", 1)
+        .await
+        .unwrap()
+        .expect("divine-invite-admin should be seeded as a registered OAuth client");
+
+    assert_eq!(
+        allowed_redirects,
+        vec!["https://invite.divine.video/admin".to_string()]
+    );
+
+    repo.validate_redirect_uri(
+        "divine-invite-admin",
+        "https://invite.divine.video/admin",
+        1,
+    )
+    .await
+    .unwrap();
+
+    assert!(repo
+        .validate_redirect_uri(
+            "divine-invite-admin",
+            "https://invite.divine.video/callback",
+            1,
+        )
+        .await
+        .is_err());
+}

--- a/database/migrations/20260426192000_seed_divine_invite_admin_client.sql
+++ b/database/migrations/20260426192000_seed_divine_invite_admin_client.sql
@@ -1,0 +1,20 @@
+-- Register the invite admin dashboard as a first-party OAuth client.
+-- Production Keycast requires registered OAuth clients, and the embedded
+-- invite admin UI redirects back to https://invite.divine.video/admin.
+INSERT INTO public.registered_clients (
+    tenant_id,
+    client_id,
+    name,
+    allowed_redirect_uris
+)
+VALUES (
+    1,
+    'divine-invite-admin',
+    'Divine Invite Admin',
+    ARRAY['https://invite.divine.video/admin']::TEXT[]
+)
+ON CONFLICT (tenant_id, client_id) DO UPDATE
+SET
+    name = EXCLUDED.name,
+    allowed_redirect_uris = EXCLUDED.allowed_redirect_uris,
+    updated_at = NOW();


### PR DESCRIPTION
## Summary

- Seed the production registered OAuth client row for `divine-invite-admin`
- Allow only `https://invite.divine.video/admin` as its redirect URI
- Add an integration test that verifies migrations seed the client and reject a wrong redirect path

## Why

Production now defaults to `REQUIRE_REGISTERED_OAUTH_CLIENTS=true` in release builds. The invite admin UI at `invite.divine.video/admin` still uses `client_id=divine-invite-admin`, but Keycast had no registered client row for it, so the OAuth authorize endpoint returns `Unregistered client`.

## Verification

- `rg` confirmed `divine-invite-admin` was only defined in `divine-invite-darshan/src/admin.html` and was not seeded in Keycast migrations
- `cargo fmt --all -- --check`
- `cargo test -p keycast_api --features integration-tests --test registered_clients_migration_test --no-run`
- `cargo test -p keycast_core registered_client::tests -- --nocapture --test-threads=1`
- Local DB-backed execution is blocked by local Postgres resetting connections; GitHub CI runs with a fresh Postgres service and should execute the new integration test.