### PR TITLE
chore(admin): add durable audit trail for registered_clients admin changes

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -1761,10 +1761,12 @@ pub async fn delete_registered_client(
     )
     .await;
 
+    let admin_display = &auth.pubkey[..8];
     tracing::info!(
-        "Registered client deleted: id={} client_id={}",
+        "Registered client deleted: id={} client_id={} (by admin {})",
         deleted.id,
-        deleted.client_id
+        deleted.client_id,
+        admin_display
     );
     Ok(Json(serde_json::json!({ "deleted": true })))
 }

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -12,8 +12,9 @@ use super::routes::AuthState;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extractors::UcanAuth;
 use keycast_core::repositories::{
-    test_redirect_pattern, AuthEventRepository, ClaimTokenRepository, OAuthAuthorizationRepository,
-    RegisteredClient, RegisteredClientRepository, RepositoryError, UserRepository,
+    test_redirect_pattern, AdminAuditEventRecord, AdminAuditEventRepository, AuthEventRepository,
+    ClaimTokenRepository, OAuthAuthorizationRepository, RegisteredClient,
+    RegisteredClientRepository, RepositoryError, UserRepository,
 };
 use keycast_core::types::claim_token::generate_claim_token;
 
@@ -1537,6 +1538,41 @@ fn map_repo_error(err: RepositoryError) -> ApiError {
     }
 }
 
+/// Best-effort audit-trail write for a registered_client mutation.
+/// A failed insert logs an error and returns; it never fails the admin action.
+async fn record_registered_client_audit(
+    pool: &sqlx::PgPool,
+    actor_pubkey: &str,
+    action: &'static str,
+    client: &RegisteredClient,
+) {
+    let metadata = serde_json::json!({
+        "name": client.name,
+        "allowed_redirect_uris": client.allowed_redirect_uris,
+    });
+    let repo = AdminAuditEventRepository::new(pool.clone());
+    if let Err(error) = repo
+        .record(AdminAuditEventRecord {
+            tenant_id: client.tenant_id,
+            actor_pubkey: actor_pubkey.to_string(),
+            action: action.to_string(),
+            target_resource_type: "registered_client".to_string(),
+            target_resource_id: Some(client.id.to_string()),
+            target_client_id: Some(client.client_id.clone()),
+            metadata_json: metadata,
+        })
+        .await
+    {
+        tracing::error!(
+            action = action,
+            client_id = %client.client_id,
+            tenant_id = client.tenant_id,
+            error = %error,
+            "Failed to write admin_audit_events row for registered_client"
+        );
+    }
+}
+
 /// GET /api/admin/registered-clients
 /// List all registered OAuth clients for the current tenant.
 pub async fn list_registered_clients(
@@ -1585,6 +1621,14 @@ pub async fn create_registered_client(
         .await
         .map_err(map_repo_error)?;
 
+    record_registered_client_audit(
+        &auth_state.state.db,
+        &auth.pubkey,
+        "registered_client.create",
+        &created,
+    )
+    .await;
+
     tracing::info!(
         "Registered client created: {} (by admin {})",
         created.client_id,
@@ -1632,6 +1676,14 @@ pub async fn update_registered_client(
         .await
         .map_err(map_repo_error)?;
 
+    record_registered_client_audit(
+        &auth_state.state.db,
+        &auth.pubkey,
+        "registered_client.update",
+        &updated,
+    )
+    .await;
+
     tracing::info!(
         "Registered client updated: id={} client_id={} (by admin {})",
         updated.id,
@@ -1653,12 +1705,20 @@ pub async fn delete_registered_client(
     }
 
     let repo = RegisteredClientRepository::new(auth_state.state.db.clone());
-    repo.delete(id, tenant.0.id).await.map_err(map_repo_error)?;
+    let deleted = repo.delete(id, tenant.0.id).await.map_err(map_repo_error)?;
+
+    record_registered_client_audit(
+        &auth_state.state.db,
+        &auth.pubkey,
+        "registered_client.delete",
+        &deleted,
+    )
+    .await;
 
     tracing::info!(
-        "Registered client deleted: id={} (by admin {})",
-        id,
-        &auth.pubkey[..8]
+        "Registered client deleted: id={} client_id={}",
+        deleted.id,
+        deleted.client_id
     );
     Ok(Json(serde_json::json!({ "deleted": true })))
 }

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -1538,8 +1538,11 @@ fn map_repo_error(err: RepositoryError) -> ApiError {
     }
 }
 
-/// Best-effort audit-trail write for a registered_client mutation.
+/// Best-effort audit-trail write for a registered_client create/delete.
 /// A failed insert logs an error and returns; it never fails the admin action.
+///
+/// Updates use [`record_registered_client_update_audit`] instead so the row
+/// can carry both pre- and post-update snapshots.
 async fn record_registered_client_audit(
     pool: &sqlx::PgPool,
     actor_pubkey: &str,
@@ -1567,6 +1570,49 @@ async fn record_registered_client_audit(
             action = action,
             client_id = %client.client_id,
             tenant_id = client.tenant_id,
+            error = %error,
+            "Failed to write admin_audit_events row for registered_client"
+        );
+    }
+}
+
+/// Best-effort audit-trail write for a registered_client update, recording
+/// `{before, after}` snapshots so forensic queries can answer "what changed"
+/// from a single row. Mirrors the no-fail pattern of
+/// [`record_registered_client_audit`].
+async fn record_registered_client_update_audit(
+    pool: &sqlx::PgPool,
+    actor_pubkey: &str,
+    before: &RegisteredClient,
+    after: &RegisteredClient,
+) {
+    let metadata = serde_json::json!({
+        "before": {
+            "name": before.name,
+            "allowed_redirect_uris": before.allowed_redirect_uris,
+        },
+        "after": {
+            "name": after.name,
+            "allowed_redirect_uris": after.allowed_redirect_uris,
+        },
+    });
+    let repo = AdminAuditEventRepository::new(pool.clone());
+    if let Err(error) = repo
+        .record(AdminAuditEventRecord {
+            tenant_id: after.tenant_id,
+            actor_pubkey: actor_pubkey.to_string(),
+            action: "registered_client.update".to_string(),
+            target_resource_type: "registered_client".to_string(),
+            target_resource_id: Some(after.id.to_string()),
+            target_client_id: Some(after.client_id.clone()),
+            metadata_json: metadata,
+        })
+        .await
+    {
+        tracing::error!(
+            action = "registered_client.update",
+            client_id = %after.client_id,
+            tenant_id = after.tenant_id,
             error = %error,
             "Failed to write admin_audit_events row for registered_client"
         );
@@ -1666,7 +1712,7 @@ pub async fn update_registered_client(
     }
 
     let repo = RegisteredClientRepository::new(auth_state.state.db.clone());
-    let updated = repo
+    let update = repo
         .update(
             id,
             tenant.0.id,
@@ -1676,21 +1722,21 @@ pub async fn update_registered_client(
         .await
         .map_err(map_repo_error)?;
 
-    record_registered_client_audit(
+    record_registered_client_update_audit(
         &auth_state.state.db,
         &auth.pubkey,
-        "registered_client.update",
-        &updated,
+        &update.before,
+        &update.after,
     )
     .await;
 
     tracing::info!(
         "Registered client updated: id={} client_id={} (by admin {})",
-        updated.id,
-        updated.client_id,
+        update.after.id,
+        update.after.client_id,
         &auth.pubkey[..8]
     );
-    Ok(Json(updated.into()))
+    Ok(Json(update.after.into()))
 }
 
 /// DELETE /api/admin/registered-clients/:id

--- a/api/tests/registered_clients_admin_test.rs
+++ b/api/tests/registered_clients_admin_test.rs
@@ -237,9 +237,9 @@ async fn update_renames_and_replaces_uris() {
         .await
         .unwrap();
 
-    assert_eq!(updated.name, "Renamed");
-    assert_eq!(updated.allowed_redirect_uris.len(), 2);
-    assert!(updated.updated_at >= created.updated_at);
+    assert_eq!(updated.after.name, "Renamed");
+    assert_eq!(updated.after.allowed_redirect_uris.len(), 2);
+    assert!(updated.after.updated_at >= created.updated_at);
 }
 
 #[tokio::test]
@@ -398,11 +398,59 @@ async fn update_trims_redirect_uri_whitespace() {
         .await
         .unwrap();
 
-    assert_eq!(updated.allowed_redirect_uris.len(), 1);
+    assert_eq!(updated.after.allowed_redirect_uris.len(), 1);
     assert_eq!(
-        updated.allowed_redirect_uris[0], "https://new.example.com/cb",
+        updated.after.allowed_redirect_uris[0], "https://new.example.com/cb",
         "redirect URIs should be trimmed on update"
     );
+}
+
+#[tokio::test]
+async fn update_returns_before_and_after_snapshots() {
+    let repo = fresh_repo(&["test-update-before-after"]).await;
+
+    let created = repo
+        .create(
+            TENANT_A,
+            "test-update-before-after",
+            "Original",
+            &["https://before.example.com/cb".to_string()],
+        )
+        .await
+        .unwrap();
+
+    let update = repo
+        .update(
+            created.id,
+            TENANT_A,
+            Some("Renamed"),
+            Some(&["https://after.example.com/cb".to_string()]),
+        )
+        .await
+        .unwrap();
+
+    // Pre-image carries the original state captured before the UPDATE applied.
+    assert_eq!(update.before.id, created.id);
+    assert_eq!(update.before.tenant_id, TENANT_A);
+    assert_eq!(update.before.client_id, "test-update-before-after");
+    assert_eq!(update.before.name, "Original");
+    assert_eq!(
+        update.before.allowed_redirect_uris,
+        vec!["https://before.example.com/cb".to_string()]
+    );
+
+    // Post-image carries the new state.
+    assert_eq!(update.after.id, created.id);
+    assert_eq!(update.after.tenant_id, TENANT_A);
+    assert_eq!(update.after.client_id, "test-update-before-after");
+    assert_eq!(update.after.name, "Renamed");
+    assert_eq!(
+        update.after.allowed_redirect_uris,
+        vec!["https://after.example.com/cb".to_string()]
+    );
+
+    // The CTE uses NOW() in the UPDATE so updated_at must advance.
+    assert!(update.after.updated_at >= update.before.updated_at);
 }
 
 #[tokio::test]

--- a/api/tests/registered_clients_admin_test.rs
+++ b/api/tests/registered_clients_admin_test.rs
@@ -404,3 +404,33 @@ async fn update_trims_redirect_uri_whitespace() {
         "redirect URIs should be trimmed on update"
     );
 }
+
+#[tokio::test]
+async fn delete_returns_deleted_row_for_audit() {
+    let repo = fresh_repo(&["test-delete-returning"]).await;
+
+    let created = repo
+        .create(
+            TENANT_A,
+            "test-delete-returning",
+            "Returning Test",
+            &["https://example.com/cb".to_string()],
+        )
+        .await
+        .unwrap();
+
+    let deleted = repo.delete(created.id, TENANT_A).await.unwrap();
+
+    assert_eq!(deleted.id, created.id);
+    assert_eq!(deleted.tenant_id, TENANT_A);
+    assert_eq!(deleted.client_id, "test-delete-returning");
+    assert_eq!(deleted.name, "Returning Test");
+    assert_eq!(
+        deleted.allowed_redirect_uris,
+        vec!["https://example.com/cb".to_string()]
+    );
+
+    // And the row really is gone.
+    let listed = repo.list(TENANT_A).await.unwrap();
+    assert!(!listed.iter().any(|c| c.id == created.id));
+}

--- a/api/tests/registered_clients_audit_test.rs
+++ b/api/tests/registered_clients_audit_test.rs
@@ -1,0 +1,234 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: HTTP-handler tests verifying registered_client admin actions write
+// ABOUTME: durable audit rows to admin_audit_events.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::Json;
+use chrono::Utc;
+use keycast_api::{
+    api::{
+        extractors::UcanAuth,
+        http::{
+            admin::{
+                create_registered_client, delete_registered_client, update_registered_client,
+                CreateRegisteredClientRequest, UpdateRegisteredClientRequest,
+            },
+            routes::AuthState,
+        },
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+mod common;
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to test database");
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+    pool
+}
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn make_auth_state(pool: PgPool) -> AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+fn make_tenant(id: i64) -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id,
+        domain: "localhost".to_string(),
+        name: "Audit Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+fn make_admin_auth(pubkey: &str) -> UcanAuth {
+    UcanAuth {
+        pubkey: pubkey.to_string(),
+        admin_role: Some("full".to_string()),
+    }
+}
+
+async fn cleanup(pool: &PgPool, tenant_id: i64, client_id: &str, actor_pubkey: &str) {
+    let _ = sqlx::query("DELETE FROM registered_clients WHERE tenant_id = $1 AND client_id = $2")
+        .bind(tenant_id)
+        .bind(client_id)
+        .execute(pool)
+        .await;
+    let _ =
+        sqlx::query("DELETE FROM admin_audit_events WHERE tenant_id = $1 AND actor_pubkey = $2")
+            .bind(tenant_id)
+            .bind(actor_pubkey)
+            .execute(pool)
+            .await;
+}
+
+#[derive(sqlx::FromRow)]
+struct AuditRow {
+    actor_pubkey: String,
+    action: String,
+    target_resource_type: String,
+    target_resource_id: Option<String>,
+    target_client_id: Option<String>,
+    metadata_json: serde_json::Value,
+}
+
+async fn read_audit_rows(pool: &PgPool, tenant_id: i64, actor_pubkey: &str) -> Vec<AuditRow> {
+    sqlx::query_as::<_, AuditRow>(
+        "SELECT actor_pubkey, action, target_resource_type, target_resource_id,
+                target_client_id, metadata_json
+         FROM admin_audit_events
+         WHERE tenant_id = $1 AND actor_pubkey = $2
+         ORDER BY occurred_at ASC, id ASC",
+    )
+    .bind(tenant_id)
+    .bind(actor_pubkey)
+    .fetch_all(pool)
+    .await
+    .expect("audit rows fetch")
+}
+
+#[tokio::test]
+async fn create_update_delete_each_writes_admin_audit_event() {
+    let pool = setup_pool().await;
+
+    // Synthetic tenant id well outside the seeded range to avoid colliding with
+    // other tests running in parallel against the shared DB.
+    let tenant_id: i64 = 9_300_000 + (Uuid::new_v4().as_u128() as i64).rem_euclid(1_000_000);
+    let actor_pubkey = format!("{:0>64}", Uuid::new_v4().simple());
+    let client_id = format!("audit-http-{}", &Uuid::new_v4().to_string()[..8]);
+
+    cleanup(&pool, tenant_id, &client_id, &actor_pubkey).await;
+
+    let state = make_auth_state(pool.clone());
+
+    // CREATE
+    let created = create_registered_client(
+        make_tenant(tenant_id),
+        State(state.clone()),
+        make_admin_auth(&actor_pubkey),
+        Json(CreateRegisteredClientRequest {
+            client_id: client_id.clone(),
+            name: "Audit HTTP".to_string(),
+            allowed_redirect_uris: vec!["https://example.com/cb".to_string()],
+        }),
+    )
+    .await
+    .expect("create handler ok")
+    .0;
+
+    // UPDATE
+    let _ = update_registered_client(
+        make_tenant(tenant_id),
+        State(state.clone()),
+        make_admin_auth(&actor_pubkey),
+        Path(created.id),
+        Json(UpdateRegisteredClientRequest {
+            name: Some("Audit HTTP renamed".to_string()),
+            allowed_redirect_uris: Some(vec!["https://example.com/cb2".to_string()]),
+        }),
+    )
+    .await
+    .expect("update handler ok");
+
+    // DELETE
+    let _ = delete_registered_client(
+        make_tenant(tenant_id),
+        State(state),
+        make_admin_auth(&actor_pubkey),
+        Path(created.id),
+    )
+    .await
+    .expect("delete handler ok");
+
+    let rows = read_audit_rows(&pool, tenant_id, &actor_pubkey).await;
+    assert_eq!(rows.len(), 3, "create+update+delete each emit one row");
+
+    let actions: Vec<&str> = rows.iter().map(|r| r.action.as_str()).collect();
+    assert_eq!(
+        actions,
+        vec![
+            "registered_client.create",
+            "registered_client.update",
+            "registered_client.delete",
+        ]
+    );
+
+    for row in &rows {
+        assert_eq!(row.actor_pubkey, actor_pubkey);
+        assert_eq!(row.target_resource_type, "registered_client");
+        assert_eq!(
+            row.target_resource_id.as_deref(),
+            Some(created.id.to_string()).as_deref()
+        );
+        assert_eq!(row.target_client_id.as_deref(), Some(client_id.as_str()));
+    }
+
+    // Spot-check metadata payloads carry the state we expect.
+    assert_eq!(rows[0].metadata_json["name"], "Audit HTTP");
+    assert_eq!(rows[1].metadata_json["name"], "Audit HTTP renamed");
+    assert_eq!(rows[2].metadata_json["name"], "Audit HTTP renamed");
+    assert_eq!(
+        rows[2].metadata_json["allowed_redirect_uris"][0],
+        "https://example.com/cb2"
+    );
+
+    cleanup(&pool, tenant_id, &client_id, &actor_pubkey).await;
+}

--- a/api/tests/registered_clients_audit_test.rs
+++ b/api/tests/registered_clients_audit_test.rs
@@ -222,8 +222,28 @@ async fn create_update_delete_each_writes_admin_audit_event() {
     }
 
     // Spot-check metadata payloads carry the state we expect.
+    // create: flat snapshot of the just-created row.
     assert_eq!(rows[0].metadata_json["name"], "Audit HTTP");
-    assert_eq!(rows[1].metadata_json["name"], "Audit HTTP renamed");
+    assert_eq!(
+        rows[0].metadata_json["allowed_redirect_uris"][0],
+        "https://example.com/cb"
+    );
+
+    // update: {before, after} captured atomically by the CTE in
+    // RegisteredClientRepository::update. before holds the pre-update
+    // snapshot; after holds the post-update snapshot.
+    assert_eq!(rows[1].metadata_json["before"]["name"], "Audit HTTP");
+    assert_eq!(
+        rows[1].metadata_json["before"]["allowed_redirect_uris"][0],
+        "https://example.com/cb"
+    );
+    assert_eq!(rows[1].metadata_json["after"]["name"], "Audit HTTP renamed");
+    assert_eq!(
+        rows[1].metadata_json["after"]["allowed_redirect_uris"][0],
+        "https://example.com/cb2"
+    );
+
+    // delete: flat snapshot of the row at the moment of deletion.
     assert_eq!(rows[2].metadata_json["name"], "Audit HTTP renamed");
     assert_eq!(
         rows[2].metadata_json["allowed_redirect_uris"][0],

--- a/core/src/repositories/admin_audit_event.rs
+++ b/core/src/repositories/admin_audit_event.rs
@@ -1,0 +1,108 @@
+// ABOUTME: Repository for durable admin-action audit events
+// ABOUTME: Append-only forensic log capturing actor, action, target, and metadata
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use sqlx::{FromRow, PgPool};
+
+use crate::repositories::RepositoryError;
+
+#[derive(Debug, Clone)]
+pub struct AdminAuditEventRecord {
+    pub tenant_id: i64,
+    pub actor_pubkey: String,
+    pub action: String,
+    pub target_resource_type: String,
+    pub target_resource_id: Option<String>,
+    pub target_client_id: Option<String>,
+    pub metadata_json: Value,
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct AdminAuditEventRow {
+    pub id: i64,
+    pub occurred_at: DateTime<Utc>,
+    pub tenant_id: i64,
+    pub actor_pubkey: String,
+    pub action: String,
+    pub target_resource_type: String,
+    pub target_resource_id: Option<String>,
+    pub target_client_id: Option<String>,
+    pub metadata_json: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct AdminAuditEventRepository {
+    pool: PgPool,
+}
+
+impl AdminAuditEventRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn record(
+        &self,
+        record: AdminAuditEventRecord,
+    ) -> Result<AdminAuditEventRow, RepositoryError> {
+        sqlx::query_as::<_, AdminAuditEventRow>(
+            "INSERT INTO admin_audit_events (
+                tenant_id,
+                actor_pubkey,
+                action,
+                target_resource_type,
+                target_resource_id,
+                target_client_id,
+                metadata_json
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+             RETURNING
+                id,
+                occurred_at,
+                tenant_id,
+                actor_pubkey,
+                action,
+                target_resource_type,
+                target_resource_id,
+                target_client_id,
+                metadata_json",
+        )
+        .bind(record.tenant_id)
+        .bind(record.actor_pubkey)
+        .bind(record.action)
+        .bind(record.target_resource_type)
+        .bind(record.target_resource_id)
+        .bind(record.target_client_id)
+        .bind(record.metadata_json)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    pub async fn list_recent(
+        &self,
+        tenant_id: i64,
+        limit: i64,
+    ) -> Result<Vec<AdminAuditEventRow>, RepositoryError> {
+        sqlx::query_as::<_, AdminAuditEventRow>(
+            "SELECT
+                id,
+                occurred_at,
+                tenant_id,
+                actor_pubkey,
+                action,
+                target_resource_type,
+                target_resource_id,
+                target_client_id,
+                metadata_json
+             FROM admin_audit_events
+             WHERE tenant_id = $1
+             ORDER BY occurred_at DESC, id DESC
+             LIMIT $2",
+        )
+        .bind(tenant_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+}

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -17,9 +17,7 @@ mod stored_key;
 mod team;
 mod user;
 
-pub use admin_audit_event::{
-    AdminAuditEventRecord, AdminAuditEventRepository, AdminAuditEventRow,
-};
+pub use admin_audit_event::{AdminAuditEventRecord, AdminAuditEventRepository, AdminAuditEventRow};
 pub use atproto_oauth_session::{
     AtprotoOAuthSession, AtprotoOAuthSessionRepository, CreateAtprotoOAuthSessionParams,
     IssueAtprotoTokensParams,

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -1,6 +1,7 @@
 // ABOUTME: Repository module for data access operations
 // ABOUTME: Provides abstraction layer between handlers and database
 
+mod admin_audit_event;
 mod atproto_oauth_session;
 mod auth_event;
 mod authorization;
@@ -16,6 +17,9 @@ mod stored_key;
 mod team;
 mod user;
 
+pub use admin_audit_event::{
+    AdminAuditEventRecord, AdminAuditEventRepository, AdminAuditEventRow,
+};
 pub use atproto_oauth_session::{
     AtprotoOAuthSession, AtprotoOAuthSessionRepository, CreateAtprotoOAuthSessionParams,
     IssueAtprotoTokensParams,

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -33,7 +33,9 @@ pub use oauth_code::{
 pub use personal_keys::PersonalKeysRepository;
 pub use policy::PolicyRepository;
 pub use refresh_token::RefreshTokenRepository;
-pub use registered_client::{test_redirect_pattern, RegisteredClient, RegisteredClientRepository};
+pub use registered_client::{
+    test_redirect_pattern, RegisteredClient, RegisteredClientRepository, RegisteredClientUpdate,
+};
 pub use stored_key::StoredKeyRepository;
 pub use team::TeamRepository;
 pub use user::{AdminUserDetails, DeleteAccountResult, UserRepository, VerificationTokenData};

--- a/core/src/repositories/registered_client.rs
+++ b/core/src/repositories/registered_client.rs
@@ -108,7 +108,7 @@ impl RegisteredClientRepository {
     /// List all registered clients for a tenant, ordered by client_id.
     pub async fn list(&self, tenant_id: i64) -> Result<Vec<RegisteredClient>, RepositoryError> {
         let rows = sqlx::query_as::<_, RegisteredClient>(
-            "SELECT id, tenant_id::BIGINT AS tenant_id, client_id, name,
+            "SELECT id, tenant_id, client_id, name,
                     allowed_redirect_uris, created_at, updated_at
              FROM registered_clients
              WHERE tenant_id = $1
@@ -123,7 +123,7 @@ impl RegisteredClientRepository {
     /// Get a single registered client by id, scoped to a tenant.
     pub async fn get(&self, id: i32, tenant_id: i64) -> Result<RegisteredClient, RepositoryError> {
         let row = sqlx::query_as::<_, RegisteredClient>(
-            "SELECT id, tenant_id::BIGINT AS tenant_id, client_id, name,
+            "SELECT id, tenant_id, client_id, name,
                     allowed_redirect_uris, created_at, updated_at
              FROM registered_clients
              WHERE id = $1 AND tenant_id = $2",
@@ -164,7 +164,7 @@ impl RegisteredClientRepository {
             "INSERT INTO registered_clients
                  (tenant_id, client_id, name, allowed_redirect_uris)
              VALUES ($1, $2, $3, $4)
-             RETURNING id, tenant_id::BIGINT AS tenant_id, client_id, name,
+             RETURNING id, tenant_id, client_id, name,
                        allowed_redirect_uris, created_at, updated_at",
         )
         .bind(tenant_id)
@@ -211,7 +211,7 @@ impl RegisteredClientRepository {
         let mut tx = self.pool.begin().await?;
 
         let before = sqlx::query_as::<_, RegisteredClient>(
-            "SELECT id, tenant_id::BIGINT AS tenant_id, client_id, name,
+            "SELECT id, tenant_id, client_id, name,
                     allowed_redirect_uris, created_at, updated_at
              FROM registered_clients
              WHERE id = $1 AND tenant_id = $2
@@ -234,7 +234,7 @@ impl RegisteredClientRepository {
                  allowed_redirect_uris = COALESCE($4, allowed_redirect_uris),
                  updated_at = NOW()
              WHERE id = $1 AND tenant_id = $2
-             RETURNING id, tenant_id::BIGINT AS tenant_id, client_id, name,
+             RETURNING id, tenant_id, client_id, name,
                        allowed_redirect_uris, created_at, updated_at",
         )
         .bind(id)
@@ -260,7 +260,7 @@ impl RegisteredClientRepository {
         let row = sqlx::query_as::<_, RegisteredClient>(
             "DELETE FROM registered_clients
              WHERE id = $1 AND tenant_id = $2
-             RETURNING id, tenant_id::BIGINT AS tenant_id, client_id, name,
+             RETURNING id, tenant_id, client_id, name,
                        allowed_redirect_uris, created_at, updated_at",
         )
         .bind(id)

--- a/core/src/repositories/registered_client.rs
+++ b/core/src/repositories/registered_client.rs
@@ -207,21 +207,30 @@ impl RegisteredClientRepository {
     }
 
     /// Delete a registered client. Tenant-scoped.
+    /// Returns the deleted row so callers can audit-log the removed state.
     /// Returns NotFound if no row matches (id, tenant_id).
-    pub async fn delete(&self, id: i32, tenant_id: i64) -> Result<(), RepositoryError> {
-        let result = sqlx::query("DELETE FROM registered_clients WHERE id = $1 AND tenant_id = $2")
-            .bind(id)
-            .bind(tenant_id)
-            .execute(&self.pool)
-            .await?;
+    pub async fn delete(
+        &self,
+        id: i32,
+        tenant_id: i64,
+    ) -> Result<RegisteredClient, RepositoryError> {
+        let row = sqlx::query_as::<_, RegisteredClient>(
+            "DELETE FROM registered_clients
+             WHERE id = $1 AND tenant_id = $2
+             RETURNING id, tenant_id::BIGINT AS tenant_id, client_id, name,
+                       allowed_redirect_uris, created_at, updated_at",
+        )
+        .bind(id)
+        .bind(tenant_id)
+        .fetch_optional(&self.pool)
+        .await?;
 
-        if result.rows_affected() == 0 {
-            return Err(RepositoryError::NotFound(format!(
+        row.ok_or_else(|| {
+            RepositoryError::NotFound(format!(
                 "registered_client id={} for tenant {}",
                 id, tenant_id
-            )));
-        }
-        Ok(())
+            ))
+        })
     }
 }
 

--- a/core/src/repositories/registered_client.rs
+++ b/core/src/repositories/registered_client.rs
@@ -23,6 +23,19 @@ pub struct RegisteredClient {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Pre- and post-update snapshots returned by `RegisteredClientRepository::update`.
+///
+/// Captured atomically via a CTE: a non-data-modifying SELECT (`pre`) reads the
+/// snapshot before the UPDATE applies, and the data-modifying CTE (`upd`) returns
+/// the post-update row. Both run against the same Postgres snapshot, so callers
+/// (e.g. the admin audit log) see a consistent before/after pair with no TOCTOU
+/// window.
+#[derive(Debug, Clone)]
+pub struct RegisteredClientUpdate {
+    pub before: RegisteredClient,
+    pub after: RegisteredClient,
+}
+
 /// Repository for registered OAuth client operations.
 /// When a client_id is registered, only its allowed redirect URIs are accepted.
 /// Unregistered client_ids fall back to accepting any HTTPS redirect_uri.
@@ -163,13 +176,17 @@ impl RegisteredClientRepository {
 
     /// Update name and/or allowed_redirect_uris for a registered client.
     /// Tenant-scoped: returns NotFound when (id, tenant_id) does not match.
+    ///
+    /// Returns both the pre-update and post-update snapshots so callers (e.g.
+    /// the admin audit log) can record a single before/after entry. The
+    /// snapshots are captured atomically by a CTE: see `RegisteredClientUpdate`.
     pub async fn update(
         &self,
         id: i32,
         tenant_id: i64,
         name: Option<&str>,
         allowed_redirect_uris: Option<&[String]>,
-    ) -> Result<RegisteredClient, RepositoryError> {
+    ) -> Result<RegisteredClientUpdate, RepositoryError> {
         if let Some(uris) = allowed_redirect_uris {
             validate_redirect_uri_list(uris)?;
         }
@@ -181,15 +198,51 @@ impl RegisteredClientRepository {
         let trimmed_uris: Option<Vec<String>> =
             allowed_redirect_uris.map(|uris| uris.iter().map(|s| s.trim().to_string()).collect());
 
-        // COALESCE pattern lets us patch either field without separate queries.
-        let row = sqlx::query_as::<_, RegisteredClient>(
-            "UPDATE registered_clients
-             SET name = COALESCE($3, name),
-                 allowed_redirect_uris = COALESCE($4, allowed_redirect_uris),
-                 updated_at = NOW()
-             WHERE id = $1 AND tenant_id = $2
-             RETURNING id, tenant_id::BIGINT AS tenant_id, client_id, name,
-                       allowed_redirect_uris, created_at, updated_at",
+        // CTE captures pre- and post-update snapshots in a single statement.
+        // `pre` reads the original row from the statement snapshot; `upd`
+        // performs the UPDATE and returns the new row. Postgres runs both CTEs
+        // against the same snapshot, so `pre` does not see `upd`'s changes
+        // (Postgres docs: data-modifying WITH statements). The outer SELECT
+        // joins them on id, yielding one row with both states; if the target
+        // doesn't exist (or the tenant doesn't match), neither CTE produces a
+        // row and fetch_optional returns None.
+        let row: Option<UpdateRow> = sqlx::query_as::<_, UpdateRow>(
+            "WITH pre AS (
+                 SELECT id,
+                        tenant_id::BIGINT AS tenant_id,
+                        client_id, name, allowed_redirect_uris,
+                        created_at, updated_at
+                 FROM registered_clients
+                 WHERE id = $1 AND tenant_id = $2
+             ),
+             upd AS (
+                 UPDATE registered_clients
+                 SET name = COALESCE($3, name),
+                     allowed_redirect_uris = COALESCE($4, allowed_redirect_uris),
+                     updated_at = NOW()
+                 WHERE id = $1 AND tenant_id = $2
+                 RETURNING id,
+                           tenant_id::BIGINT AS tenant_id,
+                           client_id, name, allowed_redirect_uris,
+                           created_at, updated_at
+             )
+             SELECT
+                 pre.id                    AS before_id,
+                 pre.tenant_id             AS before_tenant_id,
+                 pre.client_id             AS before_client_id,
+                 pre.name                  AS before_name,
+                 pre.allowed_redirect_uris AS before_allowed_redirect_uris,
+                 pre.created_at            AS before_created_at,
+                 pre.updated_at            AS before_updated_at,
+                 upd.id                    AS after_id,
+                 upd.tenant_id             AS after_tenant_id,
+                 upd.client_id             AS after_client_id,
+                 upd.name                  AS after_name,
+                 upd.allowed_redirect_uris AS after_allowed_redirect_uris,
+                 upd.created_at            AS after_created_at,
+                 upd.updated_at            AS after_updated_at
+             FROM pre
+             JOIN upd ON upd.id = pre.id",
         )
         .bind(id)
         .bind(tenant_id)
@@ -198,7 +251,7 @@ impl RegisteredClientRepository {
         .fetch_optional(&self.pool)
         .await?;
 
-        row.ok_or_else(|| {
+        row.map(Into::into).ok_or_else(|| {
             RepositoryError::NotFound(format!(
                 "registered_client id={} for tenant {}",
                 id, tenant_id
@@ -231,6 +284,52 @@ impl RegisteredClientRepository {
                 id, tenant_id
             ))
         })
+    }
+}
+
+// ---- Update CTE row mapping --------------------------------------------------
+
+/// Flat row returned by the `update` CTE; converted into `RegisteredClientUpdate`.
+#[derive(FromRow)]
+struct UpdateRow {
+    before_id: i32,
+    before_tenant_id: i64,
+    before_client_id: String,
+    before_name: String,
+    before_allowed_redirect_uris: Vec<String>,
+    before_created_at: DateTime<Utc>,
+    before_updated_at: DateTime<Utc>,
+    after_id: i32,
+    after_tenant_id: i64,
+    after_client_id: String,
+    after_name: String,
+    after_allowed_redirect_uris: Vec<String>,
+    after_created_at: DateTime<Utc>,
+    after_updated_at: DateTime<Utc>,
+}
+
+impl From<UpdateRow> for RegisteredClientUpdate {
+    fn from(r: UpdateRow) -> Self {
+        Self {
+            before: RegisteredClient {
+                id: r.before_id,
+                tenant_id: r.before_tenant_id,
+                client_id: r.before_client_id,
+                name: r.before_name,
+                allowed_redirect_uris: r.before_allowed_redirect_uris,
+                created_at: r.before_created_at,
+                updated_at: r.before_updated_at,
+            },
+            after: RegisteredClient {
+                id: r.after_id,
+                tenant_id: r.after_tenant_id,
+                client_id: r.after_client_id,
+                name: r.after_name,
+                allowed_redirect_uris: r.after_allowed_redirect_uris,
+                created_at: r.after_created_at,
+                updated_at: r.after_updated_at,
+            },
+        }
     }
 }
 

--- a/core/src/repositories/registered_client.rs
+++ b/core/src/repositories/registered_client.rs
@@ -25,11 +25,13 @@ pub struct RegisteredClient {
 
 /// Pre- and post-update snapshots returned by `RegisteredClientRepository::update`.
 ///
-/// Captured atomically via a CTE: a non-data-modifying SELECT (`pre`) reads the
-/// snapshot before the UPDATE applies, and the data-modifying CTE (`upd`) returns
-/// the post-update row. Both run against the same Postgres snapshot, so callers
-/// (e.g. the admin audit log) see a consistent before/after pair with no TOCTOU
-/// window.
+/// Captured by holding a row-level lock for the duration of the update
+/// transaction: the repository runs `SELECT ... FOR UPDATE` on the target row,
+/// then `UPDATE` within the same transaction. Under READ COMMITTED (the
+/// default), `FOR UPDATE` waits for any concurrent updater and then re-anchors
+/// on the latest committed version of the row, so `before` reflects the actual
+/// immediately-prior state and `after` reflects the row after this admin's
+/// update — even when other admins are updating concurrently.
 #[derive(Debug, Clone)]
 pub struct RegisteredClientUpdate {
     pub before: RegisteredClient,
@@ -179,7 +181,10 @@ impl RegisteredClientRepository {
     ///
     /// Returns both the pre-update and post-update snapshots so callers (e.g.
     /// the admin audit log) can record a single before/after entry. The
-    /// snapshots are captured atomically by a CTE: see `RegisteredClientUpdate`.
+    /// repository takes a row lock via `SELECT ... FOR UPDATE`, then performs
+    /// the `UPDATE` in the same transaction, so `before` and `after` describe
+    /// the actual transition this caller produced — concurrent updaters are
+    /// serialized through the row lock.
     pub async fn update(
         &self,
         id: i32,
@@ -198,65 +203,50 @@ impl RegisteredClientRepository {
         let trimmed_uris: Option<Vec<String>> =
             allowed_redirect_uris.map(|uris| uris.iter().map(|s| s.trim().to_string()).collect());
 
-        // CTE captures pre- and post-update snapshots in a single statement.
-        // `pre` reads the original row from the statement snapshot; `upd`
-        // performs the UPDATE and returns the new row. Postgres runs both CTEs
-        // against the same snapshot, so `pre` does not see `upd`'s changes
-        // (Postgres docs: data-modifying WITH statements). The outer SELECT
-        // joins them on id, yielding one row with both states; if the target
-        // doesn't exist (or the tenant doesn't match), neither CTE produces a
-        // row and fetch_optional returns None.
-        let row: Option<UpdateRow> = sqlx::query_as::<_, UpdateRow>(
-            "WITH pre AS (
-                 SELECT id,
-                        tenant_id::BIGINT AS tenant_id,
-                        client_id, name, allowed_redirect_uris,
-                        created_at, updated_at
-                 FROM registered_clients
-                 WHERE id = $1 AND tenant_id = $2
-             ),
-             upd AS (
-                 UPDATE registered_clients
-                 SET name = COALESCE($3, name),
-                     allowed_redirect_uris = COALESCE($4, allowed_redirect_uris),
-                     updated_at = NOW()
-                 WHERE id = $1 AND tenant_id = $2
-                 RETURNING id,
-                           tenant_id::BIGINT AS tenant_id,
-                           client_id, name, allowed_redirect_uris,
-                           created_at, updated_at
-             )
-             SELECT
-                 pre.id                    AS before_id,
-                 pre.tenant_id             AS before_tenant_id,
-                 pre.client_id             AS before_client_id,
-                 pre.name                  AS before_name,
-                 pre.allowed_redirect_uris AS before_allowed_redirect_uris,
-                 pre.created_at            AS before_created_at,
-                 pre.updated_at            AS before_updated_at,
-                 upd.id                    AS after_id,
-                 upd.tenant_id             AS after_tenant_id,
-                 upd.client_id             AS after_client_id,
-                 upd.name                  AS after_name,
-                 upd.allowed_redirect_uris AS after_allowed_redirect_uris,
-                 upd.created_at            AS after_created_at,
-                 upd.updated_at            AS after_updated_at
-             FROM pre
-             JOIN upd ON upd.id = pre.id",
+        // Hold a row lock for the entire transaction so `before` and `after`
+        // describe the actual transition this caller produced. Under READ
+        // COMMITTED, SELECT FOR UPDATE waits for any concurrent updater and
+        // then re-reads against the latest committed version; the subsequent
+        // UPDATE then runs on top of that locked row with no interleaving.
+        let mut tx = self.pool.begin().await?;
+
+        let before = sqlx::query_as::<_, RegisteredClient>(
+            "SELECT id, tenant_id::BIGINT AS tenant_id, client_id, name,
+                    allowed_redirect_uris, created_at, updated_at
+             FROM registered_clients
+             WHERE id = $1 AND tenant_id = $2
+             FOR UPDATE",
+        )
+        .bind(id)
+        .bind(tenant_id)
+        .fetch_optional(&mut *tx)
+        .await?
+        .ok_or_else(|| {
+            RepositoryError::NotFound(format!(
+                "registered_client id={} for tenant {}",
+                id, tenant_id
+            ))
+        })?;
+
+        let after = sqlx::query_as::<_, RegisteredClient>(
+            "UPDATE registered_clients
+             SET name = COALESCE($3, name),
+                 allowed_redirect_uris = COALESCE($4, allowed_redirect_uris),
+                 updated_at = NOW()
+             WHERE id = $1 AND tenant_id = $2
+             RETURNING id, tenant_id::BIGINT AS tenant_id, client_id, name,
+                       allowed_redirect_uris, created_at, updated_at",
         )
         .bind(id)
         .bind(tenant_id)
         .bind(name.map(str::trim))
         .bind(trimmed_uris.as_deref())
-        .fetch_optional(&self.pool)
+        .fetch_one(&mut *tx)
         .await?;
 
-        row.map(Into::into).ok_or_else(|| {
-            RepositoryError::NotFound(format!(
-                "registered_client id={} for tenant {}",
-                id, tenant_id
-            ))
-        })
+        tx.commit().await?;
+
+        Ok(RegisteredClientUpdate { before, after })
     }
 
     /// Delete a registered client. Tenant-scoped.
@@ -284,52 +274,6 @@ impl RegisteredClientRepository {
                 id, tenant_id
             ))
         })
-    }
-}
-
-// ---- Update CTE row mapping --------------------------------------------------
-
-/// Flat row returned by the `update` CTE; converted into `RegisteredClientUpdate`.
-#[derive(FromRow)]
-struct UpdateRow {
-    before_id: i32,
-    before_tenant_id: i64,
-    before_client_id: String,
-    before_name: String,
-    before_allowed_redirect_uris: Vec<String>,
-    before_created_at: DateTime<Utc>,
-    before_updated_at: DateTime<Utc>,
-    after_id: i32,
-    after_tenant_id: i64,
-    after_client_id: String,
-    after_name: String,
-    after_allowed_redirect_uris: Vec<String>,
-    after_created_at: DateTime<Utc>,
-    after_updated_at: DateTime<Utc>,
-}
-
-impl From<UpdateRow> for RegisteredClientUpdate {
-    fn from(r: UpdateRow) -> Self {
-        Self {
-            before: RegisteredClient {
-                id: r.before_id,
-                tenant_id: r.before_tenant_id,
-                client_id: r.before_client_id,
-                name: r.before_name,
-                allowed_redirect_uris: r.before_allowed_redirect_uris,
-                created_at: r.before_created_at,
-                updated_at: r.before_updated_at,
-            },
-            after: RegisteredClient {
-                id: r.after_id,
-                tenant_id: r.after_tenant_id,
-                client_id: r.after_client_id,
-                name: r.after_name,
-                allowed_redirect_uris: r.after_allowed_redirect_uris,
-                created_at: r.after_created_at,
-                updated_at: r.after_updated_at,
-            },
-        }
     }
 }
 

--- a/core/tests/admin_audit_event_repository_test.rs
+++ b/core/tests/admin_audit_event_repository_test.rs
@@ -62,7 +62,10 @@ async fn records_and_lists_admin_audit_event() {
     assert_eq!(inserted.action, "registered_client.create");
     assert_eq!(inserted.target_resource_type, "registered_client");
     assert_eq!(inserted.target_resource_id.as_deref(), Some("123"));
-    assert_eq!(inserted.target_client_id.as_deref(), Some(target_client_id.as_str()));
+    assert_eq!(
+        inserted.target_client_id.as_deref(),
+        Some(target_client_id.as_str())
+    );
     assert_eq!(inserted.metadata_json["name"], "Audit Test");
 
     let listed = repo

--- a/core/tests/admin_audit_event_repository_test.rs
+++ b/core/tests/admin_audit_event_repository_test.rs
@@ -1,0 +1,128 @@
+use keycast_core::repositories::{AdminAuditEventRecord, AdminAuditEventRepository};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn assert_test_database_url() {
+    let url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+
+    assert!(
+        url.contains("localhost") || url.contains("127.0.0.1"),
+        "Tests must run against localhost database"
+    );
+}
+
+async fn setup_pool() -> PgPool {
+    assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+#[tokio::test]
+async fn records_and_lists_admin_audit_event() {
+    let pool = setup_pool().await;
+    let repo = AdminAuditEventRepository::new(pool.clone());
+
+    // Use a synthetic tenant id so this test does not collide with other
+    // suites running in parallel against the shared test DB.
+    let tenant_id: i64 = 9_000_000 + (Uuid::new_v4().as_u128() as i64).rem_euclid(1_000_000);
+    let actor_pubkey = format!("{:0>64}", Uuid::new_v4().simple());
+    let target_client_id = format!("audit-test-client-{}", &Uuid::new_v4().to_string()[..8]);
+
+    let inserted = repo
+        .record(AdminAuditEventRecord {
+            tenant_id,
+            actor_pubkey: actor_pubkey.clone(),
+            action: "registered_client.create".to_string(),
+            target_resource_type: "registered_client".to_string(),
+            target_resource_id: Some("123".to_string()),
+            target_client_id: Some(target_client_id.clone()),
+            metadata_json: json!({
+                "name": "Audit Test",
+                "allowed_redirect_uris": ["https://example.com/cb"]
+            }),
+        })
+        .await
+        .expect("audit insert should succeed");
+
+    assert!(inserted.id > 0, "id should be set");
+    assert_eq!(inserted.tenant_id, tenant_id);
+    assert_eq!(inserted.actor_pubkey, actor_pubkey);
+    assert_eq!(inserted.action, "registered_client.create");
+    assert_eq!(inserted.target_resource_type, "registered_client");
+    assert_eq!(inserted.target_resource_id.as_deref(), Some("123"));
+    assert_eq!(inserted.target_client_id.as_deref(), Some(target_client_id.as_str()));
+    assert_eq!(inserted.metadata_json["name"], "Audit Test");
+
+    let listed = repo
+        .list_recent(tenant_id, 10)
+        .await
+        .expect("list_recent should succeed");
+
+    assert_eq!(listed.len(), 1, "exactly one event for this tenant");
+    assert_eq!(listed[0].id, inserted.id);
+    assert_eq!(listed[0].action, "registered_client.create");
+    assert_eq!(
+        listed[0].target_client_id.as_deref(),
+        Some(target_client_id.as_str())
+    );
+}
+
+#[tokio::test]
+async fn list_recent_returns_newest_first_and_respects_tenant_scope() {
+    let pool = setup_pool().await;
+    let repo = AdminAuditEventRepository::new(pool.clone());
+
+    let tenant_a: i64 = 9_100_000 + (Uuid::new_v4().as_u128() as i64).rem_euclid(1_000_000);
+    let tenant_b: i64 = 9_200_000 + (Uuid::new_v4().as_u128() as i64).rem_euclid(1_000_000);
+    let actor = format!("{:0>64}", Uuid::new_v4().simple());
+
+    // Insert two events for tenant_a, one for tenant_b.
+    for action in ["registered_client.create", "registered_client.update"] {
+        repo.record(AdminAuditEventRecord {
+            tenant_id: tenant_a,
+            actor_pubkey: actor.clone(),
+            action: action.to_string(),
+            target_resource_type: "registered_client".to_string(),
+            target_resource_id: Some("1".to_string()),
+            target_client_id: Some("client-a".to_string()),
+            metadata_json: json!({}),
+        })
+        .await
+        .unwrap();
+    }
+    repo.record(AdminAuditEventRecord {
+        tenant_id: tenant_b,
+        actor_pubkey: actor.clone(),
+        action: "registered_client.delete".to_string(),
+        target_resource_type: "registered_client".to_string(),
+        target_resource_id: Some("9".to_string()),
+        target_client_id: Some("client-b".to_string()),
+        metadata_json: json!({}),
+    })
+    .await
+    .unwrap();
+
+    let a_list = repo.list_recent(tenant_a, 10).await.unwrap();
+    assert_eq!(a_list.len(), 2, "tenant_a should see only its own rows");
+    assert!(
+        a_list[0].id > a_list[1].id,
+        "list_recent should be newest first (descending id)"
+    );
+    assert!(a_list.iter().all(|row| row.tenant_id == tenant_a));
+
+    let b_list = repo.list_recent(tenant_b, 10).await.unwrap();
+    assert_eq!(b_list.len(), 1);
+    assert_eq!(b_list[0].target_client_id.as_deref(), Some("client-b"));
+}

--- a/database/migrations/20260429030500_add_admin_audit_events.sql
+++ b/database/migrations/20260429030500_add_admin_audit_events.sql
@@ -1,0 +1,24 @@
+-- Durable, append-only audit log for admin actions.
+-- Initial use is registered_clients create/update/delete; the table is
+-- intentionally generic so other admin actions (claim-token regenerate,
+-- support-admin add/remove, preload-user) can reuse it without a new schema.
+CREATE TABLE IF NOT EXISTS admin_audit_events (
+    id BIGSERIAL PRIMARY KEY,
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    tenant_id BIGINT NOT NULL,
+    actor_pubkey TEXT NOT NULL,
+    action TEXT NOT NULL,
+    target_resource_type TEXT NOT NULL,
+    target_resource_id TEXT,
+    target_client_id TEXT,
+    metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_audit_events_tenant_occurred_at
+    ON admin_audit_events (tenant_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_admin_audit_events_resource
+    ON admin_audit_events (tenant_id, target_resource_type, target_resource_id);
+
+CREATE INDEX IF NOT EXISTS idx_admin_audit_events_action_occurred_at
+    ON admin_audit_events (action, occurred_at DESC);


### PR DESCRIPTION
## Summary

Admin changes to the OAuth client allowlist only emitted log lines.
Logs age out and aren't joinable by tenant or actor, so we couldn't answer "who changed what client, and when" without re-grepping.
This change writes a durable row to a new `admin_audit_events` table for every create / update / delete.
The update path uses `SELECT ... FOR UPDATE` then `UPDATE` in one transaction so the audit row carries the actual `{before, after}` transition this admin produced — even when other admins update concurrently.

Closes #170.

## What Changed

The change spans the database, the repository layer, and the admin handlers.
The table is intentionally generic so future admin actions can reuse it.

- New `admin_audit_events` table (id, occurred_at, tenant_id, actor_pubkey, action, target_resource_type/id, target_client_id, metadata_json) with indexes on `(tenant_id, occurred_at)`, `(tenant_id, target_resource_type, target_resource_id)`, and `(action, occurred_at)`. New `AdminAuditEventRepository` with `record()` and `list_recent()`.
- `RegisteredClientRepository::delete` uses `DELETE ... RETURNING` and returns the deleted row, so the handler can audit the pre-delete state without a race.
- `RegisteredClientRepository::update` runs `SELECT ... FOR UPDATE` then `UPDATE` inside a single transaction and returns `RegisteredClientUpdate { before, after }`. Under READ COMMITTED, the row lock waits for any concurrent updater and re-anchors on the latest committed version, so `before` is the actual immediately-prior state and `after` is this admin's update applied on top.
- `create_registered_client`, `update_registered_client`, and `delete_registered_client` each write an `admin_audit_events` row after the repo call. Writes are best-effort: a failed insert logs and the admin action still succeeds (matches the `auth_observability` pattern). Updates use a dedicated helper that emits `{before, after}` metadata.
- All three tracing logs include `(by admin {pubkey-prefix})`, so the actor is captured in logs even when the best-effort audit insert fails.

Only the registered_clients endpoints write rows in this PR. The schema is shaped so claim-token regenerate, support-admin add/remove, preload-user, and friends can reuse it later.

## Testing

I added two repo-level tests (record + tenant-scoped list; update before/after snapshots) and one HTTP-handler test, and reran existing coverage.

- `cargo test -p keycast_core` — 50 + 2 + 1 pass.
- `cargo test -p keycast_api --features integration-tests --test registered_clients_admin_test --test registered_clients_audit_test --test registered_clients_migration_test` — 18 + 1 + 1 pass. Includes `update_returns_before_and_after_snapshots` (asserts the repo returns both snapshots and `updated_at` advances) and the HTTP-level test asserting create/update/delete each emit one row with the right action, target, and metadata (the update row carries `metadata_json.before` and `metadata_json.after`).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.

I did not add a deterministic concurrency test for the row lock; forcing the race window requires synchronization primitives across two connections. The `SELECT ... FOR UPDATE` semantics are standard, and the existing tests assert the public contract.
I did not exercise this against the live signer or a deployed environment.

## Risks

Behavior change is small and confined to admin endpoints.

- Audit insert is best-effort. Postgres errors get logged and the admin call still returns 200; this matches `auth_observability` and avoids tying admin availability to audit availability.
- The `update` call now opens a short transaction and holds a row lock, serializing concurrent updates of the same row. Admin updates are infrequent, so this is acceptable.
- No UI surface for the audit log yet. Querying is SQL-only until we want to expose it.
- No `request_id` linkage to API request traces yet — the `auth_observability` middleware already populates one; wiring it through the admin handlers is a small follow-up.