### PR TITLE
fix(keycast): harden autoscaling shutdown for viral spikes

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -69,7 +69,12 @@ steps:
       - '--subnet=default'
       - '--vpc-egress=private-ranges-only'
       - '--set-secrets=DATABASE_URL=keycast-database-url:latest,SERVER_NSEC=keycast-ucan-secret:latest,SENDGRID_API_KEY=keycast-sendgrid-api-key:latest,REDIS_URL=keycast-redis-url:latest,KEYCAST_SERVICE_TOKEN=keycast-service-token:latest'
-      - '--set-env-vars=^;^NODE_ENV=production;USE_GCP_KMS=true;GCP_PROJECT_ID=${PROJECT_ID};ALLOWED_ORIGINS=https://login.divine.video,https://divine.video,https://*.openvine-app.pages.dev;ALLOWED_TENANT_DOMAINS=login.divine.video;REQUIRE_REGISTERED_OAUTH_CLIENTS=false;APP_URL=https://login.divine.video;FROM_EMAIL=noreply@divine.video;RUST_LOG=info;ENABLE_EXAMPLES=true;SQLX_STATEMENT_CACHE=100;SQLX_POOL_SIZE=50;ALLOWED_PUBKEYS=89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5,76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa;BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol;ENABLE_DIVINE_NAMES=true;SHOW_TEAMS_FUNCTIONALITY=true'
+      # SHUTDOWN_* vars size the graceful-drain phases to Cloud Run's ~10s
+      # SIGTERM->SIGKILL grace (CEILING=10). PRE_DRAIN=0 because Cloud Run has
+      # no readiness-probe-driven endpoint removal (peer rebalancing comes from
+      # the cluster coordinator leave event); HTTP(4)+SIGNER(2)+MARGIN(4)=10
+      # fits exactly. GKE uses the larger built-in defaults instead.
+      - '--set-env-vars=^;^NODE_ENV=production;USE_GCP_KMS=true;GCP_PROJECT_ID=${PROJECT_ID};ALLOWED_ORIGINS=https://login.divine.video,https://divine.video,https://*.openvine-app.pages.dev;ALLOWED_TENANT_DOMAINS=login.divine.video;REQUIRE_REGISTERED_OAUTH_CLIENTS=false;APP_URL=https://login.divine.video;FROM_EMAIL=noreply@divine.video;RUST_LOG=info;ENABLE_EXAMPLES=true;SQLX_STATEMENT_CACHE=100;SQLX_POOL_SIZE=50;ALLOWED_PUBKEYS=89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5,76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa;BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol;ENABLE_DIVINE_NAMES=true;SHOW_TEAMS_FUNCTIONALITY=true;SHUTDOWN_GRACE_PERIOD_CEILING_SECS=10;SHUTDOWN_PRE_DRAIN_SECS=0;SHUTDOWN_HTTP_DRAIN_SECS=4;SHUTDOWN_SIGNER_DRAIN_SECS=2;SHUTDOWN_TEARDOWN_MARGIN_SECS=4'
 
   # Smoke tests - verify deployment
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -71,10 +71,13 @@ steps:
       - '--set-secrets=DATABASE_URL=keycast-database-url:latest,SERVER_NSEC=keycast-ucan-secret:latest,SENDGRID_API_KEY=keycast-sendgrid-api-key:latest,REDIS_URL=keycast-redis-url:latest,KEYCAST_SERVICE_TOKEN=keycast-service-token:latest'
       # SHUTDOWN_* vars size the graceful-drain phases to Cloud Run's ~10s
       # SIGTERM->SIGKILL grace (CEILING=10). PRE_DRAIN=0 because Cloud Run has
-      # no readiness-probe-driven endpoint removal (peer rebalancing comes from
-      # the cluster coordinator leave event); HTTP(4)+SIGNER(2)+MARGIN(4)=10
-      # fits exactly. GKE uses the larger built-in defaults instead.
-      - '--set-env-vars=^;^NODE_ENV=production;USE_GCP_KMS=true;GCP_PROJECT_ID=${PROJECT_ID};ALLOWED_ORIGINS=https://login.divine.video,https://divine.video,https://*.openvine-app.pages.dev;ALLOWED_TENANT_DOMAINS=login.divine.video;REQUIRE_REGISTERED_OAUTH_CLIENTS=false;APP_URL=https://login.divine.video;FROM_EMAIL=noreply@divine.video;RUST_LOG=info;ENABLE_EXAMPLES=true;SQLX_STATEMENT_CACHE=100;SQLX_POOL_SIZE=50;ALLOWED_PUBKEYS=89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5,76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa;BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol;ENABLE_DIVINE_NAMES=true;SHOW_TEAMS_FUNCTIONALITY=true;SHUTDOWN_GRACE_PERIOD_CEILING_SECS=10;SHUTDOWN_PRE_DRAIN_SECS=0;SHUTDOWN_HTTP_DRAIN_SECS=4;SHUTDOWN_SIGNER_DRAIN_SECS=2;SHUTDOWN_TEARDOWN_MARGIN_SECS=4'
+      # no readiness-probe-driven endpoint removal; peer rebalancing comes from
+      # the cluster coordinator leave event, published in phase 1 within a ~2s
+      # bound that overlaps the (zero) pre-drain. Drains are kept small so even
+      # a dead-Redis worst case (deregister 2 + HTTP 3 + SIGNER 1 + pool close
+      # 2 = 8) fits under 10 with log headroom. GKE uses the larger built-in
+      # defaults instead.
+      - '--set-env-vars=^;^NODE_ENV=production;USE_GCP_KMS=true;GCP_PROJECT_ID=${PROJECT_ID};ALLOWED_ORIGINS=https://login.divine.video,https://divine.video,https://*.openvine-app.pages.dev;ALLOWED_TENANT_DOMAINS=login.divine.video;REQUIRE_REGISTERED_OAUTH_CLIENTS=false;APP_URL=https://login.divine.video;FROM_EMAIL=noreply@divine.video;RUST_LOG=info;ENABLE_EXAMPLES=true;SQLX_STATEMENT_CACHE=100;SQLX_POOL_SIZE=50;ALLOWED_PUBKEYS=89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5,76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa;BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol;ENABLE_DIVINE_NAMES=true;SHOW_TEAMS_FUNCTIONALITY=true;SHUTDOWN_GRACE_PERIOD_CEILING_SECS=10;SHUTDOWN_PRE_DRAIN_SECS=0;SHUTDOWN_HTTP_DRAIN_SECS=3;SHUTDOWN_SIGNER_DRAIN_SECS=1;SHUTDOWN_TEARDOWN_MARGIN_SECS=4'
 
   # Smoke tests - verify deployment
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -72,12 +72,13 @@ steps:
       # SHUTDOWN_* vars size the graceful-drain phases to Cloud Run's ~10s
       # SIGTERM->SIGKILL grace (CEILING=10). PRE_DRAIN=0 because Cloud Run has
       # no readiness-probe-driven endpoint removal; peer rebalancing comes from
-      # the cluster coordinator leave event, published in phase 1 within a ~2s
-      # bound that overlaps the (zero) pre-drain. Drains are kept small so even
-      # a dead-Redis worst case (deregister 2 + HTTP 3 + SIGNER 1 + pool close
-      # 2 = 8) fits under 10 with log headroom. GKE uses the larger built-in
-      # defaults instead.
-      - '--set-env-vars=^;^NODE_ENV=production;USE_GCP_KMS=true;GCP_PROJECT_ID=${PROJECT_ID};ALLOWED_ORIGINS=https://login.divine.video,https://divine.video,https://*.openvine-app.pages.dev;ALLOWED_TENANT_DOMAINS=login.divine.video;REQUIRE_REGISTERED_OAUTH_CLIENTS=false;APP_URL=https://login.divine.video;FROM_EMAIL=noreply@divine.video;RUST_LOG=info;ENABLE_EXAMPLES=true;SQLX_STATEMENT_CACHE=100;SQLX_POOL_SIZE=50;ALLOWED_PUBKEYS=89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5,76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa;BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol;ENABLE_DIVINE_NAMES=true;SHOW_TEAMS_FUNCTIONALITY=true;SHUTDOWN_GRACE_PERIOD_CEILING_SECS=10;SHUTDOWN_PRE_DRAIN_SECS=0;SHUTDOWN_HTTP_DRAIN_SECS=3;SHUTDOWN_SIGNER_DRAIN_SECS=1;SHUTDOWN_TEARDOWN_MARGIN_SECS=4'
+      # the cluster coordinator leave event, published at the start of phase 3
+      # inside the SIGNER budget (deregister <=2s carved from SIGNER=3, >=1s
+      # left for the relay-queue drain). The dead-Redis worst case is fully
+      # modeled by the startup fit check: PRE 0 + HTTP 3 + SIGNER 3 + MARGIN 4
+      # (pool close 2 + log headroom 2) = 10 <= 10, no unbudgeted overhang.
+      # GKE uses the larger built-in defaults instead.
+      - '--set-env-vars=^;^NODE_ENV=production;USE_GCP_KMS=true;GCP_PROJECT_ID=${PROJECT_ID};ALLOWED_ORIGINS=https://login.divine.video,https://divine.video,https://*.openvine-app.pages.dev;ALLOWED_TENANT_DOMAINS=login.divine.video;REQUIRE_REGISTERED_OAUTH_CLIENTS=false;APP_URL=https://login.divine.video;FROM_EMAIL=noreply@divine.video;RUST_LOG=info;ENABLE_EXAMPLES=true;SQLX_STATEMENT_CACHE=100;SQLX_POOL_SIZE=50;ALLOWED_PUBKEYS=89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5,76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa;BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol;ENABLE_DIVINE_NAMES=true;SHOW_TEAMS_FUNCTIONALITY=true;SHUTDOWN_GRACE_PERIOD_CEILING_SECS=10;SHUTDOWN_PRE_DRAIN_SECS=0;SHUTDOWN_HTTP_DRAIN_SECS=3;SHUTDOWN_SIGNER_DRAIN_SECS=3;SHUTDOWN_TEARDOWN_MARGIN_SECS=4'
 
   # Smoke tests - verify deployment
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/cluster-hashring/src/coordinator.rs
+++ b/cluster-hashring/src/coordinator.rs
@@ -3,6 +3,7 @@ use crate::{Error, HashRing, RedisRegistry};
 use arc_swap::ArcSwap;
 use redis::aio::PubSub;
 use std::collections::HashSet;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast;
@@ -245,7 +246,16 @@ impl ClusterCoordinator {
                     _ = sync_interval.tick() => {
                         // Periodic full sync as backup
                         let mut reg = registry.lock().await;
-                        match reg.get_active_instances().await {
+                        let Some(instances_result) =
+                            await_unless_cancelled(&cancel_token, reg.get_active_instances()).await
+                        else {
+                            tracing::debug!(
+                                "Full sync observed cancellation under lock; stopping sync"
+                            );
+                            break;
+                        };
+
+                        match instances_result {
                             Ok(instances) => {
                                 let current_members: HashSet<String> = instances.iter().cloned().collect();
 
@@ -548,12 +558,43 @@ impl ClusterCoordinator {
     }
 }
 
+async fn await_unless_cancelled<T>(
+    cancel_token: &CancellationToken,
+    future: impl Future<Output = T>,
+) -> Option<T> {
+    if cancel_token.is_cancelled() {
+        return None;
+    }
+
+    tokio::select! {
+        biased;
+        _ = cancel_token.cancelled() => None,
+        result = future => Some(result),
+    }
+}
+
 use futures_util::StreamExt;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::task::{Context, Poll};
     use uuid::Uuid;
+
+    struct PollFlagFuture {
+        was_polled: Arc<AtomicBool>,
+    }
+
+    impl Future for PollFlagFuture {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            self.was_polled.store(true, Ordering::SeqCst);
+            Poll::Pending
+        }
+    }
 
     fn get_redis_url() -> String {
         std::env::var("TEST_REDIS_URL").unwrap_or_else(|_| "redis://localhost:16379".to_string())
@@ -570,6 +611,61 @@ mod tests {
         let left = MembershipEvent::Left("xyz-789".to_string());
         assert_eq!(joined, MembershipEvent::Joined("abc-123".to_string()));
         assert_eq!(left, MembershipEvent::Left("xyz-789".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_await_unless_cancelled_skips_future_when_already_cancelled() {
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+        let was_polled = Arc::new(AtomicBool::new(false));
+
+        let result = await_unless_cancelled(
+            &cancel_token,
+            PollFlagFuture {
+                was_polled: was_polled.clone(),
+            },
+        )
+        .await;
+
+        assert!(result.is_none());
+        assert!(
+            !was_polled.load(Ordering::SeqCst),
+            "cancelled full sync must not poll the Redis fetch future"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_await_unless_cancelled_returns_when_cancelled_while_pending() {
+        let cancel_token = CancellationToken::new();
+        let was_polled = Arc::new(AtomicBool::new(false));
+
+        let waiter = tokio::spawn({
+            let cancel_token = cancel_token.clone();
+            let was_polled = was_polled.clone();
+            async move {
+                await_unless_cancelled(
+                    &cancel_token,
+                    PollFlagFuture {
+                        was_polled: was_polled.clone(),
+                    },
+                )
+                .await
+            }
+        });
+
+        tokio::task::yield_now().await;
+        assert!(
+            was_polled.load(Ordering::SeqCst),
+            "pending future should be polled before cancellation"
+        );
+
+        cancel_token.cancel();
+        let result = tokio::time::timeout(Duration::from_millis(100), waiter)
+            .await
+            .expect("cancellation-aware wait should not remain stuck behind pending full sync")
+            .expect("waiter task should not panic");
+
+        assert!(result.is_none());
     }
 
     #[tokio::test]

--- a/cluster-hashring/src/coordinator.rs
+++ b/cluster-hashring/src/coordinator.rs
@@ -184,6 +184,22 @@ impl ClusterCoordinator {
                     _ = heartbeat_interval.tick() => {
                         let mut reg = registry.lock().await;
 
+                        // Shutdown race guard: if the cancel token fired while
+                        // we were waiting on the registry lock, a concurrent
+                        // `deregister_and_stop_heartbeat` may have already
+                        // removed this instance under this same lock. Sending a
+                        // heartbeat now would re-register us (ZADD) and the
+                        // instance would linger in the ring for a full heartbeat
+                        // interval after we meant to leave. The select! arm for
+                        // `cancel_token.cancelled()` does not protect us here:
+                        // when both arms are ready select! may pick this one.
+                        // We MUST check while holding the lock so the check is
+                        // serialized against the deregister's DEL.
+                        if cancel_token.is_cancelled() {
+                            tracing::debug!("Heartbeat task observed cancellation under lock; not re-registering");
+                            break;
+                        }
+
                         // Check if IAM token needs refresh (before it expires)
                         if factory.uses_iam_auth() {
                             let ttl = factory.token_ttl_secs().await;
@@ -462,16 +478,38 @@ impl ClusterCoordinator {
         Ok(())
     }
 
-    /// Deregister from the cluster without consuming self.
+    /// Gracefully deregister from the cluster without consuming `self`.
     ///
-    /// Use when you can't take ownership (e.g., Arc::try_unwrap fails).
-    pub async fn force_deregister(&self) -> Result<(), Error> {
+    /// Use during process shutdown when the coordinator is shared behind an
+    /// `Arc` (with the signer and relay workers) and ownership cannot be
+    /// reclaimed for [`shutdown`](Self::shutdown).
+    ///
+    /// Mirrors [`shutdown`](Self::shutdown)'s ordering: the background tasks are
+    /// stopped FIRST (by cancelling the shared token) so the heartbeat cannot
+    /// re-register, then the `leave` event is published and the instance is
+    /// deregistered. Because this takes `&self` it cannot `await` the heartbeat
+    /// `JoinHandle` (which lives behind `&mut self`); instead it relies on the
+    /// heartbeat loop re-checking the cancel token *while holding the registry
+    /// lock* before each re-register. This method holds that same registry lock
+    /// for the deregister, so the heartbeat's ZADD and this method's DEL are
+    /// serialized and the instance cannot be resurrected after removal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deregistration fails. Failure to publish the `leave`
+    /// event is logged and swallowed (peers still converge via heartbeat
+    /// staleness), matching [`shutdown`](Self::shutdown).
+    pub async fn deregister_and_stop_heartbeat(&self) -> Result<(), Error> {
+        // 1. Stop background tasks first so the heartbeat cannot re-register.
+        self.cancel_token.cancel();
+
+        // 2. Publish leave + deregister under the registry lock (serialized
+        //    against any in-flight heartbeat ZADD — see the method docs).
         let mut reg = self.registry.lock().await;
-
-        // Publish leave event
         let instance_id = reg.instance_id().to_string();
-        Self::publish_event(&mut reg, "leave", &instance_id).await?;
-
+        if let Err(e) = Self::publish_event(&mut reg, "leave", &instance_id).await {
+            tracing::warn!("Failed to publish leave event: {}", e);
+        }
         reg.deregister().await
     }
 
@@ -550,6 +588,51 @@ mod tests {
         assert_eq!(coordinator.instance_count(), 1);
 
         coordinator.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis via TEST_REDIS_URL or local Redis on localhost:16379"]
+    async fn test_deregister_and_stop_heartbeat_does_not_reappear() {
+        // Regression for the SIGTERM-time graceful deregister: after
+        // `deregister_and_stop_heartbeat` the instance must NOT be resurrected
+        // by a surviving heartbeat tick. We wait past one full heartbeat
+        // interval — long enough for the race (cancel vs. heartbeat ZADD) to
+        // manifest if the token check were not serialized under the registry
+        // lock — and assert the instance stays gone in Redis.
+        let redis_url = get_redis_url();
+        let prefix = test_prefix();
+
+        let coordinator = ClusterCoordinator::start_with_prefix(&redis_url, Some(&prefix))
+            .await
+            .unwrap();
+        let instance_id = coordinator.instance_id();
+
+        // Independent registry on the same prefix to read the ground truth in
+        // Redis (its own presence is irrelevant; we only check `instance_id`).
+        let mut observer = RedisRegistry::register_with_prefix(&redis_url, Some(&prefix))
+            .await
+            .unwrap();
+
+        let before = observer.get_active_instances().await.unwrap();
+        assert!(
+            before.contains(&instance_id),
+            "coordinator must be registered before deregister, got {before:?}"
+        );
+
+        // Graceful deregister via the `&self` (Arc-shared) path.
+        coordinator.deregister_and_stop_heartbeat().await.unwrap();
+
+        // Wait well past one heartbeat interval so a surviving heartbeat task
+        // would have re-registered (ZADD) if the race were open.
+        tokio::time::sleep(Duration::from_secs(DEFAULT_HEARTBEAT_INTERVAL_SECS + 2)).await;
+
+        let after = observer.get_active_instances().await.unwrap();
+        assert!(
+            !after.contains(&instance_id),
+            "deregistered instance must not reappear after more than one heartbeat interval, got {after:?}"
+        );
+
+        observer.deregister().await.unwrap();
     }
 
     #[tokio::test]

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -50,8 +50,12 @@ pub struct Metrics {
     pub nip46_requests_handler_not_found: AtomicU64,
     /// NIP-46 requests successfully processed
     pub nip46_requests_processed: AtomicU64,
-    /// NIP-46 requests dropped due to queue full (backpressure)
+    /// NIP-46 requests dropped due to queue full (overload backpressure)
     pub nip46_requests_queue_dropped: AtomicU64,
+    /// NIP-46 requests rejected because the queue was closed (graceful
+    /// shutdown). Tracked separately from `queue_dropped` so shutdown-time
+    /// rejections are not misread as overload.
+    pub nip46_requests_queue_closed: AtomicU64,
     /// NIP-46 tombstone responses sent (revoked/expired authorizations)
     pub nip46_tombstone_responses: AtomicU64,
 
@@ -104,6 +108,7 @@ impl Metrics {
             nip46_requests_handler_not_found: AtomicU64::new(0),
             nip46_requests_processed: AtomicU64::new(0),
             nip46_requests_queue_dropped: AtomicU64::new(0),
+            nip46_requests_queue_closed: AtomicU64::new(0),
             nip46_tombstone_responses: AtomicU64::new(0),
             // HTTP RPC metrics
             http_rpc_requests_total: AtomicU64::new(0),
@@ -161,6 +166,11 @@ impl Metrics {
 
     pub fn inc_queue_dropped(&self) {
         self.nip46_requests_queue_dropped
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_queue_closed(&self) {
+        self.nip46_requests_queue_closed
             .fetch_add(1, Ordering::Relaxed);
     }
 
@@ -343,11 +353,18 @@ impl Metrics {
             self.nip46_requests_processed.load(Ordering::Relaxed)
         ));
 
-        output.push_str("\n# HELP keycast_nip46_queue_dropped_total NIP-46 requests dropped due to queue full (backpressure)\n");
+        output.push_str("\n# HELP keycast_nip46_queue_dropped_total NIP-46 requests dropped due to queue full (overload backpressure)\n");
         output.push_str("# TYPE keycast_nip46_queue_dropped_total counter\n");
         output.push_str(&format!(
             "keycast_nip46_queue_dropped_total {}\n",
             self.nip46_requests_queue_dropped.load(Ordering::Relaxed)
+        ));
+
+        output.push_str("\n# HELP keycast_nip46_queue_closed_total NIP-46 requests rejected because the queue was closed (graceful shutdown)\n");
+        output.push_str("# TYPE keycast_nip46_queue_closed_total counter\n");
+        output.push_str(&format!(
+            "keycast_nip46_queue_closed_total {}\n",
+            self.nip46_requests_queue_closed.load(Ordering::Relaxed)
         ));
 
         output.push_str("\n# HELP keycast_nip46_tombstone_responses_total NIP-46 error responses sent for revoked/expired authorizations\n");

--- a/keycast/Cargo.toml
+++ b/keycast/Cargo.toml
@@ -42,3 +42,6 @@ zeroize = { workspace = true }
 
 [dev-dependencies]
 serial_test = "3.2"
+# `test-util` enables `tokio::time::pause` / `advance` for deterministic timing
+# tests of the shutdown sequence. Not part of the `full` feature set.
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -70,6 +70,21 @@ const DEFAULT_SHUTDOWN_HTTP_DRAIN_SECS: u64 = 45;
 /// `SHUTDOWN_SIGNER_DRAIN_SECS`.
 const DEFAULT_SHUTDOWN_SIGNER_DRAIN_SECS: u64 = 10;
 
+/// Conservative upper bound on the Deployment's `terminationGracePeriodSeconds`
+/// used at startup to sanity-check the shutdown phase budgets. The iac repo
+/// (TODO(#692): track in divinevideo/divine-iac-coreconfig sibling PR) targets
+/// 75s but the issue spec accepts 60–90s; 120s covers the full range with
+/// headroom. If an operator bumps grace higher they can raise this via
+/// `SHUTDOWN_GRACE_PERIOD_CEILING_SECS`. This constant does NOT change the
+/// kubelet behavior — it is purely a misconfig guardrail.
+const DEFAULT_SHUTDOWN_GRACE_CEILING_SECS: u64 = 120;
+
+/// Headroom reserved between the end of the phased drain and the kubelet
+/// SIGKILL for DB pool close, tracing flush, and other post-drain cleanup.
+/// Subtracted from the ceiling when validating that the configured phase
+/// budgets fit.
+const SHUTDOWN_TEARDOWN_MARGIN: Duration = Duration::from_secs(10);
+
 /// Parsed shutdown phase timings. See the `DEFAULT_SHUTDOWN_*` constants and
 /// the graceful-shutdown sequence in `async_main` for the phase breakdown.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,6 +95,15 @@ struct ShutdownTimings {
     http_drain: Duration,
     /// Maximum wait for signer + tracked background tasks.
     signer_drain: Duration,
+}
+
+impl ShutdownTimings {
+    /// Sum of all three phase durations. Does NOT include
+    /// `SHUTDOWN_TEARDOWN_MARGIN` — add that separately when comparing
+    /// against a grace-period ceiling.
+    fn total_budget(&self) -> Duration {
+        self.pre_drain + self.http_drain + self.signer_drain
+    }
 }
 
 /// Read a non-negative integer duration (in seconds) from the given env var,
@@ -118,6 +142,54 @@ fn parse_shutdown_timings() -> ShutdownTimings {
             "SHUTDOWN_SIGNER_DRAIN_SECS",
             DEFAULT_SHUTDOWN_SIGNER_DRAIN_SECS,
         ),
+    }
+}
+
+/// Parse the configured `terminationGracePeriodSeconds` ceiling against
+/// which the phased shutdown budget is validated at startup. Override with
+/// `SHUTDOWN_GRACE_PERIOD_CEILING_SECS` when the Deployment's grace period
+/// changes without a keycast release.
+fn parse_shutdown_grace_ceiling() -> Duration {
+    parse_duration_secs_env(
+        "SHUTDOWN_GRACE_PERIOD_CEILING_SECS",
+        DEFAULT_SHUTDOWN_GRACE_CEILING_SECS,
+    )
+}
+
+/// Check that `timings.total_budget() + SHUTDOWN_TEARDOWN_MARGIN <= ceiling`.
+/// The margin is the reserved headroom for DB pool close, tracing flush, and
+/// process teardown between the end of the phased drain and the kubelet
+/// SIGKILL at `terminationGracePeriodSeconds`. Exact equality is accepted
+/// (the margin fully fits); anything larger is rejected.
+///
+/// Returned `Err(String)` is operator-actionable and includes the current
+/// budget, margin, and ceiling so it can be dropped straight into a log
+/// line. We deliberately warn (not abort) on violation at the call site:
+/// the ceiling is cross-repo-coupled to the iac repo, and an operator may
+/// legitimately need to boot ahead of an iac-side grace bump.
+///
+/// TODO(#692): remove the soft-warning fallback in `async_main` once the
+/// sibling divinevideo/divine-iac-coreconfig PR lands and `terminationGracePeriodSeconds`
+/// is pinned at ≥75s in all environments.
+fn validate_shutdown_timings(timings: &ShutdownTimings, ceiling: Duration) -> Result<(), String> {
+    let total = timings.total_budget();
+    let required = total + SHUTDOWN_TEARDOWN_MARGIN;
+    if required > ceiling {
+        Err(format!(
+            "shutdown phase budget ({total_secs}s) + teardown margin ({margin_secs}s) \
+             = {required_secs}s does not fit inside SHUTDOWN_GRACE_PERIOD_CEILING_SECS \
+             = {ceiling_secs}s (pre_drain={pre}s, http_drain={http}s, signer_drain={sig}s); \
+             the kubelet will SIGKILL mid-drain on terminationGracePeriodSeconds",
+            total_secs = total.as_secs(),
+            margin_secs = SHUTDOWN_TEARDOWN_MARGIN.as_secs(),
+            required_secs = required.as_secs(),
+            ceiling_secs = ceiling.as_secs(),
+            pre = timings.pre_drain.as_secs(),
+            http = timings.http_drain.as_secs(),
+            sig = timings.signer_drain.as_secs(),
+        ))
+    } else {
+        Ok(())
     }
 }
 
@@ -684,6 +756,43 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         "Instance starting: id={} cpus={} workers={} pool={}",
         instance_id, cpu_count, worker_threads, pool_size
     );
+
+    // Validate the shutdown phase budget against the configured grace-period
+    // ceiling as a startup-time sanity check. This is defense in depth against
+    // (a) an operator setting e.g. `SHUTDOWN_HTTP_DRAIN_SECS=120` against a
+    // 75s grace period and (b) the sibling divinevideo/divine-iac-coreconfig
+    // PR (tracked in issue #692) landing with `terminationGracePeriodSeconds`
+    // below the configured defaults. We log a loud warning rather than
+    // refusing to boot: the ceiling is cross-repo-coupled, and an operator
+    // may legitimately need to start before the iac repo catches up.
+    // TODO(#692): remove the warn-only fallback once the iac-side PR pins
+    // `terminationGracePeriodSeconds` to ≥75s in every environment.
+    {
+        let startup_timings = parse_shutdown_timings();
+        let grace_ceiling = parse_shutdown_grace_ceiling();
+        match validate_shutdown_timings(&startup_timings, grace_ceiling) {
+            Ok(()) => {
+                tracing::info!(
+                    pre_drain_secs = startup_timings.pre_drain.as_secs(),
+                    http_drain_secs = startup_timings.http_drain.as_secs(),
+                    signer_drain_secs = startup_timings.signer_drain.as_secs(),
+                    grace_ceiling_secs = grace_ceiling.as_secs(),
+                    "Shutdown phase budget fits inside configured grace ceiling"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    event = "shutdown_budget_exceeds_grace_ceiling",
+                    pre_drain_secs = startup_timings.pre_drain.as_secs(),
+                    http_drain_secs = startup_timings.http_drain.as_secs(),
+                    signer_drain_secs = startup_timings.signer_drain.as_secs(),
+                    grace_ceiling_secs = grace_ceiling.as_secs(),
+                    "{}",
+                    err
+                );
+            }
+        }
+    }
 
     // Setup database
     let database = Database::new().await?;
@@ -1798,5 +1907,126 @@ mod tests {
         pre_drain_pause(&unready, Duration::ZERO).await;
 
         assert!(unready.load(Ordering::Relaxed));
+    }
+
+    // --- Shutdown grace-period ceiling validation ---
+    //
+    // The iac repo pins `terminationGracePeriodSeconds` in the Deployment; the
+    // kubelet SIGKILLs any pod whose graceful shutdown exceeds that. The three
+    // shutdown env vars (`SHUTDOWN_PRE_DRAIN_SECS` / `HTTP_DRAIN` /
+    // `SIGNER_DRAIN`) are independent u64s with no upper bound, so a misconfig
+    // (e.g. `SHUTDOWN_HTTP_DRAIN_SECS=120` against a 75s grace) would silently
+    // lose in-flight requests on scale-down — exactly the failure this
+    // feature is supposed to prevent. We validate the total + teardown margin
+    // against a configurable ceiling on startup and log a loud warning if it
+    // exceeds. We deliberately warn rather than refuse to boot: the ceiling is
+    // cross-repo-coupled and an operator may legitimately need to boot with a
+    // larger grace period before the iac repo catches up.
+
+    fn clear_shutdown_ceiling_env() {
+        std::env::remove_var("SHUTDOWN_GRACE_PERIOD_CEILING_SECS");
+    }
+
+    #[test]
+    #[serial]
+    fn test_parse_shutdown_grace_ceiling_default() {
+        clear_shutdown_ceiling_env();
+
+        // Default matches DEFAULT_SHUTDOWN_GRACE_CEILING_SECS. Chosen to be
+        // an upper bound that covers the iac PR's 60–90s range with headroom.
+        assert_eq!(
+            parse_shutdown_grace_ceiling(),
+            Duration::from_secs(DEFAULT_SHUTDOWN_GRACE_CEILING_SECS)
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_parse_shutdown_grace_ceiling_override() {
+        clear_shutdown_ceiling_env();
+        std::env::set_var("SHUTDOWN_GRACE_PERIOD_CEILING_SECS", "60");
+
+        assert_eq!(parse_shutdown_grace_ceiling(), Duration::from_secs(60));
+
+        clear_shutdown_ceiling_env();
+    }
+
+    #[test]
+    fn test_shutdown_timings_total_budget() {
+        let t = ShutdownTimings {
+            pre_drain: Duration::from_secs(10),
+            http_drain: Duration::from_secs(45),
+            signer_drain: Duration::from_secs(10),
+        };
+        assert_eq!(t.total_budget(), Duration::from_secs(65));
+    }
+
+    #[test]
+    fn test_validate_shutdown_timings_ok_when_under_ceiling() {
+        // Default timings (65s) + teardown margin (10s) = 75s. A 75s or
+        // larger ceiling must validate cleanly; this is the iac PR's target.
+        let t = ShutdownTimings {
+            pre_drain: Duration::from_secs(10),
+            http_drain: Duration::from_secs(45),
+            signer_drain: Duration::from_secs(10),
+        };
+
+        assert!(validate_shutdown_timings(&t, Duration::from_secs(75)).is_ok());
+        assert!(validate_shutdown_timings(&t, Duration::from_secs(90)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_shutdown_timings_error_when_over_ceiling() {
+        // The 65s default budget + 10s margin does NOT fit a 60s grace
+        // period. This is the concrete failure mode flagged in review:
+        // if the sibling iac PR lands with terminationGracePeriodSeconds=60,
+        // the kubelet will SIGKILL mid-signer-drain. Validation must catch
+        // this and return a descriptive error string.
+        let t = ShutdownTimings {
+            pre_drain: Duration::from_secs(10),
+            http_drain: Duration::from_secs(45),
+            signer_drain: Duration::from_secs(10),
+        };
+
+        let err = validate_shutdown_timings(&t, Duration::from_secs(60))
+            .expect_err("65s budget + 10s margin must not fit in 60s ceiling");
+        // Error message should be operator-actionable: include the total,
+        // the margin, and the ceiling so they can tune either side.
+        assert!(err.contains("65"), "error should name total budget: {err}");
+        assert!(err.contains("60"), "error should name ceiling: {err}");
+    }
+
+    #[test]
+    fn test_validate_shutdown_timings_error_when_single_field_exceeds_ceiling() {
+        // Operator misconfig: SHUTDOWN_HTTP_DRAIN_SECS=120 against default
+        // 75s ceiling. Single-field overshoot must still be caught.
+        let t = ShutdownTimings {
+            pre_drain: Duration::from_secs(10),
+            http_drain: Duration::from_secs(120),
+            signer_drain: Duration::from_secs(10),
+        };
+
+        assert!(validate_shutdown_timings(&t, Duration::from_secs(75)).is_err());
+    }
+
+    #[test]
+    fn test_validate_shutdown_timings_boundary_exactly_at_ceiling() {
+        // total_budget + SHUTDOWN_TEARDOWN_MARGIN = 65 + 10 = 75.
+        // A ceiling of 75 means the teardown margin exactly fits — that is
+        // precisely what the margin is reserved for, so accept. The iac
+        // PR's terminationGracePeriodSeconds=75s should validate cleanly
+        // against the defaults with no operator action.
+        let t = ShutdownTimings {
+            pre_drain: Duration::from_secs(10),
+            http_drain: Duration::from_secs(45),
+            signer_drain: Duration::from_secs(10),
+        };
+
+        // Exactly the ceiling: OK (margin fits).
+        assert!(validate_shutdown_timings(&t, Duration::from_secs(75)).is_ok());
+        // One second below: reject — margin no longer fits.
+        assert!(validate_shutdown_timings(&t, Duration::from_secs(74)).is_err());
+        // One second above: OK — extra headroom.
+        assert!(validate_shutdown_timings(&t, Duration::from_secs(76)).is_ok());
     }
 }

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -114,6 +114,14 @@ const DEFAULT_SHUTDOWN_TEARDOWN_MARGIN_SECS: u64 = 10;
 /// always has time to flush.
 const POOL_CLOSE_LOG_HEADROOM: Duration = Duration::from_secs(2);
 
+/// Upper bound on the SIGTERM-time cluster deregister (publish `leave` +
+/// remove from the registry). This runs concurrently with the pre-drain pause,
+/// so on GKE (pre_drain ≥ this) it adds no wall-clock; on Cloud Run
+/// (pre_drain = 0) it is the only phase-1 cost, kept small so a dead Redis
+/// cannot stall shutdown past the grace period. The Cloud Run drain budgets in
+/// `cloudbuild.yaml` are sized to absorb this worst case.
+const CLUSTER_DEREGISTER_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// Per-field sanity ceiling on each `SHUTDOWN_*_SECS` env var. Values above
 /// this fall back to the per-field default with a warning. 1 day is far
 /// above any plausible operational value (real drains are seconds, not
@@ -1719,9 +1727,38 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         "Graceful shutdown: starting pre-drain phase (readiness now 503)"
     );
 
-    // Phase 1: flip readiness and sleep so endpoint/NEG detach (GKE) propagates
-    // before we stop accepting.
-    pre_drain_pause(&shutting_down, timings.pre_drain).await;
+    // Phase 1: flip readiness and sleep so endpoint/NEG detach (GKE)
+    // propagates, AND concurrently publish the cluster `leave` event so peers
+    // rebalance off this instance immediately. The deregister is the *only*
+    // rebalance trigger on Cloud Run (no readiness-driven endpoint removal);
+    // on GKE it runs alongside endpoint detach. We join the two so peers learn
+    // we are leaving before we tear down relays, but bound the deregister so a
+    // dead Redis cannot stall shutdown. The heartbeat task is stopped as part
+    // of the deregister (it cancels the shared token), so it cannot re-register
+    // us after this point.
+    let deregister = async {
+        match tokio::time::timeout(
+            CLUSTER_DEREGISTER_TIMEOUT,
+            coordinator.deregister_and_stop_heartbeat(),
+        )
+        .await
+        {
+            Ok(Ok(())) => {
+                tracing::info!("Graceful shutdown: cluster leave published, instance deregistered")
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, "Graceful shutdown: cluster deregister failed; peers will converge via heartbeat staleness")
+            }
+            Err(_) => tracing::warn!(
+                timeout_secs = CLUSTER_DEREGISTER_TIMEOUT.as_secs(),
+                "Graceful shutdown: cluster deregister timed out (Redis slow/down); continuing"
+            ),
+        }
+    };
+    tokio::join!(
+        pre_drain_pause(&shutting_down, timings.pre_drain),
+        deregister
+    );
 
     // Phase 2: tell axum to stop accepting new HTTP connections and wait for
     // in-flight requests to finish.
@@ -1759,8 +1796,10 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     // wait for signer + other tracked tasks. We do this **after** HTTP drain so
     // NIP-46 requests that arrived before SIGTERM have a chance to complete and
     // publish responses back to the requesting client before we disconnect from
-    // the relays. `ClusterCoordinator` will be dropped automatically on return,
-    // triggering deregister.
+    // the relays. The cluster `leave` was already published in phase 1 (the
+    // coordinator is an `Arc` shared with the signer/workers and has no Drop
+    // hook, so it is NOT deregistered implicitly on return — see the explicit
+    // `deregister_and_stop_heartbeat` above).
     //
     // `drain_signer_or_abort` applies ONE outer `tokio::time::timeout`
     // at `timings.signer_drain` across both awaits so `signer_drain`

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -204,6 +204,57 @@ async fn pre_drain_pause(unready: &Arc<AtomicBool>, duration: Duration) {
     }
 }
 
+/// Result of awaiting the axum HTTP server's graceful-shutdown future with a
+/// bounded budget.
+#[derive(Debug)]
+enum HttpDrainOutcome {
+    /// The server finished its graceful-shutdown future before the budget ran
+    /// out. Join errors are logged by the caller but do not change the phase.
+    Completed,
+    /// The budget expired before the server finished. The task was aborted
+    /// and awaited to cancellation; the caller can safely proceed to phase 3
+    /// (relay teardown) and phase 4 (DB pool close) without racing a
+    /// still-live accept loop.
+    AbortedAfterTimeout,
+}
+
+/// Await the axum server's `JoinHandle` for up to `budget`. If it finishes
+/// in time, return `Completed`. Otherwise call `abort()` on the task,
+/// await its cancellation, and return `AbortedAfterTimeout`.
+///
+/// This exists because dropping a `tokio::task::JoinHandle` does NOT cancel
+/// the underlying task — the axum server would keep running concurrently
+/// with the relay-teardown and DB-pool-close phases, causing decode errors
+/// on late-arriving requests and forcing the kubelet SIGKILL to be the
+/// ultimate stop. The abort makes the HTTP drain budget a real bound on
+/// axum's lifetime.
+async fn drain_http_or_abort(
+    mut handle: tokio::task::JoinHandle<()>,
+    budget: Duration,
+) -> HttpDrainOutcome {
+    // `JoinHandle<T>` is `Unpin` and implements `Future<Output = Result<T,
+    // JoinError>>`, so `&mut handle` can be awaited by `timeout` without
+    // consuming it. This lets us still call `abort()` on the same handle on
+    // the timeout path.
+    match tokio::time::timeout(budget, &mut handle).await {
+        Ok(join_result) => {
+            if let Err(e) = join_result {
+                tracing::warn!("API server task error: {:?}", e);
+            }
+            HttpDrainOutcome::Completed
+        }
+        Err(_) => {
+            handle.abort();
+            // Await cancellation so we don't return while the accept loop is
+            // still being torn down. A cancelled task completes quickly; if
+            // it somehow doesn't, the outer kubelet grace period is still
+            // the final backstop, so no second timeout here.
+            let _ = (&mut handle).await;
+            HttpDrainOutcome::AbortedAfterTimeout
+        }
+    }
+}
+
 #[derive(Clone)]
 struct LivenessState {
     shutting_down: Arc<AtomicBool>,
@@ -1334,16 +1385,18 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         elapsed_secs = shutdown_started_at.elapsed().as_secs(),
         "Graceful shutdown: draining HTTP (axum with_graceful_shutdown)"
     );
-    match tokio::time::timeout(timings.http_drain, api_handle).await {
-        Ok(result) => {
-            if let Err(e) = result {
-                tracing::warn!("API server task error: {:?}", e);
-            }
-        }
-        Err(_) => {
+    match drain_http_or_abort(api_handle, timings.http_drain).await {
+        HttpDrainOutcome::Completed => {}
+        HttpDrainOutcome::AbortedAfterTimeout => {
+            // Axum did not finish its graceful-shutdown future in time, so
+            // we aborted the task. Log at warn — this means either (a) a
+            // handler hung for longer than the drain budget, or (b) there
+            // are stuck upstream connections. Either way, phase 3 (relay
+            // teardown) and phase 4 (DB pool close) can now proceed
+            // without racing a still-live accept loop.
             tracing::warn!(
                 http_drain_secs = timings.http_drain.as_secs(),
-                "API server shutdown timed out"
+                "API server shutdown timed out; axum task aborted to prevent DB pool close from racing late requests"
             );
         }
     }
@@ -2007,6 +2060,79 @@ mod tests {
         };
 
         assert!(validate_shutdown_timings(&t, Duration::from_secs(75)).is_err());
+    }
+
+    // --- HTTP drain abort-on-timeout ---
+    //
+    // On shutdown, the HTTP drain phase waits up to `SHUTDOWN_HTTP_DRAIN_SECS`
+    // for axum's `.with_graceful_shutdown()` future to complete. The axum
+    // task is a raw `tokio::spawn`, NOT on TaskTracker. Previously the
+    // timeout arm just logged "API server shutdown timed out" and fell
+    // through — but dropping a JoinHandle does NOT cancel the underlying
+    // task (std+tokio semantics). axum would keep running (potentially
+    // still accepting / serving new connections) during phase 3 (relay
+    // client teardown) and phase 4 (DB pool close), with pool-close
+    // generating decode errors on late-arriving requests until the kubelet
+    // SIGKILL finally stopped the process at terminationGracePeriodSeconds.
+    // The abort-on-timeout helper below makes the budget a real bound.
+
+    #[tokio::test(start_paused = true)]
+    async fn test_drain_http_or_abort_returns_completed_when_task_finishes_before_budget() {
+        // Fast path: if the spawned task completes inside the drain budget,
+        // we should report Completed and not touch abort().
+        let handle = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        });
+
+        let outcome = drain_http_or_abort(handle, Duration::from_secs(5)).await;
+
+        assert!(
+            matches!(outcome, HttpDrainOutcome::Completed),
+            "expected Completed, got {:?}",
+            outcome
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_drain_http_or_abort_aborts_task_when_budget_exceeded() {
+        // The behavioral promise: if the axum task is still running at the
+        // end of the HTTP drain budget, drain_http_or_abort must stop it
+        // before returning so phase 3 (relay teardown) and phase 4 (DB pool
+        // close) aren't racing a still-live accept loop.
+        //
+        // We spawn a task that would sleep for an hour; with a 5s drain
+        // budget the helper must abort it. After the helper returns, the
+        // spawned task must be finished (cancelled), NOT still pending.
+
+        let cancel_flag = Arc::new(AtomicBool::new(false));
+        let cancel_flag_task = cancel_flag.clone();
+
+        let handle = tokio::spawn(async move {
+            // Use an async block with a drop guard so we can observe that
+            // the task was actually cancelled, not just left pending.
+            struct CancelSignal(Arc<AtomicBool>);
+            impl Drop for CancelSignal {
+                fn drop(&mut self) {
+                    self.0.store(true, Ordering::Relaxed);
+                }
+            }
+            let _guard = CancelSignal(cancel_flag_task);
+
+            // Would sleep for an hour if not aborted.
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        });
+
+        let outcome = drain_http_or_abort(handle, Duration::from_secs(5)).await;
+
+        assert!(
+            matches!(outcome, HttpDrainOutcome::AbortedAfterTimeout),
+            "expected AbortedAfterTimeout, got {:?}",
+            outcome
+        );
+        assert!(
+            cancel_flag.load(Ordering::Relaxed),
+            "drain_http_or_abort must abort the spawned task — task drop guard did not fire, meaning the task is still running past the HTTP drain budget"
+        );
     }
 
     #[test]

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -48,41 +48,71 @@ use zeroize::Zeroizing;
 const READYZ_DB_TIMEOUT: Duration = Duration::from_millis(800);
 
 /// Duration the process pauses between flipping the readiness probe to 503
-/// and starting to drain accepted connections. This is the window during which
-/// Kubernetes observes the failing probe and removes the pod from the Service
-/// EndpointSlice so the load balancer stops routing new traffic to us. Keeping
-/// this out of the drain budget is critical — otherwise new NIP-46 sign
-/// requests arriving during these seconds would be rejected mid-request and
-/// trigger client-side reconnect storms on scale-down. Override with
-/// `SHUTDOWN_PRE_DRAIN_SECS` (e.g. `0` in local dev / tests).
-const DEFAULT_SHUTDOWN_PRE_DRAIN_SECS: u64 = 10;
+/// and starting to drain accepted connections. On GKE this is the window during
+/// which the pod's deletion triggers endpoint/NEG detach (the Pod is removed
+/// from the Service EndpointSlice and the GCLB NEG) so the load balancer stops
+/// routing new traffic to us; the readiness probe flipping to 503 only
+/// *reinforces* this — it is the Pod's `deletionTimestamp`, not a failing
+/// readiness probe, that drives endpoint removal on a normal scale-down. NEG
+/// detach propagation can take >10s, so the default covers a conservative upper
+/// bound. Keeping this out of the drain budget is critical — otherwise new
+/// NIP-46 sign requests arriving during these seconds would be rejected
+/// mid-request and trigger client-side reconnect storms on scale-down.
+///
+/// Cloud Run has **no** readiness-probe-driven endpoint removal: a terminating
+/// instance is removed from routing by the platform, and peer rebalancing comes
+/// from the cluster coordinator's `leave` event (see the SIGTERM-time
+/// deregister in `async_main`), not from this pause. Set
+/// `SHUTDOWN_PRE_DRAIN_SECS=0` there. Override with `SHUTDOWN_PRE_DRAIN_SECS`
+/// (e.g. `0` in local dev / tests).
+const DEFAULT_SHUTDOWN_PRE_DRAIN_SECS: u64 = 15;
 
 /// Maximum time we wait for axum to drain in-flight HTTP requests after we
 /// stop accepting new connections. The sum of `pre_drain + http_drain +
-/// signer_drain` plus ~5–10s of teardown headroom must fit inside the
-/// Deployment's `terminationGracePeriodSeconds` — otherwise the kubelet
-/// SIGKILLs us mid-drain. Default sized for `terminationGracePeriodSeconds: 75`.
-/// Override with `SHUTDOWN_HTTP_DRAIN_SECS`.
-const DEFAULT_SHUTDOWN_HTTP_DRAIN_SECS: u64 = 45;
+/// signer_drain` plus the teardown margin must fit inside the Deployment's
+/// `terminationGracePeriodSeconds` — otherwise the kubelet SIGKILLs us
+/// mid-drain. Defaults are sized so `pre_drain(15) + http_drain(40) +
+/// signer_drain(10) + margin(10) = 75` fits `terminationGracePeriodSeconds: 75`
+/// exactly. When the configured budget does not fit the ceiling it is clamped
+/// down proportionally at runtime (see `clamp_shutdown_timings`). Override with
+/// `SHUTDOWN_HTTP_DRAIN_SECS`.
+const DEFAULT_SHUTDOWN_HTTP_DRAIN_SECS: u64 = 40;
 
 /// Maximum time we wait for the relay queue, NIP-46 signer, and tracked
 /// background tasks to finish before/while tearing down the relay client.
 /// Override with `SHUTDOWN_SIGNER_DRAIN_SECS`.
 const DEFAULT_SHUTDOWN_SIGNER_DRAIN_SECS: u64 = 10;
 
-/// Conservative upper bound on the Deployment's `terminationGracePeriodSeconds`
-/// used at startup to sanity-check the shutdown phase budgets. The default must
-/// match the intended Deployment grace period so validation cannot pass against
-/// a ceiling higher than the kubelet actually enforces. If an operator bumps
-/// grace higher they can raise this via `SHUTDOWN_GRACE_PERIOD_CEILING_SECS`.
-/// This constant does NOT change kubelet behavior — it is purely a guardrail.
+/// Upper bound on the platform's post-SIGTERM grace (the kubelet's
+/// `terminationGracePeriodSeconds` on GKE, or the ~10s SIGTERM→SIGKILL window
+/// on Cloud Run) used to size and clamp the shutdown phase budgets.
+///
+/// **This default must be set per deployment** — it does NOT change platform
+/// behavior, it only tells keycast how much grace it actually has so the phased
+/// drain provably fits. The default of 75 matches the intended GKE grace
+/// (`terminationGracePeriodSeconds: 75`) ONLY; Cloud Run, which enforces ~10s,
+/// MUST set `SHUTDOWN_GRACE_PERIOD_CEILING_SECS=10` (see `cloudbuild.yaml`).
+/// Leaving the default on a platform with a smaller real grace would let the
+/// full budget run and be SIGKILLed mid-drain. When the configured budget
+/// exceeds the ceiling it is clamped down proportionally at runtime rather than
+/// run as-is (see `clamp_shutdown_timings`). Override with
+/// `SHUTDOWN_GRACE_PERIOD_CEILING_SECS`.
 const DEFAULT_SHUTDOWN_GRACE_CEILING_SECS: u64 = 75;
 
-/// Headroom reserved between the end of the phased drain and the kubelet
+/// Headroom reserved between the end of the phased drain and the platform
 /// SIGKILL for DB pool close, tracing flush, and other post-drain cleanup.
-/// Subtracted from the ceiling when validating that the configured phase
-/// budgets fit.
-const SHUTDOWN_TEARDOWN_MARGIN: Duration = Duration::from_secs(10);
+/// Subtracted from the ceiling when sizing/clamping the phase budgets and used
+/// as the phase-4 pool-close bound. Configurable because on a tight grace
+/// (Cloud Run's ~10s) the GKE-sized 10s margin alone would consume the whole
+/// ceiling; there it must be set small (1–2s) via `SHUTDOWN_TEARDOWN_MARGIN_SECS`.
+const DEFAULT_SHUTDOWN_TEARDOWN_MARGIN_SECS: u64 = 10;
+
+/// Headroom carved out of the teardown margin for the final "Graceful shutdown
+/// complete" log line (and tracing flush) to be emitted *after* the DB pool
+/// close future resolves but *before* the platform SIGKILL. The phase-4 pool
+/// close is bounded by `teardown_margin - this` so the success/timeout log
+/// always has time to flush.
+const POOL_CLOSE_LOG_HEADROOM: Duration = Duration::from_secs(2);
 
 /// Per-field sanity ceiling on each `SHUTDOWN_*_SECS` env var. Values above
 /// this fall back to the per-field default with a warning. 1 day is far
@@ -106,9 +136,9 @@ struct ShutdownTimings {
 }
 
 impl ShutdownTimings {
-    /// Sum of all three phase durations. Does NOT include
-    /// `SHUTDOWN_TEARDOWN_MARGIN` — add that separately when comparing
-    /// against a grace-period ceiling.
+    /// Sum of all three phase durations. Does NOT include the teardown
+    /// margin — add that separately when comparing against a grace-period
+    /// ceiling.
     fn total_budget(&self) -> Duration {
         self.pre_drain + self.http_drain + self.signer_drain
     }
@@ -180,32 +210,58 @@ fn parse_shutdown_grace_ceiling() -> Duration {
     )
 }
 
-/// Check that `timings.total_budget() + SHUTDOWN_TEARDOWN_MARGIN <= ceiling`.
+/// Parse the teardown margin (post-drain headroom for DB pool close, tracing
+/// flush, and process teardown). Override with `SHUTDOWN_TEARDOWN_MARGIN_SECS`.
+fn parse_shutdown_teardown_margin() -> Duration {
+    parse_duration_secs_env(
+        "SHUTDOWN_TEARDOWN_MARGIN_SECS",
+        DEFAULT_SHUTDOWN_TEARDOWN_MARGIN_SECS,
+    )
+}
+
+/// Whether `SHUTDOWN_PRE_DRAIN_SECS` was explicitly set to a valid value.
+///
+/// Used by `clamp_shutdown_timings` to decide whether the pre-drain pause is
+/// load-bearing (operator chose it deliberately — e.g. to cover GKE NEG-detach
+/// propagation, or `0` on Cloud Run) and must be preserved when clamping, or
+/// is merely the built-in default and may be scaled down with the drains to
+/// fit a tight ceiling.
+fn pre_drain_was_explicitly_set() -> bool {
+    matches!(
+        env::var("SHUTDOWN_PRE_DRAIN_SECS"),
+        Ok(raw) if raw
+            .trim()
+            .parse::<u64>()
+            .map(|secs| secs <= SHUTDOWN_PER_FIELD_CEILING_SECS)
+            .unwrap_or(false)
+    )
+}
+
+/// Check that `timings.total_budget() + margin <= ceiling`.
 /// The margin is the reserved headroom for DB pool close, tracing flush, and
-/// process teardown between the end of the phased drain and the kubelet
-/// SIGKILL at `terminationGracePeriodSeconds`. Exact equality is accepted
-/// (the margin fully fits); anything larger is rejected.
+/// process teardown between the end of the phased drain and the platform
+/// SIGKILL. Exact equality is accepted (the margin fully fits); anything
+/// larger is rejected.
 ///
 /// Returned `Err(String)` is operator-actionable and includes the current
-/// budget, margin, and ceiling so it can be dropped straight into a log
-/// line. We deliberately warn (not abort) on violation at the call site:
-/// the ceiling is cross-repo-coupled to the iac repo, and an operator may
-/// legitimately need to boot ahead of an iac-side grace bump.
-///
-/// TODO(#692): remove the soft-warning fallback in `async_main` once the
-/// sibling divinevideo/divine-iac-coreconfig PR lands and `terminationGracePeriodSeconds`
-/// is pinned at ≥75s in all environments.
-fn validate_shutdown_timings(timings: &ShutdownTimings, ceiling: Duration) -> Result<(), String> {
+/// budget, margin, and ceiling so it can be dropped straight into a log line.
+/// This is the predicate `clamp_shutdown_timings` uses to decide whether the
+/// configured budget must be scaled down to fit the platform grace.
+fn validate_shutdown_timings(
+    timings: &ShutdownTimings,
+    ceiling: Duration,
+    margin: Duration,
+) -> Result<(), String> {
     let total = timings.total_budget();
-    let required = total + SHUTDOWN_TEARDOWN_MARGIN;
+    let required = total + margin;
     if required > ceiling {
         Err(format!(
             "shutdown phase budget ({total_secs}s) + teardown margin ({margin_secs}s) \
              = {required_secs}s does not fit inside SHUTDOWN_GRACE_PERIOD_CEILING_SECS \
              = {ceiling_secs}s (pre_drain={pre}s, http_drain={http}s, signer_drain={sig}s); \
-             the kubelet will SIGKILL mid-drain on terminationGracePeriodSeconds",
+             the platform will SIGKILL mid-drain at its grace period",
             total_secs = total.as_secs(),
-            margin_secs = SHUTDOWN_TEARDOWN_MARGIN.as_secs(),
+            margin_secs = margin.as_secs(),
             required_secs = required.as_secs(),
             ceiling_secs = ceiling.as_secs(),
             pre = timings.pre_drain.as_secs(),
@@ -214,6 +270,104 @@ fn validate_shutdown_timings(timings: &ShutdownTimings, ceiling: Duration) -> Re
         ))
     } else {
         Ok(())
+    }
+}
+
+/// Outcome of clamping the configured phase budget against the platform grace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ClampedTimings {
+    timings: ShutdownTimings,
+    /// True when the configured budget did not fit and was scaled down.
+    clamped: bool,
+}
+
+/// Scale the phase budget down so it provably fits the platform grace:
+/// `pre_drain + http_drain + signer_drain + margin <= ceiling`.
+///
+/// If the configured budget already fits, the timings are returned unchanged
+/// with `clamped == false`. Otherwise the phases are reduced into the
+/// `available = ceiling - margin` window:
+///
+/// - When `pre_drain_explicit` is true the pre-drain pause is load-bearing
+///   (the operator chose it — e.g. to cover GKE NEG-detach propagation, or `0`
+///   on Cloud Run), so it is preserved (capped at `available`) and only
+///   `http_drain`/`signer_drain` are scaled proportionally into the remainder.
+/// - Otherwise pre_drain is just the built-in default and is scaled
+///   proportionally alongside the drains, so a tight ceiling does not get its
+///   whole budget eaten by an unconfigured pre-drain.
+///
+/// Proportional scaling uses millisecond integer math and floors each result,
+/// so the clamped sum is always `<= available` (never overshoots the ceiling).
+fn clamp_shutdown_timings(
+    timings: ShutdownTimings,
+    ceiling: Duration,
+    margin: Duration,
+    pre_drain_explicit: bool,
+) -> ClampedTimings {
+    let available = ceiling.saturating_sub(margin);
+    if timings.total_budget() <= available {
+        return ClampedTimings {
+            timings,
+            clamped: false,
+        };
+    }
+
+    // pre_drain kept fixed (capped) when explicit; otherwise it joins the
+    // proportional pool with the two drains.
+    let (kept_pre, scalable_pre) = if pre_drain_explicit {
+        (timings.pre_drain.min(available), Duration::ZERO)
+    } else {
+        (Duration::ZERO, timings.pre_drain)
+    };
+
+    let remaining = available.saturating_sub(kept_pre);
+    let scalable_total = scalable_pre + timings.http_drain + timings.signer_drain;
+
+    // Scale `d` into `remaining` by the share it holds of `scalable_total`.
+    let scale = |d: Duration| -> Duration {
+        if scalable_total.is_zero() {
+            Duration::ZERO
+        } else {
+            let scaled_ms = d.as_millis() * remaining.as_millis() / scalable_total.as_millis();
+            Duration::from_millis(scaled_ms as u64)
+        }
+    };
+
+    ClampedTimings {
+        timings: ShutdownTimings {
+            pre_drain: kept_pre + scale(scalable_pre),
+            http_drain: scale(timings.http_drain),
+            signer_drain: scale(timings.signer_drain),
+        },
+        clamped: true,
+    }
+}
+
+/// The effective shutdown plan resolved from the environment: the
+/// operator-configured timings, the clamped (effective) timings, the grace
+/// ceiling, and the teardown margin. Resolved once at startup (for the
+/// fits/clamped log) and once at shutdown (for the real phase budgets) so both
+/// paths apply identical clamping.
+struct ShutdownPlan {
+    configured: ShutdownTimings,
+    clamped: ClampedTimings,
+    ceiling: Duration,
+    margin: Duration,
+}
+
+/// Parse phase timings, ceiling, and teardown margin from the environment and
+/// clamp the phases so they provably fit the grace ceiling.
+fn resolve_shutdown_plan() -> ShutdownPlan {
+    let configured = parse_shutdown_timings();
+    let ceiling = parse_shutdown_grace_ceiling();
+    let margin = parse_shutdown_teardown_margin();
+    let clamped =
+        clamp_shutdown_timings(configured, ceiling, margin, pre_drain_was_explicitly_set());
+    ShutdownPlan {
+        configured,
+        clamped,
+        ceiling,
+        margin,
     }
 }
 
@@ -236,22 +390,22 @@ enum PoolCloseOutcome {
     /// emit the clean "Graceful shutdown complete" log.
     Completed,
     /// The margin elapsed before the pool finished. The caller logs a
-    /// warning and proceeds — the kubelet SIGKILL at
-    /// `terminationGracePeriodSeconds` is the final backstop.
+    /// warning and proceeds — the platform SIGKILL at the grace period is the
+    /// final backstop.
     TimedOut,
 }
 
 /// Await `close_fut` for up to `margin`. If it finishes in time, return
 /// `Completed`; otherwise return `TimedOut`. The close future is dropped on
 /// timeout — sqlx's `Pool::close()` is cancellation-safe, and we would not
-/// gain anything by continuing to await past the documented margin when the
-/// kubelet is about to SIGKILL us anyway.
+/// gain anything by continuing to await past the margin when the platform is
+/// about to SIGKILL us anyway.
 ///
-/// This enforces `SHUTDOWN_TEARDOWN_MARGIN` as a real bound on phase 4 so a
-/// stuck DB connection (e.g. a preload task mid-query when
+/// This enforces the teardown margin (less `POOL_CLOSE_LOG_HEADROOM`) as a real
+/// bound on phase 4 so a stuck DB connection (e.g. a preload task mid-query when
 /// `task_tracker.wait()` timed out and `signer_handle.abort()` was called
-/// but not awaited) cannot block past `terminationGracePeriodSeconds` and
-/// swallow the final "Graceful shutdown complete" log.
+/// but not awaited) cannot block past the platform SIGKILL and swallow the
+/// final "Graceful shutdown complete" log.
 ///
 /// Generic over `F: Future<Output = ()>` so we can exercise the timeout
 /// behaviour deterministically with `tokio::time::pause` in tests without
@@ -273,10 +427,14 @@ enum HttpDrainOutcome {
     /// The server finished its graceful-shutdown future before the budget ran
     /// out. Join errors are logged by the caller but do not change the phase.
     Completed,
-    /// The budget expired before the server finished. The task was aborted
-    /// and awaited to cancellation; the caller can safely proceed to phase 3
-    /// (relay teardown) and phase 4 (DB pool close) without racing a
-    /// still-live accept loop.
+    /// The budget expired before the server finished. The server task was
+    /// aborted and awaited to cancellation, which stops the **accept loop** so
+    /// the caller can proceed to phase 3 (relay teardown) and phase 4 (DB pool
+    /// close) without racing a still-live accept loop. Note this does NOT
+    /// guarantee every in-flight per-connection task is finished — hyper's
+    /// per-connection tasks are not children of the aborted handle and may
+    /// still be running; phase 4's bounded pool close covers any that linger
+    /// holding a DB connection.
     AbortedAfterTimeout,
 }
 
@@ -328,9 +486,9 @@ fn abort_join_handles(handles: &[tokio::task::AbortHandle]) {
 /// relay worker) hangs.
 ///
 /// Why one shared budget, not two independent ones: the design contract
-/// enforced by `validate_shutdown_timings` is
-/// `pre_drain + http_drain + signer_drain + SHUTDOWN_TEARDOWN_MARGIN
-/// <= terminationGracePeriodSeconds`. If each inner await got its own
+/// enforced by `validate_shutdown_timings`/`clamp_shutdown_timings` is
+/// `pre_drain + http_drain + signer_drain + teardown_margin
+/// <= grace ceiling`. If each inner await got its own
 /// `budget`-sized timeout, phase 3 could take up to `2 * signer_drain`
 /// in the worst case and silently bust the contract.
 ///
@@ -970,40 +1128,49 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         instance_id, cpu_count, worker_threads, pool_size
     );
 
-    // Validate the shutdown phase budget against the configured grace-period
-    // ceiling as a startup-time sanity check. This is defense in depth against
-    // (a) an operator setting e.g. `SHUTDOWN_HTTP_DRAIN_SECS=120` against a
-    // 75s grace period and (b) the sibling divinevideo/divine-iac-coreconfig
-    // PR (tracked in issue #692) landing with `terminationGracePeriodSeconds`
-    // below the configured defaults. We log a loud warning rather than
-    // refusing to boot: the ceiling is cross-repo-coupled, and an operator
-    // may legitimately need to start before the iac repo catches up.
-    // TODO(#692): remove the warn-only fallback once the iac-side PR pins
-    // `terminationGracePeriodSeconds` to ≥75s in every environment.
+    // Resolve and log the effective shutdown phase budget at startup. The
+    // configured budget is clamped to provably fit the configured grace
+    // ceiling (`SHUTDOWN_GRACE_PERIOD_CEILING_SECS`, which must be set to the
+    // platform's real post-SIGTERM grace — ~10s on Cloud Run, 75s on GKE). If
+    // the operator-configured budget does not fit (e.g. `SHUTDOWN_HTTP_DRAIN_SECS=120`
+    // against a 75s ceiling, or the GKE-sized defaults against a 10s Cloud Run
+    // ceiling), the phases are scaled down proportionally at runtime rather
+    // than run as-is and SIGKILLed mid-drain. We log the clamp loudly so the
+    // operator can retune; we do not refuse to boot.
     {
-        let startup_timings = parse_shutdown_timings();
-        let grace_ceiling = parse_shutdown_grace_ceiling();
-        match validate_shutdown_timings(&startup_timings, grace_ceiling) {
-            Ok(()) => {
-                tracing::info!(
-                    pre_drain_secs = startup_timings.pre_drain.as_secs(),
-                    http_drain_secs = startup_timings.http_drain.as_secs(),
-                    signer_drain_secs = startup_timings.signer_drain.as_secs(),
-                    grace_ceiling_secs = grace_ceiling.as_secs(),
-                    "Shutdown phase budget fits inside configured grace ceiling"
-                );
-            }
-            Err(err) => {
-                tracing::warn!(
-                    event = "shutdown_budget_exceeds_grace_ceiling",
-                    pre_drain_secs = startup_timings.pre_drain.as_secs(),
-                    http_drain_secs = startup_timings.http_drain.as_secs(),
-                    signer_drain_secs = startup_timings.signer_drain.as_secs(),
-                    grace_ceiling_secs = grace_ceiling.as_secs(),
+        let plan = resolve_shutdown_plan();
+        if plan.clamped.clamped {
+            let eff = plan.clamped.timings;
+            tracing::warn!(
+                event = "shutdown_budget_clamped_to_grace_ceiling",
+                configured_pre_drain_secs = plan.configured.pre_drain.as_secs(),
+                configured_http_drain_secs = plan.configured.http_drain.as_secs(),
+                configured_signer_drain_secs = plan.configured.signer_drain.as_secs(),
+                effective_pre_drain_secs = eff.pre_drain.as_secs(),
+                effective_http_drain_secs = eff.http_drain.as_secs(),
+                effective_signer_drain_secs = eff.signer_drain.as_secs(),
+                teardown_margin_secs = plan.margin.as_secs(),
+                grace_ceiling_secs = plan.ceiling.as_secs(),
+                "Configured shutdown phase budget exceeds the grace ceiling; phases clamped down proportionally to fit"
+            );
+            if let Err(err) = validate_shutdown_timings(&eff, plan.ceiling, plan.margin) {
+                // Should be unreachable: clamp guarantees a fit. Surface loudly
+                // if the invariant is ever broken.
+                tracing::error!(
+                    event = "shutdown_budget_clamp_invariant_violated",
                     "{}",
                     err
                 );
             }
+        } else {
+            tracing::info!(
+                pre_drain_secs = plan.clamped.timings.pre_drain.as_secs(),
+                http_drain_secs = plan.clamped.timings.http_drain.as_secs(),
+                signer_drain_secs = plan.clamped.timings.signer_drain.as_secs(),
+                teardown_margin_secs = plan.margin.as_secs(),
+                grace_ceiling_secs = plan.ceiling.as_secs(),
+                "Shutdown phase budget fits inside configured grace ceiling"
+            );
         }
     }
 
@@ -1503,17 +1670,22 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
 
     // --- Graceful shutdown ---
     //
-    // Phase ordering matters. On scale-down events Kubernetes sends SIGTERM
-    // and *also* starts removing the pod from the Service EndpointSlice based
-    // on the readiness probe, but endpoint-slice propagation is asynchronous.
-    // If we stop accepting connections the instant we see SIGTERM, the LB may
-    // still be routing new NIP-46 / HTTP requests to us for several seconds
-    // and those requests fail mid-flight — the exact client-reconnect storm
-    // that issue #692 targets.
+    // Phase ordering matters. On scale-down the platform sends SIGTERM and
+    // *also* starts removing the instance from load-balancer routing, but that
+    // removal is asynchronous. On GKE the Pod's `deletionTimestamp` (not a
+    // failing readiness probe) drives endpoint/NEG detach from the Service
+    // EndpointSlice and the GCLB NEG; the readiness probe flipping to 503 only
+    // reinforces it. On Cloud Run the platform stops routing to a terminating
+    // instance directly. Either way propagation lags SIGTERM by seconds. If we
+    // stop accepting connections the instant we see SIGTERM, the LB may still
+    // be routing new NIP-46 / HTTP requests to us and those fail mid-flight —
+    // the exact client-reconnect storm that issue #692 targets.
     //
     // So the sequence is:
-    //   1. Flip `/healthz/ready` to 503 and sleep `pre_drain`. Kubelet observes
-    //      the failing probe; the Service controller removes us from endpoints.
+    //   1. Flip `/healthz/ready` to 503 and sleep `pre_drain` so endpoint/NEG
+    //      detach (GKE) propagates before we stop accepting. On Cloud Run there
+    //      is no readiness-driven endpoint removal, so `pre_drain` is set to 0
+    //      and peer rebalancing comes from the cluster coordinator `leave`.
     //   2. Stop accepting new HTTP connections (axum `.with_graceful_shutdown`
     //      future resolves) and wait up to `http_drain` for in-flight requests.
     //   3. Tear down the NIP-46 relay client (which stops `signer.run()` and
@@ -1521,11 +1693,25 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     //      tracked background tasks.
     //   4. Close the DB pool.
     //
-    // Sum of `pre_drain + http_drain + signer_drain` + DB-pool-close headroom
-    // must fit inside the Deployment's `terminationGracePeriodSeconds` or the
-    // kubelet SIGKILLs us mid-drain.
-    let timings = parse_shutdown_timings();
+    // The effective budget `pre_drain + http_drain + signer_drain +
+    // teardown_margin` is clamped at resolve time to fit the configured grace
+    // ceiling (`SHUTDOWN_GRACE_PERIOD_CEILING_SECS`) so the platform does not
+    // SIGKILL us mid-drain.
+    let plan = resolve_shutdown_plan();
+    let timings = plan.clamped.timings;
+    let teardown_margin = plan.margin;
     let shutdown_started_at = std::time::Instant::now();
+    if plan.clamped.clamped {
+        tracing::warn!(
+            event = "shutdown_budget_clamped_to_grace_ceiling",
+            effective_pre_drain_secs = timings.pre_drain.as_secs(),
+            effective_http_drain_secs = timings.http_drain.as_secs(),
+            effective_signer_drain_secs = timings.signer_drain.as_secs(),
+            teardown_margin_secs = teardown_margin.as_secs(),
+            grace_ceiling_secs = plan.ceiling.as_secs(),
+            "Graceful shutdown: configured budget exceeds grace ceiling; using clamped phase budget"
+        );
+    }
     tracing::info!(
         pre_drain_secs = timings.pre_drain.as_secs(),
         http_drain_secs = timings.http_drain.as_secs(),
@@ -1533,8 +1719,8 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         "Graceful shutdown: starting pre-drain phase (readiness now 503)"
     );
 
-    // Phase 1: flip readiness and sleep so K8s can remove us from the Service
-    // endpoints before we stop accepting.
+    // Phase 1: flip readiness and sleep so endpoint/NEG detach (GKE) propagates
+    // before we stop accepting.
     pre_drain_pause(&shutting_down, timings.pre_drain).await;
 
     // Phase 2: tell axum to stop accepting new HTTP connections and wait for
@@ -1550,15 +1736,19 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     match drain_http_or_abort(api_handle, timings.http_drain).await {
         HttpDrainOutcome::Completed => {}
         HttpDrainOutcome::AbortedAfterTimeout => {
-            // Axum did not finish its graceful-shutdown future in time, so
-            // we aborted the task. Log at warn — this means either (a) a
-            // handler hung for longer than the drain budget, or (b) there
-            // are stuck upstream connections. Either way, phase 3 (relay
-            // teardown) and phase 4 (DB pool close) can now proceed
-            // without racing a still-live accept loop.
+            // Axum did not finish its graceful-shutdown future in time, so we
+            // aborted the server task. Log at warn — this means either (a) a
+            // handler hung for longer than the drain budget, or (b) there are
+            // stuck upstream connections. Aborting the server task stops the
+            // accept loop, but per-connection tasks spawned by hyper are NOT
+            // children of this handle and may still be running; phase 4's
+            // bounded pool close is what ultimately covers any of those still
+            // holding a DB connection. The point of the abort is to stop
+            // accepting *new* connections so phase 3 (relay teardown) and
+            // phase 4 (DB pool close) don't race a still-live accept loop.
             tracing::warn!(
                 http_drain_secs = timings.http_drain.as_secs(),
-                "API server shutdown timed out; axum task aborted to prevent DB pool close from racing late requests"
+                "API server shutdown timed out; axum accept loop aborted (in-flight connection tasks may still run; bounded DB pool close covers any lingering ones)"
             );
         }
     }
@@ -1607,14 +1797,16 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         }
     }
 
-    // Phase 4: close database pool. Bounded by SHUTDOWN_TEARDOWN_MARGIN so
-    // a connection stuck in a long-running query (e.g. a tenant-cache
-    // preload task mid-query when task_tracker.wait() timed out and
-    // signer_handle.abort() was called but not awaited) cannot block past
-    // the kubelet SIGKILL and swallow the final "Graceful shutdown
-    // complete" log. sqlx's Pool::close is cancellation-safe, so dropping
-    // the future on timeout is safe.
-    match close_within_margin(pool_for_shutdown.close(), SHUTDOWN_TEARDOWN_MARGIN).await {
+    // Phase 4: close database pool. Bounded by the teardown margin less
+    // POOL_CLOSE_LOG_HEADROOM so a connection stuck in a long-running query
+    // (e.g. a tenant-cache preload task mid-query when task_tracker.wait()
+    // timed out and signer_handle.abort() was called but not awaited) cannot
+    // block past the platform SIGKILL. The reserved headroom guarantees the
+    // final "Graceful shutdown complete" log (and tracing flush) lands before
+    // the SIGKILL even on the timeout path. sqlx's Pool::close is
+    // cancellation-safe, so dropping the future on timeout is safe.
+    let pool_close_budget = teardown_margin.saturating_sub(POOL_CLOSE_LOG_HEADROOM);
+    match close_within_margin(pool_for_shutdown.close(), pool_close_budget).await {
         PoolCloseOutcome::Completed => {
             tracing::info!(
                 total_shutdown_secs = shutdown_started_at.elapsed().as_secs(),
@@ -1624,8 +1816,9 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         PoolCloseOutcome::TimedOut => {
             tracing::warn!(
                 total_shutdown_secs = shutdown_started_at.elapsed().as_secs(),
-                teardown_margin_secs = SHUTDOWN_TEARDOWN_MARGIN.as_secs(),
-                "Graceful shutdown complete with warning: DB pool close exceeded teardown margin; stuck checked-out connections were dropped"
+                pool_close_budget_secs = pool_close_budget.as_secs(),
+                teardown_margin_secs = teardown_margin.as_secs(),
+                "Graceful shutdown complete with warning: DB pool close exceeded its budget; stuck checked-out connections were dropped"
             );
         }
     }
@@ -2056,8 +2249,10 @@ mod tests {
         let timings = parse_shutdown_timings();
 
         // Documented defaults — see main.rs docs on graceful shutdown.
-        assert_eq!(timings.pre_drain, Duration::from_secs(10));
-        assert_eq!(timings.http_drain, Duration::from_secs(45));
+        // Sized so pre(15) + http(40) + signer(10) + margin(10) = 75 fits the
+        // intended GKE terminationGracePeriodSeconds exactly.
+        assert_eq!(timings.pre_drain, Duration::from_secs(15));
+        assert_eq!(timings.http_drain, Duration::from_secs(40));
         assert_eq!(timings.signer_drain, Duration::from_secs(10));
     }
 
@@ -2108,7 +2303,10 @@ mod tests {
 
         let timings = parse_shutdown_timings();
 
-        assert_eq!(timings.pre_drain, Duration::from_secs(10));
+        assert_eq!(
+            timings.pre_drain,
+            Duration::from_secs(DEFAULT_SHUTDOWN_PRE_DRAIN_SECS)
+        );
 
         clear_shutdown_env();
     }
@@ -2131,8 +2329,11 @@ mod tests {
 
         let timings = parse_shutdown_timings();
 
-        // Fell back to default (10s), NOT the u64::MAX-ish value.
-        assert_eq!(timings.pre_drain, Duration::from_secs(10));
+        // Fell back to the default, NOT the u64::MAX-ish value.
+        assert_eq!(
+            timings.pre_drain,
+            Duration::from_secs(DEFAULT_SHUTDOWN_PRE_DRAIN_SECS)
+        );
 
         // And the downstream total_budget() MUST NOT panic. This is the
         // actual safety property — the validate-and-warn path must be
@@ -2310,8 +2511,9 @@ mod tests {
             signer_drain: Duration::from_secs(10),
         };
 
-        assert!(validate_shutdown_timings(&t, Duration::from_secs(75)).is_ok());
-        assert!(validate_shutdown_timings(&t, Duration::from_secs(90)).is_ok());
+        let margin = Duration::from_secs(10);
+        assert!(validate_shutdown_timings(&t, Duration::from_secs(75), margin).is_ok());
+        assert!(validate_shutdown_timings(&t, Duration::from_secs(90), margin).is_ok());
     }
 
     #[test]
@@ -2327,7 +2529,7 @@ mod tests {
             signer_drain: Duration::from_secs(10),
         };
 
-        let err = validate_shutdown_timings(&t, Duration::from_secs(60))
+        let err = validate_shutdown_timings(&t, Duration::from_secs(60), Duration::from_secs(10))
             .expect_err("65s budget + 10s margin must not fit in 60s ceiling");
         // Error message should be operator-actionable: include the total,
         // the margin, and the ceiling so they can tune either side.
@@ -2345,7 +2547,10 @@ mod tests {
             signer_drain: Duration::from_secs(10),
         };
 
-        assert!(validate_shutdown_timings(&t, Duration::from_secs(75)).is_err());
+        assert!(
+            validate_shutdown_timings(&t, Duration::from_secs(75), Duration::from_secs(10))
+                .is_err()
+        );
     }
 
     // --- HTTP drain abort-on-timeout ---
@@ -2423,23 +2628,201 @@ mod tests {
 
     #[test]
     fn test_validate_shutdown_timings_boundary_exactly_at_ceiling() {
-        // total_budget + SHUTDOWN_TEARDOWN_MARGIN = 65 + 10 = 75.
+        // total_budget + teardown margin = 65 + 10 = 75.
         // A ceiling of 75 means the teardown margin exactly fits — that is
         // precisely what the margin is reserved for, so accept. The iac
         // PR's terminationGracePeriodSeconds=75s should validate cleanly
-        // against the defaults with no operator action.
+        // against these timings with no operator action.
         let t = ShutdownTimings {
             pre_drain: Duration::from_secs(10),
             http_drain: Duration::from_secs(45),
             signer_drain: Duration::from_secs(10),
         };
 
+        let margin = Duration::from_secs(10);
         // Exactly the ceiling: OK (margin fits).
-        assert!(validate_shutdown_timings(&t, Duration::from_secs(75)).is_ok());
+        assert!(validate_shutdown_timings(&t, Duration::from_secs(75), margin).is_ok());
         // One second below: reject — margin no longer fits.
-        assert!(validate_shutdown_timings(&t, Duration::from_secs(74)).is_err());
+        assert!(validate_shutdown_timings(&t, Duration::from_secs(74), margin).is_err());
         // One second above: OK — extra headroom.
-        assert!(validate_shutdown_timings(&t, Duration::from_secs(76)).is_ok());
+        assert!(validate_shutdown_timings(&t, Duration::from_secs(76), margin).is_ok());
+    }
+
+    #[test]
+    fn test_default_timings_fit_default_ceiling_without_clamping() {
+        // The shipped defaults (pre=15, http=40, signer=10) plus the default
+        // margin (10) must fit the default GKE ceiling (75) exactly so the
+        // normal GKE path never clamps.
+        let defaults = ShutdownTimings {
+            pre_drain: Duration::from_secs(DEFAULT_SHUTDOWN_PRE_DRAIN_SECS),
+            http_drain: Duration::from_secs(DEFAULT_SHUTDOWN_HTTP_DRAIN_SECS),
+            signer_drain: Duration::from_secs(DEFAULT_SHUTDOWN_SIGNER_DRAIN_SECS),
+        };
+        let ceiling = Duration::from_secs(DEFAULT_SHUTDOWN_GRACE_CEILING_SECS);
+        let margin = Duration::from_secs(DEFAULT_SHUTDOWN_TEARDOWN_MARGIN_SECS);
+
+        assert!(validate_shutdown_timings(&defaults, ceiling, margin).is_ok());
+        // pre_drain explicitly set or not, an already-fitting budget is never
+        // clamped.
+        for explicit in [true, false] {
+            let result = clamp_shutdown_timings(defaults, ceiling, margin, explicit);
+            assert!(
+                !result.clamped,
+                "defaults must not be clamped (explicit={explicit})"
+            );
+            assert_eq!(result.timings, defaults);
+        }
+    }
+
+    // --- Teardown margin parsing ---
+
+    fn clear_shutdown_margin_env() {
+        std::env::remove_var("SHUTDOWN_TEARDOWN_MARGIN_SECS");
+    }
+
+    #[test]
+    #[serial]
+    fn test_parse_shutdown_teardown_margin_default() {
+        clear_shutdown_margin_env();
+        assert_eq!(parse_shutdown_teardown_margin(), Duration::from_secs(10));
+    }
+
+    #[test]
+    #[serial]
+    fn test_parse_shutdown_teardown_margin_override() {
+        clear_shutdown_margin_env();
+        std::env::set_var("SHUTDOWN_TEARDOWN_MARGIN_SECS", "2");
+        assert_eq!(parse_shutdown_teardown_margin(), Duration::from_secs(2));
+        clear_shutdown_margin_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_pre_drain_explicit_detection() {
+        clear_shutdown_env();
+        assert!(
+            !pre_drain_was_explicitly_set(),
+            "unset must not count as explicit"
+        );
+
+        std::env::set_var("SHUTDOWN_PRE_DRAIN_SECS", "0");
+        assert!(
+            pre_drain_was_explicitly_set(),
+            "an explicit 0 must count as set"
+        );
+
+        std::env::set_var("SHUTDOWN_PRE_DRAIN_SECS", "not-a-number");
+        assert!(
+            !pre_drain_was_explicitly_set(),
+            "an unparseable value falls back to default and must not count as explicit"
+        );
+        clear_shutdown_env();
+    }
+
+    // --- Clamp shutdown timings ---
+    //
+    // The clamp makes the phased drain provably fit whatever post-SIGTERM grace
+    // the platform actually enforces. The GKE-sized defaults validate cleanly
+    // against a 75s ceiling but bust a Cloud Run ~10s ceiling; rather than run
+    // the full budget and get SIGKILLed mid-drain, the phases are scaled down.
+
+    #[test]
+    fn test_clamp_scales_drains_into_cloud_run_ceiling_keeping_explicit_pre_drain() {
+        // Cloud Run: pre_drain explicitly 0, tiny ceiling, small margin. The
+        // two drains must be scaled to fit `ceiling - margin = 8`.
+        let configured = ShutdownTimings {
+            pre_drain: Duration::ZERO,
+            http_drain: Duration::from_secs(40),
+            signer_drain: Duration::from_secs(10),
+        };
+        let ceiling = Duration::from_secs(10);
+        let margin = Duration::from_secs(2);
+
+        let result = clamp_shutdown_timings(configured, ceiling, margin, /* explicit */ true);
+
+        assert!(
+            result.clamped,
+            "GKE-sized drains must be clamped to a 10s ceiling"
+        );
+        assert_eq!(
+            result.timings.pre_drain,
+            Duration::ZERO,
+            "explicit pre_drain preserved"
+        );
+        // Must provably fit, with the margin reserved.
+        assert!(
+            result.timings.total_budget() + margin <= ceiling,
+            "clamped budget {:?} + margin {:?} must fit ceiling {:?}",
+            result.timings.total_budget(),
+            margin,
+            ceiling
+        );
+        // Proportions roughly preserved (http was 4x signer): http stays larger.
+        assert!(result.timings.http_drain > result.timings.signer_drain);
+    }
+
+    #[test]
+    fn test_clamp_scales_pre_drain_too_when_not_explicit() {
+        // Default (non-explicit) pre_drain against a tight ceiling: pre_drain
+        // is eligible for scaling so it does not eat the whole budget.
+        let configured = ShutdownTimings {
+            pre_drain: Duration::from_secs(15),
+            http_drain: Duration::from_secs(40),
+            signer_drain: Duration::from_secs(10),
+        };
+        let ceiling = Duration::from_secs(10);
+        let margin = Duration::from_secs(2);
+
+        let result = clamp_shutdown_timings(configured, ceiling, margin, /* explicit */ false);
+
+        assert!(result.clamped);
+        assert!(
+            result.timings.pre_drain > Duration::ZERO
+                && result.timings.pre_drain < Duration::from_secs(15),
+            "non-explicit pre_drain should be scaled down, not preserved or zeroed: {:?}",
+            result.timings.pre_drain
+        );
+        assert!(result.timings.total_budget() + margin <= ceiling);
+    }
+
+    #[test]
+    fn test_clamp_preserves_explicit_pre_drain_even_when_it_consumes_budget() {
+        // Operator explicitly demanded a large pre_drain on a tight ceiling:
+        // honor it (capped at available) and starve the drains rather than
+        // silently shrinking the endpoint-propagation wait they asked for.
+        let configured = ShutdownTimings {
+            pre_drain: Duration::from_secs(30),
+            http_drain: Duration::from_secs(40),
+            signer_drain: Duration::from_secs(10),
+        };
+        let ceiling = Duration::from_secs(10);
+        let margin = Duration::from_secs(2);
+
+        let result = clamp_shutdown_timings(configured, ceiling, margin, /* explicit */ true);
+
+        assert!(result.clamped);
+        // pre_drain capped at available (ceiling - margin = 8); drains squeezed to 0.
+        assert_eq!(result.timings.pre_drain, Duration::from_secs(8));
+        assert_eq!(result.timings.http_drain, Duration::ZERO);
+        assert_eq!(result.timings.signer_drain, Duration::ZERO);
+        assert!(result.timings.total_budget() + margin <= ceiling);
+    }
+
+    #[test]
+    fn test_clamp_noop_when_budget_fits() {
+        let configured = ShutdownTimings {
+            pre_drain: Duration::from_secs(1),
+            http_drain: Duration::from_secs(2),
+            signer_drain: Duration::from_secs(1),
+        };
+        let result = clamp_shutdown_timings(
+            configured,
+            Duration::from_secs(60),
+            Duration::from_secs(10),
+            true,
+        );
+        assert!(!result.clamped);
+        assert_eq!(result.timings, configured);
     }
 
     // --- Phase 4 bounded DB pool close ---

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -85,6 +85,15 @@ const DEFAULT_SHUTDOWN_GRACE_CEILING_SECS: u64 = 120;
 /// budgets fit.
 const SHUTDOWN_TEARDOWN_MARGIN: Duration = Duration::from_secs(10);
 
+/// Per-field sanity ceiling on each `SHUTDOWN_*_SECS` env var. Values above
+/// this fall back to the per-field default with a warning. 1 day is far
+/// above any plausible operational value (real drains are seconds, not
+/// hours) but prevents a typo like `SHUTDOWN_PRE_DRAIN_SECS=18446744073709551600`
+/// from making `ShutdownTimings::total_budget()` overflow — which would
+/// panic before the validate-and-warn path could surface an operator-actionable
+/// message. Three fields at the ceiling sum to 3 days, comfortably inside u64.
+const SHUTDOWN_PER_FIELD_CEILING_SECS: u64 = 24 * 3600;
+
 /// Parsed shutdown phase timings. See the `DEFAULT_SHUTDOWN_*` constants and
 /// the graceful-shutdown sequence in `async_main` for the phase breakdown.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -107,11 +116,27 @@ impl ShutdownTimings {
 }
 
 /// Read a non-negative integer duration (in seconds) from the given env var,
-/// falling back to `default_secs` if unset or unparseable. Zero is a valid
-/// value and is respected (not treated as "use default").
+/// falling back to `default_secs` if unset, unparseable, or above
+/// `SHUTDOWN_PER_FIELD_CEILING_SECS`. Zero is a valid value and is respected
+/// (not treated as "use default").
+///
+/// The per-field ceiling prevents an operator typo near `u64::MAX` from
+/// propagating into `ShutdownTimings::total_budget()` where the `+` sum
+/// would panic on overflow — which would abort the process before the
+/// validate-and-warn path could surface an operator-actionable message.
 fn parse_duration_secs_env(var: &str, default_secs: u64) -> Duration {
     match env::var(var) {
         Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(secs) if secs > SHUTDOWN_PER_FIELD_CEILING_SECS => {
+                tracing::warn!(
+                    env_var = var,
+                    value = secs,
+                    ceiling_secs = SHUTDOWN_PER_FIELD_CEILING_SECS,
+                    default_secs,
+                    "Shutdown timing env var exceeds per-field sanity ceiling; using default"
+                );
+                Duration::from_secs(default_secs)
+            }
             Ok(secs) => Duration::from_secs(secs),
             Err(_) => {
                 tracing::warn!(
@@ -1968,6 +1993,98 @@ mod tests {
         assert_eq!(timings.pre_drain, Duration::from_secs(10));
 
         clear_shutdown_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_parse_shutdown_timings_rejects_u64_max_and_falls_back_to_default() {
+        // Regression: if a misconfig sets SHUTDOWN_PRE_DRAIN_SECS near
+        // u64::MAX, `Duration::from_secs` itself is fine but the later
+        // `total_budget()` sum with `+` panics on overflow. That aborts
+        // the process before the validate-and-warn path can run, turning
+        // an operator misconfig into a raw crashloop. Parsing must clamp
+        // or reject any value above SHUTDOWN_PER_FIELD_CEILING_SECS so
+        // the sum can never overflow.
+        clear_shutdown_env();
+        std::env::set_var(
+            "SHUTDOWN_PRE_DRAIN_SECS",
+            "18446744073709551600", // u64::MAX - 15, well above the ceiling
+        );
+
+        let timings = parse_shutdown_timings();
+
+        // Fell back to default (10s), NOT the u64::MAX-ish value.
+        assert_eq!(timings.pre_drain, Duration::from_secs(10));
+
+        // And the downstream total_budget() MUST NOT panic. This is the
+        // actual safety property — the validate-and-warn path must be
+        // reachable even under this misconfig.
+        let _ = timings.total_budget(); // must not panic
+
+        clear_shutdown_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_parse_shutdown_timings_rejects_value_above_per_field_ceiling() {
+        // Exactly one second above the ceiling. Reject and fall back to
+        // default so total_budget cannot overflow and the warn-with-context
+        // path in validate_shutdown_timings still runs.
+        clear_shutdown_env();
+        let too_big = SHUTDOWN_PER_FIELD_CEILING_SECS + 1;
+        std::env::set_var("SHUTDOWN_HTTP_DRAIN_SECS", too_big.to_string());
+
+        let timings = parse_shutdown_timings();
+
+        assert_eq!(
+            timings.http_drain,
+            Duration::from_secs(DEFAULT_SHUTDOWN_HTTP_DRAIN_SECS),
+            "value above per-field ceiling must fall back to default"
+        );
+
+        clear_shutdown_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_parse_shutdown_timings_accepts_value_at_per_field_ceiling() {
+        // The ceiling itself is a legitimate value (though far above any
+        // real operational setting). Reject only values strictly greater
+        // than the ceiling, so operators can explicitly opt into the max
+        // if they know what they are doing.
+        clear_shutdown_env();
+        std::env::set_var(
+            "SHUTDOWN_PRE_DRAIN_SECS",
+            SHUTDOWN_PER_FIELD_CEILING_SECS.to_string(),
+        );
+
+        let timings = parse_shutdown_timings();
+
+        assert_eq!(
+            timings.pre_drain,
+            Duration::from_secs(SHUTDOWN_PER_FIELD_CEILING_SECS)
+        );
+
+        clear_shutdown_env();
+    }
+
+    #[test]
+    fn test_total_budget_no_overflow_at_per_field_ceiling() {
+        // Safety property: with every field at the per-field ceiling,
+        // total_budget() must not panic and must stay comfortably inside
+        // u64 range. 3 * 86400 = 259200s = 3 days, far below u64::MAX.
+        let t = ShutdownTimings {
+            pre_drain: Duration::from_secs(SHUTDOWN_PER_FIELD_CEILING_SECS),
+            http_drain: Duration::from_secs(SHUTDOWN_PER_FIELD_CEILING_SECS),
+            signer_drain: Duration::from_secs(SHUTDOWN_PER_FIELD_CEILING_SECS),
+        };
+
+        // Must not panic.
+        let total = t.total_budget();
+        assert_eq!(
+            total,
+            Duration::from_secs(3 * SHUTDOWN_PER_FIELD_CEILING_SECS)
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -61,8 +61,8 @@ const READYZ_DB_TIMEOUT: Duration = Duration::from_millis(800);
 ///
 /// Cloud Run has **no** readiness-probe-driven endpoint removal: a terminating
 /// instance is removed from routing by the platform, and peer rebalancing comes
-/// from the cluster coordinator's `leave` event (see the SIGTERM-time
-/// deregister in `async_main`), not from this pause. Set
+/// from the cluster coordinator's `leave` event (published at the start of
+/// phase 3 — see `deregister_within_signer_budget`), not from this pause. Set
 /// `SHUTDOWN_PRE_DRAIN_SECS=0` there. Override with `SHUTDOWN_PRE_DRAIN_SECS`
 /// (e.g. `0` in local dev / tests).
 const DEFAULT_SHUTDOWN_PRE_DRAIN_SECS: u64 = 15;
@@ -78,9 +78,12 @@ const DEFAULT_SHUTDOWN_PRE_DRAIN_SECS: u64 = 15;
 /// `SHUTDOWN_HTTP_DRAIN_SECS`.
 const DEFAULT_SHUTDOWN_HTTP_DRAIN_SECS: u64 = 40;
 
-/// Maximum time we wait for the relay queue, NIP-46 signer, and tracked
-/// background tasks to finish before/while tearing down the relay client.
-/// Override with `SHUTDOWN_SIGNER_DRAIN_SECS`.
+/// Budget for the whole of phase 3: the bounded cluster deregister
+/// (`CLUSTER_DEREGISTER_TIMEOUT`, carved out of this budget — see
+/// `deregister_within_signer_budget`) followed by the relay queue, NIP-46
+/// signer, and tracked background task drain before/while tearing down the
+/// relay client. Must comfortably exceed `CLUSTER_DEREGISTER_TIMEOUT` or the
+/// drain is starved. Override with `SHUTDOWN_SIGNER_DRAIN_SECS`.
 const DEFAULT_SHUTDOWN_SIGNER_DRAIN_SECS: u64 = 10;
 
 /// Upper bound on the platform's post-SIGTERM grace (the kubelet's
@@ -114,12 +117,15 @@ const DEFAULT_SHUTDOWN_TEARDOWN_MARGIN_SECS: u64 = 10;
 /// always has time to flush.
 const POOL_CLOSE_LOG_HEADROOM: Duration = Duration::from_secs(2);
 
-/// Upper bound on the SIGTERM-time cluster deregister (publish `leave` +
-/// remove from the registry). This runs concurrently with the pre-drain pause,
-/// so on GKE (pre_drain ≥ this) it adds no wall-clock; on Cloud Run
-/// (pre_drain = 0) it is the only phase-1 cost, kept small so a dead Redis
-/// cannot stall shutdown past the grace period. The Cloud Run drain budgets in
-/// `cloudbuild.yaml` are sized to absorb this worst case.
+/// Upper bound on the shutdown-time cluster deregister (publish `leave` +
+/// remove from the registry). It opens phase 3 — immediately before the relay
+/// queue closes — and is carved OUT of the `signer_drain` budget (further
+/// capped at `signer_drain` itself; see `deregister_within_signer_budget`), so
+/// it never adds wall-clock on top of the phase budgets that
+/// `validate_shutdown_timings`/`clamp_shutdown_timings` prove fit the grace
+/// ceiling. Kept small so a dead Redis cannot eat the drain budget.
+/// `signer_drain` must comfortably exceed this or the queue drain is starved —
+/// the Cloud Run sizing in `cloudbuild.yaml` accounts for it explicitly.
 const CLUSTER_DEREGISTER_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Slice of the phase-3 `signer_drain` budget reserved for a best-effort relay
@@ -154,7 +160,9 @@ struct ShutdownTimings {
 impl ShutdownTimings {
     /// Sum of all three phase durations. Does NOT include the teardown
     /// margin — add that separately when comparing against a grace-period
-    /// ceiling.
+    /// ceiling. The phase-3 cluster deregister needs no separate term:
+    /// it is carved out of `signer_drain` (see
+    /// `deregister_within_signer_budget`), so this sum already covers it.
     fn total_budget(&self) -> Duration {
         self.pre_drain + self.http_drain + self.signer_drain
     }
@@ -490,6 +498,67 @@ fn abort_join_handles(handles: &[tokio::task::AbortHandle]) {
     }
 }
 
+/// Outcome of the bounded SIGTERM-time cluster deregister that opens phase 3.
+/// All variants continue shutdown; `Failed`/`TimedOut` mean peers converge via
+/// heartbeat staleness instead of the explicit `leave` event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClusterDeregisterOutcome {
+    /// `leave` published and instance removed from the registry.
+    Deregistered,
+    /// The deregister returned an error (e.g. Redis unreachable).
+    Failed,
+    /// The deregister exceeded its slice of the `signer_drain` budget.
+    TimedOut,
+}
+
+/// Run the bounded cluster deregister that opens phase 3 and return the
+/// signer-drain budget left for the relay/tracker drain.
+///
+/// Publishing the cluster `leave` here — immediately before the relay queue
+/// closes — makes peers rebuild the hashring and take over this shard while
+/// we drain, shrinking the dual-ownership window (peer and this instance both
+/// handling the same bunker pubkeys) to Pub/Sub propagation time. Handover is
+/// deliberately at-least-once: duplicates over drops.
+///
+/// Budget accounting: the deregister is bounded by
+/// `CLUSTER_DEREGISTER_TIMEOUT.min(signer_drain)` and its elapsed wall-clock
+/// is subtracted from the returned drain budget, so phase 3's total
+/// (deregister + drain) never exceeds `signer_drain`. That keeps the
+/// deregister inside the budget already proven to fit the grace ceiling by
+/// `validate_shutdown_timings`/`clamp_shutdown_timings` — no unmodeled
+/// overhang, no reliance on slack in other constants.
+async fn deregister_within_signer_budget<F, E>(
+    deregister: F,
+    signer_drain: Duration,
+) -> (ClusterDeregisterOutcome, Duration)
+where
+    F: std::future::Future<Output = Result<(), E>>,
+    E: std::fmt::Display,
+{
+    let budget = CLUSTER_DEREGISTER_TIMEOUT.min(signer_drain);
+    // tokio::time::Instant (not std) so paused-clock tests measure the same
+    // virtual time the timeout runs on.
+    let started = tokio::time::Instant::now();
+    let outcome = match tokio::time::timeout(budget, deregister).await {
+        Ok(Ok(())) => {
+            tracing::info!("Graceful shutdown: cluster leave published, instance deregistered");
+            ClusterDeregisterOutcome::Deregistered
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "Graceful shutdown: cluster deregister failed; peers will converge via heartbeat staleness");
+            ClusterDeregisterOutcome::Failed
+        }
+        Err(_) => {
+            tracing::warn!(
+                timeout_secs = budget.as_secs(),
+                "Graceful shutdown: cluster deregister timed out (Redis slow/down); continuing"
+            );
+            ClusterDeregisterOutcome::TimedOut
+        }
+    };
+    (outcome, signer_drain.saturating_sub(started.elapsed()))
+}
+
 /// Run phase 3 under the shared `budget`, split into a drain sub-budget and a
 /// reserved relay-close slice (`RELAY_CLOSE_BUDGET`, capped at half the budget):
 ///
@@ -513,9 +582,11 @@ fn abort_join_handles(handles: &[tokio::task::AbortHandle]) {
 ///
 /// Budget contract: drain sub-budget + relay-close slice == `budget`, and only
 /// one of them runs the relay close, so total wall-clock never exceeds `budget`.
-/// This preserves the design contract enforced by `validate_shutdown_timings`/
-/// `clamp_shutdown_timings`: `pre_drain + http_drain + signer_drain +
-/// teardown_margin <= grace ceiling`.
+/// In production `budget` is the `signer_drain` remainder returned by
+/// `deregister_within_signer_budget`, so the whole of phase 3 (deregister +
+/// drain) stays within `signer_drain`. This preserves the design contract
+/// enforced by `validate_shutdown_timings`/`clamp_shutdown_timings`:
+/// `pre_drain + http_drain + signer_drain + teardown_margin <= grace ceiling`.
 ///
 /// `client_shutdown` is a factory (`Fn() -> Future`) rather than a single
 /// future so it can be invoked again on the timeout path. It is generic, along
@@ -1754,37 +1825,13 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     );
 
     // Phase 1: flip readiness and sleep so endpoint/NEG detach (GKE)
-    // propagates, AND concurrently publish the cluster `leave` event so peers
-    // rebalance off this instance immediately. The deregister is the *only*
-    // rebalance trigger on Cloud Run (no readiness-driven endpoint removal);
-    // on GKE it runs alongside endpoint detach. We join the two so peers learn
-    // we are leaving before we tear down relays, but bound the deregister so a
-    // dead Redis cannot stall shutdown. The heartbeat task is stopped as part
-    // of the deregister (it cancels the shared token), so it cannot re-register
-    // us after this point.
-    let deregister = async {
-        match tokio::time::timeout(
-            CLUSTER_DEREGISTER_TIMEOUT,
-            coordinator.deregister_and_stop_heartbeat(),
-        )
-        .await
-        {
-            Ok(Ok(())) => {
-                tracing::info!("Graceful shutdown: cluster leave published, instance deregistered")
-            }
-            Ok(Err(e)) => {
-                tracing::warn!(error = %e, "Graceful shutdown: cluster deregister failed; peers will converge via heartbeat staleness")
-            }
-            Err(_) => tracing::warn!(
-                timeout_secs = CLUSTER_DEREGISTER_TIMEOUT.as_secs(),
-                "Graceful shutdown: cluster deregister timed out (Redis slow/down); continuing"
-            ),
-        }
-    };
-    tokio::join!(
-        pre_drain_pause(&shutting_down, timings.pre_drain),
-        deregister
-    );
+    // propagates. The cluster `leave` is deliberately NOT published yet: this
+    // instance keeps sole ownership of its shard while it is still processing
+    // NIP-46 work (phases 1-2), and deregisters at the start of phase 3
+    // instead — right before the relay queue closes — so the dual-ownership
+    // window where a peer and this instance both handle the same bunker
+    // pubkeys shrinks from pre_drain+http_drain to Pub/Sub propagation time.
+    pre_drain_pause(&shutting_down, timings.pre_drain).await;
 
     // Phase 2: tell axum to stop accepting new HTTP connections and wait for
     // in-flight requests to finish.
@@ -1816,30 +1863,44 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         }
     }
 
-    // Phase 3: close the relay queue so relay workers stop accepting new
-    // events, drain queued relay work while the relay client remains connected,
-    // then tear down the relay client (stopping signer.run() subscription) and
-    // wait for signer + other tracked tasks. We do this **after** HTTP drain so
-    // NIP-46 requests that arrived before SIGTERM have a chance to complete and
-    // publish responses back to the requesting client before we disconnect from
-    // the relays. The cluster `leave` was already published in phase 1 (the
-    // coordinator is an `Arc` shared with the signer/workers and has no Drop
-    // hook, so it is NOT deregistered implicitly on return — see the explicit
-    // `deregister_and_stop_heartbeat` above).
+    // Phase 3: publish the cluster `leave` and deregister FIRST (bounded,
+    // carved out of the signer_drain budget — see
+    // `deregister_within_signer_budget`), so peers rebuild the hashring and
+    // take over this shard while we close and drain the relay queue right
+    // after. The deregister is the *only* rebalance trigger on Cloud Run (no
+    // readiness-driven endpoint removal); on GKE it follows endpoint detach.
+    // The coordinator is an `Arc` shared with the signer/workers and has no
+    // Drop hook, so it is NOT deregistered implicitly on return — this
+    // explicit call is required. The heartbeat task is stopped as part of the
+    // deregister (it cancels the shared token), so it cannot re-register us
+    // after this point.
     //
-    // `drain_signer_or_abort` bounds the whole of phase 3 by
-    // `timings.signer_drain` (split into a drain sub-budget plus a reserved
-    // relay-close slice) so `signer_drain` is a real bound — previously only
-    // the trailing `task_tracker.wait()` was bounded, leaving
+    // Then close the relay queue so relay workers stop accepting new events,
+    // drain queued relay work while the relay client remains connected, then
+    // tear down the relay client (stopping signer.run()'s subscription) and
+    // wait for signer + other tracked tasks. This runs **after** HTTP drain so
+    // NIP-46 requests that arrived before the queue closed have a chance to
+    // complete and publish responses back to the requesting client before we
+    // disconnect from the relays.
+    //
+    // `drain_signer_or_abort` bounds the drain by the signer budget REMAINING
+    // after the deregister (split into a drain sub-budget plus a reserved
+    // relay-close slice) so `signer_drain` is a real bound on the whole of
+    // phase 3, deregister included — previously only the trailing
+    // `task_tracker.wait()` was bounded, leaving
     // `client_for_shutdown.shutdown()` (a nostr_sdk WebSocket close handshake)
     // unbounded in practice. A hung close could therefore blow past the grace
     // period and swallow phase 4. The reserved slice also guarantees a graceful
     // relay close is attempted even when the drain itself times out.
     tracing::info!(
         elapsed_secs = shutdown_started_at.elapsed().as_secs(),
-        "Graceful shutdown: draining relay workers, then tearing down NIP-46 relay client and signer tasks"
+        "Graceful shutdown: deregistering from cluster, then draining relay workers and tearing down NIP-46 relay client and signer tasks"
     );
-    let signer_drain_budget = timings.signer_drain;
+    let (_deregister_outcome, signer_drain_budget) = deregister_within_signer_budget(
+        coordinator.deregister_and_stop_heartbeat(),
+        timings.signer_drain,
+    )
+    .await;
     let signer_handle_for_abort = signer_handle;
     let close_relay_queue = move || relay_queue.close();
     // Factory (not a single future) so the relay close can be re-attempted on
@@ -1864,8 +1925,9 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         }
         SignerDrainOutcome::AbortedAfterTimeout => {
             tracing::warn!(
-                signer_drain_secs = signer_drain_budget.as_secs(),
-                "Signer drain timed out (client.shutdown(), relay workers, and/or task_tracker.wait() exceeded signer_drain budget); aborted signer and relay workers"
+                signer_drain_secs = timings.signer_drain.as_secs(),
+                drain_budget_secs = signer_drain_budget.as_secs(),
+                "Signer drain timed out (client.shutdown(), relay workers, and/or task_tracker.wait() exceeded the signer_drain budget remaining after the cluster deregister); aborted signer and relay workers"
             );
         }
     }
@@ -2989,6 +3051,65 @@ mod tests {
     // are inside. On timeout it invokes the caller-supplied abort callback
     // (which aborts the
     // signer JoinHandle in production).
+
+    #[tokio::test(start_paused = true)]
+    async fn test_deregister_within_signer_budget_fast_path_keeps_full_drain_budget() {
+        // An instant deregister must not eat into the drain budget.
+        let signer_drain = Duration::from_secs(10);
+        let (outcome, remaining) =
+            deregister_within_signer_budget(async { Ok::<(), String>(()) }, signer_drain).await;
+        assert_eq!(outcome, ClusterDeregisterOutcome::Deregistered);
+        assert_eq!(remaining, signer_drain);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_deregister_within_signer_budget_hung_deregister_capped_at_cluster_timeout() {
+        // A hung Redis costs at most CLUSTER_DEREGISTER_TIMEOUT of the
+        // signer_drain budget; the rest stays available for the queue drain.
+        let signer_drain = Duration::from_secs(10);
+        let started = tokio::time::Instant::now();
+        let (outcome, remaining) = deregister_within_signer_budget(
+            std::future::pending::<Result<(), String>>(),
+            signer_drain,
+        )
+        .await;
+        assert_eq!(outcome, ClusterDeregisterOutcome::TimedOut);
+        assert_eq!(started.elapsed(), CLUSTER_DEREGISTER_TIMEOUT);
+        assert_eq!(remaining, signer_drain - CLUSTER_DEREGISTER_TIMEOUT);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_deregister_within_signer_budget_hung_deregister_capped_at_signer_drain() {
+        // When signer_drain is smaller than CLUSTER_DEREGISTER_TIMEOUT the
+        // phase-3 wall clock must still never exceed signer_drain — the
+        // deregister is carved out of the phase budget, not added on top.
+        let signer_drain = Duration::from_secs(1);
+        assert!(signer_drain < CLUSTER_DEREGISTER_TIMEOUT);
+        let started = tokio::time::Instant::now();
+        let (outcome, remaining) = deregister_within_signer_budget(
+            std::future::pending::<Result<(), String>>(),
+            signer_drain,
+        )
+        .await;
+        assert_eq!(outcome, ClusterDeregisterOutcome::TimedOut);
+        assert_eq!(started.elapsed(), signer_drain);
+        assert_eq!(remaining, Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_deregister_within_signer_budget_error_path_keeps_drain_budget() {
+        // A fast Redis error (connection refused) must not eat the drain
+        // budget either; shutdown continues and peers converge via heartbeat
+        // staleness.
+        let signer_drain = Duration::from_secs(10);
+        let (outcome, remaining) = deregister_within_signer_budget(
+            async { Err::<(), String>("redis connection refused".to_string()) },
+            signer_drain,
+        )
+        .await;
+        assert_eq!(outcome, ClusterDeregisterOutcome::Failed);
+        assert_eq!(remaining, signer_drain);
+    }
 
     #[tokio::test(start_paused = true)]
     async fn test_drain_signer_or_abort_returns_completed_when_both_finish_before_budget() {

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -47,6 +47,91 @@ use zeroize::Zeroizing;
 /// fails the probe fast instead of hanging it.
 const READYZ_DB_TIMEOUT: Duration = Duration::from_millis(800);
 
+/// Duration the process pauses between flipping the readiness probe to 503
+/// and starting to drain accepted connections. This is the window during which
+/// Kubernetes observes the failing probe and removes the pod from the Service
+/// EndpointSlice so the load balancer stops routing new traffic to us. Keeping
+/// this out of the drain budget is critical — otherwise new NIP-46 sign
+/// requests arriving during these seconds would be rejected mid-request and
+/// trigger client-side reconnect storms on scale-down. Override with
+/// `SHUTDOWN_PRE_DRAIN_SECS` (e.g. `0` in local dev / tests).
+const DEFAULT_SHUTDOWN_PRE_DRAIN_SECS: u64 = 10;
+
+/// Maximum time we wait for axum to drain in-flight HTTP requests after we
+/// stop accepting new connections. The sum of `pre_drain + http_drain +
+/// signer_drain` plus ~5–10s of teardown headroom must fit inside the
+/// Deployment's `terminationGracePeriodSeconds` — otherwise the kubelet
+/// SIGKILLs us mid-drain. Default sized for `terminationGracePeriodSeconds: 75`.
+/// Override with `SHUTDOWN_HTTP_DRAIN_SECS`.
+const DEFAULT_SHUTDOWN_HTTP_DRAIN_SECS: u64 = 45;
+
+/// Maximum time we wait for the NIP-46 signer + tracked background tasks to
+/// finish after we tear down the relay client. Override with
+/// `SHUTDOWN_SIGNER_DRAIN_SECS`.
+const DEFAULT_SHUTDOWN_SIGNER_DRAIN_SECS: u64 = 10;
+
+/// Parsed shutdown phase timings. See the `DEFAULT_SHUTDOWN_*` constants and
+/// the graceful-shutdown sequence in `async_main` for the phase breakdown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ShutdownTimings {
+    /// Sleep between setting readiness=503 and closing the accept loop.
+    pre_drain: Duration,
+    /// Maximum wait for axum HTTP drain.
+    http_drain: Duration,
+    /// Maximum wait for signer + tracked background tasks.
+    signer_drain: Duration,
+}
+
+/// Read a non-negative integer duration (in seconds) from the given env var,
+/// falling back to `default_secs` if unset or unparseable. Zero is a valid
+/// value and is respected (not treated as "use default").
+fn parse_duration_secs_env(var: &str, default_secs: u64) -> Duration {
+    match env::var(var) {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(secs) => Duration::from_secs(secs),
+            Err(_) => {
+                tracing::warn!(
+                    env_var = var,
+                    value = %raw,
+                    default_secs,
+                    "Invalid value for shutdown timing env var; using default"
+                );
+                Duration::from_secs(default_secs)
+            }
+        },
+        Err(_) => Duration::from_secs(default_secs),
+    }
+}
+
+/// Parse all three shutdown phase durations from the environment.
+fn parse_shutdown_timings() -> ShutdownTimings {
+    ShutdownTimings {
+        pre_drain: parse_duration_secs_env(
+            "SHUTDOWN_PRE_DRAIN_SECS",
+            DEFAULT_SHUTDOWN_PRE_DRAIN_SECS,
+        ),
+        http_drain: parse_duration_secs_env(
+            "SHUTDOWN_HTTP_DRAIN_SECS",
+            DEFAULT_SHUTDOWN_HTTP_DRAIN_SECS,
+        ),
+        signer_drain: parse_duration_secs_env(
+            "SHUTDOWN_SIGNER_DRAIN_SECS",
+            DEFAULT_SHUTDOWN_SIGNER_DRAIN_SECS,
+        ),
+    }
+}
+
+/// Flip the unready flag (so `/healthz/ready` returns 503) and then sleep for
+/// `duration` to give Kubernetes time to remove us from the Service
+/// EndpointSlice before we close the accept loop. Must set the flag **before**
+/// awaiting anything so the next readiness probe sees the new value.
+async fn pre_drain_pause(unready: &Arc<AtomicBool>, duration: Duration) {
+    unready.store(true, Ordering::Relaxed);
+    if duration > Duration::ZERO {
+        tokio::time::sleep(duration).await;
+    }
+}
+
 #[derive(Clone)]
 struct LivenessState {
     shutting_down: Arc<AtomicBool>,
@@ -1093,45 +1178,99 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
 
     // Wait for shutdown signal
     wait_for_shutdown_signal().await;
-    shutting_down.store(true, Ordering::Relaxed);
+
+    // --- Graceful shutdown ---
+    //
+    // Phase ordering matters. On scale-down events Kubernetes sends SIGTERM
+    // and *also* starts removing the pod from the Service EndpointSlice based
+    // on the readiness probe, but endpoint-slice propagation is asynchronous.
+    // If we stop accepting connections the instant we see SIGTERM, the LB may
+    // still be routing new NIP-46 / HTTP requests to us for several seconds
+    // and those requests fail mid-flight — the exact client-reconnect storm
+    // that issue #692 targets.
+    //
+    // So the sequence is:
+    //   1. Flip `/healthz/ready` to 503 and sleep `pre_drain`. Kubelet observes
+    //      the failing probe; the Service controller removes us from endpoints.
+    //   2. Stop accepting new HTTP connections (axum `.with_graceful_shutdown`
+    //      future resolves) and wait up to `http_drain` for in-flight requests.
+    //   3. Tear down the NIP-46 relay client (which stops `signer.run()` and
+    //      drains the relay worker queue) and wait up to `signer_drain` for
+    //      tracked background tasks.
+    //   4. Close the DB pool.
+    //
+    // Sum of `pre_drain + http_drain + signer_drain` + DB-pool-close headroom
+    // must fit inside the Deployment's `terminationGracePeriodSeconds` or the
+    // kubelet SIGKILLs us mid-drain.
+    let timings = parse_shutdown_timings();
+    let shutdown_started_at = std::time::Instant::now();
+    tracing::info!(
+        pre_drain_secs = timings.pre_drain.as_secs(),
+        http_drain_secs = timings.http_drain.as_secs(),
+        signer_drain_secs = timings.signer_drain.as_secs(),
+        "Graceful shutdown: starting pre-drain phase (readiness now 503)"
+    );
+
+    // Phase 1: flip readiness and sleep so K8s can remove us from the Service
+    // endpoints before we stop accepting.
+    pre_drain_pause(&shutting_down, timings.pre_drain).await;
+
+    // Phase 2: tell axum to stop accepting new HTTP connections and wait for
+    // in-flight requests to finish.
     shutdown_signal.notify_waiters();
-
-    tracing::info!("Shutting down gracefully...");
-
-    // Close task tracker to prevent new tasks from being spawned
+    // Close task tracker to prevent new tracked tasks from being spawned.
     task_tracker.close();
 
-    // Shutdown signer client (disconnect from relays)
-    // Note: ClusterCoordinator will be dropped automatically, triggering deregister
-    client_for_shutdown.shutdown().await;
-
-    // Wait for API server to drain (max 15s to leave buffer before Cloud Run's 30s timeout)
-    match tokio::time::timeout(Duration::from_secs(15), api_handle).await {
+    tracing::info!(
+        elapsed_secs = shutdown_started_at.elapsed().as_secs(),
+        "Graceful shutdown: draining HTTP (axum with_graceful_shutdown)"
+    );
+    match tokio::time::timeout(timings.http_drain, api_handle).await {
         Ok(result) => {
             if let Err(e) = result {
                 tracing::warn!("API server task error: {:?}", e);
             }
         }
         Err(_) => {
-            tracing::warn!("API server shutdown timed out after 15s");
+            tracing::warn!(
+                http_drain_secs = timings.http_drain.as_secs(),
+                "API server shutdown timed out"
+            );
         }
     }
 
-    // Wait for signer and other tracked tasks to complete (max 10s)
-    match tokio::time::timeout(Duration::from_secs(10), task_tracker.wait()).await {
+    // Phase 3: tear down the relay client (stops signer.run() subscription)
+    // and wait for signer + other tracked tasks. We do this **after** HTTP
+    // drain so NIP-46 requests that arrived before SIGTERM have a chance to
+    // complete and publish responses back to the requesting client before we
+    // disconnect from the relays. `ClusterCoordinator` will be dropped
+    // automatically on return, triggering deregister.
+    tracing::info!(
+        elapsed_secs = shutdown_started_at.elapsed().as_secs(),
+        "Graceful shutdown: tearing down NIP-46 relay client"
+    );
+    client_for_shutdown.shutdown().await;
+
+    match tokio::time::timeout(timings.signer_drain, task_tracker.wait()).await {
         Ok(()) => {
             tracing::info!("All tracked tasks completed");
         }
         Err(_) => {
-            tracing::warn!("Task tracker wait timed out after 10s, aborting signer");
+            tracing::warn!(
+                signer_drain_secs = timings.signer_drain.as_secs(),
+                "Task tracker wait timed out, aborting signer"
+            );
             signer_handle.abort();
         }
     }
 
-    // Close database pool
+    // Phase 4: close database pool.
     pool_for_shutdown.close().await;
 
-    tracing::info!("Graceful shutdown complete");
+    tracing::info!(
+        total_shutdown_secs = shutdown_started_at.elapsed().as_secs(),
+        "Graceful shutdown complete"
+    );
 
     Ok(())
 }
@@ -1535,5 +1674,129 @@ mod tests {
                 .unwrap();
             assert_eq!(response.status(), StatusCode::OK, "route {path} not OK");
         }
+    }
+
+    // --- Shutdown timings ---
+    //
+    // These tests exercise the env-var-driven shutdown phase durations used by
+    // the graceful-shutdown sequence in `async_main`. Values must be stable
+    // because the iac repo's `terminationGracePeriodSeconds` is tuned against
+    // them: PRE_DRAIN + HTTP_DRAIN + SIGNER_DRAIN must fit inside the grace
+    // period with margin for process teardown.
+
+    fn clear_shutdown_env() {
+        std::env::remove_var("SHUTDOWN_PRE_DRAIN_SECS");
+        std::env::remove_var("SHUTDOWN_HTTP_DRAIN_SECS");
+        std::env::remove_var("SHUTDOWN_SIGNER_DRAIN_SECS");
+    }
+
+    #[test]
+    #[serial]
+    fn test_parse_shutdown_timings_defaults() {
+        clear_shutdown_env();
+
+        let timings = parse_shutdown_timings();
+
+        // Documented defaults — see main.rs docs on graceful shutdown.
+        assert_eq!(timings.pre_drain, Duration::from_secs(10));
+        assert_eq!(timings.http_drain, Duration::from_secs(45));
+        assert_eq!(timings.signer_drain, Duration::from_secs(10));
+    }
+
+    #[test]
+    #[serial]
+    fn test_parse_shutdown_timings_overrides_each_field() {
+        clear_shutdown_env();
+        std::env::set_var("SHUTDOWN_PRE_DRAIN_SECS", "3");
+        std::env::set_var("SHUTDOWN_HTTP_DRAIN_SECS", "20");
+        std::env::set_var("SHUTDOWN_SIGNER_DRAIN_SECS", "5");
+
+        let timings = parse_shutdown_timings();
+
+        assert_eq!(timings.pre_drain, Duration::from_secs(3));
+        assert_eq!(timings.http_drain, Duration::from_secs(20));
+        assert_eq!(timings.signer_drain, Duration::from_secs(5));
+
+        clear_shutdown_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_parse_shutdown_timings_accepts_zero() {
+        // Zero is a legitimate value for tests and local dev: skip the
+        // endpoint-propagation wait, drain as fast as possible. It must NOT
+        // collapse back to the default.
+        clear_shutdown_env();
+        std::env::set_var("SHUTDOWN_PRE_DRAIN_SECS", "0");
+        std::env::set_var("SHUTDOWN_HTTP_DRAIN_SECS", "0");
+        std::env::set_var("SHUTDOWN_SIGNER_DRAIN_SECS", "0");
+
+        let timings = parse_shutdown_timings();
+
+        assert_eq!(timings.pre_drain, Duration::ZERO);
+        assert_eq!(timings.http_drain, Duration::ZERO);
+        assert_eq!(timings.signer_drain, Duration::ZERO);
+
+        clear_shutdown_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_parse_shutdown_timings_invalid_value_falls_back_to_default() {
+        // An unparseable value should fall through to the default rather than
+        // panic at startup — we'd rather ship with a sane default than crash.
+        clear_shutdown_env();
+        std::env::set_var("SHUTDOWN_PRE_DRAIN_SECS", "not-a-number");
+
+        let timings = parse_shutdown_timings();
+
+        assert_eq!(timings.pre_drain, Duration::from_secs(10));
+
+        clear_shutdown_env();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_pre_drain_pause_flips_unready_before_sleeping() {
+        // The pre-drain pause exists so K8s can remove the pod from the
+        // Service EndpointSlice (readiness probe failing) BEFORE we stop
+        // accepting new connections. The AtomicBool MUST be set to true
+        // before the sleep — otherwise the probe never fails and the grace
+        // window is wasted.
+
+        let unready = Arc::new(AtomicBool::new(false));
+        let unready_for_task = unready.clone();
+
+        let pause_handle = tokio::spawn(async move {
+            pre_drain_pause(&unready_for_task, Duration::from_secs(5)).await
+        });
+
+        // Yield once so the spawned task gets a chance to set the flag before
+        // the `tokio::time` pause machinery advances. With start_paused=true
+        // real time is frozen; only `tokio::time::advance` or awaiting a
+        // sleep moves it. The flag is set synchronously before the first
+        // `.await` inside `pre_drain_pause`, so a yield is enough.
+        tokio::task::yield_now().await;
+
+        assert!(
+            unready.load(Ordering::Relaxed),
+            "pre_drain_pause must flip unready before sleeping so /healthz/ready starts returning 503 immediately"
+        );
+
+        // Now advance virtual time past the sleep and confirm the function
+        // returns (no hang, no early return before the sleep).
+        tokio::time::advance(Duration::from_secs(5)).await;
+        pause_handle.await.expect("pre_drain_pause panicked");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_pre_drain_pause_with_zero_duration_returns_immediately() {
+        // Local dev / tests set SHUTDOWN_PRE_DRAIN_SECS=0 to skip the wait.
+        // The function must still set the flag and then return without
+        // requiring any time to pass.
+        let unready = Arc::new(AtomicBool::new(false));
+
+        pre_drain_pause(&unready, Duration::ZERO).await;
+
+        assert!(unready.load(Ordering::Relaxed));
     }
 }

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -71,13 +71,12 @@ const DEFAULT_SHUTDOWN_HTTP_DRAIN_SECS: u64 = 45;
 const DEFAULT_SHUTDOWN_SIGNER_DRAIN_SECS: u64 = 10;
 
 /// Conservative upper bound on the Deployment's `terminationGracePeriodSeconds`
-/// used at startup to sanity-check the shutdown phase budgets. The iac repo
-/// (TODO(#692): track in divinevideo/divine-iac-coreconfig sibling PR) targets
-/// 75s but the issue spec accepts 60–90s; 120s covers the full range with
-/// headroom. If an operator bumps grace higher they can raise this via
-/// `SHUTDOWN_GRACE_PERIOD_CEILING_SECS`. This constant does NOT change the
-/// kubelet behavior — it is purely a misconfig guardrail.
-const DEFAULT_SHUTDOWN_GRACE_CEILING_SECS: u64 = 120;
+/// used at startup to sanity-check the shutdown phase budgets. The default must
+/// match the intended Deployment grace period so validation cannot pass against
+/// a ceiling higher than the kubelet actually enforces. If an operator bumps
+/// grace higher they can raise this via `SHUTDOWN_GRACE_PERIOD_CEILING_SECS`.
+/// This constant does NOT change kubelet behavior — it is purely a guardrail.
+const DEFAULT_SHUTDOWN_GRACE_CEILING_SECS: u64 = 75;
 
 /// Headroom reserved between the end of the phased drain and the kubelet
 /// SIGKILL for DB pool close, tracing flush, and other post-drain cleanup.
@@ -2272,11 +2271,12 @@ mod tests {
     fn test_parse_shutdown_grace_ceiling_default() {
         clear_shutdown_ceiling_env();
 
-        // Default matches DEFAULT_SHUTDOWN_GRACE_CEILING_SECS. Chosen to be
-        // an upper bound that covers the iac PR's 60–90s range with headroom.
+        // Default must match the intended Deployment grace period. A default
+        // higher than the real pod grace would let unsafe phase budgets pass
+        // validation locally and only fail later under kubelet SIGKILL.
         assert_eq!(
             parse_shutdown_grace_ceiling(),
-            Duration::from_secs(DEFAULT_SHUTDOWN_GRACE_CEILING_SECS)
+            Duration::from_secs(75)
         );
     }
 

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -281,12 +281,12 @@ enum HttpDrainOutcome {
     AbortedAfterTimeout,
 }
 
-/// Result of awaiting phase 3 (relay client teardown + tracked task drain)
-/// under the `signer_drain` budget.
+/// Result of awaiting phase 3 (relay client teardown + relay worker drain +
+/// tracked task drain) under the `signer_drain` budget.
 #[derive(Debug)]
 enum SignerDrainOutcome {
-    /// Both `client.shutdown()` and `task_tracker.wait()` finished before
-    /// the shared phase budget elapsed.
+    /// `client.shutdown()`, relay worker joins, and `task_tracker.wait()`
+    /// finished before the shared phase budget elapsed.
     Completed,
     /// The shared phase budget elapsed before both futures finished. The
     /// abort callback was invoked to stop the signer task; the caller can
@@ -294,16 +294,38 @@ enum SignerDrainOutcome {
     AbortedAfterTimeout,
 }
 
+/// Await relay worker handles until they finish after the queue is closed.
+async fn wait_for_join_handles(handles: Vec<tokio::task::JoinHandle<()>>) {
+    for handle in handles {
+        match handle.await {
+            Ok(()) => {}
+            Err(error) if error.is_cancelled() => {
+                tracing::debug!("Relay worker task cancelled during shutdown");
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "Relay worker task failed during shutdown");
+            }
+        }
+    }
+}
+
+fn abort_join_handles(handles: &[tokio::task::AbortHandle]) {
+    for handle in handles {
+        handle.abort();
+    }
+}
+
 /// Run phase 3 under a single shared `budget`: await `client_shutdown`
-/// (which stops `signer.run()` and the relay worker loop so in-flight
-/// sign responses can still be published on the way out) followed by
-/// `tracker_wait` (which waits for tracked background tasks to finish).
+/// (which stops `signer.run()`), close the relay queue so workers drain and
+/// exit, await `relay_worker_handles`, then await `tracker_wait` (which waits
+/// for tracked background tasks to finish).
 ///
-/// On timeout the caller-supplied `abort_signer` callback is invoked —
-/// in production this calls `signer_handle.abort()` — and the helper
-/// returns `AbortedAfterTimeout`. The entire phase is bounded by
-/// `budget` via one outer `tokio::time::timeout`, so the helper returns
-/// in at most `budget` regardless of which sub-future (or both) hangs.
+/// On timeout the caller-supplied `abort_signer` callback is invoked — in
+/// production this calls `signer_handle.abort()` — and any unfinished relay
+/// worker handles are aborted before returning `AbortedAfterTimeout`. The
+/// entire phase is bounded by `budget` via one outer `tokio::time::timeout`, so
+/// the helper returns in at most `budget` regardless of which sub-future (or
+/// relay worker) hangs.
 ///
 /// Why one shared budget, not two independent ones: the design contract
 /// enforced by `validate_shutdown_timings` is
@@ -324,25 +346,35 @@ enum SignerDrainOutcome {
 /// behaviour can be exercised deterministically with `tokio::time::pause`
 /// in tests without standing up a real `nostr_sdk::Client` or a real
 /// signer `JoinHandle`.
-async fn drain_signer_or_abort<C, W, A>(
+async fn drain_signer_or_abort<C, Q, W, A>(
     client_shutdown: C,
+    close_relay_queue: Q,
+    relay_worker_handles: Vec<tokio::task::JoinHandle<()>>,
     tracker_wait: W,
     abort_signer: A,
     budget: Duration,
 ) -> SignerDrainOutcome
 where
     C: std::future::Future<Output = ()>,
+    Q: FnOnce(),
     W: std::future::Future<Output = ()>,
     A: FnOnce(),
 {
+    let relay_worker_abort_handles: Vec<_> = relay_worker_handles
+        .iter()
+        .map(tokio::task::JoinHandle::abort_handle)
+        .collect();
     let combined = async move {
         client_shutdown.await;
+        close_relay_queue();
+        wait_for_join_handles(relay_worker_handles).await;
         tracker_wait.await;
     };
     match tokio::time::timeout(budget, combined).await {
         Ok(()) => SignerDrainOutcome::Completed,
         Err(_) => {
             abort_signer();
+            abort_join_handles(&relay_worker_abort_handles);
             SignerDrainOutcome::AbortedAfterTimeout
         }
     }
@@ -1077,7 +1109,7 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or_else(|| num_cpus::get().max(4) * 2);
-    let _relay_worker_handles = relay_queue.spawn_workers(
+    let relay_worker_handles = relay_queue.spawn_workers(
         num_workers,
         signer.handlers(),
         signer.client(),
@@ -1531,12 +1563,13 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         }
     }
 
-    // Phase 3: tear down the relay client (stops signer.run() subscription)
-    // and wait for signer + other tracked tasks. We do this **after** HTTP
-    // drain so NIP-46 requests that arrived before SIGTERM have a chance to
-    // complete and publish responses back to the requesting client before we
-    // disconnect from the relays. `ClusterCoordinator` will be dropped
-    // automatically on return, triggering deregister.
+    // Phase 3: tear down the relay client (stops signer.run() subscription),
+    // close the relay queue so relay workers drain and exit, and wait for
+    // signer + other tracked tasks. We do this **after** HTTP drain so NIP-46
+    // requests that arrived before SIGTERM have a chance to complete and
+    // publish responses back to the requesting client before we disconnect
+    // from the relays. `ClusterCoordinator` will be dropped automatically on
+    // return, triggering deregister.
     //
     // `drain_signer_or_abort` applies ONE outer `tokio::time::timeout`
     // at `timings.signer_drain` across both awaits so `signer_drain`
@@ -1551,8 +1584,11 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     );
     let signer_drain_budget = timings.signer_drain;
     let signer_handle_for_abort = signer_handle;
+    let close_relay_queue = move || drop(relay_queue);
     match drain_signer_or_abort(
         client_for_shutdown.shutdown(),
+        close_relay_queue,
+        relay_worker_handles,
         task_tracker.wait(),
         || signer_handle_for_abort.abort(),
         signer_drain_budget,
@@ -1565,7 +1601,7 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         SignerDrainOutcome::AbortedAfterTimeout => {
             tracing::warn!(
                 signer_drain_secs = signer_drain_budget.as_secs(),
-                "Signer drain timed out (client.shutdown() and/or task_tracker.wait() exceeded signer_drain budget); aborted signer"
+                "Signer drain timed out (client.shutdown(), relay workers, and/or task_tracker.wait() exceeded signer_drain budget); aborted signer and relay workers"
             );
         }
     }
@@ -2515,9 +2551,12 @@ mod tests {
         let tracker_wait = async {
             tokio::time::sleep(Duration::from_secs(1)).await;
         };
+        let relay_worker_handles = Vec::new();
 
         let outcome = drain_signer_or_abort(
             client_shutdown,
+            || {},
+            relay_worker_handles,
             tracker_wait,
             abort_signer,
             Duration::from_secs(10),
@@ -2532,6 +2571,133 @@ mod tests {
         assert!(
             !abort_called.load(Ordering::Relaxed),
             "abort_signer must NOT be called on the happy path"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_drain_signer_or_abort_closes_queue_and_waits_for_relay_workers() {
+        // Regression target: relay workers spawned by RelayQueue are not in
+        // TaskTracker. Phase 3 must explicitly close the relay queue and await
+        // those worker handles before reporting Completed, otherwise phase 4
+        // can close the DB pool while relay workers are still processing queued
+        // NIP-46 requests.
+        let queue_closed = Arc::new(AtomicBool::new(false));
+        let worker_finished = Arc::new(AtomicBool::new(false));
+        let abort_called = Arc::new(AtomicBool::new(false));
+
+        let queue_closed_for_worker = queue_closed.clone();
+        let worker_finished_for_worker = worker_finished.clone();
+        let relay_worker_handles = vec![tokio::spawn(async move {
+            while !queue_closed_for_worker.load(Ordering::Relaxed) {
+                tokio::task::yield_now().await;
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            worker_finished_for_worker.store(true, Ordering::Relaxed);
+        })];
+
+        let queue_closed_for_cb = queue_closed.clone();
+        let close_relay_queue = move || {
+            queue_closed_for_cb.store(true, Ordering::Relaxed);
+        };
+        let abort_called_cb = abort_called.clone();
+        let abort_signer = move || {
+            abort_called_cb.store(true, Ordering::Relaxed);
+        };
+
+        let outcome = drain_signer_or_abort(
+            async {},
+            close_relay_queue,
+            relay_worker_handles,
+            async {},
+            abort_signer,
+            Duration::from_secs(10),
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, SignerDrainOutcome::Completed),
+            "expected Completed, got {:?}",
+            outcome
+        );
+        assert!(
+            queue_closed.load(Ordering::Relaxed),
+            "phase 3 must close the relay queue before waiting for relay workers"
+        );
+        assert!(
+            worker_finished.load(Ordering::Relaxed),
+            "phase 3 must wait for relay worker handles before reporting Completed"
+        );
+        assert!(
+            !abort_called.load(Ordering::Relaxed),
+            "abort_signer must NOT be called on the happy path"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_drain_signer_or_abort_aborts_relay_workers_on_timeout() {
+        // If a relay worker is stuck past signer_drain, dropping its JoinHandle
+        // is insufficient: tokio keeps the task running. Phase 3 must abort
+        // the relay worker handles on the timeout path before phase 4 closes
+        // the DB pool.
+        let queue_closed = Arc::new(AtomicBool::new(false));
+        let abort_called = Arc::new(AtomicBool::new(false));
+        let relay_worker_aborted = Arc::new(AtomicBool::new(false));
+
+        struct MarkOnDrop {
+            dropped: Arc<AtomicBool>,
+        }
+
+        impl Drop for MarkOnDrop {
+            fn drop(&mut self) {
+                self.dropped.store(true, Ordering::Relaxed);
+            }
+        }
+
+        let relay_worker_aborted_for_task = relay_worker_aborted.clone();
+        let relay_worker_handles = vec![tokio::spawn(async move {
+            let mark_on_drop = MarkOnDrop {
+                dropped: relay_worker_aborted_for_task,
+            };
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            std::mem::forget(mark_on_drop);
+        })];
+
+        let queue_closed_for_cb = queue_closed.clone();
+        let close_relay_queue = move || {
+            queue_closed_for_cb.store(true, Ordering::Relaxed);
+        };
+        let abort_called_cb = abort_called.clone();
+        let abort_signer = move || {
+            abort_called_cb.store(true, Ordering::Relaxed);
+        };
+
+        let outcome = drain_signer_or_abort(
+            async {},
+            close_relay_queue,
+            relay_worker_handles,
+            async {},
+            abort_signer,
+            Duration::from_secs(10),
+        )
+        .await;
+        tokio::task::yield_now().await;
+
+        assert!(
+            matches!(outcome, SignerDrainOutcome::AbortedAfterTimeout),
+            "expected AbortedAfterTimeout, got {:?}",
+            outcome
+        );
+        assert!(
+            queue_closed.load(Ordering::Relaxed),
+            "phase 3 must close the relay queue even when a worker exceeds signer_drain"
+        );
+        assert!(
+            abort_called.load(Ordering::Relaxed),
+            "abort_signer must be called when the shared phase budget is exceeded"
+        );
+        assert!(
+            relay_worker_aborted.load(Ordering::Relaxed),
+            "relay worker handle must be aborted on timeout, not just dropped"
         );
     }
 
@@ -2558,9 +2724,12 @@ mod tests {
             // and never completes inside the budget.
             tokio::time::sleep(Duration::from_secs(0)).await;
         };
+        let relay_worker_handles = Vec::new();
 
         let outcome = drain_signer_or_abort(
             client_shutdown,
+            || {},
+            relay_worker_handles,
             tracker_wait,
             abort_signer,
             Duration::from_secs(10),
@@ -2599,9 +2768,12 @@ mod tests {
         let tracker_wait = async {
             tokio::time::sleep(Duration::from_secs(3600)).await;
         };
+        let relay_worker_handles = Vec::new();
 
         let outcome = drain_signer_or_abort(
             client_shutdown,
+            || {},
+            relay_worker_handles,
             tracker_wait,
             abort_signer,
             Duration::from_secs(10),
@@ -2636,9 +2808,17 @@ mod tests {
             tokio::time::sleep(Duration::from_secs(3600)).await;
         };
         let abort_signer = || {};
+        let relay_worker_handles = Vec::new();
 
-        let _outcome =
-            drain_signer_or_abort(client_shutdown, tracker_wait, abort_signer, budget).await;
+        let _outcome = drain_signer_or_abort(
+            client_shutdown,
+            || {},
+            relay_worker_handles,
+            tracker_wait,
+            abort_signer,
+            budget,
+        )
+        .await;
         let elapsed = start.elapsed();
 
         assert!(
@@ -2673,9 +2853,17 @@ mod tests {
         let tracker_wait = async {
             tokio::time::sleep(Duration::from_secs(8)).await;
         };
+        let relay_worker_handles = Vec::new();
 
-        let outcome =
-            drain_signer_or_abort(client_shutdown, tracker_wait, abort_signer, budget).await;
+        let outcome = drain_signer_or_abort(
+            client_shutdown,
+            || {},
+            relay_worker_handles,
+            tracker_wait,
+            abort_signer,
+            budget,
+        )
+        .await;
         let elapsed = start.elapsed();
 
         assert!(

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -1585,7 +1585,7 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     );
     let signer_drain_budget = timings.signer_drain;
     let signer_handle_for_abort = signer_handle;
-    let close_relay_queue = move || drop(relay_queue);
+    let close_relay_queue = move || relay_queue.close();
     match drain_signer_or_abort(
         client_for_shutdown.shutdown(),
         close_relay_queue,
@@ -2641,6 +2641,56 @@ mod tests {
         assert!(
             !abort_called.load(Ordering::Relaxed),
             "abort_signer must NOT be called on the happy path"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_drain_signer_or_abort_completes_with_retained_relay_sender_clone() {
+        let relay_queue = RelayQueue::new();
+        let retained_sender = relay_queue.sender();
+        let worker_sender_view = retained_sender.clone();
+        let abort_called = Arc::new(AtomicBool::new(false));
+        let worker_finished = Arc::new(AtomicBool::new(false));
+
+        let worker_finished_for_task = worker_finished.clone();
+        let relay_worker_handles = vec![tokio::spawn(async move {
+            while !worker_sender_view.is_closed() {
+                tokio::task::yield_now().await;
+            }
+            worker_finished_for_task.store(true, Ordering::Relaxed);
+        })];
+
+        let abort_called_cb = abort_called.clone();
+        let abort_signer = move || {
+            abort_called_cb.store(true, Ordering::Relaxed);
+        };
+
+        let outcome = drain_signer_or_abort(
+            async {},
+            move || relay_queue.close(),
+            relay_worker_handles,
+            async {},
+            abort_signer,
+            Duration::from_secs(10),
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, SignerDrainOutcome::Completed),
+            "expected Completed with retained RelaySender clone, got {:?}",
+            outcome
+        );
+        assert!(
+            retained_sender.is_closed(),
+            "explicit close must be visible through retained RelaySender clones"
+        );
+        assert!(
+            worker_finished.load(Ordering::Relaxed),
+            "phase 3 must drain relay workers after explicit close"
+        );
+        assert!(
+            !abort_called.load(Ordering::Relaxed),
+            "retained RelaySender clones must not force the timeout path"
         );
     }
 

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -65,9 +65,9 @@ const DEFAULT_SHUTDOWN_PRE_DRAIN_SECS: u64 = 10;
 /// Override with `SHUTDOWN_HTTP_DRAIN_SECS`.
 const DEFAULT_SHUTDOWN_HTTP_DRAIN_SECS: u64 = 45;
 
-/// Maximum time we wait for the NIP-46 signer + tracked background tasks to
-/// finish after we tear down the relay client. Override with
-/// `SHUTDOWN_SIGNER_DRAIN_SECS`.
+/// Maximum time we wait for the relay queue, NIP-46 signer, and tracked
+/// background tasks to finish before/while tearing down the relay client.
+/// Override with `SHUTDOWN_SIGNER_DRAIN_SECS`.
 const DEFAULT_SHUTDOWN_SIGNER_DRAIN_SECS: u64 = 10;
 
 /// Conservative upper bound on the Deployment's `terminationGracePeriodSeconds`
@@ -314,10 +314,11 @@ fn abort_join_handles(handles: &[tokio::task::AbortHandle]) {
     }
 }
 
-/// Run phase 3 under a single shared `budget`: await `client_shutdown`
-/// (which stops `signer.run()`), close the relay queue so workers drain and
-/// exit, await `relay_worker_handles`, then await `tracker_wait` (which waits
-/// for tracked background tasks to finish).
+/// Run phase 3 under a single shared `budget`: close the relay queue so workers
+/// drain and exit while the relay client is still connected, await
+/// `relay_worker_handles`, await `client_shutdown` (which stops `signer.run()`),
+/// then await `tracker_wait` (which waits for tracked background tasks to
+/// finish).
 ///
 /// On timeout the caller-supplied `abort_signer` callback is invoked — in
 /// production this calls `signer_handle.abort()` — and any unfinished relay
@@ -364,9 +365,9 @@ where
         .map(tokio::task::JoinHandle::abort_handle)
         .collect();
     let combined = async move {
-        client_shutdown.await;
         close_relay_queue();
         wait_for_join_handles(relay_worker_handles).await;
+        client_shutdown.await;
         tracker_wait.await;
     };
     match tokio::time::timeout(budget, combined).await {
@@ -1562,13 +1563,14 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         }
     }
 
-    // Phase 3: tear down the relay client (stops signer.run() subscription),
-    // close the relay queue so relay workers drain and exit, and wait for
-    // signer + other tracked tasks. We do this **after** HTTP drain so NIP-46
-    // requests that arrived before SIGTERM have a chance to complete and
-    // publish responses back to the requesting client before we disconnect
-    // from the relays. `ClusterCoordinator` will be dropped automatically on
-    // return, triggering deregister.
+    // Phase 3: close the relay queue so relay workers stop accepting new
+    // events, drain queued relay work while the relay client remains connected,
+    // then tear down the relay client (stopping signer.run() subscription) and
+    // wait for signer + other tracked tasks. We do this **after** HTTP drain so
+    // NIP-46 requests that arrived before SIGTERM have a chance to complete and
+    // publish responses back to the requesting client before we disconnect from
+    // the relays. `ClusterCoordinator` will be dropped automatically on return,
+    // triggering deregister.
     //
     // `drain_signer_or_abort` applies ONE outer `tokio::time::timeout`
     // at `timings.signer_drain` across both awaits so `signer_drain`
@@ -1579,7 +1581,7 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     // blow past `terminationGracePeriodSeconds` and swallow phase 4.
     tracing::info!(
         elapsed_secs = shutdown_started_at.elapsed().as_secs(),
-        "Graceful shutdown: tearing down NIP-46 relay client and draining signer tasks"
+        "Graceful shutdown: draining relay workers, then tearing down NIP-46 relay client and signer tasks"
     );
     let signer_drain_budget = timings.signer_drain;
     let signer_handle_for_abort = signer_handle;
@@ -2274,10 +2276,7 @@ mod tests {
         // Default must match the intended Deployment grace period. A default
         // higher than the real pod grace would let unsafe phase budgets pass
         // validation locally and only fail later under kubelet SIGKILL.
-        assert_eq!(
-            parse_shutdown_grace_ceiling(),
-            Duration::from_secs(75)
-        );
+        assert_eq!(parse_shutdown_grace_ceiling(), Duration::from_secs(75));
     }
 
     #[test]
@@ -2518,8 +2517,8 @@ mod tests {
 
     // --- Phase 3 bounded signer drain ---
     //
-    // Phase 3 runs `client_for_shutdown.shutdown().await` followed by
-    // `task_tracker.wait().await`. Previously `client.shutdown()` was
+    // Phase 3 drains relay workers, runs `client_for_shutdown.shutdown().await`,
+    // then `task_tracker.wait().await`. Previously `client.shutdown()` was
     // unbounded: a stuck WebSocket close handshake, a bug in
     // `nostr_sdk::Client::shutdown`, or a dead relay socket could hang
     // the phase past `terminationGracePeriodSeconds` and swallow phase 4
@@ -2575,7 +2574,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_drain_signer_or_abort_closes_queue_and_waits_for_relay_workers() {
+    async fn test_drain_signer_or_abort_drains_relay_workers_before_client_shutdown() {
         // Regression target: relay workers spawned by RelayQueue are not in
         // TaskTracker. Phase 3 must explicitly close the relay queue and await
         // those worker handles before reporting Completed, otherwise phase 4
@@ -2603,9 +2602,21 @@ mod tests {
         let abort_signer = move || {
             abort_called_cb.store(true, Ordering::Relaxed);
         };
+        let queue_closed_for_client = queue_closed.clone();
+        let worker_finished_for_client = worker_finished.clone();
+        let client_shutdown = async move {
+            assert!(
+                queue_closed_for_client.load(Ordering::Relaxed),
+                "phase 3 must close relay intake before shutting down the relay client"
+            );
+            assert!(
+                worker_finished_for_client.load(Ordering::Relaxed),
+                "phase 3 must drain relay workers before shutting down the relay client"
+            );
+        };
 
         let outcome = drain_signer_or_abort(
-            async {},
+            client_shutdown,
             close_relay_queue,
             relay_worker_handles,
             async {},

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -281,6 +281,73 @@ enum HttpDrainOutcome {
     AbortedAfterTimeout,
 }
 
+/// Result of awaiting phase 3 (relay client teardown + tracked task drain)
+/// under the `signer_drain` budget.
+#[derive(Debug)]
+enum SignerDrainOutcome {
+    /// Both `client.shutdown()` and `task_tracker.wait()` finished before
+    /// the shared phase budget elapsed.
+    Completed,
+    /// The shared phase budget elapsed before both futures finished. The
+    /// abort callback was invoked to stop the signer task; the caller can
+    /// safely proceed to phase 4 (DB pool close).
+    AbortedAfterTimeout,
+}
+
+/// Run phase 3 under a single shared `budget`: await `client_shutdown`
+/// (which stops `signer.run()` and the relay worker loop so in-flight
+/// sign responses can still be published on the way out) followed by
+/// `tracker_wait` (which waits for tracked background tasks to finish).
+///
+/// On timeout the caller-supplied `abort_signer` callback is invoked —
+/// in production this calls `signer_handle.abort()` — and the helper
+/// returns `AbortedAfterTimeout`. The entire phase is bounded by
+/// `budget` via one outer `tokio::time::timeout`, so the helper returns
+/// in at most `budget` regardless of which sub-future (or both) hangs.
+///
+/// Why one shared budget, not two independent ones: the design contract
+/// enforced by `validate_shutdown_timings` is
+/// `pre_drain + http_drain + signer_drain + SHUTDOWN_TEARDOWN_MARGIN
+/// <= terminationGracePeriodSeconds`. If each inner await got its own
+/// `budget`-sized timeout, phase 3 could take up to `2 * signer_drain`
+/// in the worst case and silently bust the contract.
+///
+/// Previously `client_shutdown` (`nostr_sdk::Client::shutdown`) was
+/// awaited unbounded in `async_main` and only the trailing `tracker_wait`
+/// was wrapped in `timeout(signer_drain, ...)`. A hung WebSocket close
+/// handshake, a bug in `Client::shutdown`, or a dead relay socket would
+/// therefore block phase 3 past the kubelet SIGKILL at
+/// `terminationGracePeriodSeconds`, swallowing phase 4 entirely. This
+/// helper makes `signer_drain` a real phase-3 bound.
+///
+/// Generic over both inner futures and the abort callback so the timeout
+/// behaviour can be exercised deterministically with `tokio::time::pause`
+/// in tests without standing up a real `nostr_sdk::Client` or a real
+/// signer `JoinHandle`.
+async fn drain_signer_or_abort<C, W, A>(
+    client_shutdown: C,
+    tracker_wait: W,
+    abort_signer: A,
+    budget: Duration,
+) -> SignerDrainOutcome
+where
+    C: std::future::Future<Output = ()>,
+    W: std::future::Future<Output = ()>,
+    A: FnOnce(),
+{
+    let combined = async move {
+        client_shutdown.await;
+        tracker_wait.await;
+    };
+    match tokio::time::timeout(budget, combined).await {
+        Ok(()) => SignerDrainOutcome::Completed,
+        Err(_) => {
+            abort_signer();
+            SignerDrainOutcome::AbortedAfterTimeout
+        }
+    }
+}
+
 /// Await the axum server's `JoinHandle` for up to `budget`. If it finishes
 /// in time, return `Completed`. Otherwise call `abort()` on the task,
 /// await its cancellation, and return `AbortedAfterTimeout`.
@@ -1470,22 +1537,36 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     // complete and publish responses back to the requesting client before we
     // disconnect from the relays. `ClusterCoordinator` will be dropped
     // automatically on return, triggering deregister.
+    //
+    // `drain_signer_or_abort` applies ONE outer `tokio::time::timeout`
+    // at `timings.signer_drain` across both awaits so `signer_drain`
+    // is a real bound on the whole of phase 3 — previously only the
+    // trailing `task_tracker.wait()` was bounded, leaving
+    // `client_for_shutdown.shutdown()` (a nostr_sdk WebSocket close
+    // handshake) unbounded in practice. A hung close could therefore
+    // blow past `terminationGracePeriodSeconds` and swallow phase 4.
     tracing::info!(
         elapsed_secs = shutdown_started_at.elapsed().as_secs(),
-        "Graceful shutdown: tearing down NIP-46 relay client"
+        "Graceful shutdown: tearing down NIP-46 relay client and draining signer tasks"
     );
-    client_for_shutdown.shutdown().await;
-
-    match tokio::time::timeout(timings.signer_drain, task_tracker.wait()).await {
-        Ok(()) => {
+    let signer_drain_budget = timings.signer_drain;
+    let signer_handle_for_abort = signer_handle;
+    match drain_signer_or_abort(
+        client_for_shutdown.shutdown(),
+        task_tracker.wait(),
+        || signer_handle_for_abort.abort(),
+        signer_drain_budget,
+    )
+    .await
+    {
+        SignerDrainOutcome::Completed => {
             tracing::info!("All tracked tasks completed");
         }
-        Err(_) => {
+        SignerDrainOutcome::AbortedAfterTimeout => {
             tracing::warn!(
-                signer_drain_secs = timings.signer_drain.as_secs(),
-                "Task tracker wait timed out, aborting signer"
+                signer_drain_secs = signer_drain_budget.as_secs(),
+                "Signer drain timed out (client.shutdown() and/or task_tracker.wait() exceeded signer_drain budget); aborted signer"
             );
-            signer_handle.abort();
         }
     }
 
@@ -2396,6 +2477,221 @@ mod tests {
             "close_within_margin must return within the margin, not block on the inner future; elapsed={:?}, margin={:?}",
             elapsed,
             margin
+        );
+    }
+
+    // --- Phase 3 bounded signer drain ---
+    //
+    // Phase 3 runs `client_for_shutdown.shutdown().await` followed by
+    // `task_tracker.wait().await`. Previously `client.shutdown()` was
+    // unbounded: a stuck WebSocket close handshake, a bug in
+    // `nostr_sdk::Client::shutdown`, or a dead relay socket could hang
+    // the phase past `terminationGracePeriodSeconds` and swallow phase 4
+    // entirely. The `signer_drain` timeout only wrapped the trailing
+    // `task_tracker.wait()`, silently busting the design contract
+    // (enforced by `validate_shutdown_timings`) that `pre_drain +
+    // http_drain + signer_drain + SHUTDOWN_TEARDOWN_MARGIN <= ceiling`.
+    //
+    // `drain_signer_or_abort` applies ONE outer `timeout(signer_drain,
+    // ...)` over the whole phase so `signer_drain` is a real bound on
+    // phase 3 regardless of how many awaits are inside. On timeout it
+    // invokes the caller-supplied abort callback (which aborts the
+    // signer JoinHandle in production).
+
+    #[tokio::test(start_paused = true)]
+    async fn test_drain_signer_or_abort_returns_completed_when_both_finish_before_budget() {
+        // Fast path: both client.shutdown() and task_tracker.wait()
+        // complete inside the signer_drain budget. Should report
+        // Completed and NOT invoke the abort callback.
+        let abort_called = Arc::new(AtomicBool::new(false));
+        let abort_called_cb = abort_called.clone();
+        let abort_signer = move || {
+            abort_called_cb.store(true, Ordering::Relaxed);
+        };
+
+        let client_shutdown = async {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        };
+        let tracker_wait = async {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        };
+
+        let outcome = drain_signer_or_abort(
+            client_shutdown,
+            tracker_wait,
+            abort_signer,
+            Duration::from_secs(10),
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, SignerDrainOutcome::Completed),
+            "expected Completed, got {:?}",
+            outcome
+        );
+        assert!(
+            !abort_called.load(Ordering::Relaxed),
+            "abort_signer must NOT be called on the happy path"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_drain_signer_or_abort_aborts_when_client_shutdown_hangs() {
+        // Regression target: the reviewer-flagged failure mode. The
+        // client.shutdown() future hangs (stuck WebSocket close
+        // handshake). The helper must bound the whole phase at
+        // `signer_drain` and invoke the abort callback — previously
+        // the unbounded client.shutdown().await would have blocked
+        // phase 3 indefinitely.
+        let abort_called = Arc::new(AtomicBool::new(false));
+        let abort_called_cb = abort_called.clone();
+        let abort_signer = move || {
+            abort_called_cb.store(true, Ordering::Relaxed);
+        };
+
+        let client_shutdown = async {
+            // Would hang for an hour if not bounded.
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        };
+        let tracker_wait = async {
+            // Never reached because client_shutdown is awaited first
+            // and never completes inside the budget.
+            tokio::time::sleep(Duration::from_secs(0)).await;
+        };
+
+        let outcome = drain_signer_or_abort(
+            client_shutdown,
+            tracker_wait,
+            abort_signer,
+            Duration::from_secs(10),
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, SignerDrainOutcome::AbortedAfterTimeout),
+            "expected AbortedAfterTimeout, got {:?}",
+            outcome
+        );
+        assert!(
+            abort_called.load(Ordering::Relaxed),
+            "abort_signer must be called when the signer_drain budget is exceeded by a hung client.shutdown()"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_drain_signer_or_abort_aborts_when_tracker_wait_hangs() {
+        // The other half of the failure space: client.shutdown()
+        // completes cleanly but task_tracker.wait() hangs (a tracked
+        // task stuck in a long-running operation). The whole phase
+        // must still be bounded by `signer_drain` and the signer
+        // handle aborted. This matches the pre-patch behavior for
+        // this specific case but must be preserved under the new
+        // outer-timeout structure.
+        let abort_called = Arc::new(AtomicBool::new(false));
+        let abort_called_cb = abort_called.clone();
+        let abort_signer = move || {
+            abort_called_cb.store(true, Ordering::Relaxed);
+        };
+
+        let client_shutdown = async {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        };
+        let tracker_wait = async {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        };
+
+        let outcome = drain_signer_or_abort(
+            client_shutdown,
+            tracker_wait,
+            abort_signer,
+            Duration::from_secs(10),
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, SignerDrainOutcome::AbortedAfterTimeout),
+            "expected AbortedAfterTimeout, got {:?}",
+            outcome
+        );
+        assert!(
+            abort_called.load(Ordering::Relaxed),
+            "abort_signer must be called when the signer_drain budget is exceeded by a hung tracker_wait"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_drain_signer_or_abort_enforces_real_bound_past_budget() {
+        // The safety property: the helper returns within `budget`
+        // regardless of how long the inner futures would take.
+        // This is what makes `validate_shutdown_timings`'s contract
+        // honest — phase 3 cannot eat into phase 4 or the kubelet
+        // SIGKILL window.
+        let start = tokio::time::Instant::now();
+        let budget = Duration::from_secs(10);
+
+        let client_shutdown = async {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        };
+        let tracker_wait = async {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        };
+        let abort_signer = || {};
+
+        let _outcome =
+            drain_signer_or_abort(client_shutdown, tracker_wait, abort_signer, budget).await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed <= budget + Duration::from_millis(100),
+            "drain_signer_or_abort must return within the signer_drain budget, not block on the inner futures; elapsed={:?}, budget={:?}",
+            elapsed,
+            budget
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_drain_signer_or_abort_shares_budget_across_client_and_tracker() {
+        // Subtle but critical: the phase budget is shared across the
+        // two awaits, NOT applied independently to each. If each got
+        // its own `budget`-sized timeout, phase 3 worst-case would be
+        // `2 * signer_drain`, quietly busting the design contract in
+        // validate_shutdown_timings. This test pins the shared-budget
+        // semantic: client.shutdown() takes 80% of the budget, and
+        // task_tracker.wait() would take another 80% — total 160% of
+        // budget. The helper must time out at exactly `budget`.
+        let start = tokio::time::Instant::now();
+        let budget = Duration::from_secs(10);
+        let abort_called = Arc::new(AtomicBool::new(false));
+        let abort_called_cb = abort_called.clone();
+        let abort_signer = move || {
+            abort_called_cb.store(true, Ordering::Relaxed);
+        };
+
+        let client_shutdown = async {
+            tokio::time::sleep(Duration::from_secs(8)).await;
+        };
+        let tracker_wait = async {
+            tokio::time::sleep(Duration::from_secs(8)).await;
+        };
+
+        let outcome =
+            drain_signer_or_abort(client_shutdown, tracker_wait, abort_signer, budget).await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            matches!(outcome, SignerDrainOutcome::AbortedAfterTimeout),
+            "8s + 8s > 10s budget; expected AbortedAfterTimeout, got {:?}",
+            outcome
+        );
+        assert!(
+            elapsed <= budget + Duration::from_millis(100),
+            "helper must return at the shared budget, not extend to 2x it; elapsed={:?}, budget={:?}",
+            elapsed,
+            budget
+        );
+        assert!(
+            abort_called.load(Ordering::Relaxed),
+            "abort_signer must be called when the shared phase budget is exceeded by the sum of the two awaits"
         );
     }
 }

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -204,6 +204,44 @@ async fn pre_drain_pause(unready: &Arc<AtomicBool>, duration: Duration) {
     }
 }
 
+/// Result of awaiting the DB pool's close future with the documented
+/// teardown margin as an upper bound.
+#[derive(Debug)]
+enum PoolCloseOutcome {
+    /// The pool finished closing before the margin elapsed. The caller can
+    /// emit the clean "Graceful shutdown complete" log.
+    Completed,
+    /// The margin elapsed before the pool finished. The caller logs a
+    /// warning and proceeds — the kubelet SIGKILL at
+    /// `terminationGracePeriodSeconds` is the final backstop.
+    TimedOut,
+}
+
+/// Await `close_fut` for up to `margin`. If it finishes in time, return
+/// `Completed`; otherwise return `TimedOut`. The close future is dropped on
+/// timeout — sqlx's `Pool::close()` is cancellation-safe, and we would not
+/// gain anything by continuing to await past the documented margin when the
+/// kubelet is about to SIGKILL us anyway.
+///
+/// This enforces `SHUTDOWN_TEARDOWN_MARGIN` as a real bound on phase 4 so a
+/// stuck DB connection (e.g. a preload task mid-query when
+/// `task_tracker.wait()` timed out and `signer_handle.abort()` was called
+/// but not awaited) cannot block past `terminationGracePeriodSeconds` and
+/// swallow the final "Graceful shutdown complete" log.
+///
+/// Generic over `F: Future<Output = ()>` so we can exercise the timeout
+/// behaviour deterministically with `tokio::time::pause` in tests without
+/// standing up a real Postgres pool.
+async fn close_within_margin<F>(close_fut: F, margin: Duration) -> PoolCloseOutcome
+where
+    F: std::future::Future<Output = ()>,
+{
+    match tokio::time::timeout(margin, close_fut).await {
+        Ok(()) => PoolCloseOutcome::Completed,
+        Err(_) => PoolCloseOutcome::TimedOut,
+    }
+}
+
 /// Result of awaiting the axum HTTP server's graceful-shutdown future with a
 /// bounded budget.
 #[derive(Debug)]
@@ -1426,13 +1464,28 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         }
     }
 
-    // Phase 4: close database pool.
-    pool_for_shutdown.close().await;
-
-    tracing::info!(
-        total_shutdown_secs = shutdown_started_at.elapsed().as_secs(),
-        "Graceful shutdown complete"
-    );
+    // Phase 4: close database pool. Bounded by SHUTDOWN_TEARDOWN_MARGIN so
+    // a connection stuck in a long-running query (e.g. a tenant-cache
+    // preload task mid-query when task_tracker.wait() timed out and
+    // signer_handle.abort() was called but not awaited) cannot block past
+    // the kubelet SIGKILL and swallow the final "Graceful shutdown
+    // complete" log. sqlx's Pool::close is cancellation-safe, so dropping
+    // the future on timeout is safe.
+    match close_within_margin(pool_for_shutdown.close(), SHUTDOWN_TEARDOWN_MARGIN).await {
+        PoolCloseOutcome::Completed => {
+            tracing::info!(
+                total_shutdown_secs = shutdown_started_at.elapsed().as_secs(),
+                "Graceful shutdown complete"
+            );
+        }
+        PoolCloseOutcome::TimedOut => {
+            tracing::warn!(
+                total_shutdown_secs = shutdown_started_at.elapsed().as_secs(),
+                teardown_margin_secs = SHUTDOWN_TEARDOWN_MARGIN.as_secs(),
+                "Graceful shutdown complete with warning: DB pool close exceeded teardown margin; stuck checked-out connections were dropped"
+            );
+        }
+    }
 
     Ok(())
 }
@@ -2154,5 +2207,78 @@ mod tests {
         assert!(validate_shutdown_timings(&t, Duration::from_secs(74)).is_err());
         // One second above: OK — extra headroom.
         assert!(validate_shutdown_timings(&t, Duration::from_secs(76)).is_ok());
+    }
+
+    // --- Phase 4 bounded DB pool close ---
+    //
+    // sqlx's `Pool::close()` waits for every checked-out connection to be
+    // returned to the pool. If a long-running query is still outstanding
+    // when we enter phase 4 (e.g. a tenant-cache preload task was mid-query
+    // when task_tracker.wait() timed out and signer_handle.abort() was
+    // called but did not await), close can block indefinitely into the
+    // kubelet SIGKILL. That swallows the final "Graceful shutdown complete"
+    // log, so operators have no positive signal of clean shutdown.
+    // close_within_margin enforces the documented SHUTDOWN_TEARDOWN_MARGIN
+    // as a real bound.
+
+    #[tokio::test(start_paused = true)]
+    async fn test_close_within_margin_returns_completed_when_future_finishes_before_margin() {
+        // Fast path: close completes immediately. Should report Completed
+        // so the caller can emit the clean "Graceful shutdown complete"
+        // log with no warning.
+        let close_fut = async {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        };
+
+        let outcome = close_within_margin(close_fut, Duration::from_secs(10)).await;
+
+        assert!(
+            matches!(outcome, PoolCloseOutcome::Completed),
+            "expected Completed, got {:?}",
+            outcome
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_close_within_margin_reports_timed_out_when_margin_exceeded() {
+        // Slow path: close blocks past the margin. Should report TimedOut
+        // so the caller logs a warning and proceeds — we cannot hang the
+        // process on pool teardown when the kubelet SIGKILL is about to
+        // hit us anyway.
+        let close_fut = async {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        };
+
+        let outcome = close_within_margin(close_fut, Duration::from_secs(10)).await;
+
+        assert!(
+            matches!(outcome, PoolCloseOutcome::TimedOut),
+            "expected TimedOut, got {:?}",
+            outcome
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_close_within_margin_enforces_real_bound_past_margin() {
+        // A close future that blocks well past the margin must NOT extend
+        // the helper's runtime past `margin`. We measure virtual time
+        // elapsed under start_paused: it must be exactly the margin (not
+        // the 1h sleep). This is the safety property the reviewer asked
+        // for — phase 4 cannot eat into the kubelet's SIGKILL window.
+        let start = tokio::time::Instant::now();
+        let margin = Duration::from_secs(10);
+        let close_fut = async {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        };
+
+        let _outcome = close_within_margin(close_fut, margin).await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed <= margin + Duration::from_millis(100),
+            "close_within_margin must return within the margin, not block on the inner future; elapsed={:?}, margin={:?}",
+            elapsed,
+            margin
+        );
     }
 }

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -122,6 +122,14 @@ const POOL_CLOSE_LOG_HEADROOM: Duration = Duration::from_secs(2);
 /// `cloudbuild.yaml` are sized to absorb this worst case.
 const CLUSTER_DEREGISTER_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Slice of the phase-3 `signer_drain` budget reserved for a best-effort relay
+/// client close (`Client::shutdown`) — graceful WebSocket close plus a flush of
+/// any already-published NIP-46 responses. It is reserved so the relay close is
+/// never starved by a slow worker/tracker drain, and it bounds the *additional*
+/// close attempt made on the drain-timeout path. Capped at half the budget so
+/// the worker/tracker drain always keeps the larger share.
+const RELAY_CLOSE_BUDGET: Duration = Duration::from_secs(2);
+
 /// Per-field sanity ceiling on each `SHUTDOWN_*_SECS` env var. Values above
 /// this fall back to the per-field default with a warning. 1 day is far
 /// above any plausible operational value (real drains are seconds, not
@@ -450,12 +458,14 @@ enum HttpDrainOutcome {
 /// tracked task drain) under the `signer_drain` budget.
 #[derive(Debug)]
 enum SignerDrainOutcome {
-    /// `client.shutdown()`, relay worker joins, and `task_tracker.wait()`
-    /// finished before the shared phase budget elapsed.
+    /// Relay worker joins, `client.shutdown()`, and `task_tracker.wait()`
+    /// finished before the drain sub-budget elapsed.
     Completed,
-    /// The shared phase budget elapsed before both futures finished. The
-    /// abort callback was invoked to stop the signer task; the caller can
-    /// safely proceed to phase 4 (DB pool close).
+    /// The drain sub-budget elapsed before the drain finished. The abort
+    /// callback was invoked to stop the signer task and the relay workers were
+    /// aborted; a best-effort bounded relay close was then attempted so the
+    /// relay client still closes gracefully. The caller can safely proceed to
+    /// phase 4 (DB pool close).
     AbortedAfterTimeout,
 }
 
@@ -480,40 +490,40 @@ fn abort_join_handles(handles: &[tokio::task::AbortHandle]) {
     }
 }
 
-/// Run phase 3 under a single shared `budget`: close the relay queue so workers
-/// drain and exit while the relay client is still connected, await
-/// `relay_worker_handles`, await `client_shutdown` (which stops `signer.run()`),
-/// then await `tracker_wait` (which waits for tracked background tasks to
-/// finish).
+/// Run phase 3 under the shared `budget`, split into a drain sub-budget and a
+/// reserved relay-close slice (`RELAY_CLOSE_BUDGET`, capped at half the budget):
 ///
-/// On timeout the caller-supplied `abort_signer` callback is invoked — in
-/// production this calls `signer_handle.abort()` — and any unfinished relay
-/// worker handles are aborted before returning `AbortedAfterTimeout`. The
-/// entire phase is bounded by `budget` via one outer `tokio::time::timeout`, so
-/// the helper returns in at most `budget` regardless of which sub-future (or
-/// relay worker) hangs.
+/// 1. **Drain** (`budget - slice`): close the relay queue so workers drain and
+///    exit while the relay client is still connected, await
+///    `relay_worker_handles`, call `client_shutdown` (which stops `signer.run()`
+///    so `tracker_wait` can complete), then await `tracker_wait`. `client_shutdown`
+///    must run before `tracker_wait` because `signer.run()` is tracked by the
+///    task tracker and only ends once the relay client disconnects.
+/// 2. **Relay close** (`slice`): on the drain-timeout path, after aborting the
+///    signer and relay workers, attempt a fresh bounded `client_shutdown` so
+///    the relay client still closes its WebSockets gracefully and flushes any
+///    already-published responses even though the drain timed out. (On the
+///    happy path the relay client was already shut down in step 1, so this slice
+///    goes unused.) `Client::shutdown` is idempotent, so the second call is
+///    safe.
 ///
-/// Why one shared budget, not two independent ones: the design contract
-/// enforced by `validate_shutdown_timings`/`clamp_shutdown_timings` is
-/// `pre_drain + http_drain + signer_drain + teardown_margin
-/// <= grace ceiling`. If each inner await got its own
-/// `budget`-sized timeout, phase 3 could take up to `2 * signer_drain`
-/// in the worst case and silently bust the contract.
+/// Returns `Completed` only when the drain finished within its sub-budget;
+/// otherwise `abort_signer` (in production `signer_handle.abort()`) and the
+/// relay worker handles are aborted and it returns `AbortedAfterTimeout`.
 ///
-/// Previously `client_shutdown` (`nostr_sdk::Client::shutdown`) was
-/// awaited unbounded in `async_main` and only the trailing `tracker_wait`
-/// was wrapped in `timeout(signer_drain, ...)`. A hung WebSocket close
-/// handshake, a bug in `Client::shutdown`, or a dead relay socket would
-/// therefore block phase 3 past the kubelet SIGKILL at
-/// `terminationGracePeriodSeconds`, swallowing phase 4 entirely. This
-/// helper makes `signer_drain` a real phase-3 bound.
+/// Budget contract: drain sub-budget + relay-close slice == `budget`, and only
+/// one of them runs the relay close, so total wall-clock never exceeds `budget`.
+/// This preserves the design contract enforced by `validate_shutdown_timings`/
+/// `clamp_shutdown_timings`: `pre_drain + http_drain + signer_drain +
+/// teardown_margin <= grace ceiling`.
 ///
-/// Generic over both inner futures and the abort callback so the timeout
-/// behaviour can be exercised deterministically with `tokio::time::pause`
-/// in tests without standing up a real `nostr_sdk::Client` or a real
-/// signer `JoinHandle`.
-async fn drain_signer_or_abort<C, Q, W, A>(
-    client_shutdown: C,
+/// `client_shutdown` is a factory (`Fn() -> Future`) rather than a single
+/// future so it can be invoked again on the timeout path. It is generic, along
+/// with the inner futures and the abort callback, so the timeout behaviour can
+/// be exercised deterministically with `tokio::time::pause` in tests without
+/// standing up a real `nostr_sdk::Client` or a real signer `JoinHandle`.
+async fn drain_signer_or_abort<CF, CFut, Q, W, A>(
+    client_shutdown: CF,
     close_relay_queue: Q,
     relay_worker_handles: Vec<tokio::task::JoinHandle<()>>,
     tracker_wait: W,
@@ -521,7 +531,8 @@ async fn drain_signer_or_abort<C, Q, W, A>(
     budget: Duration,
 ) -> SignerDrainOutcome
 where
-    C: std::future::Future<Output = ()>,
+    CF: Fn() -> CFut,
+    CFut: std::future::Future<Output = ()>,
     Q: FnOnce(),
     W: std::future::Future<Output = ()>,
     A: FnOnce(),
@@ -530,17 +541,32 @@ where
         .iter()
         .map(tokio::task::JoinHandle::abort_handle)
         .collect();
-    let combined = async move {
+
+    // Reserve a slice for the relay close so it cannot be starved by a slow
+    // drain; cap at half the budget so the drain keeps the larger share.
+    let relay_close_slice = RELAY_CLOSE_BUDGET.min(budget / 2);
+    let drain_budget = budget.saturating_sub(relay_close_slice);
+
+    // Borrow (not move) the factory into the drain future so it can be called
+    // again on the timeout path after the drain future is dropped.
+    let client_shutdown_ref = &client_shutdown;
+    let drain = async move {
         close_relay_queue();
         wait_for_join_handles(relay_worker_handles).await;
-        client_shutdown.await;
+        client_shutdown_ref().await;
         tracker_wait.await;
     };
-    match tokio::time::timeout(budget, combined).await {
+
+    match tokio::time::timeout(drain_budget, drain).await {
         Ok(()) => SignerDrainOutcome::Completed,
         Err(_) => {
             abort_signer();
             abort_join_handles(&relay_worker_abort_handles);
+            // Best-effort graceful relay close even though the drain timed out:
+            // workers may have been stuck before reaching the in-drain
+            // client_shutdown, leaving the relay client connected with
+            // unflushed responses. Bounded by the reserved slice.
+            let _ = tokio::time::timeout(relay_close_slice, client_shutdown()).await;
             SignerDrainOutcome::AbortedAfterTimeout
         }
     }
@@ -1801,13 +1827,14 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     // hook, so it is NOT deregistered implicitly on return — see the explicit
     // `deregister_and_stop_heartbeat` above).
     //
-    // `drain_signer_or_abort` applies ONE outer `tokio::time::timeout`
-    // at `timings.signer_drain` across both awaits so `signer_drain`
-    // is a real bound on the whole of phase 3 — previously only the
-    // trailing `task_tracker.wait()` was bounded, leaving
-    // `client_for_shutdown.shutdown()` (a nostr_sdk WebSocket close
-    // handshake) unbounded in practice. A hung close could therefore
-    // blow past `terminationGracePeriodSeconds` and swallow phase 4.
+    // `drain_signer_or_abort` bounds the whole of phase 3 by
+    // `timings.signer_drain` (split into a drain sub-budget plus a reserved
+    // relay-close slice) so `signer_drain` is a real bound — previously only
+    // the trailing `task_tracker.wait()` was bounded, leaving
+    // `client_for_shutdown.shutdown()` (a nostr_sdk WebSocket close handshake)
+    // unbounded in practice. A hung close could therefore blow past the grace
+    // period and swallow phase 4. The reserved slice also guarantees a graceful
+    // relay close is attempted even when the drain itself times out.
     tracing::info!(
         elapsed_secs = shutdown_started_at.elapsed().as_secs(),
         "Graceful shutdown: draining relay workers, then tearing down NIP-46 relay client and signer tasks"
@@ -1815,8 +1842,15 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     let signer_drain_budget = timings.signer_drain;
     let signer_handle_for_abort = signer_handle;
     let close_relay_queue = move || relay_queue.close();
+    // Factory (not a single future) so the relay close can be re-attempted on
+    // the drain-timeout path. Each call clones the cheap Arc-backed Client and
+    // returns an owning ('static) future. `Client::shutdown` is idempotent.
+    let client_shutdown = move || {
+        let client = client_for_shutdown.clone();
+        async move { client.shutdown().await }
+    };
     match drain_signer_or_abort(
-        client_for_shutdown.shutdown(),
+        client_shutdown,
         close_relay_queue,
         relay_worker_handles,
         task_tracker.wait(),
@@ -2943,16 +2977,17 @@ mod tests {
     // then `task_tracker.wait().await`. Previously `client.shutdown()` was
     // unbounded: a stuck WebSocket close handshake, a bug in
     // `nostr_sdk::Client::shutdown`, or a dead relay socket could hang
-    // the phase past `terminationGracePeriodSeconds` and swallow phase 4
-    // entirely. The `signer_drain` timeout only wrapped the trailing
-    // `task_tracker.wait()`, silently busting the design contract
-    // (enforced by `validate_shutdown_timings`) that `pre_drain +
-    // http_drain + signer_drain + SHUTDOWN_TEARDOWN_MARGIN <= ceiling`.
+    // the phase past the grace period and swallow phase 4 entirely. The
+    // `signer_drain` timeout only wrapped the trailing `task_tracker.wait()`,
+    // silently busting the design contract (enforced by
+    // `validate_shutdown_timings`) that `pre_drain + http_drain + signer_drain
+    // + teardown_margin <= ceiling`.
     //
-    // `drain_signer_or_abort` applies ONE outer `timeout(signer_drain,
-    // ...)` over the whole phase so `signer_drain` is a real bound on
-    // phase 3 regardless of how many awaits are inside. On timeout it
-    // invokes the caller-supplied abort callback (which aborts the
+    // `drain_signer_or_abort` bounds the whole phase by `signer_drain`, split
+    // into a drain sub-budget plus a reserved relay-close slice, so
+    // `signer_drain` is a real bound on phase 3 regardless of how many awaits
+    // are inside. On timeout it invokes the caller-supplied abort callback
+    // (which aborts the
     // signer JoinHandle in production).
 
     #[tokio::test(start_paused = true)]
@@ -2966,7 +3001,7 @@ mod tests {
             abort_called_cb.store(true, Ordering::Relaxed);
         };
 
-        let client_shutdown = async {
+        let client_shutdown = || async {
             tokio::time::sleep(Duration::from_secs(1)).await;
         };
         let tracker_wait = async {
@@ -3026,15 +3061,20 @@ mod tests {
         };
         let queue_closed_for_client = queue_closed.clone();
         let worker_finished_for_client = worker_finished.clone();
-        let client_shutdown = async move {
-            assert!(
-                queue_closed_for_client.load(Ordering::Relaxed),
-                "phase 3 must close relay intake before shutting down the relay client"
-            );
-            assert!(
-                worker_finished_for_client.load(Ordering::Relaxed),
-                "phase 3 must drain relay workers before shutting down the relay client"
-            );
+        // Factory: clone the Arcs per call so the closure stays `Fn`.
+        let client_shutdown = move || {
+            let queue_closed_for_client = queue_closed_for_client.clone();
+            let worker_finished_for_client = worker_finished_for_client.clone();
+            async move {
+                assert!(
+                    queue_closed_for_client.load(Ordering::Relaxed),
+                    "phase 3 must close relay intake before shutting down the relay client"
+                );
+                assert!(
+                    worker_finished_for_client.load(Ordering::Relaxed),
+                    "phase 3 must drain relay workers before shutting down the relay client"
+                );
+            }
         };
 
         let outcome = drain_signer_or_abort(
@@ -3088,7 +3128,7 @@ mod tests {
         };
 
         let outcome = drain_signer_or_abort(
-            async {},
+            || async {},
             move || relay_queue.close(),
             relay_worker_handles,
             async {},
@@ -3155,7 +3195,7 @@ mod tests {
         };
 
         let outcome = drain_signer_or_abort(
-            async {},
+            || async {},
             close_relay_queue,
             relay_worker_handles,
             async {},
@@ -3185,6 +3225,58 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn test_drain_signer_or_abort_attempts_relay_close_on_timeout() {
+        // flow-f2: when the drain times out because relay workers are stuck
+        // BEFORE the in-drain client.shutdown() is reached, the relay client
+        // must still receive a bounded close so it disconnects gracefully and
+        // flushes any already-published responses.
+        let shutdown_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let shutdown_calls_factory = shutdown_calls.clone();
+        let client_shutdown = move || {
+            let shutdown_calls_factory = shutdown_calls_factory.clone();
+            async move {
+                shutdown_calls_factory.fetch_add(1, Ordering::Relaxed);
+            }
+        };
+
+        // Worker never finishes inside the budget, so the drain times out in
+        // wait_for_join_handles before the in-drain client.shutdown() is reached.
+        let relay_worker_handles = vec![tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        })];
+
+        let abort_called = Arc::new(AtomicBool::new(false));
+        let abort_called_cb = abort_called.clone();
+
+        let outcome = drain_signer_or_abort(
+            client_shutdown,
+            || {},
+            relay_worker_handles,
+            async {},
+            move || {
+                abort_called_cb.store(true, Ordering::Relaxed);
+            },
+            Duration::from_secs(10),
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, SignerDrainOutcome::AbortedAfterTimeout),
+            "expected AbortedAfterTimeout, got {:?}",
+            outcome
+        );
+        assert!(
+            abort_called.load(Ordering::Relaxed),
+            "abort_signer must be called on the drain-timeout path"
+        );
+        assert!(
+            shutdown_calls.load(Ordering::Relaxed) >= 1,
+            "relay client.shutdown() must be attempted on the drain-timeout path (flow-f2), calls={}",
+            shutdown_calls.load(Ordering::Relaxed)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn test_drain_signer_or_abort_aborts_when_client_shutdown_hangs() {
         // Regression target: the reviewer-flagged failure mode. The
         // client.shutdown() future hangs (stuck WebSocket close
@@ -3198,7 +3290,7 @@ mod tests {
             abort_called_cb.store(true, Ordering::Relaxed);
         };
 
-        let client_shutdown = async {
+        let client_shutdown = || async {
             // Would hang for an hour if not bounded.
             tokio::time::sleep(Duration::from_secs(3600)).await;
         };
@@ -3245,7 +3337,7 @@ mod tests {
             abort_called_cb.store(true, Ordering::Relaxed);
         };
 
-        let client_shutdown = async {
+        let client_shutdown = || async {
             tokio::time::sleep(Duration::from_millis(100)).await;
         };
         let tracker_wait = async {
@@ -3284,7 +3376,7 @@ mod tests {
         let start = tokio::time::Instant::now();
         let budget = Duration::from_secs(10);
 
-        let client_shutdown = async {
+        let client_shutdown = || async {
             tokio::time::sleep(Duration::from_secs(3600)).await;
         };
         let tracker_wait = async {
@@ -3330,7 +3422,7 @@ mod tests {
             abort_called_cb.store(true, Ordering::Relaxed);
         };
 
-        let client_shutdown = async {
+        let client_shutdown = || async {
             tokio::time::sleep(Duration::from_secs(8)).await;
         };
         let tracker_wait = async {

--- a/signer/src/work_queue.rs
+++ b/signer/src/work_queue.rs
@@ -134,23 +134,38 @@ impl RelaySender {
     /// Try to send an item to the queue
     /// Returns error if queue is full (backpressure)
     pub fn try_send(&self, item: Nip46RpcItem) -> Result<(), RelayQueueError> {
-        let closed = self
+        self.try_send_with_open_queue_probe(item, || {})
+    }
+
+    fn try_send_with_open_queue_probe<F>(
+        &self,
+        item: Nip46RpcItem,
+        after_open_check: F,
+    ) -> Result<(), RelayQueueError>
+    where
+        F: FnOnce(),
+    {
+        let close_guard = self
             .closed
             .lock()
             .expect("relay queue close state mutex poisoned");
-        if *closed {
+        if *close_guard {
             METRICS.inc_queue_dropped();
             return Err(RelayQueueError::Closed);
         }
 
-        match self.tx.try_send(item) {
+        after_open_check();
+
+        let result = match self.tx.try_send(item) {
             Ok(()) => Ok(()),
             Err(TrySendError::Full(_)) => {
                 METRICS.inc_queue_dropped();
                 Err(RelayQueueError::QueueFull)
             }
             Err(TrySendError::Disconnected(_)) => Err(RelayQueueError::Disconnected),
-        }
+        };
+        drop(close_guard);
+        result
     }
 
     /// Check whether the queue has been explicitly closed.
@@ -371,6 +386,27 @@ mod tests {
             result
         );
         assert!(sender.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_relay_sender_blocks_close_until_enqueue_attempt_completes() {
+        let queue = RelayQueue::new();
+        let sender = queue.sender();
+
+        let result = sender.try_send_with_open_queue_probe(test_item().await, || {
+            assert!(
+                matches!(
+                    sender.closed.try_lock(),
+                    Err(std::sync::TryLockError::WouldBlock)
+                ),
+                "close state mutex must stay locked until the enqueue attempt finishes"
+            );
+        });
+
+        assert!(result.is_ok(), "send should complete before close wins");
+        queue.close();
+        assert!(queue.is_closed());
+        assert_eq!(sender.len(), 1);
     }
 
     #[test]

--- a/signer/src/work_queue.rs
+++ b/signer/src/work_queue.rs
@@ -4,15 +4,17 @@
 use crate::error::{SignerError, SignerResult};
 use crate::signer_daemon::Nip46Handler;
 use cluster_hashring::ClusterCoordinator;
-use crossbeam_channel::{bounded, Receiver, Sender, TrySendError};
+use crossbeam_channel::{bounded, Receiver, RecvTimeoutError, Sender, TrySendError};
 use keycast_core::encryption::KeyManager;
 use keycast_core::metrics::METRICS;
 use moka::future::Cache;
 use nostr_sdk::prelude::*;
 use sqlx::PgPool;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 const QUEUE_CAPACITY: usize = 4096;
+const WORKER_RECV_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// NIP-46 request item for the relay queue
 /// Contains all data needed to process a single NIP-46 request
@@ -30,19 +32,41 @@ pub struct Nip46RpcItem {
 pub struct RelayQueue {
     tx: Sender<Nip46RpcItem>,
     rx: Receiver<Nip46RpcItem>,
+    closed: Arc<Mutex<bool>>,
 }
 
 impl RelayQueue {
     /// Create a new relay queue with bounded capacity
     pub fn new() -> Self {
         let (tx, rx) = bounded(QUEUE_CAPACITY);
-        Self { tx, rx }
+        Self {
+            tx,
+            rx,
+            closed: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    /// Close the queue to new work while allowing workers to drain queued items.
+    pub fn close(&self) {
+        *self
+            .closed
+            .lock()
+            .expect("relay queue close state mutex poisoned") = true;
+    }
+
+    /// Check whether the queue has been explicitly closed.
+    pub fn is_closed(&self) -> bool {
+        *self
+            .closed
+            .lock()
+            .expect("relay queue close state mutex poisoned")
     }
 
     /// Get a sender handle for enqueueing items
     pub fn sender(&self) -> RelaySender {
         RelaySender {
             tx: self.tx.clone(),
+            closed: self.closed.clone(),
         }
     }
 
@@ -68,6 +92,7 @@ impl RelayQueue {
         (0..num_workers)
             .map(|worker_id| {
                 let rx = self.rx.clone();
+                let closed = self.closed.clone();
                 let handlers = handlers.clone();
                 let client = client.clone();
                 let pool = pool.clone();
@@ -75,9 +100,10 @@ impl RelayQueue {
                 let coordinator = coordinator.clone();
 
                 tokio::spawn(async move {
+                    let worker_queue = RelayWorkerQueue { rx, closed };
                     relay_worker_loop(
                         worker_id,
-                        rx,
+                        worker_queue,
                         handlers,
                         client,
                         pool,
@@ -101,12 +127,22 @@ impl Default for RelayQueue {
 #[derive(Clone)]
 pub struct RelaySender {
     tx: Sender<Nip46RpcItem>,
+    closed: Arc<Mutex<bool>>,
 }
 
 impl RelaySender {
     /// Try to send an item to the queue
     /// Returns error if queue is full (backpressure)
     pub fn try_send(&self, item: Nip46RpcItem) -> Result<(), RelayQueueError> {
+        let closed = self
+            .closed
+            .lock()
+            .expect("relay queue close state mutex poisoned");
+        if *closed {
+            METRICS.inc_queue_dropped();
+            return Err(RelayQueueError::Closed);
+        }
+
         match self.tx.try_send(item) {
             Ok(()) => Ok(()),
             Err(TrySendError::Full(_)) => {
@@ -115,6 +151,14 @@ impl RelaySender {
             }
             Err(TrySendError::Disconnected(_)) => Err(RelayQueueError::Disconnected),
         }
+    }
+
+    /// Check whether the queue has been explicitly closed.
+    pub fn is_closed(&self) -> bool {
+        *self
+            .closed
+            .lock()
+            .expect("relay queue close state mutex poisoned")
     }
 
     /// Get current queue length (approximate, for metrics)
@@ -133,14 +177,21 @@ impl RelaySender {
 pub enum RelayQueueError {
     #[error("Relay queue is full - system overloaded")]
     QueueFull,
+    #[error("Relay queue is closed")]
+    Closed,
     #[error("Relay queue disconnected")]
     Disconnected,
+}
+
+struct RelayWorkerQueue {
+    rx: Receiver<Nip46RpcItem>,
+    closed: Arc<Mutex<bool>>,
 }
 
 /// Worker loop that processes NIP-46 items from the relay queue
 async fn relay_worker_loop(
     worker_id: usize,
-    rx: Receiver<Nip46RpcItem>,
+    queue: RelayWorkerQueue,
     handlers: Cache<String, Nip46Handler>,
     client: Client,
     pool: PgPool,
@@ -150,16 +201,30 @@ async fn relay_worker_loop(
     tracing::debug!("Relay worker {} started", worker_id);
 
     loop {
+        if *queue
+            .closed
+            .lock()
+            .expect("relay queue close state mutex poisoned")
+            && queue.rx.is_empty()
+        {
+            tracing::info!(
+                "Relay worker {} shutting down (queue closed and empty)",
+                worker_id
+            );
+            break;
+        }
+
         // Block on receiving next item (in spawn_blocking to not block async runtime)
         let item = {
-            let rx = rx.clone();
-            match tokio::task::spawn_blocking(move || rx.recv()).await {
+            let rx = queue.rx.clone();
+            match tokio::task::spawn_blocking(move || rx.recv_timeout(WORKER_RECV_TIMEOUT)).await {
                 Ok(Ok(item)) => item,
-                Ok(Err(_)) => {
+                Ok(Err(RecvTimeoutError::Disconnected)) => {
                     // Channel disconnected - shutdown
                     tracing::info!("Relay worker {} shutting down (channel closed)", worker_id);
                     break;
                 }
+                Ok(Err(RecvTimeoutError::Timeout)) => continue,
                 Err(e) => {
                     tracing::error!("Relay worker {} spawn_blocking panicked: {}", worker_id, e);
                     continue;
@@ -248,6 +313,19 @@ impl Default for VerifyQueue {
 mod tests {
     use super::*;
 
+    async fn test_item() -> Nip46RpcItem {
+        let keys = Keys::generate();
+        let unsigned = EventBuilder::text_note("test").build(keys.public_key());
+        let event = keys
+            .sign_event(unsigned)
+            .await
+            .expect("test event should sign");
+        Nip46RpcItem {
+            event: Box::new(event),
+            bunker_pubkey: keys.public_key().to_hex(),
+        }
+    }
+
     #[test]
     fn test_relay_queue_creation() {
         let queue = RelayQueue::new();
@@ -264,6 +342,35 @@ mod tests {
         // Both senders should work with the same queue
         assert!(sender1.is_empty());
         assert!(sender2.is_empty());
+    }
+
+    #[test]
+    fn test_relay_queue_close_is_visible_to_sender_clones() {
+        let queue = RelayQueue::new();
+        let sender1 = queue.sender();
+        let sender2 = sender1.clone();
+
+        queue.close();
+
+        assert!(queue.is_closed());
+        assert!(sender1.is_closed());
+        assert!(sender2.is_closed());
+    }
+
+    #[tokio::test]
+    async fn test_relay_sender_rejects_new_work_after_close() {
+        let queue = RelayQueue::new();
+        let sender = queue.sender();
+
+        queue.close();
+
+        let result = sender.try_send(test_item().await);
+        assert!(
+            matches!(result, Err(RelayQueueError::Closed)),
+            "expected closed queue error, got {:?}",
+            result
+        );
+        assert!(sender.is_empty());
     }
 
     #[test]

--- a/signer/src/work_queue.rs
+++ b/signer/src/work_queue.rs
@@ -150,7 +150,10 @@ impl RelaySender {
             .lock()
             .expect("relay queue close state mutex poisoned");
         if *close_guard {
-            METRICS.inc_queue_dropped();
+            // Distinct from the queue-full counter below: a closed queue means
+            // we are draining for graceful shutdown, not overloaded. Conflating
+            // the two would make shutdown look like a capacity incident.
+            METRICS.inc_queue_closed();
             return Err(RelayQueueError::Closed);
         }
 
@@ -386,6 +389,26 @@ mod tests {
             result
         );
         assert!(sender.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_closed_queue_rejection_counts_as_closed_not_overload() {
+        use std::sync::atomic::Ordering;
+
+        let queue = RelayQueue::new();
+        let sender = queue.sender();
+        queue.close();
+
+        // Global process metrics: other tests may run concurrently, so assert a
+        // strict increase (monotonic counter) rather than an exact value.
+        let before = METRICS.nip46_requests_queue_closed.load(Ordering::Relaxed);
+        let result = sender.try_send(test_item().await);
+        assert!(matches!(result, Err(RelayQueueError::Closed)));
+        let after = METRICS.nip46_requests_queue_closed.load(Ordering::Relaxed);
+        assert!(
+            after > before,
+            "a closed-queue rejection must increment the queue_closed (shutdown) counter, not the overload drop counter"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Plain summary

On a scale-down event, keycast could drop in-flight NIP-46 sign requests before their responses reached the client. That can cause a reconnect storm right when we are trying to reduce instance count.

This PR reorders shutdown into explicit bounded phases so the platform stops routing traffic before keycast stops accepting, HTTP drains first, relay work drains while the relay client is still connected, cluster peers are told this instance is leaving, and cleanup remains inside the platform grace window. Every phase budget is env-var tunable and clamped at startup against the configured grace-period ceiling.

This is the keycast application slice of autoscaling hardening. Infrastructure-side HPA/PDB/topology/grace-period work belongs in the sibling IaC rollout.

> No UI change. No public brand/partner references in the diff.

## Motivation

Keycast holds two shutdown-sensitive pieces of per-instance state:

1. Long-lived NIP-46 WebSocket relay connections.
2. A bounded relay-worker queue for in-flight sign requests.

The old shutdown path could stop the relay client before queued requests had delivered responses, and some phases were not bounded tightly enough to fit the real deploy grace window. During scale-down, that could turn ordinary termination into dropped sign requests and client reconnect/retry amplification.

## Related Issue

Closes #275.

## What Changed

The shutdown sequence in `async_main` is now four explicit phases:

1. **Pre-drain**: set readiness to 503 and sleep `SHUTDOWN_PRE_DRAIN_SECS` so GKE endpoint/NEG detach can propagate before keycast stops accepting. Default: 15s. Cloud Run sets this to 0 because Cloud Run does not use readiness-probe-driven endpoint removal.
2. **HTTP drain**: notify axum to stop accepting and wait up to `SHUTDOWN_HTTP_DRAIN_SECS`. Default: 40s. On timeout, `drain_http_or_abort` aborts and awaits the axum task so later phases do not race a still-live accept loop.
3. **Cluster deregister + signer/relay drain**: publish the cluster leave event and deregister under a bounded slice of `SHUTDOWN_SIGNER_DRAIN_SECS`, close the relay queue to new work, drain relay workers while the relay client remains connected, then shut down the relay client and wait for tracked tasks. Default signer budget: 10s. The cluster deregister is capped at 2s and carved out of this same signer budget, so it adds no unmodeled overhang.
4. **Cleanup**: close the DB pool within `SHUTDOWN_TEARDOWN_MARGIN_SECS - 2s` so the final shutdown log still has headroom before SIGKILL. Default margin: 10s.

At startup, keycast resolves the configured plan and clamps phase durations so:

`pre_drain + http_drain + signer_drain + teardown_margin <= SHUTDOWN_GRACE_PERIOD_CEILING_SECS`

The built-in defaults target the intended GKE budget:

`15 + 40 + 10 + 10 = 75s`

Cloud Run is handled explicitly in `cloudbuild.yaml` with:

`CEILING=10, PRE=0, HTTP=3, SIGNER=3, MARGIN=4`

That gives Cloud Run a modeled 10s shutdown budget:

`0 + 3 + 3 + 4 = 10s`

Other supporting changes:

- `RelayQueue::close()` rejects new work during drain while preserving already-queued work for workers to process.
- Relay close/send are serialized through the queue close mutex so a request is either accepted before close and drained, or rejected after close.
- Shutdown-time queue rejections are counted as `keycast_nip46_queue_closed_total`, separate from overload drops.
- `ClusterCoordinator::deregister_and_stop_heartbeat()` explicitly publishes leave and deregisters during SIGTERM shutdown.
- Heartbeat and full-sync loops check cancellation while holding the registry lock or before polling Redis work, preventing shutdown-time re-registration races.
- Shutdown env parsing rejects values above the one-day per-field sanity ceiling to avoid overflow before validation can report an actionable warning.

## Testing

Author-reported verification:

- `cargo test -p keycast --bin keycast`
- `cargo test --workspace --lib --bins`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- `cargo fmt --all -- --check`

Additional takeover verification:

- `cargo test -p keycast --bin keycast` — 65 passed.
- `cargo test -p keycast_signer work_queue` — 7 passed.
- `cargo test -p cluster-hashring await_unless_cancelled` — 2 passed.
- `git diff --check origin/main...pr-196` — clean.

Not tested here: full kill-instance-and-observe-reconnect-spike acceptance. That needs the deploy environment and IaC rollout.

## Risks

- **Grace-period mismatch**: the defaults assume a 75s GKE grace. Cloud Run is explicitly overridden in `cloudbuild.yaml`; any future deploy path must set `SHUTDOWN_GRACE_PERIOD_CEILING_SECS` to its real post-SIGTERM grace.
- **Short Cloud Run drain window**: Cloud Run is constrained to about 10s, so its configured signer drain is intentionally small. The code prioritizes bounded, observable shutdown over pretending Cloud Run can run the GKE-sized budget.
- **Duplicate handling during handoff**: cluster leave is published before relay queue drain so peers can take over promptly. The design accepts at-least-once handoff behavior to avoid drops.
- **Slow Redis during deregister**: deregister is capped and shutdown proceeds; peers then converge through heartbeat staleness.
- **Stuck DB close**: pool close is bounded and logs a warning rather than blocking past platform SIGKILL.

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

## Related Issue

Closes #275
