### PR TITLE
ci(aws): run aws-featured tests for core and keycast in CI

### DIFF
--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -85,8 +85,10 @@ jobs:
         run: |
           cargo test --workspace --verbose
           cargo test -p keycast_core --features integration-tests --lib --verbose
+          cargo test -p keycast_core --features aws --lib --verbose
           cargo test -p keycast_api --features integration-tests --lib --tests --verbose
           cargo test -p keycast_signer --features integration-tests --lib --tests --verbose
+          cargo test -p keycast --features aws --bin keycast --verbose
           cargo test -p cluster-hashring --lib -- --ignored
 
       - name: Run clippy


### PR DESCRIPTION
## Summary

- Adding explicit AWS-feature test coverage in CI

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- A follow-up for #100 

## Related Issue

- Closes #118

## Testing

- [x] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] Manual verification completed

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

