### PR TITLE
chore(ci): use absolute KEYCAST_BINARY in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -71,7 +71,7 @@ jobs:
       ATPROTO_OAUTH_PDS_DID: "did:web:pds.divine.test"
       ENABLE_TENANT_AUTO_PROVISIONING: "true"
       API_URL: http://localhost:3000
-      KEYCAST_BINARY: ./target/debug/keycast
+      KEYCAST_BINARY: ${{ github.workspace }}/target/debug/keycast
 
     steps:
       - uses: actions/checkout@v6
@@ -97,7 +97,7 @@ jobs:
           ./scripts/generate_key.sh
 
       - name: Run database migrations
-        run: ./target/debug/keycast --migrate
+        run: "$KEYCAST_BINARY" --migrate
 
       - name: Install e2e dependencies
         working-directory: e2e
@@ -113,7 +113,7 @@ jobs:
           RUST_LOG: "info,sqlx=warn,nostr_relay_pool=warn"
         run: |
           mkdir -p e2e/test-results
-          nohup ./target/debug/keycast \
+          nohup "$KEYCAST_BINARY" \
             > e2e/test-results/keycast.log 2>&1 < /dev/null &
           echo $! > .keycast.pid
           disown


### PR DESCRIPTION
## Summary

- Made KEYCAST_BINARY absolute in GitHub workflow.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- A follow-up for #173

## Related Issue

- Closes #177

## Testing

- [x] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] Manual verification completed

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

