### PR TITLE
feat(api): add /.well-known/openid-configuration discovery endpoint

### DIFF
--- a/api/src/api/http/atproto_oauth_metadata.rs
+++ b/api/src/api/http/atproto_oauth_metadata.rs
@@ -20,32 +20,40 @@ pub struct AuthorizationServerMetadata {
     require_pushed_authorization_requests: bool,
 }
 
-pub fn authorization_server_origin() -> String {
-    std::env::var("ATPROTO_ENTRYWAY_ORIGIN")
+fn parse_origin(raw: &str) -> Option<String> {
+    Url::parse(raw).ok().and_then(|url| {
+        let host = url.host_str()?;
+        let scheme = url.scheme();
+        let mut origin = format!("{scheme}://{host}");
+
+        if let Some(port) = url.port() {
+            let is_default_port =
+                (scheme == "https" && port == 443) || (scheme == "http" && port == 80);
+            if !is_default_port {
+                origin.push_str(&format!(":{port}"));
+            }
+        }
+
+        Some(origin)
+    })
+}
+
+pub(crate) fn app_origin() -> String {
+    std::env::var("APP_URL")
         .ok()
-        .or_else(|| std::env::var("APP_URL").ok())
         .or_else(|| std::env::var("VITE_DOMAIN").ok())
-        .and_then(|raw| {
-            Url::parse(&raw).ok().and_then(|url| {
-                let host = url.host_str()?;
-                let scheme = url.scheme();
-                let mut origin = format!("{scheme}://{host}");
-
-                if let Some(port) = url.port() {
-                    let is_default_port =
-                        (scheme == "https" && port == 443) || (scheme == "http" && port == 80);
-                    if !is_default_port {
-                        origin.push_str(&format!(":{port}"));
-                    }
-                }
-
-                Some(origin)
-            })
-        })
+        .and_then(|raw| parse_origin(&raw))
         .unwrap_or_else(|| "http://localhost:3000".to_string())
 }
 
-fn endpoint(origin: &str, path: &str) -> String {
+pub fn authorization_server_origin() -> String {
+    std::env::var("ATPROTO_ENTRYWAY_ORIGIN")
+        .ok()
+        .and_then(|raw| parse_origin(&raw))
+        .unwrap_or_else(app_origin)
+}
+
+pub(crate) fn endpoint(origin: &str, path: &str) -> String {
     format!(
         "{}/{}",
         origin.trim_end_matches('/'),

--- a/api/src/api/http/mod.rs
+++ b/api/src/api/http/mod.rs
@@ -10,6 +10,7 @@ pub mod html_safety;
 pub mod metrics;
 pub mod nostr_rpc;
 pub mod oauth;
+pub mod openid_configuration;
 pub mod policies;
 pub mod routes;
 pub mod teams;

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -2,10 +2,11 @@
 // ABOUTME: Implements authorization code flow that issues bunker URLs for NIP-46 remote signing
 
 use axum::{
-    extract::{Query, State},
-    http::{HeaderMap, StatusCode},
+    async_trait,
+    extract::{FromRequest, Query, Request, State},
+    http::{header::CONTENT_TYPE, HeaderMap, StatusCode},
     response::{Html, IntoResponse, Redirect, Response},
-    Form, Json,
+    Form, Json, RequestExt,
 };
 use base64::Engine;
 use bcrypt::verify;
@@ -265,6 +266,47 @@ pub struct TokenRequest {
     pub redirect_uri: Option<String>, // For authorization_code grant
     pub code_verifier: Option<String>, // For PKCE (authorization_code grant)
     pub refresh_token: Option<String>, // For refresh_token grant
+}
+
+pub struct TokenRequestBody(pub TokenRequest);
+
+#[async_trait]
+impl<S> FromRequest<S> for TokenRequestBody
+where
+    S: Send + Sync,
+{
+    type Rejection = OAuthError;
+
+    async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
+        let content_type = req
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+
+        if content_type.starts_with("application/json") {
+            let Json(req) = req
+                .extract::<Json<TokenRequest>, _>()
+                .await
+                .map_err(|err| {
+                    OAuthError::InvalidRequest(format!("Invalid JSON token request: {err}"))
+                })?;
+            Ok(Self(req))
+        } else if content_type.starts_with("application/x-www-form-urlencoded") {
+            let Form(req) = req
+                .extract::<Form<TokenRequest>, _>()
+                .await
+                .map_err(|err| {
+                    OAuthError::InvalidRequest(format!("Invalid form token request: {err}"))
+                })?;
+            Ok(Self(req))
+        } else {
+            Err(OAuthError::InvalidRequest(
+                "Token endpoint requires application/json or application/x-www-form-urlencoded"
+                    .to_string(),
+            ))
+        }
+    }
 }
 
 /// Generate UCAN token signed by user's key
@@ -2359,7 +2401,7 @@ pub async fn authorize_post(
 pub async fn token(
     tenant: crate::api::tenant::TenantExtractor,
     State(auth_state): State<super::routes::AuthState>,
-    Json(req): Json<TokenRequest>,
+    TokenRequestBody(req): TokenRequestBody,
 ) -> Result<Response, OAuthError> {
     let tenant_id = tenant.0.id;
     let grant_type = req.grant_type.as_deref().unwrap_or("authorization_code");

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -277,12 +277,19 @@ where
 {
     type Rejection = OAuthError;
 
-    async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request(mut req: Request, _state: &S) -> Result<Self, Self::Rejection> {
+        // Media type type/subtype are case-insensitive (RFC 9110 8.3.1). Normalize
+        // the header itself, because `Json` and `Form` disagree on case handling.
         let content_type = req
             .headers()
             .get(CONTENT_TYPE)
             .and_then(|value| value.to_str().ok())
+            .map(|value| value.to_ascii_lowercase())
             .unwrap_or_default();
+
+        if let Ok(normalized) = axum::http::HeaderValue::from_str(&content_type) {
+            req.headers_mut().insert(CONTENT_TYPE, normalized);
+        }
 
         if content_type.starts_with("application/json") {
             let Json(req) = req

--- a/api/src/api/http/openid_configuration.rs
+++ b/api/src/api/http/openid_configuration.rs
@@ -1,0 +1,73 @@
+// ABOUTME: OpenID Connect Discovery 1.0 metadata endpoint.
+// ABOUTME: Reuses the OAuth 2.0 origin helper so the discovery document is
+// rooted at the same APP_URL as the rest of the service.
+//
+// Keycast is primarily an OAuth 2.0 + Nostr Bunker (NIP-46) provider rather
+// than a fully-fledged OpenID Connect provider — we don't issue spec-shaped
+// id_tokens or expose a userinfo endpoint at this time. Even so, OIDC
+// autodiscovery clients (and the reliability assurance suite's
+// `oidc_discovery` probe) hit `/.well-known/openid-configuration` to find
+// the OAuth endpoints. Without this handler the SvelteKit SPA fallback
+// served the index HTML instead of JSON; clients then got a JSON parse
+// error and treated keycast as unreachable.
+//
+// The document below is deliberately conservative: it advertises only the
+// capabilities keycast actually supports today. A client that tries to use
+// strict OIDC features (id_token signing, userinfo) will fail at runtime
+// rather than fail silently — that's the correct degradation.
+//
+// Sibling: `atproto_oauth_metadata.rs` serves
+// `/.well-known/oauth-authorization-server` for ATProto-flavoured clients.
+
+use axum::Json;
+use serde::Serialize;
+
+use super::atproto_oauth_metadata::authorization_server_origin;
+
+#[derive(Debug, Serialize)]
+pub struct OpenIdConfiguration {
+    issuer: String,
+    authorization_endpoint: String,
+    token_endpoint: String,
+    response_types_supported: Vec<String>,
+    grant_types_supported: Vec<String>,
+    scopes_supported: Vec<String>,
+    token_endpoint_auth_methods_supported: Vec<String>,
+    code_challenge_methods_supported: Vec<String>,
+    // OIDC-required capability lists. Keycast does not currently issue
+    // OIDC-shaped id_tokens, but every value here describes what the
+    // service WOULD support if/when it does — keeping the list non-empty
+    // satisfies strict autodiscovery clients without misrepresenting
+    // current behavior. ``subject_types: ["public"]`` is the only sensible
+    // value for a Nostr-pubkey-rooted identity model.
+    subject_types_supported: Vec<String>,
+    id_token_signing_alg_values_supported: Vec<String>,
+}
+
+fn endpoint(origin: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        origin.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
+}
+
+pub async fn openid_configuration_metadata() -> Json<OpenIdConfiguration> {
+    let origin = authorization_server_origin();
+
+    Json(OpenIdConfiguration {
+        issuer: origin.clone(),
+        authorization_endpoint: endpoint(&origin, "/api/oauth/authorize"),
+        token_endpoint: endpoint(&origin, "/api/oauth/token"),
+        response_types_supported: vec!["code".to_string()],
+        grant_types_supported: vec![
+            "authorization_code".to_string(),
+            "refresh_token".to_string(),
+        ],
+        scopes_supported: vec!["openid".to_string(), "profile".to_string()],
+        token_endpoint_auth_methods_supported: vec!["none".to_string()],
+        code_challenge_methods_supported: vec!["S256".to_string()],
+        subject_types_supported: vec!["public".to_string()],
+        id_token_signing_alg_values_supported: vec!["ES256".to_string()],
+    })
+}

--- a/api/src/api/http/openid_configuration.rs
+++ b/api/src/api/http/openid_configuration.rs
@@ -1,28 +1,18 @@
-// ABOUTME: OpenID Connect Discovery 1.0 metadata endpoint.
-// ABOUTME: Reuses the OAuth 2.0 origin helper so the discovery document is
-// rooted at the same APP_URL as the rest of the service.
+// ABOUTME: Compatibility metadata for OpenID autodiscovery clients.
+// ABOUTME: Keeps the OpenID well-known path from falling through to the SPA
+// fallback while advertising only Keycast's current OAuth behavior.
 //
 // Keycast is primarily an OAuth 2.0 + Nostr Bunker (NIP-46) provider rather
-// than a fully-fledged OpenID Connect provider — we don't issue spec-shaped
-// id_tokens or expose a userinfo endpoint at this time. Even so, OIDC
-// autodiscovery clients (and the reliability assurance suite's
-// `oidc_discovery` probe) hit `/.well-known/openid-configuration` to find
-// the OAuth endpoints. Without this handler the SvelteKit SPA fallback
-// served the index HTML instead of JSON; clients then got a JSON parse
-// error and treated keycast as unreachable.
-//
-// The document below is deliberately conservative: it advertises only the
-// capabilities keycast actually supports today. A client that tries to use
-// strict OIDC features (id_token signing, userinfo) will fail at runtime
-// rather than fail silently — that's the correct degradation.
-//
-// Sibling: `atproto_oauth_metadata.rs` serves
-// `/.well-known/oauth-authorization-server` for ATProto-flavoured clients.
+// than an OpenID Provider: it does not issue ID Tokens, expose UserInfo, or
+// publish signing keys for OIDC token validation. Even so, some clients and
+// reliability probes hit `/.well-known/openid-configuration` first. Returning
+// this small OAuth-shaped JSON document is more useful than serving the SPA
+// index HTML, while avoiding unsupported `openid`/`id_token` claims.
 
 use axum::Json;
 use serde::Serialize;
 
-use super::atproto_oauth_metadata::authorization_server_origin;
+use super::atproto_oauth_metadata::{app_origin, endpoint};
 
 #[derive(Debug, Serialize)]
 pub struct OpenIdConfiguration {
@@ -31,29 +21,12 @@ pub struct OpenIdConfiguration {
     token_endpoint: String,
     response_types_supported: Vec<String>,
     grant_types_supported: Vec<String>,
-    scopes_supported: Vec<String>,
     token_endpoint_auth_methods_supported: Vec<String>,
     code_challenge_methods_supported: Vec<String>,
-    // OIDC-required capability lists. Keycast does not currently issue
-    // OIDC-shaped id_tokens, but every value here describes what the
-    // service WOULD support if/when it does — keeping the list non-empty
-    // satisfies strict autodiscovery clients without misrepresenting
-    // current behavior. ``subject_types: ["public"]`` is the only sensible
-    // value for a Nostr-pubkey-rooted identity model.
-    subject_types_supported: Vec<String>,
-    id_token_signing_alg_values_supported: Vec<String>,
-}
-
-fn endpoint(origin: &str, path: &str) -> String {
-    format!(
-        "{}/{}",
-        origin.trim_end_matches('/'),
-        path.trim_start_matches('/')
-    )
 }
 
 pub async fn openid_configuration_metadata() -> Json<OpenIdConfiguration> {
-    let origin = authorization_server_origin();
+    let origin = app_origin();
 
     Json(OpenIdConfiguration {
         issuer: origin.clone(),
@@ -64,10 +37,7 @@ pub async fn openid_configuration_metadata() -> Json<OpenIdConfiguration> {
             "authorization_code".to_string(),
             "refresh_token".to_string(),
         ],
-        scopes_supported: vec!["openid".to_string(), "profile".to_string()],
         token_endpoint_auth_methods_supported: vec!["none".to_string()],
         code_challenge_methods_supported: vec!["S256".to_string()],
-        subject_types_supported: vec!["public".to_string()],
-        id_token_signing_alg_values_supported: vec!["ES256".to_string()],
     })
 }

--- a/api/tests/oauth_token_request_body_test.rs
+++ b/api/tests/oauth_token_request_body_test.rs
@@ -1,0 +1,105 @@
+// ABOUTME: Token request decoding coverage for the OAuth endpoint.
+// ABOUTME: Standard OAuth clients submit token grants as form data, while
+// existing Keycast clients still use JSON.
+
+use axum::{
+    body::Body,
+    http::{header::CONTENT_TYPE, Request, StatusCode},
+    response::IntoResponse,
+    routing::post,
+    Json, Router,
+};
+use http_body_util::BodyExt;
+use keycast_api::api::http::oauth::TokenRequestBody;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn echo_token_request(TokenRequestBody(req): TokenRequestBody) -> impl IntoResponse {
+    Json(json!({
+        "grant_type": req.grant_type,
+        "code": req.code,
+        "client_id": req.client_id,
+        "redirect_uri": req.redirect_uri,
+        "code_verifier": req.code_verifier,
+        "refresh_token": req.refresh_token,
+    }))
+}
+
+fn test_app() -> Router {
+    Router::new().route("/api/oauth/token", post(echo_token_request))
+}
+
+async fn response_json(response: axum::response::Response) -> Value {
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&body).unwrap()
+}
+
+#[tokio::test]
+async fn token_request_accepts_form_encoded_oauth_body() {
+    let response = test_app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/oauth/token")
+                .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from(
+                    "grant_type=authorization_code&code=code-123&client_id=client-123&redirect_uri=https%3A%2F%2Fclient.example%2Fcallback&code_verifier=verifier-123",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await;
+    assert_eq!(body["grant_type"], "authorization_code");
+    assert_eq!(body["code"], "code-123");
+    assert_eq!(body["client_id"], "client-123");
+    assert_eq!(body["redirect_uri"], "https://client.example/callback");
+    assert_eq!(body["code_verifier"], "verifier-123");
+}
+
+#[tokio::test]
+async fn token_request_keeps_existing_json_body_support() {
+    let response = test_app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/oauth/token")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "grant_type": "refresh_token",
+                        "client_id": "client-123",
+                        "refresh_token": "refresh-123"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await;
+    assert_eq!(body["grant_type"], "refresh_token");
+    assert_eq!(body["client_id"], "client-123");
+    assert_eq!(body["refresh_token"], "refresh-123");
+}
+
+#[tokio::test]
+async fn token_request_rejects_unsupported_content_type() {
+    let response = test_app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/oauth/token")
+                .header(CONTENT_TYPE, "text/plain")
+                .body(Body::from("grant_type=authorization_code"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/api/tests/oauth_token_request_body_test.rs
+++ b/api/tests/oauth_token_request_body_test.rs
@@ -88,6 +88,53 @@ async fn token_request_keeps_existing_json_body_support() {
 }
 
 #[tokio::test]
+async fn token_request_accepts_mixed_case_form_content_type() {
+    let response = test_app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/oauth/token")
+                .header(CONTENT_TYPE, "Application/X-Www-Form-Urlencoded")
+                .body(Body::from(
+                    "grant_type=authorization_code&code=code-123&client_id=client-123",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await;
+    assert_eq!(body["client_id"], "client-123");
+}
+
+#[tokio::test]
+async fn token_request_accepts_mixed_case_json_content_type() {
+    let response = test_app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/oauth/token")
+                .header(CONTENT_TYPE, "Application/JSON")
+                .body(Body::from(
+                    json!({
+                        "grant_type": "refresh_token",
+                        "client_id": "client-123",
+                        "refresh_token": "refresh-123"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await;
+    assert_eq!(body["client_id"], "client-123");
+}
+
+#[tokio::test]
 async fn token_request_rejects_unsupported_content_type() {
     let response = test_app()
         .oneshot(

--- a/api/tests/oauth_verifier_nsec_scope_test.rs
+++ b/api/tests/oauth_verifier_nsec_scope_test.rs
@@ -5,7 +5,7 @@
 
 mod common;
 
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{extract::State, http::StatusCode};
 use chrono::{Duration, Utc};
 use keycast_api::{
     api::{
@@ -135,7 +135,7 @@ async fn exchange_code(pool: &PgPool, code: &str, verifier: &str) -> StatusCode 
     let result = oauth::token(
         test_tenant(),
         State(auth_state),
-        Json(oauth::TokenRequest {
+        oauth::TokenRequestBody(oauth::TokenRequest {
             grant_type: Some("authorization_code".to_string()),
             code: Some(code.to_string()),
             client_id: "Verifier Scope Test".to_string(),

--- a/api/tests/openid_configuration_test.rs
+++ b/api/tests/openid_configuration_test.rs
@@ -14,13 +14,44 @@ use axum::{
 use http_body_util::BodyExt;
 use keycast_api::api::http::openid_configuration::openid_configuration_metadata;
 use serde_json::Value;
+use serial_test::serial;
 use tower::ServiceExt;
 
-#[tokio::test]
-async fn openid_configuration_returns_json_with_issuer() {
-    unsafe {
-        std::env::set_var("APP_URL", "https://login.divine.video");
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
     }
+
+    fn remove(key: &'static str) -> Self {
+        let previous = std::env::var(key).ok();
+        unsafe { std::env::remove_var(key) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn openid_configuration_returns_json_with_issuer() {
+    let _entryway = EnvGuard::remove("ATPROTO_ENTRYWAY_ORIGIN");
+    let _app = EnvGuard::set("APP_URL", "https://login.divine.video");
 
     let app = Router::new().route(
         "/.well-known/openid-configuration",
@@ -61,8 +92,8 @@ async fn openid_configuration_returns_json_with_issuer() {
         "https://login.divine.video/api/oauth/token"
     );
 
-    // OIDC discovery is required by spec to advertise these capability lists.
-    // Empty arrays here would let a strict client reject the document.
+    // Keycast is not an OpenID Provider yet, so this compatibility document
+    // must stay honest about the OAuth capabilities it actually has.
     assert!(payload["response_types_supported"]
         .as_array()
         .expect("response_types_supported must be an array")
@@ -73,31 +104,39 @@ async fn openid_configuration_returns_json_with_issuer() {
         .expect("grant_types_supported must be an array")
         .iter()
         .any(|v| v == "authorization_code"));
-    assert!(payload["subject_types_supported"]
-        .as_array()
-        .expect("subject_types_supported must be an array")
-        .iter()
-        .any(|v| v == "public"));
-    assert!(payload["id_token_signing_alg_values_supported"]
-        .as_array()
-        .expect("id_token_signing_alg_values_supported must be an array")
-        .iter()
-        .any(|v| v == "ES256"));
     assert!(payload["code_challenge_methods_supported"]
         .as_array()
         .expect("code_challenge_methods_supported must be an array")
         .iter()
         .any(|v| v == "S256"));
+    assert!(
+        payload.get("scopes_supported").is_none(),
+        "Keycast scopes are policy:slug values, not OpenID scopes"
+    );
+    assert!(
+        payload.get("subject_types_supported").is_none(),
+        "subject_types_supported would imply OpenID Provider support"
+    );
+    assert!(
+        payload
+            .get("id_token_signing_alg_values_supported")
+            .is_none(),
+        "Keycast does not issue OIDC ID Tokens"
+    );
+    assert!(
+        payload.get("jwks_uri").is_none(),
+        "Keycast does not publish OIDC signing keys"
+    );
 }
 
 #[tokio::test]
+#[serial]
 async fn openid_configuration_strips_trailing_slash_from_issuer() {
     // Defensive: APP_URL is configured by deploys and humans; tolerate a
     // trailing slash without producing `https://login.divine.video//api/...`
     // links that violate spec.
-    unsafe {
-        std::env::set_var("APP_URL", "https://login.divine.video/");
-    }
+    let _entryway = EnvGuard::remove("ATPROTO_ENTRYWAY_ORIGIN");
+    let _app = EnvGuard::set("APP_URL", "https://login.divine.video/");
 
     let app = Router::new().route(
         "/.well-known/openid-configuration",
@@ -122,5 +161,43 @@ async fn openid_configuration_strips_trailing_slash_from_issuer() {
     assert!(
         !token.contains("//api/"),
         "endpoint URL has a double slash: {token}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn openid_configuration_uses_app_origin_not_atproto_entryway_origin() {
+    let _app = EnvGuard::set("APP_URL", "https://login.divine.video");
+    let _entryway = EnvGuard::set(
+        "ATPROTO_ENTRYWAY_ORIGIN",
+        "https://entryway.divine.video/ignored/path",
+    );
+
+    let app = Router::new().route(
+        "/.well-known/openid-configuration",
+        get(openid_configuration_metadata),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/.well-known/openid-configuration")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let payload: Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(payload["issuer"], "https://login.divine.video");
+    assert_eq!(
+        payload["authorization_endpoint"],
+        "https://login.divine.video/api/oauth/authorize"
+    );
+    assert_eq!(
+        payload["token_endpoint"],
+        "https://login.divine.video/api/oauth/token"
     );
 }

--- a/api/tests/openid_configuration_test.rs
+++ b/api/tests/openid_configuration_test.rs
@@ -1,0 +1,126 @@
+// ABOUTME: regression test for the `/.well-known/openid-configuration` discovery
+// document. The endpoint MUST return JSON (not the SPA index HTML) so OIDC
+// autodiscovery clients can find the keycast OAuth endpoints. The bug this
+// guards against was reported on 2026-04-28: keycast had no handler at this
+// path, the SPA fallback served index.html, and any OIDC client that did
+// autodiscovery received a JSON parse error.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::get,
+    Router,
+};
+use http_body_util::BodyExt;
+use keycast_api::api::http::openid_configuration::openid_configuration_metadata;
+use serde_json::Value;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn openid_configuration_returns_json_with_issuer() {
+    unsafe {
+        std::env::set_var("APP_URL", "https://login.divine.video");
+    }
+
+    let app = Router::new().route(
+        "/.well-known/openid-configuration",
+        get(openid_configuration_metadata),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/.well-known/openid-configuration")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "application/json"
+    );
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let payload: Value = serde_json::from_slice(&body)
+        .expect("response body must be JSON, not HTML — this is the regression");
+
+    // Required by the reliability suite probe (see keycast.yaml).
+    assert_eq!(payload["issuer"], "https://login.divine.video");
+
+    // Endpoints MUST be absolute URLs anchored at the issuer so clients
+    // doing autodiscovery don't have to guess the base.
+    assert_eq!(
+        payload["authorization_endpoint"],
+        "https://login.divine.video/api/oauth/authorize"
+    );
+    assert_eq!(
+        payload["token_endpoint"],
+        "https://login.divine.video/api/oauth/token"
+    );
+
+    // OIDC discovery is required by spec to advertise these capability lists.
+    // Empty arrays here would let a strict client reject the document.
+    assert!(payload["response_types_supported"]
+        .as_array()
+        .expect("response_types_supported must be an array")
+        .iter()
+        .any(|v| v == "code"));
+    assert!(payload["grant_types_supported"]
+        .as_array()
+        .expect("grant_types_supported must be an array")
+        .iter()
+        .any(|v| v == "authorization_code"));
+    assert!(payload["subject_types_supported"]
+        .as_array()
+        .expect("subject_types_supported must be an array")
+        .iter()
+        .any(|v| v == "public"));
+    assert!(payload["id_token_signing_alg_values_supported"]
+        .as_array()
+        .expect("id_token_signing_alg_values_supported must be an array")
+        .iter()
+        .any(|v| v == "ES256"));
+    assert!(payload["code_challenge_methods_supported"]
+        .as_array()
+        .expect("code_challenge_methods_supported must be an array")
+        .iter()
+        .any(|v| v == "S256"));
+}
+
+#[tokio::test]
+async fn openid_configuration_strips_trailing_slash_from_issuer() {
+    // Defensive: APP_URL is configured by deploys and humans; tolerate a
+    // trailing slash without producing `https://login.divine.video//api/...`
+    // links that violate spec.
+    unsafe {
+        std::env::set_var("APP_URL", "https://login.divine.video/");
+    }
+
+    let app = Router::new().route(
+        "/.well-known/openid-configuration",
+        get(openid_configuration_metadata),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/.well-known/openid-configuration")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let payload: Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(payload["issuer"], "https://login.divine.video");
+    let token = payload["token_endpoint"].as_str().unwrap();
+    assert!(
+        !token.contains("//api/"),
+        "endpoint URL has a double slash: {token}"
+    );
+}

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -1531,6 +1531,16 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
             "/oauth-authorization-server",
             get(keycast_api::api::http::atproto_oauth_metadata::authorization_server_metadata),
         )
+        // OIDC discovery sibling. Without this handler, the SPA fallback
+        // serves index.html for `/.well-known/openid-configuration`, breaking
+        // OIDC autodiscovery for any client that follows the standard.
+        // See `api/src/api/http/openid_configuration.rs` for the document
+        // shape and the rationale for advertising only the capabilities
+        // keycast actually supports today.
+        .route(
+            "/openid-configuration",
+            get(keycast_api::api::http::openid_configuration::openid_configuration_metadata),
+        )
         .with_state(web_build_dir.clone());
 
     let mut app = Router::new()


### PR DESCRIPTION
## Summary

- Adds `GET /.well-known/openid-configuration` so autodiscovery callers receive JSON instead of the SvelteKit SPA fallback HTML.
- Keeps the response honest about current Keycast behavior: OAuth authorization-code metadata only, with no `openid` scope, ID Token signing, `jwks_uri`, or UserInfo claims.
- Splits the existing origin helper so the ATProto metadata endpoint can still prefer `ATPROTO_ENTRYWAY_ORIGIN`, while the OpenID compatibility endpoint uses the normal app origin from `APP_URL`/`VITE_DOMAIN`.
- Allows `/api/oauth/token` to accept both standards-compliant `application/x-www-form-urlencoded` requests and the existing JSON request format.
- Hardens the new tests to match the sibling metadata tests: serialized process-env mutation, RAII env restoration, and explicit coverage that `ATPROTO_ENTRYWAY_ORIGIN` does not leak into this endpoint.

## Motivation

- Without a route for `/.well-known/openid-configuration`, the static SPA fallback served `index.html` with a 200 response.
- Some clients and probes check this well-known path before trying OAuth endpoints, so returning JSON is a useful compatibility improvement.
- Keycast does not currently issue OpenID Connect ID Tokens, so advertising OIDC provider capabilities would make clients fail later in the flow after trusting unsupported metadata.
- The discovered OAuth token endpoint now accepts the form-encoded token requests that standards-following OAuth clients send.

## Related Issue

- Closes #274

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo test --package keycast_api --test oauth_token_request_body_test`
- [x] `cargo test --package keycast_api --test openid_configuration_test`
- [x] `cargo test --package keycast_api --test atproto_oauth_metadata_test`
- [x] `DATABASE_URL=postgres://postgres:password@localhost:5432/keycast_test REDIS_URL=redis://localhost:16379 TEST_REDIS_URL=redis://localhost:16379 cargo test --workspace --verbose`
- [x] `DATABASE_URL=postgres://postgres:password@localhost:5432/keycast_test REDIS_URL=redis://localhost:16379 TEST_REDIS_URL=redis://localhost:16379 cargo test -p keycast_api --features integration-tests --lib --tests --verbose`
- [x] `DATABASE_URL=postgres://postgres:password@localhost:5432/keycast_test REDIS_URL=redis://localhost:16379 TEST_REDIS_URL=redis://localhost:16379 cargo test -p keycast_core --features integration-tests --lib --tests --verbose`
- [x] `cargo test -p keycast_signer --features integration-tests --lib --tests --verbose`
- [ ] Local rerun of `cargo test --workspace --verbose` after `0fa43b3` could not complete because port 5432 is occupied by non-Keycast `config-postgres-1`, whose credentials reject the repo default `postgres:password` test URL.
- [ ] `bun run test` was attempted locally, but this machine is missing `cargo-nextest`.
- [ ] Manual verification completed

## Visuals

- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved