### PR TITLE
ci(e2e): cache playwright browser install in nightly workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -103,6 +103,18 @@ jobs:
         working-directory: e2e
         run: bun install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('e2e/bun.lock', 'e2e/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Report Playwright cache status
+        run: echo "Playwright cache hit: ${{ steps.playwright-cache.outputs.cache-hit }}"
+
       - name: Install Playwright browsers
         working-directory: e2e
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## Summary

- Adding Playwright browser caching to GitHub workflow using `action/cache@v4`.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- A follow-up for #173 

## Related Issue

- Closes #176

## Testing

- [x] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] Manual verification completed

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

