### PR TITLE
fix(rpc): canonicalize sign_event pubkey to keep event self-consistent

### DIFF
--- a/api/src/handlers/http_rpc_handler.rs
+++ b/api/src/handlers/http_rpc_handler.rs
@@ -214,12 +214,31 @@ impl HttpRpcHandler {
     /// Returns an error if:
     /// - Authorization has expired or been revoked
     /// - Permission policy denies this event kind
+    ///
+    /// Note: if `unsigned.pubkey` disagrees with the signer's pubkey, this
+    /// emits a structured warning before delegating to `SigningSession`, which
+    /// canonicalizes the field. The warning gives us telemetry to confirm the
+    /// previous "Invalid signature" outage is no longer firing — see
+    /// `signing_session.rs::sign_event` for the canonicalization itself.
     pub async fn sign_event(&self, unsigned: UnsignedEvent) -> Result<Event, HandlerError> {
         if !self.is_valid() {
             return Err(HandlerError::AuthorizationInvalid);
         }
 
         self.validate_sign_permission(&unsigned)?;
+
+        let signer_pubkey = self.signing.public_key();
+        if unsigned.pubkey != signer_pubkey {
+            tracing::warn!(
+                event = "http_rpc.sign_event.pubkey_mismatch",
+                authorization_id = self.authorization_id,
+                is_oauth = self.is_oauth,
+                supplied_pubkey = %unsigned.pubkey,
+                signer_pubkey = %signer_pubkey,
+                kind = unsigned.kind.as_u16(),
+                "sign_event: client unsigned.pubkey differs from signer pubkey; SigningSession will canonicalize"
+            );
+        }
 
         self.signing
             .sign_event(unsigned)

--- a/core/src/signing_session.rs
+++ b/core/src/signing_session.rs
@@ -57,8 +57,32 @@ impl SigningSession {
     }
 
     /// Sign an unsigned event (CPU-bound crypto runs on spawn_blocking)
-    pub async fn sign_event(&self, unsigned: UnsignedEvent) -> Result<Event, SessionError> {
+    ///
+    /// **Canonicalizes the event's `pubkey` field to `self.keys.public_key()` before
+    /// signing.** This matches NIP-46 bunker semantics where the signer is the source
+    /// of truth for the author's pubkey; the client-supplied `pubkey` field is
+    /// advisory. Without this, nostr-sdk's `sign_with_keys` would happily produce an
+    /// `Event` whose `pubkey` field disagrees with the keypair that produced its
+    /// `sig`, breaking downstream Schnorr verification (e.g. divine-blossom viewer
+    /// auth). Any client-supplied `id` is cleared in the same step so the event id
+    /// is recomputed over the canonical pubkey.
+    pub async fn sign_event(&self, mut unsigned: UnsignedEvent) -> Result<Event, SessionError> {
         let keys = self.keys.clone();
+        let signer_pubkey = keys.public_key();
+
+        if unsigned.pubkey != signer_pubkey {
+            tracing::warn!(
+                event = "signing_session.pubkey_canonicalized",
+                supplied_pubkey = %unsigned.pubkey,
+                signer_pubkey = %signer_pubkey,
+                kind = unsigned.kind.as_u16(),
+                "sign_event: client-supplied unsigned.pubkey != signer pubkey; canonicalizing to signer pubkey"
+            );
+            unsigned.pubkey = signer_pubkey;
+            // The supplied id (if any) was computed over the old pubkey; force
+            // recomputation so signing produces a self-consistent event.
+            unsigned.id = None;
+        }
 
         tokio::task::spawn_blocking(move || {
             // Run the async sign on the blocking thread pool
@@ -130,5 +154,109 @@ mod tests {
         let hex = "not_valid_hex_string_at_all_definitely_not_valid_hex_string!!";
         let result = parse_cache_key(hex);
         assert!(matches!(result, Err(SessionError::HexDecode(_))));
+    }
+
+    // -- sign_event pubkey canonicalization --------------------------------
+    //
+    // Regression for divine-blossom 401 "Invalid signature" on viewer auth.
+    // nostr-sdk 0.44 `UnsignedEvent::sign` preserves whatever `pubkey` field the
+    // caller passed in and does NOT verify the produced sig against it; if the
+    // client-supplied pubkey disagrees with the signing keys (e.g. stale client
+    // cache after re-OAuth), the resulting event has `event.pubkey` not matching
+    // `event.sig` and Schnorr verify fails downstream. SigningSession::sign_event
+    // canonicalizes the pubkey field to `self.keys.public_key()` to keep the
+    // bunker as the source of truth (NIP-46 semantics).
+
+    use nostr_sdk::{EventBuilder, JsonUtil, Kind, Tag, Timestamp, UnsignedEvent};
+
+    #[tokio::test]
+    async fn sign_event_passthrough_when_pubkey_matches() {
+        let keys = Keys::generate();
+        let session = SigningSession::new(keys.clone());
+
+        let unsigned = EventBuilder::text_note("hello").build(keys.public_key());
+
+        let signed = session
+            .sign_event(unsigned)
+            .await
+            .expect("sign should succeed");
+
+        assert_eq!(signed.pubkey, keys.public_key());
+        signed
+            .verify()
+            .expect("signature must verify against signer's pubkey");
+    }
+
+    #[tokio::test]
+    async fn sign_event_canonicalizes_mismatched_pubkey() {
+        let signer_keys = Keys::generate();
+        let stale_keys = Keys::generate();
+        assert_ne!(signer_keys.public_key(), stale_keys.public_key());
+
+        let session = SigningSession::new(signer_keys.clone());
+
+        // Simulate the production failure: client cached an old pubkey
+        // (`stale_keys.public_key()`) and built the unsigned event around it,
+        // but the signer's actual keypair is `signer_keys`.
+        let unsigned = UnsignedEvent::new(
+            stale_keys.public_key(),
+            Timestamp::now(),
+            Kind::TextNote,
+            Vec::<Tag>::new(),
+            "hello",
+        );
+
+        let signed = session
+            .sign_event(unsigned)
+            .await
+            .expect("sign should succeed after canonicalization");
+
+        assert_eq!(
+            signed.pubkey,
+            signer_keys.public_key(),
+            "event.pubkey must match the keypair that produced the signature"
+        );
+        signed
+            .verify()
+            .expect("Schnorr verify must succeed after canonicalization");
+    }
+
+    #[tokio::test]
+    async fn sign_event_recovers_when_client_supplied_stale_id_too() {
+        // Defense for the "client computed event id over its old pubkey AND
+        // forwarded the id" path. Without clearing `unsigned.id`, nostr-sdk's
+        // internal_add_signature would fail with InvalidId because the id was
+        // computed over the wrong pubkey.
+        let signer_keys = Keys::generate();
+        let stale_keys = Keys::generate();
+        let session = SigningSession::new(signer_keys.clone());
+
+        let mut unsigned = UnsignedEvent::new(
+            stale_keys.public_key(),
+            Timestamp::now(),
+            Kind::TextNote,
+            Vec::<Tag>::new(),
+            "hello",
+        );
+        // Force the id to be precomputed over the stale pubkey.
+        let stale_id = unsigned.id();
+        assert!(unsigned.id.is_some());
+
+        let signed = session
+            .sign_event(unsigned)
+            .await
+            .expect("sign should succeed even with a stale precomputed id");
+
+        assert_eq!(signed.pubkey, signer_keys.public_key());
+        assert_ne!(
+            signed.id, stale_id,
+            "event id must be recomputed over the canonical pubkey"
+        );
+        signed
+            .verify()
+            .expect("Schnorr verify must succeed after id recomputation");
+        // Sanity: the produced JSON parses back to itself.
+        let json = signed.as_json();
+        assert!(json.contains(&signer_keys.public_key().to_hex()));
     }
 }


### PR DESCRIPTION
## Summary

- `SigningSession::sign_event` now canonicalizes `unsigned.pubkey` to the signer's pubkey (and clears any client-supplied `id` so it gets recomputed) before signing, matching NIP-46 bunker semantics. Self-heals divine-blossom 401 `Invalid signature` outage on viewer-auth.
- Diagnostic warns at both `core::signing_session` and `api::handlers::http_rpc_handler` when a mismatch fires, so we can confirm the bug existed and watch firing rate drop to ~0 post-rollout.
- 3 regression tests in `signing_session::tests` covering pass-through, pubkey canonicalization, and the trickier "client also forwarded a stale precomputed `id`" shape.

## Why

`nostr-sdk` 0.44.2 `UnsignedEvent::sign_with_keys` (the path `unsigned.sign(&keys).await` resolves to via the `NostrSigner` impl on `Keys`) preserves whatever `pubkey` the caller put in the unsigned event and produces an `Event` whose `event.pubkey` may not match the keypair that produced `event.sig`. It does **not** verify the resulting signature against the pubkey field — `verify_sig=false` in `internal_add_signature`, see `nostr/src/event/unsigned.rs:141`. Any downstream Schnorr verifier (for diVine that's `divine-blossom` `viewer_auth.rs:367-401`) then rejects the event with `Invalid signature` and the user 401s on every age-restricted media fetch.

Within a single `Arc<HttpRpcHandler>` `get_public_key` and `sign_event` always agree (both read `keys.public_key()` off the same `Keys`). The mismatch arises at the boundary — the divine-web client (`DivineJWTSigner.ts`) caches a pubkey from one session and reuses it when building unsigned events later; that cached value can become stale across re-OAuth (different `bunker_pubkey` → different `Keys`), key rotation via `/api/user/change-key`, or handler-cache eviction reloading the same UCAN against a freshly-written `personal_keys` row.

Per NIP-46 the bunker is the source of truth for the author's pubkey and the client value is advisory, so canonicalization (rather than 4xx-rejection) keeps the contract NIP-46-compatible and self-heals stale-cache clients without a coordinated client push. divine-web PR #283 already shipped a defensive client patch — that's a workaround; this is the spec-correct fix.

## What

- `core/src/signing_session.rs::sign_event`: when `unsigned.pubkey != self.keys.public_key()`, log `event=signing_session.pubkey_canonicalized` (warn) and overwrite both `unsigned.pubkey` and `unsigned.id` (forced recomputation) before signing. Pass-through unchanged when they already agree. The `id = None` reset is load-bearing — without it, `internal_add_signature` rejects with `Error::InvalidId` when the client also forwarded a precomputed id (`verify_id=true` whenever `self.id.is_some()`).
- `api/src/handlers/http_rpc_handler.rs::sign_event`: separate warn (`event=http_rpc.sign_event.pubkey_mismatch`) at the HTTP layer with `authorization_id` + `is_oauth` for telemetry — gives us visibility into which authorizations are sending mismatches and confirmation the firing rate drops post-rollout.
- 3 new tests in `core/src/signing_session.rs::tests`:
  1. matched pubkey passes through and `signed.verify()` succeeds.
  2. mismatched pubkey gets canonicalized; `signed.pubkey == keys.public_key()` and `signed.verify().is_ok()`.
  3. mismatched pubkey **with** stale precomputed `id` recovers; new id is recomputed; `signed.verify()` succeeds.

## Out of scope

- `signer/src/signer_daemon.rs:1662` `Nip46Handler::sign_event_direct` calls `unsigned.sign(&self.user_keys)` directly without going through `SigningSession`. Same vulnerability shape on the NIP-46-over-relay path; not implicated in the divine-blossom outage (HTTP RPC) but worth a follow-up PR to apply the same invariant if divine-mobile / Amber / nsec.app flows can also forward stale unsigned pubkeys.
- Possible upstream issue against rust-nostr asking whether `sign_with_ctx` should default to `verify_sig=true`, or at least warn-document that the default is unsafe for remote-signer use cases.

## Test plan

- [x] `cargo test -p keycast_core --lib signing_session` — 6 passed (3 pre-existing + 3 new)
- [x] `cargo test -p keycast_api --lib http_rpc_handler` — 10 passed
- [x] `cargo test -p keycast_core --lib` — 48 passed
- [x] `cargo test -p keycast_api --lib` — 105 passed (2 ignored, pre-existing)
- [x] `cargo clippy -p keycast_core -p keycast_api --lib --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] **Manual end-to-end against staging before merge**:
  ```bash
  TOKEN=...  # valid Bearer UCAN against login.staging.divine.video
  PK=$(curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
       -H "Content-Type: application/json" \
       -d '{"method":"get_public_key","params":[]}' \
       https://login.staging.divine.video/api/nostr | jq -r .result)
  WRONG=0000000000000000000000000000000000000000000000000000000000000001
  curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
       -H "Content-Type: application/json" \
       -d "{\"method\":\"sign_event\",\"params\":[{\"kind\":1,\"content\":\"hi\",\"tags\":[],\"created_at\":$(date +%s),\"pubkey\":\"$WRONG\"}]}" \
       https://login.staging.divine.video/api/nostr | jq '.result | {pubkey, id}'
  # Expect: returned event.pubkey == \$PK (not \$WRONG); local Schnorr verify passes.
  ```
- [ ] Watch logs for `signing_session.pubkey_canonicalized` / `http_rpc.sign_event.pubkey_mismatch` warns post-rollout to quantify how often the stale-client path was firing in production.

## Keycast version

Built against keycast `master` tip (see `git log` on this branch). Cargo workspace at `nostr-sdk = 0.44.1`, `nostr = 0.44.2` per `Cargo.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)