### PR TITLE
chore(api): harmonize tenant_id width between registered_clients schema and API

### DIFF
--- a/api/tests/registered_clients_migration_test.rs
+++ b/api/tests/registered_clients_migration_test.rs
@@ -35,3 +35,27 @@ async fn migrations_register_divine_invite_admin_oauth_client() {
         .await
         .is_err());
 }
+
+#[tokio::test]
+async fn registered_clients_tenant_id_is_bigint() {
+    // Every other tenant_id column in this schema is BIGINT (tenants.id,
+    // users.tenant_id, oauth_authorizations.tenant_id, etc.). 0008 originally
+    // declared registered_clients.tenant_id as INTEGER; the follow-up widens
+    // it so the API i64 surface no longer needs ::BIGINT casts on read.
+    let pool = common::setup_test_db().await;
+
+    let data_type: String = sqlx::query_scalar(
+        "SELECT data_type FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'registered_clients'
+           AND column_name = 'tenant_id'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("registered_clients.tenant_id column must exist");
+
+    assert_eq!(
+        data_type, "bigint",
+        "registered_clients.tenant_id should be bigint to match all other tenant_id columns",
+    );
+}

--- a/core/src/repositories/registered_client.rs
+++ b/core/src/repositories/registered_client.rs
@@ -8,10 +8,6 @@ use sqlx::{FromRow, PgPool};
 use crate::repositories::RepositoryError;
 
 /// A registered OAuth client row.
-///
-/// Note: the database column `tenant_id` is `INTEGER NOT NULL` (i32) but is
-/// surfaced as `i64` here for consistency with the rest of the codebase. PostgreSQL
-/// performs the implicit widening on read.
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct RegisteredClient {
     pub id: i32,
@@ -93,7 +89,7 @@ impl RegisteredClientRepository {
     /// List all registered clients for a tenant, ordered by client_id.
     pub async fn list(&self, tenant_id: i64) -> Result<Vec<RegisteredClient>, RepositoryError> {
         let rows = sqlx::query_as::<_, RegisteredClient>(
-            "SELECT id, tenant_id::BIGINT AS tenant_id, client_id, name,
+            "SELECT id, tenant_id, client_id, name,
                     allowed_redirect_uris, created_at, updated_at
              FROM registered_clients
              WHERE tenant_id = $1
@@ -108,7 +104,7 @@ impl RegisteredClientRepository {
     /// Get a single registered client by id, scoped to a tenant.
     pub async fn get(&self, id: i32, tenant_id: i64) -> Result<RegisteredClient, RepositoryError> {
         let row = sqlx::query_as::<_, RegisteredClient>(
-            "SELECT id, tenant_id::BIGINT AS tenant_id, client_id, name,
+            "SELECT id, tenant_id, client_id, name,
                     allowed_redirect_uris, created_at, updated_at
              FROM registered_clients
              WHERE id = $1 AND tenant_id = $2",
@@ -149,7 +145,7 @@ impl RegisteredClientRepository {
             "INSERT INTO registered_clients
                  (tenant_id, client_id, name, allowed_redirect_uris)
              VALUES ($1, $2, $3, $4)
-             RETURNING id, tenant_id::BIGINT AS tenant_id, client_id, name,
+             RETURNING id, tenant_id, client_id, name,
                        allowed_redirect_uris, created_at, updated_at",
         )
         .bind(tenant_id)
@@ -188,7 +184,7 @@ impl RegisteredClientRepository {
                  allowed_redirect_uris = COALESCE($4, allowed_redirect_uris),
                  updated_at = NOW()
              WHERE id = $1 AND tenant_id = $2
-             RETURNING id, tenant_id::BIGINT AS tenant_id, client_id, name,
+             RETURNING id, tenant_id, client_id, name,
                        allowed_redirect_uris, created_at, updated_at",
         )
         .bind(id)

--- a/database/migrations/20260429000000_widen_registered_clients_tenant_id.sql
+++ b/database/migrations/20260429000000_widen_registered_clients_tenant_id.sql
@@ -1,0 +1,25 @@
+-- Widen registered_clients.tenant_id from INTEGER to BIGINT.
+--
+-- Every other tenant_id column in this schema is BIGINT (tenants.id,
+-- users.tenant_id, refresh_tokens.tenant_id, oauth_authorizations.tenant_id,
+-- atproto_oauth_sessions.tenant_id, auth_events.tenant_id). 0008_registered_clients
+-- was the lone INTEGER outlier, which forced the i64 API surface to use
+-- `tenant_id::BIGINT AS tenant_id` casts on every read. Aligning the column
+-- removes the casts and the implicit i64->i32 narrowing on writes.
+--
+-- Idempotent: only ALTERs when the current data_type is `integer`, so re-runs
+-- are no-ops.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'registered_clients'
+          AND column_name = 'tenant_id'
+          AND data_type = 'integer'
+    ) THEN
+        ALTER TABLE public.registered_clients
+            ALTER COLUMN tenant_id TYPE BIGINT;
+    END IF;
+END
+$$;


### PR DESCRIPTION
## Summary

The `registered_clients.tenant_id` column was `INTEGER` while every other `tenant_id` column in the schema is `BIGINT`. The Rust API surface uses `i64` everywhere, so PR #168 worked around the mismatch by casting `tenant_id::BIGINT AS tenant_id` on every read.

This change widens the column to `BIGINT` so the schema and the API surface agree. The casts go away and the implicit `i64 → i32` narrowing on writes goes away with them.

Closes #171.

## What Changed

The column type changes in a forward-only migration. The existing `0008_registered_clients.sql` has already been applied in production, so editing it would break checksum tracking — the new migration is idempotent (guarded on `information_schema.columns.data_type = 'integer'`) and safe to re-run.

- New migration `20260429000000_widen_registered_clients_tenant_id.sql` ALTERs the column to `BIGINT` only when its current type is `integer`.
- `core/src/repositories/registered_client.rs` drops the four `tenant_id::BIGINT AS tenant_id` casts (in `list`, `get`, `create RETURNING`, `update RETURNING`) and the doc comment that explained the prior INTEGER/i64 mismatch.
- New regression test `registered_clients_tenant_id_is_bigint` queries `information_schema.columns` and asserts the post-migration type.

## Testing

I ran the affected suites against a fresh local Postgres test database, plus clippy and fmt over the whole workspace.

- `cargo test -p keycast_api --test registered_clients_admin_test` — 16 passed (CRUD round-trip, including `tenant_id` equality on returned rows).
- `cargo test -p keycast_api --test registered_clients_migration_test` — 2 passed (existing seed test + new BIGINT type assertion).
- `cargo test -p keycast_core` — 50 passed.
- `cargo clippy --all-targets --all-features` — clean.
- `cargo fmt --all -- --check` — clean.
- Red-green: confirmed the new migration test fails on the pre-migration schema and passes after the migration runs.

I did not run the full e2e suite or test against a Cloud SQL instance — both rely on infra I cannot reach from this worktree.

## Risks

The migration is a widening on an in-production table. PostgreSQL rewrites the column in place (small table, fast) and no values can be lost going `INTEGER → BIGINT`.

- The migration must run before the new binary deploys, otherwise the cast-free SELECTs would try to decode an INT4 column into `i64`. Both deployment paths preserve this ordering: cloudbuild.yaml runs the migration step before the build/deploy steps, and the binary's `--migrate` runs migrations before serving.
- Per memory `project_migration_pipeline_bug.md`, the cloudbuild psql glob `database/migrations/00[1-9][0-9]*.sql` does NOT match `2026*` filenames, so prod actually applies recent migrations through the binary's `--migrate` (sqlx::migrate) path rather than the cloudbuild psql step. That bug is out of scope for #171 — surfaced as a follow-up on #170 already.