### PR TITLE
feat: restore open OAuth — remove registered-client enforcement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,21 +80,11 @@ BASE_URL=http://localhost:5173
 # Default: false - unknown domains are rejected
 # ENABLE_TENANT_AUTO_PROVISIONING=true
 
-# Require registered OAuth clients (default: true in release builds)
-# Set to "false" to allow unregistered clients in development
-# REQUIRE_REGISTERED_OAUTH_CLIENTS=true
-
 # Rust logging level
 RUST_LOG=info,keycast_signer=debug
 
 # Enable /examples directory (development only, set to false in production)
 ENABLE_EXAMPLES=false
-
-# Require registered OAuth clients for authorization flows
-# When true, only client_ids in the registered_clients table can initiate OAuth
-# Defaults to true in release builds, false in debug builds
-# Set to "false" for local development with unregistered test clients
-REQUIRE_REGISTERED_OAUTH_CLIENTS=false
 
 # Show teams functionality in the frontend (default: hidden)
 # Set to "true" to enable team management UI

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -530,28 +530,11 @@ pub async fn authorize_get(
     let tenant_id = tenant.0.id;
     let pool = &auth_state.state.db;
 
-    // In strict mode, reject unregistered client_ids (production security)
-    // Then validate redirect_uri against registered client patterns
+    // Validate redirect_uri against registered client patterns (only if client is registered).
+    // Open OAuth: unregistered client_ids are permitted; registration only narrows redirect URIs.
     {
         let client_repo = keycast_core::repositories::RegisteredClientRepository::new(pool.clone());
 
-        // Check if the client is registered (required in strict/production mode)
-        if let Err(e) = client_repo
-            .require_registered_client(&params.client_id, tenant_id)
-            .await
-        {
-            tracing::warn!(
-                "Unregistered client_id '{}' rejected in strict mode: {}",
-                params.client_id,
-                e
-            );
-            return Err(OAuthError::InvalidRequest(format!(
-                "Unregistered client: {}",
-                e
-            )));
-        }
-
-        // Validate redirect_uri against registered client patterns (if client is registered)
         if let Err(e) = client_repo
             .validate_redirect_uri(&params.client_id, &params.redirect_uri, tenant_id)
             .await
@@ -2226,28 +2209,6 @@ pub async fn authorize_post(
     }
 
     let tenant_id = tenant.0.id;
-
-    // In strict mode, reject unregistered client_ids (defense-in-depth, mirrors authorize_get check)
-    {
-        let client_repo = keycast_core::repositories::RegisteredClientRepository::new(
-            auth_state.state.db.clone(),
-        );
-
-        if let Err(e) = client_repo
-            .require_registered_client(&req.client_id, tenant_id)
-            .await
-        {
-            tracing::warn!(
-                "Unregistered client_id '{}' rejected in strict mode (POST): {}",
-                req.client_id,
-                e
-            );
-            return Err(OAuthError::InvalidRequest(format!(
-                "Unregistered client: {}",
-                e
-            )));
-        }
-    }
 
     // Extract user public key from UCAN cookie (async)
     let user_pubkey = if let Some(token) = super::auth::extract_ucan_from_cookie(&headers) {

--- a/core/src/repositories/registered_client.rs
+++ b/core/src/repositories/registered_client.rs
@@ -37,47 +37,6 @@ impl RegisteredClientRepository {
         Ok(result)
     }
 
-    /// Check if a client_id is registered in the database.
-    /// Returns true if the client is registered, false otherwise.
-    pub async fn is_client_registered(
-        &self,
-        client_id: &str,
-        tenant_id: i64,
-    ) -> Result<bool, RepositoryError> {
-        let result = self.get_allowed_redirect_uris(client_id, tenant_id).await?;
-        Ok(result.is_some())
-    }
-
-    /// Check whether strict client admission is enabled.
-    /// In strict mode, only registered OAuth clients can initiate authorization flows.
-    /// Controlled by `REQUIRE_REGISTERED_OAUTH_CLIENTS` env var.
-    /// Defaults to `true` in release builds and `false` in debug builds.
-    pub fn is_strict_client_mode() -> bool {
-        std::env::var("REQUIRE_REGISTERED_OAUTH_CLIENTS")
-            .map(|v| v == "true")
-            .unwrap_or(cfg!(not(debug_assertions)))
-    }
-
-    /// In strict mode, verify the client_id is registered. Returns Err if not.
-    /// In non-strict mode, always returns Ok(()).
-    pub async fn require_registered_client(
-        &self,
-        client_id: &str,
-        tenant_id: i64,
-    ) -> Result<(), RepositoryError> {
-        if !Self::is_strict_client_mode() {
-            return Ok(());
-        }
-        if self.is_client_registered(client_id, tenant_id).await? {
-            Ok(())
-        } else {
-            Err(RepositoryError::NotFound(format!(
-                "client_id '{}' is not registered. In production, only registered OAuth clients are allowed.",
-                client_id
-            )))
-        }
-    }
-
     /// Validate a redirect_uri against a registered client's allowed patterns.
     /// Returns Ok(()) if valid, Err if the redirect_uri is not allowed.
     /// If the client_id is not registered, returns Ok(()) (backward compatible).
@@ -150,32 +109,6 @@ fn matches_redirect_pattern(pattern: &str, uri: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_strict_client_mode_env_true() {
-        std::env::set_var("REQUIRE_REGISTERED_OAUTH_CLIENTS", "true");
-        assert!(RegisteredClientRepository::is_strict_client_mode());
-        std::env::remove_var("REQUIRE_REGISTERED_OAUTH_CLIENTS");
-    }
-
-    #[test]
-    fn test_strict_client_mode_env_false() {
-        std::env::set_var("REQUIRE_REGISTERED_OAUTH_CLIENTS", "false");
-        assert!(!RegisteredClientRepository::is_strict_client_mode());
-        std::env::remove_var("REQUIRE_REGISTERED_OAUTH_CLIENTS");
-    }
-
-    #[test]
-    fn test_strict_client_mode_default() {
-        // When env var is not set, defaults based on build profile
-        std::env::remove_var("REQUIRE_REGISTERED_OAUTH_CLIENTS");
-        let result = RegisteredClientRepository::is_strict_client_mode();
-        if cfg!(debug_assertions) {
-            assert!(!result, "Should default to false in debug builds");
-        } else {
-            assert!(result, "Should default to true in release builds");
-        }
-    }
 
     #[test]
     fn test_exact_match() {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -151,7 +151,6 @@ This allows 5x higher concurrency without blocking request threads on bcrypt.
 | `DISABLE_EMAILS` | No | — | Set to `true` to explicitly disable email delivery in production. |
 | `ALLOWED_TENANT_DOMAINS` | Production | — | Comma-separated list of allowed tenant domains. |
 | `ENABLE_TENANT_AUTO_PROVISIONING` | No | `false` | Set to `true` to allow automatic tenant creation for unknown domains (dev only). |
-| `REQUIRE_REGISTERED_OAUTH_CLIENTS` | No | `true` (release) | Set to `false` to allow unregistered OAuth clients (dev only). |
 
 ---
 


### PR DESCRIPTION
## Summary

- Production was rejecting unregistered OAuth `client_id`s since the red-team remediation work (#67) added `require_registered_client` checks to both `authorize_get` and `authorize_post`.
- That contradicts the explicit open-OAuth intent of #52 ("Backward compatible: unregistered client_ids still accept any HTTPS redirect_uri"). The default was `REQUIRE_REGISTERED_OAUTH_CLIENTS=true` in release builds, so prod was effectively closed.
- This PR restores the open posture: any `client_id` may initiate an authorization flow; registration only narrows allowed `redirect_uri`s for clients that opt in.

## Changes

- `api/src/api/http/oauth.rs` — removed both `require_registered_client` blocks. `validate_redirect_uri` still runs for registered clients.
- `core/src/repositories/registered_client.rs` — deleted `require_registered_client`, `is_strict_client_mode`, `is_client_registered`, and their three tests. `validate_redirect_uri` and pattern-matching code are unchanged.
- `.env.example` and `docs/DEPLOYMENT.md` — dropped the now-defunct `REQUIRE_REGISTERED_OAUTH_CLIENTS` documentation (two stale entries in `.env.example`).

Diff: 4 files, +2/−119.

## Test plan

- [x] `cargo check -p keycast_core -p keycast_api` clean
- [x] `cargo test -p keycast_core --lib repositories::registered_client` passes (redirect-pattern matcher tests intact)
- [ ] Manual: third-party app with an unregistered `client_id` can complete an OAuth authorization in production
- [ ] Manual: registered client with a non-matching `redirect_uri` is still rejected (pattern validation preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)