### PR TITLE
fix(deploy): disable strict OAuth client check in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -100,7 +100,7 @@ steps:
       - '--subnet=default'
       - '--vpc-egress=private-ranges-only'
       - '--set-secrets=DATABASE_URL=keycast-database-url:latest,SERVER_NSEC=keycast-ucan-secret:latest,SENDGRID_API_KEY=keycast-sendgrid-api-key:latest,REDIS_URL=keycast-redis-url:latest'
-      - '--set-env-vars=^;^NODE_ENV=production;USE_GCP_KMS=true;GCP_PROJECT_ID=${PROJECT_ID};ALLOWED_ORIGINS=https://login.divine.video,https://divine.video,https://*.openvine-app.pages.dev;ALLOWED_TENANT_DOMAINS=login.divine.video;APP_URL=https://login.divine.video;FROM_EMAIL=noreply@divine.video;RUST_LOG=info;ENABLE_EXAMPLES=true;SQLX_STATEMENT_CACHE=100;SQLX_POOL_SIZE=50;ALLOWED_PUBKEYS=89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5,76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa;BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol;ENABLE_DIVINE_NAMES=true'
+      - '--set-env-vars=^;^NODE_ENV=production;USE_GCP_KMS=true;GCP_PROJECT_ID=${PROJECT_ID};ALLOWED_ORIGINS=https://login.divine.video,https://divine.video,https://*.openvine-app.pages.dev;ALLOWED_TENANT_DOMAINS=login.divine.video;REQUIRE_REGISTERED_OAUTH_CLIENTS=false;APP_URL=https://login.divine.video;FROM_EMAIL=noreply@divine.video;RUST_LOG=info;ENABLE_EXAMPLES=true;SQLX_STATEMENT_CACHE=100;SQLX_POOL_SIZE=50;ALLOWED_PUBKEYS=89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5,76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa;BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol;ENABLE_DIVINE_NAMES=true'
 
   # Smoke tests - verify deployment
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'


### PR DESCRIPTION
## Summary

Adds `REQUIRE_REGISTERED_OAUTH_CLIENTS=false` to the Cloud Run deploy in `cloudbuild.yaml` so production stops rejecting OAuth flows for first-party `client_id`s that have not yet been seeded into `registered_clients`.

## Background

Strict client admission was made the release-build default in #67:

```rust
pub fn is_strict_client_mode() -> bool {
    std::env::var("REQUIRE_REGISTERED_OAUTH_CLIENTS")
        .map(|v| v == "true")
        .unwrap_or(cfg!(not(debug_assertions)))
}
```

Until #148 deployed `ALLOWED_TENANT_DOMAINS`, the tenant validator was rejecting requests first and masking this. With #148 in production, requests now reach the OAuth path and fail with:

```
{"error":"Invalid request: Unregistered client: Not found: client_id 'divine-web' is not registered. In production, only registered OAuth clients are allowed."}
```

…because no first-party `client_id` (`divine-web`, `divine-invite-admin`, and several others — `divine-mobile`, `divine-badges`, `divine-blossom`, `divine-invite-sync`, `divine-relay-manager`, `divine-funnelcake`, `keycast_flutter_demo`, `divine-signer`) has been seeded yet. #150 starts seeding `divine-invite-admin` only and is still open.

## Why this approach

`REQUIRE_REGISTERED_OAUTH_CLIENTS=false` restores the pre-#67 behavior of allowing any HTTPS redirect for unregistered clients — matching the documented dev/staging opt-out in `.env.example`. It is intended as a **temporary unblock** until first-party clients are seeded into `registered_clients` via migrations, after which the env var should be removed (so the release-build default of `true` re-applies).

The alternative — seeding all first-party clients in this PR — was rejected because the full list isn't audited yet and we want to unblock production now without needing a database migration.

## Follow-ups

- Extend #150 (or a successor) to seed every first-party `client_id` with its allowed redirect URIs.
- Once seeding lands and is verified, remove `REQUIRE_REGISTERED_OAUTH_CLIENTS=false` from `cloudbuild.yaml` so strict mode re-engages.

## Test plan

- [ ] Cloud Build smoke tests pass on this PR's deploy
- [ ] `https://login.divine.video/api/oauth/authorize?client_id=divine-web&redirect_uri=https://divine.video/auth/callback&...` returns the consent page instead of `Unregistered client`
- [ ] Confirm env var present on the new Cloud Run revision