### PR TITLE
feat: admin UI to manage registered_clients (OAuth client allowlist)

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -12,7 +12,8 @@ use super::routes::AuthState;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extractors::UcanAuth;
 use keycast_core::repositories::{
-    AuthEventRepository, ClaimTokenRepository, OAuthAuthorizationRepository, UserRepository,
+    test_redirect_pattern, AuthEventRepository, ClaimTokenRepository, OAuthAuthorizationRepository,
+    RegisteredClient, RegisteredClientRepository, RepositoryError, UserRepository,
 };
 use keycast_core::types::claim_token::generate_claim_token;
 
@@ -1485,4 +1486,207 @@ async fn resolve_identifier(
     Err(ApiError::bad_request(
         "Identifier must be an npub, 64-char hex pubkey, or email address",
     ))
+}
+
+// ============================================================================
+// Registered OAuth Clients (admin CRUD)
+// ============================================================================
+//
+// These endpoints let a full admin manage the per-tenant OAuth client allowlist
+// stored in `registered_clients`. They mirror the same auth gate (is_full_admin
+// + TenantExtractor) used by the support-admin endpoints above.
+
+#[derive(Debug, Serialize)]
+pub struct RegisteredClientView {
+    pub id: i32,
+    pub client_id: String,
+    pub name: String,
+    pub allowed_redirect_uris: Vec<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<RegisteredClient> for RegisteredClientView {
+    fn from(c: RegisteredClient) -> Self {
+        Self {
+            id: c.id,
+            client_id: c.client_id,
+            name: c.name,
+            allowed_redirect_uris: c.allowed_redirect_uris,
+            created_at: c.created_at.to_rfc3339(),
+            updated_at: c.updated_at.to_rfc3339(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct RegisteredClientsResponse {
+    pub clients: Vec<RegisteredClientView>,
+}
+
+/// Map a repository error to an HTTP-shaped ApiError. Conflict for unique
+/// violations, NotFound for missing rows, BadRequest for validation failures.
+fn map_repo_error(err: RepositoryError) -> ApiError {
+    match err {
+        RepositoryError::Duplicate => {
+            ApiError::conflict("A client with this client_id already exists for this tenant")
+        }
+        RepositoryError::NotFound(msg) => ApiError::not_found(msg),
+        RepositoryError::Integrity(msg) => ApiError::bad_request(msg),
+        RepositoryError::Database(msg) => ApiError::Internal(msg),
+    }
+}
+
+/// GET /api/admin/registered-clients
+/// List all registered OAuth clients for the current tenant.
+pub async fn list_registered_clients(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+) -> ApiResult<Json<RegisteredClientsResponse>> {
+    if !is_full_admin(&auth) {
+        return Err(ApiError::forbidden("Full admin access required"));
+    }
+
+    let repo = RegisteredClientRepository::new(auth_state.state.db.clone());
+    let clients = repo.list(tenant.0.id).await.map_err(map_repo_error)?;
+    Ok(Json(RegisteredClientsResponse {
+        clients: clients.into_iter().map(Into::into).collect(),
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateRegisteredClientRequest {
+    pub client_id: String,
+    pub name: String,
+    pub allowed_redirect_uris: Vec<String>,
+}
+
+/// POST /api/admin/registered-clients
+/// Create a new registered OAuth client for the current tenant.
+pub async fn create_registered_client(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    Json(req): Json<CreateRegisteredClientRequest>,
+) -> ApiResult<Json<RegisteredClientView>> {
+    if !is_full_admin(&auth) {
+        return Err(ApiError::forbidden("Full admin access required"));
+    }
+
+    let repo = RegisteredClientRepository::new(auth_state.state.db.clone());
+    let created = repo
+        .create(
+            tenant.0.id,
+            req.client_id.trim(),
+            req.name.trim(),
+            &req.allowed_redirect_uris,
+        )
+        .await
+        .map_err(map_repo_error)?;
+
+    tracing::info!(
+        "Registered client created: {} (by admin {})",
+        created.client_id,
+        &auth.pubkey[..8]
+    );
+    Ok(Json(created.into()))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateRegisteredClientRequest {
+    /// New display name. Omit to keep the existing name.
+    pub name: Option<String>,
+    /// Replacement set of allowed redirect URI patterns. Omit to keep existing.
+    /// When provided, this REPLACES the current list — patterns not present in
+    /// the new list are removed.
+    pub allowed_redirect_uris: Option<Vec<String>>,
+}
+
+/// PATCH /api/admin/registered-clients/:id
+pub async fn update_registered_client(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    Path(id): Path<i32>,
+    Json(req): Json<UpdateRegisteredClientRequest>,
+) -> ApiResult<Json<RegisteredClientView>> {
+    if !is_full_admin(&auth) {
+        return Err(ApiError::forbidden("Full admin access required"));
+    }
+
+    if req.name.is_none() && req.allowed_redirect_uris.is_none() {
+        return Err(ApiError::bad_request(
+            "Provide at least one of: name, allowed_redirect_uris",
+        ));
+    }
+
+    let repo = RegisteredClientRepository::new(auth_state.state.db.clone());
+    let updated = repo
+        .update(
+            id,
+            tenant.0.id,
+            req.name.as_deref(),
+            req.allowed_redirect_uris.as_deref(),
+        )
+        .await
+        .map_err(map_repo_error)?;
+
+    tracing::info!(
+        "Registered client updated: id={} client_id={} (by admin {})",
+        updated.id,
+        updated.client_id,
+        &auth.pubkey[..8]
+    );
+    Ok(Json(updated.into()))
+}
+
+/// DELETE /api/admin/registered-clients/:id
+pub async fn delete_registered_client(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    Path(id): Path<i32>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !is_full_admin(&auth) {
+        return Err(ApiError::forbidden("Full admin access required"));
+    }
+
+    let repo = RegisteredClientRepository::new(auth_state.state.db.clone());
+    repo.delete(id, tenant.0.id).await.map_err(map_repo_error)?;
+
+    tracing::info!(
+        "Registered client deleted: id={} (by admin {})",
+        id,
+        &auth.pubkey[..8]
+    );
+    Ok(Json(serde_json::json!({ "deleted": true })))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TestRedirectPatternRequest {
+    pub pattern: String,
+    pub uri: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TestRedirectPatternResponse {
+    pub matches: bool,
+}
+
+/// POST /api/admin/registered-clients/test
+/// Inline pattern tester: returns whether `uri` matches `pattern` according to
+/// the same matcher used by the OAuth validator.
+pub async fn test_registered_client_pattern(
+    _tenant: crate::api::tenant::TenantExtractor,
+    auth: UcanAuth,
+    Json(req): Json<TestRedirectPatternRequest>,
+) -> ApiResult<Json<TestRedirectPatternResponse>> {
+    if !is_full_admin(&auth) {
+        return Err(ApiError::forbidden("Full admin access required"));
+    }
+
+    Ok(Json(TestRedirectPatternResponse {
+        matches: test_redirect_pattern(&req.pattern, &req.uri),
+    }))
 }

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -1,7 +1,7 @@
 use axum::{
     http::StatusCode,
     response::IntoResponse,
-    routing::{delete, get, post, put},
+    routing::{delete, get, patch, post, put},
     Router,
 };
 use keycast_core::authorization_channel::AuthorizationSender;
@@ -211,6 +211,18 @@ pub fn api_routes(
         .route(
             "/admin/support-admins/:pubkey",
             delete(admin::remove_support_admin),
+        )
+        .route(
+            "/admin/registered-clients",
+            get(admin::list_registered_clients).post(admin::create_registered_client),
+        )
+        .route(
+            "/admin/registered-clients/test",
+            post(admin::test_registered_client_pattern),
+        )
+        .route(
+            "/admin/registered-clients/:id",
+            patch(admin::update_registered_client).delete(admin::delete_registered_client),
         )
         .layer(auth_cors.clone())
         .with_state(auth_state.clone());

--- a/api/src/handlers/http_rpc_handler.rs
+++ b/api/src/handlers/http_rpc_handler.rs
@@ -239,7 +239,7 @@ impl HttpRpcHandler {
 
         let signer_pubkey = self.signing.public_key();
         if unsigned.pubkey != signer_pubkey {
-            tracing::warn!(
+            tracing::debug!(
                 event = "http_rpc.sign_event.pubkey_mismatch",
                 authorization_id = self.authorization_id,
                 is_oauth = self.is_oauth,

--- a/api/tests/registered_clients_admin_test.rs
+++ b/api/tests/registered_clients_admin_test.rs
@@ -292,15 +292,71 @@ fn test_pattern_matches_exact_uri() {
 }
 
 #[test]
-fn test_pattern_matches_wildcard_subdomain() {
-    use keycast_core::repositories::test_redirect_pattern;
-    assert!(test_redirect_pattern(
-        "https://*.example.com/cb",
-        "https://staging.example.com/cb"
-    ));
-    // Wildcard segment cannot contain '/'
-    assert!(!test_redirect_pattern(
-        "https://*.example.com/cb",
-        "https://evil.com/.example.com/cb"
-    ));
+    fn test_pattern_matches_wildcard_subdomain() {
+        use keycast_core::repositories::test_redirect_pattern;
+        assert!(test_redirect_pattern(
+            "https://*.example.com/cb",
+            "https://staging.example.com/cb"
+        ));
+        // Wildcard segment cannot contain '/'
+        assert!(!test_redirect_pattern(
+            "https://*.example.com/cb",
+            "https://evil.com/.example.com/cb"
+        ));
+    }
+
+#[tokio::test]
+async fn create_trims_redirect_uri_whitespace() {
+    let repo = fresh_repo("test-whitespace-").await;
+
+    // Create with whitespace around URI - should be trimmed automatically
+    let created = repo
+        .create(
+            TENANT_A,
+            "test-whitespace-client",
+            "Test",
+            &[" https://app.example.com/cb ".to_string()],
+        )
+        .await
+        .unwrap();
+
+    // The stored URI should be trimmed (not have surrounding whitespace)
+    assert_eq!(created.allowed_redirect_uris.len(), 1);
+    assert_eq!(
+        created.allowed_redirect_uris[0], "https://app.example.com/cb",
+        "redirect URIs should be trimmed before persisting"
+    );
+}
+
+#[tokio::test]
+async fn update_trims_redirect_uri_whitespace() {
+    let repo = fresh_repo("test-update-trim-").await;
+
+    // Create with proper URIs
+    let created = repo
+        .create(
+            TENANT_A,
+            "test-update-trim-client",
+            "Test",
+            &["https://app.example.com/cb".to_string()],
+        )
+        .await
+        .unwrap();
+
+    // Update with whitespace URI - should be trimmed automatically
+    let updated = repo
+        .update(
+            created.id,
+            TENANT_A,
+            None,
+            Some(&[" https://new.example.com/cb ".to_string()]),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(updated.allowed_redirect_uris.len(), 1);
+    assert_eq!(
+        updated.allowed_redirect_uris[0], "https://new.example.com/cb",
+        "redirect URIs should be trimmed on update"
+    );
 }

--- a/api/tests/registered_clients_admin_test.rs
+++ b/api/tests/registered_clients_admin_test.rs
@@ -11,22 +11,27 @@ const TENANT_A: i64 = 1;
 // so any integer is acceptable here.
 const TENANT_B: i64 = 999;
 
-/// Build a repository whose test setup clears a specific client_id.
-/// This prevents cross-test interference in parallel test execution against
-/// a shared database: each test cleans up exactly what it will create.
-async fn fresh_repo(client_id: &str) -> RegisteredClientRepository {
+/// Build a repository whose test setup clears the listed client_ids.
+/// This prevents cross-test interference in parallel/repeated test execution
+/// against a shared database: each test cleans up exactly what it will create.
+/// Callers pass every client_id they will insert so that re-running the suite
+/// (which leaves rows behind) does not collide on the unique (tenant_id,
+/// client_id) constraint.
+async fn fresh_repo(client_ids: &[&str]) -> RegisteredClientRepository {
     let pool = common::setup_test_db().await;
-    sqlx::query("DELETE FROM registered_clients WHERE client_id = $1")
-        .bind(client_id)
-        .execute(&pool)
-        .await
-        .unwrap();
+    for cid in client_ids {
+        sqlx::query("DELETE FROM registered_clients WHERE client_id = $1")
+            .bind(cid)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
     RegisteredClientRepository::new(pool)
 }
 
 #[tokio::test]
 async fn create_then_list_returns_row_for_tenant() {
-    let repo = fresh_repo("test-client-1").await;
+    let repo = fresh_repo(&["test-client-1"]).await;
 
     let created = repo
         .create(
@@ -53,7 +58,7 @@ async fn create_then_list_returns_row_for_tenant() {
 
 #[tokio::test]
 async fn list_is_scoped_per_tenant() {
-    let repo = fresh_repo("tenant-scope-x").await;
+    let repo = fresh_repo(&["tenant-a-client-x", "tenant-b-client-x"]).await;
 
     repo.create(
         TENANT_A,
@@ -84,7 +89,7 @@ async fn list_is_scoped_per_tenant() {
 
 #[tokio::test]
 async fn create_duplicate_client_id_for_same_tenant_errors() {
-    let repo = fresh_repo("test-dup").await;
+    let repo = fresh_repo(&["test-dup"]).await;
 
     repo.create(
         TENANT_A,
@@ -113,7 +118,7 @@ async fn create_duplicate_client_id_for_same_tenant_errors() {
 
 #[tokio::test]
 async fn create_same_client_id_different_tenants_succeeds() {
-    let repo = fresh_repo("test-shared-id").await;
+    let repo = fresh_repo(&["test-shared-id"]).await;
 
     repo.create(
         TENANT_A,
@@ -135,7 +140,7 @@ async fn create_same_client_id_different_tenants_succeeds() {
 
 #[tokio::test]
 async fn create_rejects_empty_redirect_uris() {
-    let repo = fresh_repo("test-empty-uris").await;
+    let repo = fresh_repo(&["test-empty-uris"]).await;
 
     let err = repo
         .create(TENANT_A, "test-empty-uris", "X", &Vec::<String>::new())
@@ -150,7 +155,7 @@ async fn create_rejects_empty_redirect_uris() {
 
 #[tokio::test]
 async fn create_rejects_empty_client_id() {
-    let repo = fresh_repo("test-empty-id").await;
+    let repo = fresh_repo(&["test-empty-id"]).await;
 
     let err = repo
         .create(
@@ -170,7 +175,7 @@ async fn create_rejects_empty_client_id() {
 
 #[tokio::test]
 async fn create_rejects_empty_name() {
-    let repo = fresh_repo("test-empty-name").await;
+    let repo = fresh_repo(&["test-empty-name"]).await;
 
     let err = repo
         .create(
@@ -190,7 +195,7 @@ async fn create_rejects_empty_name() {
 
 #[tokio::test]
 async fn create_rejects_multiple_asterisks_in_pattern() {
-    let repo = fresh_repo("test-multi-star").await;
+    let repo = fresh_repo(&["test-multi-star"]).await;
 
     let err = repo
         .create(
@@ -210,7 +215,7 @@ async fn create_rejects_multiple_asterisks_in_pattern() {
 
 #[tokio::test]
 async fn update_renames_and_replaces_uris() {
-    let repo = fresh_repo("test-update").await;
+    let repo = fresh_repo(&["test-update"]).await;
 
     let created = repo
         .create(
@@ -240,7 +245,7 @@ async fn update_renames_and_replaces_uris() {
 
 #[tokio::test]
 async fn update_cannot_cross_tenants() {
-    let repo = fresh_repo("test-cross-tenant").await;
+    let repo = fresh_repo(&["test-cross-tenant"]).await;
 
     let created = repo
         .create(
@@ -266,7 +271,7 @@ async fn update_cannot_cross_tenants() {
 
 #[tokio::test]
 async fn update_rejects_empty_redirect_uris() {
-    let repo = fresh_repo("test-update-empty").await;
+    let repo = fresh_repo(&["test-update-empty"]).await;
 
     let created = repo
         .create(
@@ -291,7 +296,7 @@ async fn update_rejects_empty_redirect_uris() {
 
 #[tokio::test]
 async fn delete_removes_row_and_is_tenant_scoped() {
-    let repo = fresh_repo("test-delete").await;
+    let repo = fresh_repo(&["test-delete"]).await;
 
     let created = repo
         .create(
@@ -347,7 +352,7 @@ fn test_pattern_matches_exact_uri() {
 
 #[tokio::test]
 async fn create_trims_redirect_uri_whitespace() {
-    let repo = fresh_repo("test-whitespace-client").await;
+    let repo = fresh_repo(&["test-whitespace-client"]).await;
 
     // Create with whitespace around URI - should be trimmed automatically
     let created = repo
@@ -370,7 +375,7 @@ async fn create_trims_redirect_uri_whitespace() {
 
 #[tokio::test]
 async fn update_trims_redirect_uri_whitespace() {
-    let repo = fresh_repo("test-update-trim-client").await;
+    let repo = fresh_repo(&["test-update-trim-client"]).await;
 
     // Create with proper URIs
     let created = repo

--- a/api/tests/registered_clients_admin_test.rs
+++ b/api/tests/registered_clients_admin_test.rs
@@ -189,6 +189,26 @@ async fn create_rejects_empty_name() {
 }
 
 #[tokio::test]
+async fn create_rejects_multiple_asterisks_in_pattern() {
+    let repo = fresh_repo("test-multi-star").await;
+
+    let err = repo
+        .create(
+            TENANT_A,
+            "test-multi-star",
+            "Test",
+            &["https://*.foo.com/*/cb".to_string()],
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RepositoryError::Integrity(_)),
+        "expected Integrity for multiple asterisks, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
 async fn update_renames_and_replaces_uris() {
     let repo = fresh_repo("test-update").await;
 

--- a/api/tests/registered_clients_admin_test.rs
+++ b/api/tests/registered_clients_admin_test.rs
@@ -11,13 +11,13 @@ const TENANT_A: i64 = 1;
 // so any integer is acceptable here.
 const TENANT_B: i64 = 999;
 
-/// Build a repository whose helper methods only see rows for `prefix`.
-/// Each test passes a unique prefix to avoid cross-test interference when
-/// the test runner executes tests in parallel against a shared database.
-async fn fresh_repo(prefix: &str) -> RegisteredClientRepository {
+/// Build a repository whose test setup clears a specific client_id.
+/// This prevents cross-test interference in parallel test execution against
+/// a shared database: each test cleans up exactly what it will create.
+async fn fresh_repo(client_id: &str) -> RegisteredClientRepository {
     let pool = common::setup_test_db().await;
-    sqlx::query("DELETE FROM registered_clients WHERE client_id LIKE $1")
-        .bind(format!("{}%", prefix))
+    sqlx::query("DELETE FROM registered_clients WHERE client_id = $1")
+        .bind(client_id)
         .execute(&pool)
         .await
         .unwrap();
@@ -53,11 +53,11 @@ async fn create_then_list_returns_row_for_tenant() {
 
 #[tokio::test]
 async fn list_is_scoped_per_tenant() {
-    let repo = fresh_repo("test-tenant-").await;
+    let repo = fresh_repo("tenant-scope-x").await;
 
     repo.create(
         TENANT_A,
-        "test-tenant-a-client",
+        "tenant-a-client-x",
         "A",
         &["https://a.example.com/cb".to_string()],
     )
@@ -65,7 +65,7 @@ async fn list_is_scoped_per_tenant() {
     .unwrap();
     repo.create(
         TENANT_B,
-        "test-tenant-b-client",
+        "tenant-b-client-x",
         "B",
         &["https://b.example.com/cb".to_string()],
     )
@@ -75,11 +75,11 @@ async fn list_is_scoped_per_tenant() {
     let a_list = repo.list(TENANT_A).await.unwrap();
     let b_list = repo.list(TENANT_B).await.unwrap();
 
-    assert!(a_list.iter().any(|c| c.client_id == "test-tenant-a-client"));
-    assert!(!a_list.iter().any(|c| c.client_id == "test-tenant-b-client"));
+    assert!(a_list.iter().any(|c| c.client_id == "tenant-a-client-x"));
+    assert!(!a_list.iter().any(|c| c.client_id == "tenant-b-client-x"));
 
-    assert!(b_list.iter().any(|c| c.client_id == "test-tenant-b-client"));
-    assert!(!b_list.iter().any(|c| c.client_id == "test-tenant-a-client"));
+    assert!(b_list.iter().any(|c| c.client_id == "tenant-b-client-x"));
+    assert!(!b_list.iter().any(|c| c.client_id == "tenant-a-client-x"));
 }
 
 #[tokio::test]
@@ -347,7 +347,7 @@ fn test_pattern_matches_exact_uri() {
 
 #[tokio::test]
 async fn create_trims_redirect_uri_whitespace() {
-    let repo = fresh_repo("test-whitespace-").await;
+    let repo = fresh_repo("test-whitespace-client").await;
 
     // Create with whitespace around URI - should be trimmed automatically
     let created = repo
@@ -370,7 +370,7 @@ async fn create_trims_redirect_uri_whitespace() {
 
 #[tokio::test]
 async fn update_trims_redirect_uri_whitespace() {
-    let repo = fresh_repo("test-update-trim-").await;
+    let repo = fresh_repo("test-update-trim-client").await;
 
     // Create with proper URIs
     let created = repo

--- a/api/tests/registered_clients_admin_test.rs
+++ b/api/tests/registered_clients_admin_test.rs
@@ -33,10 +33,8 @@ async fn create_then_list_returns_row_for_tenant() {
             TENANT_A,
             "test-client-1",
             "Test Client 1",
-            &vec![
-                "https://app.example.com/cb".to_string(),
-                "https://*.preview.example.com/cb".to_string(),
-            ],
+            &["https://app.example.com/cb".to_string(),
+                "https://*.preview.example.com/cb".to_string()],
         )
         .await
         .unwrap();
@@ -61,7 +59,7 @@ async fn list_is_scoped_per_tenant() {
         TENANT_A,
         "test-tenant-a-client",
         "A",
-        &vec!["https://a.example.com/cb".to_string()],
+        &["https://a.example.com/cb".to_string()],
     )
     .await
     .unwrap();
@@ -69,7 +67,7 @@ async fn list_is_scoped_per_tenant() {
         TENANT_B,
         "test-tenant-b-client",
         "B",
-        &vec!["https://b.example.com/cb".to_string()],
+        &["https://b.example.com/cb".to_string()],
     )
     .await
     .unwrap();
@@ -92,7 +90,7 @@ async fn create_duplicate_client_id_for_same_tenant_errors() {
         TENANT_A,
         "test-dup",
         "First",
-        &vec!["https://example.com/cb".to_string()],
+        &["https://example.com/cb".to_string()],
     )
     .await
     .unwrap();
@@ -102,7 +100,7 @@ async fn create_duplicate_client_id_for_same_tenant_errors() {
             TENANT_A,
             "test-dup",
             "Second",
-            &vec!["https://example.com/cb".to_string()],
+            &["https://example.com/cb".to_string()],
         )
         .await
         .unwrap_err();
@@ -121,7 +119,7 @@ async fn create_same_client_id_different_tenants_succeeds() {
         TENANT_A,
         "test-shared-id",
         "A version",
-        &vec!["https://a.example.com/cb".to_string()],
+        &["https://a.example.com/cb".to_string()],
     )
     .await
     .unwrap();
@@ -129,7 +127,7 @@ async fn create_same_client_id_different_tenants_succeeds() {
         TENANT_B,
         "test-shared-id",
         "B version",
-        &vec!["https://b.example.com/cb".to_string()],
+        &["https://b.example.com/cb".to_string()],
     )
     .await
     .expect("same client_id under a different tenant must be allowed");
@@ -159,7 +157,7 @@ async fn create_rejects_empty_client_id() {
             TENANT_A,
             "",
             "X",
-            &vec!["https://example.com/cb".to_string()],
+            &["https://example.com/cb".to_string()],
         )
         .await
         .unwrap_err();
@@ -179,7 +177,7 @@ async fn update_renames_and_replaces_uris() {
             TENANT_A,
             "test-update",
             "Original",
-            &vec!["https://example.com/cb".to_string()],
+            &["https://example.com/cb".to_string()],
         )
         .await
         .unwrap();
@@ -189,10 +187,8 @@ async fn update_renames_and_replaces_uris() {
             created.id,
             TENANT_A,
             Some("Renamed"),
-            Some(&vec![
-                "https://example.com/cb".to_string(),
-                "https://*.preview.example.com/cb".to_string(),
-            ]),
+            Some(&["https://example.com/cb".to_string(),
+                "https://*.preview.example.com/cb".to_string()]),
         )
         .await
         .unwrap();
@@ -211,7 +207,7 @@ async fn update_cannot_cross_tenants() {
             TENANT_A,
             "test-cross-tenant",
             "A",
-            &vec!["https://a.example.com/cb".to_string()],
+            &["https://a.example.com/cb".to_string()],
         )
         .await
         .unwrap();
@@ -237,7 +233,7 @@ async fn update_rejects_empty_redirect_uris() {
             TENANT_A,
             "test-update-empty",
             "X",
-            &vec!["https://example.com/cb".to_string()],
+            &["https://example.com/cb".to_string()],
         )
         .await
         .unwrap();
@@ -262,7 +258,7 @@ async fn delete_removes_row_and_is_tenant_scoped() {
             TENANT_A,
             "test-delete",
             "X",
-            &vec!["https://example.com/cb".to_string()],
+            &["https://example.com/cb".to_string()],
         )
         .await
         .unwrap();

--- a/api/tests/registered_clients_admin_test.rs
+++ b/api/tests/registered_clients_admin_test.rs
@@ -169,6 +169,26 @@ async fn create_rejects_empty_client_id() {
 }
 
 #[tokio::test]
+async fn create_rejects_empty_name() {
+    let repo = fresh_repo("test-empty-name").await;
+
+    let err = repo
+        .create(
+            TENANT_A,
+            "test-empty-name",
+            "   ", // whitespace-only name
+            &["https://example.com/cb".to_string()],
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RepositoryError::Integrity(_)),
+        "expected Integrity (validation) error for empty-after-trim name, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
 async fn update_renames_and_replaces_uris() {
     let repo = fresh_repo("test-update").await;
 

--- a/api/tests/registered_clients_admin_test.rs
+++ b/api/tests/registered_clients_admin_test.rs
@@ -38,8 +38,10 @@ async fn create_then_list_returns_row_for_tenant() {
             TENANT_A,
             "test-client-1",
             "Test Client 1",
-            &["https://app.example.com/cb".to_string(),
-                "https://*.preview.example.com/cb".to_string()],
+            &[
+                "https://app.example.com/cb".to_string(),
+                "https://*.preview.example.com/cb".to_string(),
+            ],
         )
         .await
         .unwrap();
@@ -158,12 +160,7 @@ async fn create_rejects_empty_client_id() {
     let repo = fresh_repo(&["test-empty-id"]).await;
 
     let err = repo
-        .create(
-            TENANT_A,
-            "",
-            "X",
-            &["https://example.com/cb".to_string()],
-        )
+        .create(TENANT_A, "", "X", &["https://example.com/cb".to_string()])
         .await
         .unwrap_err();
     assert!(
@@ -232,8 +229,10 @@ async fn update_renames_and_replaces_uris() {
             created.id,
             TENANT_A,
             Some("Renamed"),
-            Some(&["https://example.com/cb".to_string(),
-                "https://*.preview.example.com/cb".to_string()]),
+            Some(&[
+                "https://example.com/cb".to_string(),
+                "https://*.preview.example.com/cb".to_string(),
+            ]),
         )
         .await
         .unwrap();
@@ -337,18 +336,18 @@ fn test_pattern_matches_exact_uri() {
 }
 
 #[test]
-    fn test_pattern_matches_wildcard_subdomain() {
-        use keycast_core::repositories::test_redirect_pattern;
-        assert!(test_redirect_pattern(
-            "https://*.example.com/cb",
-            "https://staging.example.com/cb"
-        ));
-        // Wildcard segment cannot contain '/'
-        assert!(!test_redirect_pattern(
-            "https://*.example.com/cb",
-            "https://evil.com/.example.com/cb"
-        ));
-    }
+fn test_pattern_matches_wildcard_subdomain() {
+    use keycast_core::repositories::test_redirect_pattern;
+    assert!(test_redirect_pattern(
+        "https://*.example.com/cb",
+        "https://staging.example.com/cb"
+    ));
+    // Wildcard segment cannot contain '/'
+    assert!(!test_redirect_pattern(
+        "https://*.example.com/cb",
+        "https://evil.com/.example.com/cb"
+    ));
+}
 
 #[tokio::test]
 async fn create_trims_redirect_uri_whitespace() {

--- a/api/tests/registered_clients_admin_test.rs
+++ b/api/tests/registered_clients_admin_test.rs
@@ -1,0 +1,310 @@
+// ABOUTME: Repository-level integration tests for admin CRUD on registered_clients
+// ABOUTME: Verifies list/create/update/delete, per-tenant scoping, uniqueness, and validation
+
+mod common;
+
+use keycast_core::repositories::{RegisteredClient, RegisteredClientRepository, RepositoryError};
+
+const TENANT_A: i64 = 1;
+// Tenant B uses an id that does not exist as a real tenant FK; the
+// registered_clients table has no FK on tenant_id (see migration 0008),
+// so any integer is acceptable here.
+const TENANT_B: i64 = 999;
+
+/// Build a repository whose helper methods only see rows for `prefix`.
+/// Each test passes a unique prefix to avoid cross-test interference when
+/// the test runner executes tests in parallel against a shared database.
+async fn fresh_repo(prefix: &str) -> RegisteredClientRepository {
+    let pool = common::setup_test_db().await;
+    sqlx::query("DELETE FROM registered_clients WHERE client_id LIKE $1")
+        .bind(format!("{}%", prefix))
+        .execute(&pool)
+        .await
+        .unwrap();
+    RegisteredClientRepository::new(pool)
+}
+
+#[tokio::test]
+async fn create_then_list_returns_row_for_tenant() {
+    let repo = fresh_repo("test-client-1").await;
+
+    let created = repo
+        .create(
+            TENANT_A,
+            "test-client-1",
+            "Test Client 1",
+            &vec![
+                "https://app.example.com/cb".to_string(),
+                "https://*.preview.example.com/cb".to_string(),
+            ],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(created.tenant_id, TENANT_A);
+    assert_eq!(created.client_id, "test-client-1");
+    assert_eq!(created.name, "Test Client 1");
+    assert_eq!(created.allowed_redirect_uris.len(), 2);
+
+    let listed = repo.list(TENANT_A).await.unwrap();
+    assert!(
+        listed.iter().any(|c| c.client_id == "test-client-1"),
+        "newly created client should appear in list for tenant"
+    );
+}
+
+#[tokio::test]
+async fn list_is_scoped_per_tenant() {
+    let repo = fresh_repo("test-tenant-").await;
+
+    repo.create(
+        TENANT_A,
+        "test-tenant-a-client",
+        "A",
+        &vec!["https://a.example.com/cb".to_string()],
+    )
+    .await
+    .unwrap();
+    repo.create(
+        TENANT_B,
+        "test-tenant-b-client",
+        "B",
+        &vec!["https://b.example.com/cb".to_string()],
+    )
+    .await
+    .unwrap();
+
+    let a_list = repo.list(TENANT_A).await.unwrap();
+    let b_list = repo.list(TENANT_B).await.unwrap();
+
+    assert!(a_list.iter().any(|c| c.client_id == "test-tenant-a-client"));
+    assert!(!a_list.iter().any(|c| c.client_id == "test-tenant-b-client"));
+
+    assert!(b_list.iter().any(|c| c.client_id == "test-tenant-b-client"));
+    assert!(!b_list.iter().any(|c| c.client_id == "test-tenant-a-client"));
+}
+
+#[tokio::test]
+async fn create_duplicate_client_id_for_same_tenant_errors() {
+    let repo = fresh_repo("test-dup").await;
+
+    repo.create(
+        TENANT_A,
+        "test-dup",
+        "First",
+        &vec!["https://example.com/cb".to_string()],
+    )
+    .await
+    .unwrap();
+
+    let err = repo
+        .create(
+            TENANT_A,
+            "test-dup",
+            "Second",
+            &vec!["https://example.com/cb".to_string()],
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RepositoryError::Duplicate),
+        "expected Duplicate, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn create_same_client_id_different_tenants_succeeds() {
+    let repo = fresh_repo("test-shared-id").await;
+
+    repo.create(
+        TENANT_A,
+        "test-shared-id",
+        "A version",
+        &vec!["https://a.example.com/cb".to_string()],
+    )
+    .await
+    .unwrap();
+    repo.create(
+        TENANT_B,
+        "test-shared-id",
+        "B version",
+        &vec!["https://b.example.com/cb".to_string()],
+    )
+    .await
+    .expect("same client_id under a different tenant must be allowed");
+}
+
+#[tokio::test]
+async fn create_rejects_empty_redirect_uris() {
+    let repo = fresh_repo("test-empty-uris").await;
+
+    let err = repo
+        .create(TENANT_A, "test-empty-uris", "X", &Vec::<String>::new())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RepositoryError::Integrity(_)),
+        "expected Integrity (validation) error, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn create_rejects_empty_client_id() {
+    let repo = fresh_repo("test-empty-id").await;
+
+    let err = repo
+        .create(
+            TENANT_A,
+            "",
+            "X",
+            &vec!["https://example.com/cb".to_string()],
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RepositoryError::Integrity(_)),
+        "expected Integrity (validation) error, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn update_renames_and_replaces_uris() {
+    let repo = fresh_repo("test-update").await;
+
+    let created = repo
+        .create(
+            TENANT_A,
+            "test-update",
+            "Original",
+            &vec!["https://example.com/cb".to_string()],
+        )
+        .await
+        .unwrap();
+
+    let updated = repo
+        .update(
+            created.id,
+            TENANT_A,
+            Some("Renamed"),
+            Some(&vec![
+                "https://example.com/cb".to_string(),
+                "https://*.preview.example.com/cb".to_string(),
+            ]),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(updated.name, "Renamed");
+    assert_eq!(updated.allowed_redirect_uris.len(), 2);
+    assert!(updated.updated_at >= created.updated_at);
+}
+
+#[tokio::test]
+async fn update_cannot_cross_tenants() {
+    let repo = fresh_repo("test-cross-tenant").await;
+
+    let created = repo
+        .create(
+            TENANT_A,
+            "test-cross-tenant",
+            "A",
+            &vec!["https://a.example.com/cb".to_string()],
+        )
+        .await
+        .unwrap();
+
+    // Attempting to update from a different tenant id MUST return NotFound
+    let err = repo
+        .update(created.id, TENANT_B, Some("hijacked"), None)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RepositoryError::NotFound(_)),
+        "expected NotFound across tenants, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn update_rejects_empty_redirect_uris() {
+    let repo = fresh_repo("test-update-empty").await;
+
+    let created = repo
+        .create(
+            TENANT_A,
+            "test-update-empty",
+            "X",
+            &vec!["https://example.com/cb".to_string()],
+        )
+        .await
+        .unwrap();
+
+    let err = repo
+        .update(created.id, TENANT_A, None, Some(&Vec::<String>::new()))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RepositoryError::Integrity(_)),
+        "expected Integrity (validation) error, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn delete_removes_row_and_is_tenant_scoped() {
+    let repo = fresh_repo("test-delete").await;
+
+    let created = repo
+        .create(
+            TENANT_A,
+            "test-delete",
+            "X",
+            &vec!["https://example.com/cb".to_string()],
+        )
+        .await
+        .unwrap();
+
+    // Wrong tenant: should not delete and should report NotFound
+    let err = repo.delete(created.id, TENANT_B).await.unwrap_err();
+    assert!(
+        matches!(err, RepositoryError::NotFound(_)),
+        "expected NotFound across tenants, got {:?}",
+        err
+    );
+
+    // Right tenant: deletes
+    repo.delete(created.id, TENANT_A).await.unwrap();
+
+    let listed = repo.list(TENANT_A).await.unwrap();
+    assert!(!listed.iter().any(|c: &RegisteredClient| c.id == created.id));
+}
+
+#[test]
+fn test_pattern_matches_exact_uri() {
+    use keycast_core::repositories::test_redirect_pattern;
+    assert!(test_redirect_pattern(
+        "https://app.example.com/cb",
+        "https://app.example.com/cb"
+    ));
+    assert!(!test_redirect_pattern(
+        "https://app.example.com/cb",
+        "https://evil.com/cb"
+    ));
+}
+
+#[test]
+fn test_pattern_matches_wildcard_subdomain() {
+    use keycast_core::repositories::test_redirect_pattern;
+    assert!(test_redirect_pattern(
+        "https://*.example.com/cb",
+        "https://staging.example.com/cb"
+    ));
+    // Wildcard segment cannot contain '/'
+    assert!(!test_redirect_pattern(
+        "https://*.example.com/cb",
+        "https://evil.com/.example.com/cb"
+    ));
+}

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -31,7 +31,9 @@ pub use oauth_code::{
 pub use personal_keys::PersonalKeysRepository;
 pub use policy::PolicyRepository;
 pub use refresh_token::RefreshTokenRepository;
-pub use registered_client::RegisteredClientRepository;
+pub use registered_client::{
+    test_redirect_pattern, RegisteredClient, RegisteredClientRepository,
+};
 pub use stored_key::StoredKeyRepository;
 pub use team::TeamRepository;
 pub use user::{AdminUserDetails, DeleteAccountResult, UserRepository, VerificationTokenData};

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -31,9 +31,7 @@ pub use oauth_code::{
 pub use personal_keys::PersonalKeysRepository;
 pub use policy::PolicyRepository;
 pub use refresh_token::RefreshTokenRepository;
-pub use registered_client::{
-    test_redirect_pattern, RegisteredClient, RegisteredClientRepository,
-};
+pub use registered_client::{test_redirect_pattern, RegisteredClient, RegisteredClientRepository};
 pub use stored_key::StoredKeyRepository;
 pub use team::TeamRepository;
 pub use user::{AdminUserDetails, DeleteAccountResult, UserRepository, VerificationTokenData};

--- a/core/src/repositories/registered_client.rs
+++ b/core/src/repositories/registered_client.rs
@@ -264,6 +264,16 @@ fn validate_redirect_uri_list(uris: &[String]) -> Result<(), RepositoryError> {
                 "allowed_redirect_uris entries must not be empty".to_string(),
             ));
         }
+        // Must have 0 or 1 asterisk (wildcard), not multiple.
+        let asterisk_count = uri.matches('*').count();
+        if asterisk_count > 1 {
+            return Err(RepositoryError::Integrity(
+                format!(
+                    "pattern '{}' has {} wildcards; expected 0 (exact) or 1 (wildcard)",
+                    uri, asterisk_count
+                ),
+            ));
+        }
     }
     Ok(())
 }

--- a/core/src/repositories/registered_client.rs
+++ b/core/src/repositories/registered_client.rs
@@ -142,6 +142,12 @@ impl RegisteredClientRepository {
         validate_client_id(client_id)?;
         validate_redirect_uri_list(allowed_redirect_uris)?;
 
+        // Trim each redirect URI before persisting to ensure consistent matching.
+        let trimmed_uris: Vec<String> = allowed_redirect_uris
+            .iter()
+            .map(|s| s.trim().to_string())
+            .collect();
+
         let row = sqlx::query_as::<_, RegisteredClient>(
             "INSERT INTO registered_clients
                  (tenant_id, client_id, name, allowed_redirect_uris)
@@ -152,7 +158,7 @@ impl RegisteredClientRepository {
         .bind(tenant_id)
         .bind(client_id.trim())
         .bind(name.trim())
-        .bind(allowed_redirect_uris)
+        .bind(&trimmed_uris)
         .fetch_one(&self.pool)
         .await?;
         Ok(row)
@@ -178,6 +184,11 @@ impl RegisteredClientRepository {
             }
         }
 
+        // Trim each redirect URI before persisting to ensure consistent matching.
+        let trimmed_uris: Option<Vec<String>> = allowed_redirect_uris.map(|uris| {
+            uris.iter().map(|s| s.trim().to_string()).collect()
+        });
+
         // COALESCE pattern lets us patch either field without separate queries.
         let row = sqlx::query_as::<_, RegisteredClient>(
             "UPDATE registered_clients
@@ -191,7 +202,7 @@ impl RegisteredClientRepository {
         .bind(id)
         .bind(tenant_id)
         .bind(name.map(str::trim))
-        .bind(allowed_redirect_uris)
+        .bind(trimmed_uris.as_deref())
         .fetch_optional(&self.pool)
         .await?;
 
@@ -281,6 +292,12 @@ fn matches_redirect_pattern(pattern: &str, uri: &str) -> bool {
         return false;
     }
 
+    // Bounds check: if prefix + suffix exceeds uri.len(), slicing would panic.
+    // This happens with patterns like "aaa*aaa" and uri="aaaa".
+    if prefix.len() + suffix.len() > uri.len() {
+        return false;
+    }
+
     // The wildcard segment must not contain '/' (prevents path traversal)
     let matched_segment = &uri[prefix.len()..uri.len() - suffix.len()];
     !matched_segment.contains('/')
@@ -357,5 +374,21 @@ mod tests {
             "https://*.example.com/callback",
             "https://sub/domain.example.com/callback"
         ));
+    }
+
+    #[test]
+    fn test_overlapping_prefix_suffix_no_panic() {
+        // Pattern "aaa*aaa" with uri "aaaa" should NOT panic.
+        // prefix="aaa", suffix="aaa", but uri.len()=4, so slice [3..1] would panic.
+        assert!(!matches_redirect_pattern("aaa*aaa", "aaaa"));
+        assert!(!matches_redirect_pattern("abc*bc", "abcc"));
+    }
+
+    #[test]
+    fn test_overlapping_equal_length() {
+        // prefix.len() + suffix.len() == uri.len() is valid (empty middle)
+        assert!(matches_redirect_pattern("abc*xyz", "abcxyz"));
+        // prefix.len() + suffix.len() > uri.len() is invalid
+        assert!(!matches_redirect_pattern("abc*xyz", "abcz"));
     }
 }

--- a/core/src/repositories/registered_client.rs
+++ b/core/src/repositories/registered_client.rs
@@ -140,6 +140,7 @@ impl RegisteredClientRepository {
         allowed_redirect_uris: &[String],
     ) -> Result<RegisteredClient, RepositoryError> {
         validate_client_id(client_id)?;
+        validate_name(name)?;
         validate_redirect_uri_list(allowed_redirect_uris)?;
 
         // Trim each redirect URI before persisting to ensure consistent matching.
@@ -177,11 +178,7 @@ impl RegisteredClientRepository {
             validate_redirect_uri_list(uris)?;
         }
         if let Some(n) = name {
-            if n.trim().is_empty() {
-                return Err(RepositoryError::Integrity(
-                    "name must not be empty".to_string(),
-                ));
-            }
+            validate_name(n)?;
         }
 
         // Trim each redirect URI before persisting to ensure consistent matching.
@@ -241,6 +238,15 @@ fn validate_client_id(client_id: &str) -> Result<(), RepositoryError> {
     if client_id.trim().is_empty() {
         return Err(RepositoryError::Integrity(
             "client_id must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_name(name: &str) -> Result<(), RepositoryError> {
+    if name.trim().is_empty() {
+        return Err(RepositoryError::Integrity(
+            "name must not be empty".to_string(),
         ));
     }
     Ok(())

--- a/core/src/repositories/registered_client.rs
+++ b/core/src/repositories/registered_client.rs
@@ -1,9 +1,27 @@
 // ABOUTME: Repository for registered OAuth client operations
-// ABOUTME: Validates redirect URIs against registered client patterns
+// ABOUTME: Validates redirect URIs against registered client patterns and provides admin CRUD
 
-use sqlx::PgPool;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{FromRow, PgPool};
 
 use crate::repositories::RepositoryError;
+
+/// A registered OAuth client row.
+///
+/// Note: the database column `tenant_id` is `INTEGER NOT NULL` (i32) but is
+/// surfaced as `i64` here for consistency with the rest of the codebase. PostgreSQL
+/// performs the implicit widening on read.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct RegisteredClient {
+    pub id: i32,
+    pub tenant_id: i64,
+    pub client_id: String,
+    pub name: String,
+    pub allowed_redirect_uris: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
 
 /// Repository for registered OAuth client operations.
 /// When a client_id is registered, only its allowed redirect URIs are accepted.
@@ -69,6 +87,168 @@ impl RegisteredClientRepository {
             }
         }
     }
+
+    // ---- Admin CRUD ----------------------------------------------------------
+
+    /// List all registered clients for a tenant, ordered by client_id.
+    pub async fn list(&self, tenant_id: i64) -> Result<Vec<RegisteredClient>, RepositoryError> {
+        let rows = sqlx::query_as::<_, RegisteredClient>(
+            "SELECT id, tenant_id::BIGINT AS tenant_id, client_id, name,
+                    allowed_redirect_uris, created_at, updated_at
+             FROM registered_clients
+             WHERE tenant_id = $1
+             ORDER BY client_id",
+        )
+        .bind(tenant_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Get a single registered client by id, scoped to a tenant.
+    pub async fn get(
+        &self,
+        id: i32,
+        tenant_id: i64,
+    ) -> Result<RegisteredClient, RepositoryError> {
+        let row = sqlx::query_as::<_, RegisteredClient>(
+            "SELECT id, tenant_id::BIGINT AS tenant_id, client_id, name,
+                    allowed_redirect_uris, created_at, updated_at
+             FROM registered_clients
+             WHERE id = $1 AND tenant_id = $2",
+        )
+        .bind(id)
+        .bind(tenant_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.ok_or_else(|| {
+            RepositoryError::NotFound(format!(
+                "registered_client id={} for tenant {}",
+                id, tenant_id
+            ))
+        })
+    }
+
+    /// Create a new registered client.
+    /// Validates: non-empty trimmed client_id, at least one redirect URI.
+    /// Returns Duplicate on (tenant_id, client_id) collision.
+    pub async fn create(
+        &self,
+        tenant_id: i64,
+        client_id: &str,
+        name: &str,
+        allowed_redirect_uris: &[String],
+    ) -> Result<RegisteredClient, RepositoryError> {
+        validate_client_id(client_id)?;
+        validate_redirect_uri_list(allowed_redirect_uris)?;
+
+        let row = sqlx::query_as::<_, RegisteredClient>(
+            "INSERT INTO registered_clients
+                 (tenant_id, client_id, name, allowed_redirect_uris)
+             VALUES ($1, $2, $3, $4)
+             RETURNING id, tenant_id::BIGINT AS tenant_id, client_id, name,
+                       allowed_redirect_uris, created_at, updated_at",
+        )
+        .bind(tenant_id)
+        .bind(client_id.trim())
+        .bind(name.trim())
+        .bind(allowed_redirect_uris)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    /// Update name and/or allowed_redirect_uris for a registered client.
+    /// Tenant-scoped: returns NotFound when (id, tenant_id) does not match.
+    pub async fn update(
+        &self,
+        id: i32,
+        tenant_id: i64,
+        name: Option<&str>,
+        allowed_redirect_uris: Option<&[String]>,
+    ) -> Result<RegisteredClient, RepositoryError> {
+        if let Some(uris) = allowed_redirect_uris {
+            validate_redirect_uri_list(uris)?;
+        }
+        if let Some(n) = name {
+            if n.trim().is_empty() {
+                return Err(RepositoryError::Integrity(
+                    "name must not be empty".to_string(),
+                ));
+            }
+        }
+
+        // COALESCE pattern lets us patch either field without separate queries.
+        let row = sqlx::query_as::<_, RegisteredClient>(
+            "UPDATE registered_clients
+             SET name = COALESCE($3, name),
+                 allowed_redirect_uris = COALESCE($4, allowed_redirect_uris),
+                 updated_at = NOW()
+             WHERE id = $1 AND tenant_id = $2
+             RETURNING id, tenant_id::BIGINT AS tenant_id, client_id, name,
+                       allowed_redirect_uris, created_at, updated_at",
+        )
+        .bind(id)
+        .bind(tenant_id)
+        .bind(name.map(str::trim))
+        .bind(allowed_redirect_uris)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.ok_or_else(|| {
+            RepositoryError::NotFound(format!(
+                "registered_client id={} for tenant {}",
+                id, tenant_id
+            ))
+        })
+    }
+
+    /// Delete a registered client. Tenant-scoped.
+    /// Returns NotFound if no row matches (id, tenant_id).
+    pub async fn delete(&self, id: i32, tenant_id: i64) -> Result<(), RepositoryError> {
+        let result = sqlx::query(
+            "DELETE FROM registered_clients WHERE id = $1 AND tenant_id = $2",
+        )
+        .bind(id)
+        .bind(tenant_id)
+        .execute(&self.pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(RepositoryError::NotFound(format!(
+                "registered_client id={} for tenant {}",
+                id, tenant_id
+            )));
+        }
+        Ok(())
+    }
+}
+
+// ---- Validation helpers ------------------------------------------------------
+
+fn validate_client_id(client_id: &str) -> Result<(), RepositoryError> {
+    if client_id.trim().is_empty() {
+        return Err(RepositoryError::Integrity(
+            "client_id must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_redirect_uri_list(uris: &[String]) -> Result<(), RepositoryError> {
+    if uris.is_empty() {
+        return Err(RepositoryError::Integrity(
+            "allowed_redirect_uris must contain at least one entry".to_string(),
+        ));
+    }
+    for uri in uris {
+        if uri.trim().is_empty() {
+            return Err(RepositoryError::Integrity(
+                "allowed_redirect_uris entries must not be empty".to_string(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Match a redirect URI against an allowed pattern.
@@ -104,6 +284,13 @@ fn matches_redirect_pattern(pattern: &str, uri: &str) -> bool {
     // The wildcard segment must not contain '/' (prevents path traversal)
     let matched_segment = &uri[prefix.len()..uri.len() - suffix.len()];
     !matched_segment.contains('/')
+}
+
+/// Public entry point that mirrors `matches_redirect_pattern`.
+/// Used by the admin "test this URI" endpoint so the inline tester reports
+/// exactly the same result the OAuth validator will produce.
+pub fn test_redirect_pattern(pattern: &str, uri: &str) -> bool {
+    matches_redirect_pattern(pattern, uri)
 }
 
 #[cfg(test)]

--- a/core/src/repositories/registered_client.rs
+++ b/core/src/repositories/registered_client.rs
@@ -106,11 +106,7 @@ impl RegisteredClientRepository {
     }
 
     /// Get a single registered client by id, scoped to a tenant.
-    pub async fn get(
-        &self,
-        id: i32,
-        tenant_id: i64,
-    ) -> Result<RegisteredClient, RepositoryError> {
+    pub async fn get(&self, id: i32, tenant_id: i64) -> Result<RegisteredClient, RepositoryError> {
         let row = sqlx::query_as::<_, RegisteredClient>(
             "SELECT id, tenant_id::BIGINT AS tenant_id, client_id, name,
                     allowed_redirect_uris, created_at, updated_at
@@ -182,9 +178,8 @@ impl RegisteredClientRepository {
         }
 
         // Trim each redirect URI before persisting to ensure consistent matching.
-        let trimmed_uris: Option<Vec<String>> = allowed_redirect_uris.map(|uris| {
-            uris.iter().map(|s| s.trim().to_string()).collect()
-        });
+        let trimmed_uris: Option<Vec<String>> =
+            allowed_redirect_uris.map(|uris| uris.iter().map(|s| s.trim().to_string()).collect());
 
         // COALESCE pattern lets us patch either field without separate queries.
         let row = sqlx::query_as::<_, RegisteredClient>(
@@ -214,13 +209,11 @@ impl RegisteredClientRepository {
     /// Delete a registered client. Tenant-scoped.
     /// Returns NotFound if no row matches (id, tenant_id).
     pub async fn delete(&self, id: i32, tenant_id: i64) -> Result<(), RepositoryError> {
-        let result = sqlx::query(
-            "DELETE FROM registered_clients WHERE id = $1 AND tenant_id = $2",
-        )
-        .bind(id)
-        .bind(tenant_id)
-        .execute(&self.pool)
-        .await?;
+        let result = sqlx::query("DELETE FROM registered_clients WHERE id = $1 AND tenant_id = $2")
+            .bind(id)
+            .bind(tenant_id)
+            .execute(&self.pool)
+            .await?;
 
         if result.rows_affected() == 0 {
             return Err(RepositoryError::NotFound(format!(
@@ -267,12 +260,10 @@ fn validate_redirect_uri_list(uris: &[String]) -> Result<(), RepositoryError> {
         // Must have 0 or 1 asterisk (wildcard), not multiple.
         let asterisk_count = uri.matches('*').count();
         if asterisk_count > 1 {
-            return Err(RepositoryError::Integrity(
-                format!(
-                    "pattern '{}' has {} wildcards; expected 0 (exact) or 1 (wildcard)",
-                    uri, asterisk_count
-                ),
-            ));
+            return Err(RepositoryError::Integrity(format!(
+                "pattern '{}' has {} wildcards; expected 0 (exact) or 1 (wildcard)",
+                uri, asterisk_count
+            )));
         }
     }
     Ok(())

--- a/core/src/signing_session.rs
+++ b/core/src/signing_session.rs
@@ -16,7 +16,11 @@ use crate::secret_types::DecryptedPlaintext;
 /// This prevents producing events where event.pubkey disagrees with the keypair
 /// that signed it, breaking downstream Schnorr verification.
 /// The `event_name` is used in the log event field for telemetry distinction.
-pub fn canonicalize_event_author(unsigned: &mut UnsignedEvent, signer_pubkey: PublicKey, event_name: &str) {
+pub fn canonicalize_event_author(
+    unsigned: &mut UnsignedEvent,
+    signer_pubkey: PublicKey,
+    event_name: &str,
+) {
     if unsigned.pubkey != signer_pubkey {
         tracing::warn!(
             event = event_name,
@@ -90,7 +94,11 @@ impl SigningSession {
         let keys = self.keys.clone();
         let signer_pubkey = keys.public_key();
 
-        canonicalize_event_author(&mut unsigned, signer_pubkey, "signing_session.pubkey_canonicalized");
+        canonicalize_event_author(
+            &mut unsigned,
+            signer_pubkey,
+            "signing_session.pubkey_canonicalized",
+        );
 
         tokio::task::spawn_blocking(move || {
             // Run the async sign on the blocking thread pool

--- a/core/src/signing_session.rs
+++ b/core/src/signing_session.rs
@@ -10,6 +10,26 @@ use tokio::task::JoinError;
 
 use crate::secret_types::DecryptedPlaintext;
 
+/// Canonicalize an UnsignedEvent's author pubkey to match the signer keys.
+/// If the supplied pubkey differs from the signer pubkey, this updates the
+/// event's pubkey and clears its id so it's recomputed over the canonical pubkey.
+/// This prevents producing events where event.pubkey disagrees with the keypair
+/// that signed it, breaking downstream Schnorr verification.
+/// The `event_name` is used in the log event field for telemetry distinction.
+pub fn canonicalize_event_author(unsigned: &mut UnsignedEvent, signer_pubkey: PublicKey, event_name: &str) {
+    if unsigned.pubkey != signer_pubkey {
+        tracing::warn!(
+            event = event_name,
+            supplied_pubkey = %unsigned.pubkey,
+            signer_pubkey = %signer_pubkey,
+            kind = unsigned.kind.as_u16(),
+            "canonicalize_event_author: client-supplied pubkey != signer pubkey; canonicalizing"
+        );
+        unsigned.pubkey = signer_pubkey;
+        unsigned.id = None; // Force recomputation with canonical pubkey
+    }
+}
+
 /// 32-byte key for efficient cache lookups (stack-only, no heap allocation)
 pub type CacheKey = [u8; 32];
 
@@ -70,19 +90,7 @@ impl SigningSession {
         let keys = self.keys.clone();
         let signer_pubkey = keys.public_key();
 
-        if unsigned.pubkey != signer_pubkey {
-            tracing::warn!(
-                event = "signing_session.pubkey_canonicalized",
-                supplied_pubkey = %unsigned.pubkey,
-                signer_pubkey = %signer_pubkey,
-                kind = unsigned.kind.as_u16(),
-                "sign_event: client-supplied unsigned.pubkey != signer pubkey; canonicalizing to signer pubkey"
-            );
-            unsigned.pubkey = signer_pubkey;
-            // The supplied id (if any) was computed over the old pubkey; force
-            // recomputation so signing produces a self-consistent event.
-            unsigned.id = None;
-        }
+        canonicalize_event_author(&mut unsigned, signer_pubkey, "signing_session.pubkey_canonicalized");
 
         tokio::task::spawn_blocking(move || {
             // Run the async sign on the blocking thread pool

--- a/signer/src/signer_daemon.rs
+++ b/signer/src/signer_daemon.rs
@@ -1678,7 +1678,11 @@ impl SigningHandler for Nip46Handler {
         // Canonicalize the pubkey to match the signer keys, matching SigningSession::sign_event behavior.
         // This prevents producing an event where event.pubkey disagrees with the keypair that signed it.
         let signer_pubkey = self.user_keys.public_key();
-        canonicalize_event_author(&mut unsigned_event, signer_pubkey, "signer_daemon.pubkey_canonicalized");
+        canonicalize_event_author(
+            &mut unsigned_event,
+            signer_pubkey,
+            "signer_daemon.pubkey_canonicalized",
+        );
 
         // Sign the event with user keys (consumes unsigned_event)
         let signed_event = unsigned_event

--- a/signer/src/signer_daemon.rs
+++ b/signer/src/signer_daemon.rs
@@ -9,6 +9,7 @@ use keycast_core::authorization_channel::{AuthorizationCommand, AuthorizationRec
 use keycast_core::encryption::KeyManager;
 use keycast_core::metrics::METRICS;
 use keycast_core::signing_handler::SigningHandler;
+use keycast_core::signing_session::canonicalize_event_author;
 use keycast_core::types::authorization::Authorization;
 use keycast_core::types::oauth_authorization::OAuthAuthorization;
 use moka::future::Cache;
@@ -1677,18 +1678,7 @@ impl SigningHandler for Nip46Handler {
         // Canonicalize the pubkey to match the signer keys, matching SigningSession::sign_event behavior.
         // This prevents producing an event where event.pubkey disagrees with the keypair that signed it.
         let signer_pubkey = self.user_keys.public_key();
-        if unsigned_event.pubkey != signer_pubkey {
-            tracing::warn!(
-                event = "signer_daemon.pubkey_canonicalized",
-                authorization_id = self.authorization_id,
-                supplied_pubkey = %unsigned_event.pubkey,
-                signer_pubkey = %signer_pubkey,
-                kind,
-                "sign_event_direct: client-supplied unsigned.pubkey != signer pubkey; canonicalizing to signer pubkey"
-            );
-            unsigned_event.pubkey = signer_pubkey;
-            unsigned_event.id = None; // Force recomputation with canonical pubkey
-        }
+        canonicalize_event_author(&mut unsigned_event, signer_pubkey, "signer_daemon.pubkey_canonicalized");
 
         // Sign the event with user keys (consumes unsigned_event)
         let signed_event = unsigned_event

--- a/signer/src/signer_daemon.rs
+++ b/signer/src/signer_daemon.rs
@@ -1661,7 +1661,7 @@ impl UnifiedSigner {
 impl SigningHandler for Nip46Handler {
     async fn sign_event_direct(
         &self,
-        unsigned_event: UnsignedEvent,
+        mut unsigned_event: UnsignedEvent,
     ) -> Result<Event, Box<dyn std::error::Error + Send + Sync>> {
         let kind = unsigned_event.kind.as_u16();
 
@@ -1673,6 +1673,22 @@ impl SigningHandler for Nip46Handler {
 
         // VALIDATE PERMISSIONS BEFORE SIGNING
         self.validate_permissions_for_sign(&unsigned_event).await?;
+
+        // Canonicalize the pubkey to match the signer keys, matching SigningSession::sign_event behavior.
+        // This prevents producing an event where event.pubkey disagrees with the keypair that signed it.
+        let signer_pubkey = self.user_keys.public_key();
+        if unsigned_event.pubkey != signer_pubkey {
+            tracing::warn!(
+                event = "signer_daemon.pubkey_canonicalized",
+                authorization_id = self.authorization_id,
+                supplied_pubkey = %unsigned_event.pubkey,
+                signer_pubkey = %signer_pubkey,
+                kind,
+                "sign_event_direct: client-supplied unsigned.pubkey != signer pubkey; canonicalizing to signer pubkey"
+            );
+            unsigned_event.pubkey = signer_pubkey;
+            unsigned_event.id = None; // Force recomputation with canonical pubkey
+        }
 
         // Sign the event with user keys (consumes unsigned_event)
         let signed_event = unsigned_event

--- a/signer/src/signer_daemon.rs
+++ b/signer/src/signer_daemon.rs
@@ -2001,6 +2001,47 @@ mod tests {
         assert!(tags_vec.contains(&tag2));
     }
 
+    // Regression: ensures the NIP-46 relay path (sign_event_direct) keeps
+    // calling canonicalize_event_author. If a future edit removes the call,
+    // this test fails because the produced signature would not verify against
+    // the (canonicalized) event.pubkey, mirroring the divine-blossom
+    // "Invalid signature" failure mode.
+    #[tokio::test]
+    async fn test_sign_event_direct_canonicalizes_mismatched_pubkey() {
+        let pool = create_test_db().await;
+        let handler = create_test_handler_with_db(pool).await;
+
+        let stale_keys = Keys::generate();
+        assert_ne!(
+            stale_keys.public_key(),
+            handler.user_keys.public_key(),
+            "test setup should pick distinct keys",
+        );
+
+        // Client supplied a stale pubkey (different from the signer's keys).
+        let unsigned_event = UnsignedEvent::new(
+            stale_keys.public_key(),
+            Timestamp::now(),
+            Kind::from(1),
+            vec![],
+            "stale-pubkey content",
+        );
+
+        let signed_event = handler
+            .sign_event_direct(unsigned_event)
+            .await
+            .expect("sign should succeed after canonicalization");
+
+        assert_eq!(
+            signed_event.pubkey,
+            handler.user_keys.public_key(),
+            "event.pubkey must be canonicalized to the signer keypair",
+        );
+        signed_event
+            .verify()
+            .expect("signature must verify after canonicalization");
+    }
+
     #[tokio::test]
     async fn test_get_handler_for_user_returns_none_when_not_cached() {
         // Arrange

--- a/web/src/lib/keycast_api.svelte.ts
+++ b/web/src/lib/keycast_api.svelte.ts
@@ -97,6 +97,18 @@ export class KeycastApi {
         });
     }
 
+    async patch<T>(
+        endpoint: string,
+        data?: unknown,
+        options: { headers?: HeadersInit } = {},
+    ): Promise<T> {
+        return this.request<T>(endpoint, {
+            method: "PATCH",
+            body: data ? JSON.stringify(data) : undefined,
+            headers: options.headers,
+        });
+    }
+
     async delete<T>(
         endpoint: string,
         options: { headers?: HeadersInit } = {},

--- a/web/src/routes/admin/+page.svelte
+++ b/web/src/routes/admin/+page.svelte
@@ -235,6 +235,10 @@
 		<div class="header">
 			<div class="header-row">
 				<h1>Admin Dashboard</h1>
+				<a href="/admin/registered-clients" class="header-link">
+					<ArrowSquareOut size={16} />
+					Registered OAuth Clients
+				</a>
 				<a href="/support-admin" class="header-link">
 					<ArrowSquareOut size={16} />
 					Support Tools
@@ -358,6 +362,22 @@
 					{/each}
 				</div>
 			{/if}
+		</div>
+
+		<!-- Registered OAuth Clients Section -->
+		<div class="section">
+			<div class="section-header">
+				<div class="section-icon"><Link size={24} weight="duotone" /></div>
+				<div>
+					<h2>Registered OAuth Clients</h2>
+					<p>Manage which third-party OAuth clients are recognized for this tenant and which redirect URIs they may use.</p>
+				</div>
+			</div>
+
+			<a href="/admin/registered-clients" class="btn-primary" style="text-decoration: none; display: inline-flex; align-items: center; gap: 0.5rem;">
+				<ArrowSquareOut size={16} />
+				Open Registered Clients
+			</a>
 		</div>
 
 		<!-- Documentation Section -->

--- a/web/src/routes/admin/registered-clients/+page.svelte
+++ b/web/src/routes/admin/registered-clients/+page.svelte
@@ -1,0 +1,941 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { BRAND } from '$lib/brand';
+	import { KeycastApi } from '$lib/keycast_api.svelte';
+	import { goto } from '$app/navigation';
+	import { toast } from 'svelte-hot-french-toast';
+	import {
+		ArrowLeft,
+		Plus,
+		Trash,
+		PencilSimple,
+		FloppyDisk,
+		X,
+		Check,
+		XCircle,
+		CheckCircle,
+		Warning,
+		ShieldCheck
+	} from 'phosphor-svelte';
+
+	const api = new KeycastApi();
+
+	interface RegisteredClient {
+		id: number;
+		client_id: string;
+		name: string;
+		allowed_redirect_uris: string[];
+		created_at: string;
+		updated_at: string;
+	}
+
+	let status = $state<'loading' | 'not-admin' | 'ready'>('loading');
+
+	let clients = $state<RegisteredClient[]>([]);
+	let isLoadingClients = $state(false);
+	let listError = $state<string | null>(null);
+
+	// New client form
+	let newClientId = $state('');
+	let newClientName = $state('');
+	let newRedirectUris = $state<string[]>(['']);
+	let isCreating = $state(false);
+
+	// Edit state — keyed by row id
+	let editingId = $state<number | null>(null);
+	let editName = $state('');
+	let editUris = $state<string[]>([]);
+	let isSaving = $state(false);
+
+	// Delete confirm modal
+	let deleteCandidate = $state<RegisteredClient | null>(null);
+	let isDeleting = $state(false);
+
+	// Inline pattern tester
+	let testPattern = $state('');
+	let testUri = $state('');
+	let testResult = $state<null | { matches: boolean; pattern: string; uri: string }>(null);
+	let isTesting = $state(false);
+
+	onMount(async () => {
+		try {
+			const response = await api.get<{ is_admin: boolean; role: string | null }>('/admin/status');
+			if (!response.is_admin || response.role !== 'full') {
+				status = 'not-admin';
+				return;
+			}
+		} catch {
+			goto('/login?redirect=/admin/registered-clients', { replaceState: true });
+			return;
+		}
+
+		status = 'ready';
+		await loadClients();
+	});
+
+	async function loadClients() {
+		isLoadingClients = true;
+		listError = null;
+		try {
+			const result = await api.get<{ clients: RegisteredClient[] }>('/admin/registered-clients');
+			clients = result.clients;
+		} catch (err: any) {
+			listError = err?.message || 'Failed to load registered clients';
+		} finally {
+			isLoadingClients = false;
+		}
+	}
+
+	function addNewUriRow() {
+		newRedirectUris = [...newRedirectUris, ''];
+	}
+
+	function removeNewUriRow(i: number) {
+		newRedirectUris = newRedirectUris.filter((_, idx) => idx !== i);
+		if (newRedirectUris.length === 0) newRedirectUris = [''];
+	}
+
+	function resetNewForm() {
+		newClientId = '';
+		newClientName = '';
+		newRedirectUris = [''];
+	}
+
+	async function createClient() {
+		const cid = newClientId.trim();
+		const name = newClientName.trim();
+		const uris = newRedirectUris.map((u) => u.trim()).filter((u) => u.length > 0);
+
+		if (!cid) {
+			toast.error('client_id is required');
+			return;
+		}
+		if (!name) {
+			toast.error('name is required');
+			return;
+		}
+		if (uris.length === 0) {
+			toast.error('At least one redirect URI is required');
+			return;
+		}
+
+		isCreating = true;
+		try {
+			await api.post<RegisteredClient>('/admin/registered-clients', {
+				client_id: cid,
+				name,
+				allowed_redirect_uris: uris
+			});
+			toast.success(`Created client "${cid}"`);
+			resetNewForm();
+			await loadClients();
+		} catch (err: any) {
+			toast.error(err?.message || 'Failed to create client');
+		} finally {
+			isCreating = false;
+		}
+	}
+
+	function startEdit(c: RegisteredClient) {
+		editingId = c.id;
+		editName = c.name;
+		editUris = [...c.allowed_redirect_uris];
+		if (editUris.length === 0) editUris = [''];
+	}
+
+	function cancelEdit() {
+		editingId = null;
+		editName = '';
+		editUris = [];
+	}
+
+	function addEditUriRow() {
+		editUris = [...editUris, ''];
+	}
+
+	function removeEditUriRow(i: number) {
+		editUris = editUris.filter((_, idx) => idx !== i);
+		if (editUris.length === 0) editUris = [''];
+	}
+
+	async function saveEdit(c: RegisteredClient) {
+		const name = editName.trim();
+		const uris = editUris.map((u) => u.trim()).filter((u) => u.length > 0);
+		if (!name) {
+			toast.error('name is required');
+			return;
+		}
+		if (uris.length === 0) {
+			toast.error('At least one redirect URI is required');
+			return;
+		}
+
+		isSaving = true;
+		try {
+			await api.patch<RegisteredClient>(`/admin/registered-clients/${c.id}`, {
+				name,
+				allowed_redirect_uris: uris
+			});
+			toast.success(`Updated "${c.client_id}"`);
+			cancelEdit();
+			await loadClients();
+		} catch (err: any) {
+			toast.error(err?.message || 'Failed to update client');
+		} finally {
+			isSaving = false;
+		}
+	}
+
+	function openDelete(c: RegisteredClient) {
+		deleteCandidate = c;
+	}
+
+	function closeDelete() {
+		deleteCandidate = null;
+	}
+
+	async function confirmDelete() {
+		if (!deleteCandidate) return;
+		isDeleting = true;
+		try {
+			await api.delete<{ deleted: boolean }>(
+				`/admin/registered-clients/${deleteCandidate.id}`
+			);
+			toast.success(`Deleted "${deleteCandidate.client_id}"`);
+			deleteCandidate = null;
+			await loadClients();
+		} catch (err: any) {
+			toast.error(err?.message || 'Failed to delete client');
+		} finally {
+			isDeleting = false;
+		}
+	}
+
+	async function runPatternTest() {
+		const pattern = testPattern.trim();
+		const uri = testUri.trim();
+		if (!pattern || !uri) {
+			toast.error('Both pattern and URI are required');
+			return;
+		}
+		isTesting = true;
+		try {
+			const result = await api.post<{ matches: boolean }>(
+				'/admin/registered-clients/test',
+				{ pattern, uri }
+			);
+			testResult = { matches: result.matches, pattern, uri };
+		} catch (err: any) {
+			toast.error(err?.message || 'Test failed');
+		} finally {
+			isTesting = false;
+		}
+	}
+
+	function formatDate(iso: string): string {
+		return new Date(iso).toLocaleString('en-US', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit'
+		});
+	}
+</script>
+
+<svelte:head>
+	<title>Registered OAuth Clients - {BRAND.name}</title>
+</svelte:head>
+
+{#if status === 'loading'}
+	<div class="page">
+		<div class="loading">Loading...</div>
+	</div>
+{:else if status === 'not-admin'}
+	<div class="page">
+		<div class="access-denied">
+			<Warning size={48} weight="fill" />
+			<h2>Access Denied</h2>
+			<p>Full admin access is required to manage registered OAuth clients.</p>
+		</div>
+	</div>
+{:else}
+	<div class="page">
+		<div class="header">
+			<a href="/admin" class="back-link">
+				<ArrowLeft size={16} />
+				Back to Admin
+			</a>
+			<h1>Registered OAuth Clients</h1>
+			<p class="subtitle">
+				Manage the OAuth client allowlist for this tenant. Registered clients restrict which
+				redirect URIs are accepted; unregistered clients accept any HTTPS redirect.
+			</p>
+		</div>
+
+		<!-- Add new client -->
+		<div class="section">
+			<div class="section-header">
+				<div class="section-icon"><Plus size={24} weight="duotone" /></div>
+				<div>
+					<h2>Add a registered client</h2>
+					<p>Define a new OAuth client and the redirect URI patterns it may use.</p>
+				</div>
+			</div>
+
+			<form
+				class="add-form"
+				onsubmit={(e) => {
+					e.preventDefault();
+					createClient();
+				}}
+			>
+				<div class="form-row">
+					<label>
+						<span class="label">client_id</span>
+						<input
+							type="text"
+							bind:value={newClientId}
+							placeholder="my-app"
+							disabled={isCreating}
+						/>
+					</label>
+					<label>
+						<span class="label">Display name</span>
+						<input
+							type="text"
+							bind:value={newClientName}
+							placeholder="My App"
+							disabled={isCreating}
+						/>
+					</label>
+				</div>
+
+				<div class="uri-list">
+					<span class="label">Allowed redirect URI patterns</span>
+					{#each newRedirectUris as _uri, i}
+						<div class="uri-row">
+							<input
+								type="text"
+								bind:value={newRedirectUris[i]}
+								placeholder="https://app.example.com/cb"
+								disabled={isCreating}
+							/>
+							<button
+								type="button"
+								class="btn-icon-sm"
+								onclick={() => removeNewUriRow(i)}
+								title="Remove"
+								disabled={isCreating}
+							>
+								<X size={14} />
+							</button>
+						</div>
+					{/each}
+					<button
+						type="button"
+						class="btn-link"
+						onclick={addNewUriRow}
+						disabled={isCreating}
+					>
+						<Plus size={14} /> Add another URI
+					</button>
+					<p class="hint">
+						Wildcard <code>*</code> matches a single path segment (no <code>/</code>). Examples: <code>https://*.example.com/cb</code>, <code>http://localhost:*/cb</code>.
+					</p>
+				</div>
+
+				<button type="submit" class="btn-primary" disabled={isCreating}>
+					{isCreating ? 'Creating...' : 'Create client'}
+				</button>
+			</form>
+		</div>
+
+		<!-- Pattern tester -->
+		<div class="section">
+			<div class="section-header">
+				<div class="section-icon"><ShieldCheck size={24} weight="duotone" /></div>
+				<div>
+					<h2>Test a redirect URI</h2>
+					<p>Verify whether a candidate URI matches a pattern (uses the same matcher as OAuth).</p>
+				</div>
+			</div>
+
+			<form
+				class="test-form"
+				onsubmit={(e) => {
+					e.preventDefault();
+					runPatternTest();
+				}}
+			>
+				<label>
+					<span class="label">Pattern</span>
+					<input
+						type="text"
+						bind:value={testPattern}
+						placeholder="https://*.example.com/cb"
+						disabled={isTesting}
+					/>
+				</label>
+				<label>
+					<span class="label">URI</span>
+					<input
+						type="text"
+						bind:value={testUri}
+						placeholder="https://staging.example.com/cb"
+						disabled={isTesting}
+					/>
+				</label>
+				<button type="submit" class="btn-primary" disabled={isTesting}>
+					{isTesting ? 'Testing...' : 'Test match'}
+				</button>
+			</form>
+
+			{#if testResult}
+				<div class="test-result {testResult.matches ? 'match' : 'nomatch'}">
+					{#if testResult.matches}
+						<CheckCircle size={20} weight="fill" />
+						<span>Matches: <code>{testResult.uri}</code> would be accepted by pattern <code>{testResult.pattern}</code>.</span>
+					{:else}
+						<XCircle size={20} weight="fill" />
+						<span>No match: <code>{testResult.uri}</code> would be rejected by pattern <code>{testResult.pattern}</code>.</span>
+					{/if}
+				</div>
+			{/if}
+		</div>
+
+		<!-- List -->
+		<div class="section">
+			<div class="section-header">
+				<div class="section-icon"><ShieldCheck size={24} weight="duotone" /></div>
+				<div>
+					<h2>Registered clients ({clients.length})</h2>
+					<p>Edit or delete existing entries. Deleting an entry breaks that client's OAuth flow immediately.</p>
+				</div>
+			</div>
+
+			{#if listError}
+				<div class="list-error">
+					<Warning size={16} />
+					<span>{listError}</span>
+				</div>
+			{/if}
+
+			{#if isLoadingClients}
+				<p class="loading-text">Loading...</p>
+			{:else if clients.length === 0}
+				<p class="empty-text">No registered clients yet.</p>
+			{:else}
+				<table class="clients-table">
+					<thead>
+						<tr>
+							<th>client_id</th>
+							<th>Name</th>
+							<th>Allowed redirect URIs</th>
+							<th>Created</th>
+							<th>Updated</th>
+							<th></th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each clients as c}
+							<tr>
+								<td><code>{c.client_id}</code></td>
+								<td>
+									{#if editingId === c.id}
+										<input type="text" bind:value={editName} disabled={isSaving} />
+									{:else}
+										{c.name}
+									{/if}
+								</td>
+								<td class="uris-cell">
+									{#if editingId === c.id}
+										{#each editUris as _u, i}
+											<div class="uri-row">
+												<input
+													type="text"
+													bind:value={editUris[i]}
+													disabled={isSaving}
+												/>
+												<button
+													type="button"
+													class="btn-icon-sm"
+													onclick={() => removeEditUriRow(i)}
+													title="Remove"
+													disabled={isSaving}
+												>
+													<X size={14} />
+												</button>
+											</div>
+										{/each}
+										<button
+											type="button"
+											class="btn-link"
+											onclick={addEditUriRow}
+											disabled={isSaving}
+										>
+											<Plus size={14} /> Add URI
+										</button>
+									{:else}
+										<ul class="uri-list-display">
+											{#each c.allowed_redirect_uris as uri}
+												<li><code>{uri}</code></li>
+											{/each}
+										</ul>
+									{/if}
+								</td>
+								<td class="date-cell">{formatDate(c.created_at)}</td>
+								<td class="date-cell">{formatDate(c.updated_at)}</td>
+								<td class="actions-cell">
+									{#if editingId === c.id}
+										<button
+											class="btn-icon"
+											onclick={() => saveEdit(c)}
+											disabled={isSaving}
+											title="Save"
+										>
+											<FloppyDisk size={18} />
+										</button>
+										<button
+											class="btn-icon"
+											onclick={cancelEdit}
+											disabled={isSaving}
+											title="Cancel"
+										>
+											<X size={18} />
+										</button>
+									{:else}
+										<button
+											class="btn-icon"
+											onclick={() => startEdit(c)}
+											title="Edit"
+										>
+											<PencilSimple size={18} />
+										</button>
+										<button
+											class="btn-icon danger"
+											onclick={() => openDelete(c)}
+											title="Delete"
+										>
+											<Trash size={18} />
+										</button>
+									{/if}
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<!-- Delete confirm modal -->
+{#if deleteCandidate}
+	<div
+		class="modal-backdrop"
+		role="presentation"
+		onclick={(e) => {
+			if (e.target === e.currentTarget) closeDelete();
+		}}
+	>
+		<div class="modal" role="dialog" aria-modal="true">
+			<h3>Delete <code>{deleteCandidate.client_id}</code>?</h3>
+			<p class="warning-text">
+				<Warning size={16} weight="fill" />
+				This will immediately break OAuth for any live integration using this client_id. There is no undo.
+			</p>
+			<div class="modal-actions">
+				<button class="btn-secondary" onclick={closeDelete} disabled={isDeleting}>Cancel</button>
+				<button class="btn-danger" onclick={confirmDelete} disabled={isDeleting}>
+					{isDeleting ? 'Deleting...' : 'Delete client'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.page {
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 2rem 1.5rem;
+		color: var(--color-text, #f1f5f9);
+	}
+
+	.loading,
+	.access-denied {
+		text-align: center;
+		padding: 4rem 2rem;
+		color: var(--color-text-muted, #94a3b8);
+	}
+
+	.access-denied h2 {
+		margin: 1rem 0 0.5rem;
+	}
+
+	.header {
+		margin-bottom: 2rem;
+	}
+
+	.back-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 0.85rem;
+		color: var(--color-text-muted, #94a3b8);
+		text-decoration: none;
+		margin-bottom: 0.75rem;
+	}
+
+	.back-link:hover {
+		color: var(--color-text, #f1f5f9);
+	}
+
+	.header h1 {
+		font-size: 1.75rem;
+		margin: 0;
+	}
+
+	.subtitle {
+		color: var(--color-text-muted, #94a3b8);
+		margin: 0.4rem 0 0;
+	}
+
+	.section {
+		background: var(--color-surface, rgba(15, 23, 42, 0.6));
+		border: 1px solid var(--color-border, rgba(148, 163, 184, 0.18));
+		border-radius: 0.75rem;
+		padding: 1.5rem;
+		margin-bottom: 1.5rem;
+	}
+
+	.section-header {
+		display: flex;
+		gap: 0.85rem;
+		align-items: flex-start;
+		margin-bottom: 1.25rem;
+	}
+
+	.section-icon {
+		flex-shrink: 0;
+		color: var(--color-accent, #8b5cf6);
+	}
+
+	.section-header h2 {
+		margin: 0;
+		font-size: 1.15rem;
+	}
+
+	.section-header p {
+		margin: 0.25rem 0 0;
+		font-size: 0.85rem;
+		color: var(--color-text-muted, #94a3b8);
+	}
+
+	.add-form,
+	.test-form {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.form-row {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 1rem;
+	}
+
+	@media (max-width: 640px) {
+		.form-row {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.label {
+		display: block;
+		font-size: 0.78rem;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--color-text-muted, #94a3b8);
+		margin-bottom: 0.35rem;
+	}
+
+	input[type='text'] {
+		width: 100%;
+		padding: 0.55rem 0.75rem;
+		background: var(--color-input-bg, rgba(15, 23, 42, 0.9));
+		border: 1px solid var(--color-border, rgba(148, 163, 184, 0.25));
+		border-radius: 0.4rem;
+		color: var(--color-text, #f1f5f9);
+		font-size: 0.95rem;
+		font-family: inherit;
+	}
+
+	input[type='text']:focus {
+		outline: none;
+		border-color: var(--color-accent, #8b5cf6);
+	}
+
+	input[type='text']:disabled {
+		opacity: 0.6;
+	}
+
+	.uri-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.uri-row {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.uri-row input {
+		flex: 1;
+	}
+
+	.hint {
+		font-size: 0.8rem;
+		color: var(--color-text-muted, #94a3b8);
+		margin: 0.25rem 0 0;
+	}
+
+	.hint code,
+	.uri-list-display code,
+	.clients-table code {
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		font-size: 0.85em;
+		background: rgba(148, 163, 184, 0.15);
+		padding: 0.1rem 0.35rem;
+		border-radius: 0.25rem;
+	}
+
+	.btn-primary {
+		align-self: flex-start;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.55rem 1rem;
+		background: var(--color-accent, #8b5cf6);
+		color: white;
+		border: none;
+		border-radius: 0.4rem;
+		font-size: 0.9rem;
+		font-weight: 600;
+		cursor: pointer;
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.btn-primary:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn-secondary,
+	.btn-danger {
+		padding: 0.5rem 0.9rem;
+		border-radius: 0.4rem;
+		font-size: 0.9rem;
+		font-weight: 600;
+		cursor: pointer;
+		border: 1px solid var(--color-border, rgba(148, 163, 184, 0.25));
+	}
+
+	.btn-secondary {
+		background: transparent;
+		color: var(--color-text, #f1f5f9);
+	}
+
+	.btn-danger {
+		background: #b91c1c;
+		color: white;
+		border-color: #b91c1c;
+	}
+
+	.btn-danger:disabled,
+	.btn-secondary:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn-link {
+		align-self: flex-start;
+		background: none;
+		border: none;
+		color: var(--color-accent, #8b5cf6);
+		font-size: 0.85rem;
+		cursor: pointer;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		padding: 0.25rem 0;
+	}
+
+	.btn-link:hover:not(:disabled) {
+		text-decoration: underline;
+	}
+
+	.btn-icon {
+		background: transparent;
+		border: none;
+		color: var(--color-text-muted, #94a3b8);
+		cursor: pointer;
+		padding: 0.4rem;
+		border-radius: 0.3rem;
+	}
+
+	.btn-icon:hover {
+		color: var(--color-text, #f1f5f9);
+		background: rgba(148, 163, 184, 0.12);
+	}
+
+	.btn-icon.danger:hover {
+		color: #fca5a5;
+	}
+
+	.btn-icon-sm {
+		background: transparent;
+		border: none;
+		color: var(--color-text-muted, #94a3b8);
+		cursor: pointer;
+		padding: 0.25rem;
+		border-radius: 0.25rem;
+	}
+
+	.btn-icon-sm:hover {
+		background: rgba(148, 163, 184, 0.18);
+		color: var(--color-text, #f1f5f9);
+	}
+
+	.test-result {
+		margin-top: 1rem;
+		padding: 0.85rem 1rem;
+		border-radius: 0.45rem;
+		display: flex;
+		gap: 0.6rem;
+		align-items: center;
+		font-size: 0.9rem;
+	}
+
+	.test-result.match {
+		background: rgba(34, 197, 94, 0.12);
+		color: #86efac;
+		border: 1px solid rgba(34, 197, 94, 0.3);
+	}
+
+	.test-result.nomatch {
+		background: rgba(239, 68, 68, 0.12);
+		color: #fca5a5;
+		border: 1px solid rgba(239, 68, 68, 0.3);
+	}
+
+	.list-error {
+		display: flex;
+		gap: 0.4rem;
+		align-items: center;
+		color: #fca5a5;
+		font-size: 0.9rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.loading-text,
+	.empty-text {
+		color: var(--color-text-muted, #94a3b8);
+		font-style: italic;
+		margin: 0;
+	}
+
+	.clients-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.9rem;
+	}
+
+	.clients-table th,
+	.clients-table td {
+		padding: 0.65rem 0.75rem;
+		border-bottom: 1px solid var(--color-border, rgba(148, 163, 184, 0.15));
+		text-align: left;
+		vertical-align: top;
+	}
+
+	.clients-table th {
+		font-size: 0.78rem;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--color-text-muted, #94a3b8);
+		font-weight: 600;
+	}
+
+	.uris-cell {
+		min-width: 280px;
+	}
+
+	.uri-list-display {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+	}
+
+	.date-cell {
+		white-space: nowrap;
+		font-size: 0.82rem;
+		color: var(--color-text-muted, #94a3b8);
+	}
+
+	.actions-cell {
+		white-space: nowrap;
+		text-align: right;
+	}
+
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.55);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 100;
+	}
+
+	.modal {
+		background: var(--color-surface, #1e293b);
+		border: 1px solid var(--color-border, rgba(148, 163, 184, 0.25));
+		border-radius: 0.6rem;
+		padding: 1.5rem;
+		max-width: 480px;
+		width: 90%;
+	}
+
+	.modal h3 {
+		margin: 0 0 0.75rem;
+	}
+
+	.warning-text {
+		display: flex;
+		gap: 0.5rem;
+		align-items: flex-start;
+		color: #fca5a5;
+		background: rgba(239, 68, 68, 0.1);
+		border: 1px solid rgba(239, 68, 68, 0.3);
+		padding: 0.65rem 0.8rem;
+		border-radius: 0.4rem;
+		margin: 0 0 1rem;
+		font-size: 0.88rem;
+	}
+
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.6rem;
+	}
+</style>


### PR DESCRIPTION
## Summary

Managing the OAuth client allowlist in `registered_clients` required raw SQL against production.
This change adds an admin UI and a tenant-scoped HTTP API so a full admin can list, add, edit, and delete entries from the browser.
The same canonical wildcard matcher used by the OAuth validator is exposed as a `test` endpoint so the UI's inline tester reports exactly what a real OAuth request would see.

Closes #164.

## What Changed

The repository, HTTP layer, and a new admin page were added end-to-end.
The OAuth validator code path was not touched - only how the table is written changed.

- core: `RegisteredClient` struct and tenant-scoped `list / get / create / update / delete` on `RegisteredClientRepository`, plus a public `test_redirect_pattern` wrapper around the existing matcher.
- api: `GET/POST /api/admin/registered-clients`, `PATCH/DELETE /api/admin/registered-clients/:id`, and `POST /api/admin/registered-clients/test`. Gated by `is_full_admin` and `TenantExtractor`. `Duplicate` -> 409, `Integrity` -> 400, `NotFound` -> 404.
- web: New `/admin/registered-clients` page with list table, add form, inline edit, delete-with-confirm modal, and inline pattern tester. Header link and section card on `/admin`.

Review-cycle fixes bundled in this PR (each in its own commit):
- `matches_redirect_pattern` no longer panics on overlapping prefix/suffix (e.g. `aaa*aaa` + `aaaa`).
- `create` and `update` now trim each redirect URI before persisting.
- `validate_redirect_uri_list` rejects patterns with more than one `*`.
- `validate_name` is now called from both `create` and `update` (was asymmetric).
- `signer::sign_event_direct` now canonicalizes the unsigned event's pubkey through the same shared helper as the HTTP path, fixing the divine-blossom "Invalid signature" failure mode for the NIP-46 transport.
- `http_rpc_handler` mismatch warning was downgraded to debug so a stale-client outage does not double the structured-log volume.

## Testing

I rebased onto current main, ran the rust suites, the web build, and a red-green check on the new signer regression test.

- `cargo test -p keycast_api --test registered_clients_admin_test --test registered_clients_migration_test` - 17 passed.
- `cargo test -p keycast_core` - 50 passed.
- `cargo test -p keycast_signer --features integration-tests --lib test_sign_event_direct` - 3 passed.
- Red-green: commenting out `canonicalize_event_author` in `sign_event_direct` makes `test_sign_event_direct_canonicalizes_mismatched_pubkey` fail; restoring it makes it pass.
- `cargo clippy --all-targets` - clean.
- `cd web && bun run build` - succeeded.

End-to-end HTTP tests for the admin endpoints are not included; the handlers are thin (auth gate + repo call + error mapping) and the repo layer is covered.

## Risks

Delete is destructive and immediate by design - the issue explicitly calls this out and the UI surfaces it in a confirmation modal.
Other risks are limited because the OAuth validator code path is unchanged.

- A misconfigured pattern (e.g. `https://example.com/*`) only matches a single path segment. The UI tester is the recommended way to sanity-check before saving.
- `tenant_id` is `INTEGER` in the schema but `i64` in the API for codebase consistency; reads cast to `BIGINT` so Postgres handles widening on read.