### PR TITLE
chore: add repo contribution guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug Report
+description: Report a bug or regression in keycast.
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken? Avoid naming corporate partners, customers, or other sensitive external brands; use generic descriptors unless explicitly approved.
+      placeholder: Briefly describe the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can someone reproduce the issue?
+      placeholder: |
+        1. Go to ...
+        2. Trigger ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      placeholder: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      placeholder: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Environment / Context
+      description: Include auth flow, tenant/domain, environment, or local setup details when relevant.
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots, Logs, or Recording
+      description: Add any relevant screenshots, logs, or recordings. Redact sensitive external brand or partner names unless explicitly approved.
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: true
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Propose a new capability or product improvement for keycast.
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What should be added or changed? Avoid naming corporate partners, customers, or other sensitive external brands; use generic descriptors unless explicitly approved.
+      placeholder: Briefly describe the feature request.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Opportunity
+      description: What user, operator, or product problem does this solve?
+      placeholder: Explain the gap or opportunity.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Approach
+      description: Describe the desired behavior or implementation direction at a high level.
+      placeholder: Outline the proposed change.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Optional alternatives, tradeoffs, or rejected ideas.
+  - type: textarea
+    id: references
+    attributes:
+      label: Mockups, Logs, or References
+      description: Add links, screenshots, logs, or examples that clarify the request. Redact sensitive external brand or partner names unless explicitly approved.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+- 
+
+> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.
+
+## Motivation
+
+- 
+
+## Related Issue
+
+- Closes #
+
+## Testing
+
+- [ ] `cargo test --workspace --verbose`
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
+- [ ] `cargo fmt --all -- --check`
+- [ ] Manual verification completed
+
+## Visuals
+
+- [ ] UI/web change with screenshots/video attached
+- [ ] No visual change
+- [ ] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
+

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -1,0 +1,13 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pull-request:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1
+

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -9,5 +9,4 @@ permissions:
 
 jobs:
   semantic-pull-request:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1
-
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@c2e27845f65775943bc310b3ab89e5c5432b8d4d # v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- This repo is a Rust workspace with core crates under `api/`, `core/`, `signer/`, `cluster-hashring/`, and the unified binary under `keycast/`.
+- Web assets live under `web/` and use SvelteKit with Bun-based workflows.
+- Database migrations live under `database/migrations/`.
+- End-to-end and integration coverage lives in `e2e/` and `tests/`.
+- Operational and design notes live in `docs/`.
+
+## Build, Test, and Development Commands
+- `bun run dev`: run the unified binary locally with hot reload.
+- `bun run dev:web`: run the web frontend locally.
+- `cargo test --workspace --verbose`: run workspace Rust tests.
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`: match CI lint expectations.
+- `cargo fmt --all -- --check`: verify formatting before review.
+- Use targeted test commands when a change is scoped to one crate or one e2e path, but record that scope clearly in the PR.
+
+## Coding Style & Naming Conventions
+- Keep Rust changes idiomatic and formatted with `rustfmt`.
+- Keep frontend changes aligned with the current SvelteKit/Bun setup rather than introducing new tooling casually.
+- Prefer small, task-scoped changes over wide refactors.
+
+## Commit & Pull Request Guidelines
+- PR titles must use Conventional Commit format: `type(scope): summary` or `type: summary`.
+- Set the correct PR title when opening the PR instead of relying on title edits afterward.
+- If a PR title must be fixed after opening, verify that the semantic PR title check reruns successfully.
+- Keep PRs tightly scoped to the task. Do not include unrelated formatting churn, lockfile noise, drive-by refactors, or incidental cleanup.
+- Temporary or transitional code must include `TODO(#issue):` with a tracking issue for later removal.
+- PR descriptions should include a concise summary, motivation, linked issue, and manual test plan.
+- For `web/` or other UI-facing changes, include screenshots/video in the PR or explicitly state that there is no visual change.
+- Do not mention corporate partners, customers, brands, campaign names, or other sensitive external identities in public issue titles, PR titles, branch names, screenshots, or descriptions unless a maintainer explicitly approves it. Use generic descriptors instead, such as "partner account", "creator page", or "external partner".
+- Do not continue speculative feature work after exploratory implementation if maintainer alignment on scope or UX is still missing.
+
+## Testing Expectations
+- Run `cargo test --workspace --verbose`, `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`, and `cargo fmt --all -- --check` before requesting review.
+- When touching OAuth, auth/session behavior, NIP-05 behavior, or signer flows, run the most relevant targeted tests and document which ones were used.
+- When changing `web/` behavior, manually verify the affected path and document the manual checks in the PR.
+
+## Security & Deployment Notes
+- Do not commit secrets or real credentials.
+- Treat OAuth client configuration, session handling, relay configuration, and production identity settings as sensitive operational context.
+- Be careful with changes that affect signing, token issuance, encryption, or multi-tenant identity semantics; call those out explicitly in the PR body.


### PR DESCRIPTION
## Summary

- add repo-local contributor and agent guidance in `AGENTS.md`
- add semantic PR title enforcement via GitHub Actions
- add PR and issue templates so contributors get consistent semantic titles, testing prompts, and review expectations
- add explicit guidance to avoid naming sensitive external brands or partners in public GitHub artifacts unless a maintainer approves it

## Motivation

`keycast` already had strong repo-specific context in `CLAUDE.md` and a comprehensive build/test/push workflow, but it did not yet have repo-local contributor guardrails, semantic PR enforcement, or GitHub-native templates. This change adds those missing pieces without replacing the existing technical guidance, and it adapts the rules to the Rust workspace plus `web/` frontend rather than copying another repo’s details verbatim.

## Related Issue

- N/A

## Testing

- [ ] `cargo test --workspace --verbose`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [ ] `cargo fmt --all -- --check`
- [x] Manual verification completed

Manual verification:
- reviewed the new `AGENTS.md` for fit with the Rust workspace and `web/` frontend
- reviewed the semantic PR workflow and new GitHub templates for correctness
- confirmed the change only adds repo guidance and GitHub scaffolding

## Visuals

- [x] No visual change
