### PR TITLE
feat(e2e): enforce sequential execution for shared-DB security suit

### DIFF
--- a/e2e/tests/oauth-security.spec.ts
+++ b/e2e/tests/oauth-security.spec.ts
@@ -14,6 +14,8 @@ import {
 import { markUserAtprotoReady } from "../helpers/db";
 import { startKeycastProcess, stopKeycastProcess } from "../helpers/keycast-process";
 
+test.describe.configure({ mode: "serial" });
+
 async function setupAtprotoReadyUser(requestCtx: any): Promise<{ cookie: string }> {
   const email = `e2e-atproto-${Date.now()}-${Math.random().toString(36).slice(2, 7)}@test.local`;
   const { cookie } = await registerAndVerify(requestCtx, email, "TestPass123!");


### PR DESCRIPTION
## Summary

- Enforce explicit serial execution for OAuth security E2E suite

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- A follow-up for #127 

## Related Issue

- Closes #143

## Testing

- [x] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] Manual verification completed

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

