### PR TITLE
fix: harden dangling OAuth policy handling and error classification

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -2888,6 +2888,35 @@ pub async fn get_authorization_for_origin(
     }
 }
 
+async fn load_policy_permissions_or_deny(
+    pool: &PgPool,
+    policy_id: i32,
+    user_pubkey: &str,
+    tenant_id: i64,
+) -> Result<Vec<keycast_core::types::permission::Permission>, AuthError> {
+    let policy_repo = PolicyRepository::new(pool.clone());
+    match policy_repo.find(policy_id).await {
+        Ok(_) => {}
+        Err(keycast_core::repositories::RepositoryError::NotFound(_)) => {
+            tracing::warn!(
+                "Denying OAuth request for user {} in tenant {} due to dangling policy_id {}",
+                user_pubkey,
+                tenant_id,
+                policy_id
+            );
+            return Err(AuthError::Forbidden(
+                "Authorization policy is missing. Re-authorize this app.".to_string(),
+            ));
+        }
+        Err(e) => return Err(e.into()),
+    }
+
+    policy_repo
+        .get_permissions(policy_id)
+        .await
+        .map_err(Into::into)
+}
+
 /// Validate that the user has permission to sign this event
 /// Returns () if successful, or an error if unauthorized
 pub async fn validate_signing_permissions(
@@ -2916,9 +2945,8 @@ pub async fn validate_signing_permissions(
         }
     };
 
-    // Load permissions for this policy
-    let policy_repo = PolicyRepository::new(pool.clone());
-    let permissions = policy_repo.get_permissions(policy_id).await?;
+    let permissions =
+        load_policy_permissions_or_deny(pool, policy_id, user_pubkey, tenant_id).await?;
 
     // Convert to custom permissions
     let custom_permissions: Result<Vec<Box<dyn CustomPermission>>, _> = permissions
@@ -2997,9 +3025,8 @@ pub async fn validate_encrypt_permissions(
         }
     };
 
-    // Load permissions for this policy
-    let policy_repo = PolicyRepository::new(pool.clone());
-    let permissions = policy_repo.get_permissions(policy_id).await?;
+    let permissions =
+        load_policy_permissions_or_deny(pool, policy_id, user_pubkey, tenant_id).await?;
 
     let custom_permissions: Result<Vec<Box<dyn CustomPermission>>, _> = permissions
         .iter()
@@ -3078,9 +3105,8 @@ pub async fn validate_decrypt_permissions(
         }
     };
 
-    // Load permissions for this policy
-    let policy_repo = PolicyRepository::new(pool.clone());
-    let permissions = policy_repo.get_permissions(policy_id).await?;
+    let permissions =
+        load_policy_permissions_or_deny(pool, policy_id, user_pubkey, tenant_id).await?;
 
     let custom_permissions: Result<Vec<Box<dyn CustomPermission>>, _> = permissions
         .iter()

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -297,6 +297,20 @@ async fn load_handler_on_demand(
     // Load permissions for this authorization's policy (if any)
     let permissions: Vec<Box<dyn CustomPermission>> = if let Some(pid) = policy_id {
         let policy_repo = PolicyRepository::new(pool.clone());
+        match policy_repo.find(pid).await {
+            Ok(_) => {}
+            Err(keycast_core::repositories::RepositoryError::NotFound(_)) => {
+                return Err(RpcError::Auth(AuthError::Forbidden(
+                    "Authorization policy is missing. Re-authorize this app.".to_string(),
+                )));
+            }
+            Err(e) => {
+                return Err(RpcError::Internal(format!(
+                    "Database error loading policy: {}",
+                    e
+                )));
+            }
+        }
         let db_permissions = policy_repo.get_permissions(pid).await.map_err(|e| {
             RpcError::Internal(format!("Database error loading permissions: {}", e))
         })?;

--- a/api/tests/rpc_permission_edge_cases_test.rs
+++ b/api/tests/rpc_permission_edge_cases_test.rs
@@ -9,6 +9,7 @@ use chrono::{Duration, Utc};
 use keycast_api::ucan_auth::{nostr_pubkey_to_did, validate_ucan_token, NostrKeyMaterial};
 use keycast_core::encryption::file_key_manager::FileKeyManager;
 use keycast_core::encryption::KeyManager;
+use keycast_core::repositories::RepositoryError;
 use nostr_sdk::prelude::*;
 use serde_json::json;
 use sqlx::PgPool;
@@ -337,7 +338,150 @@ async fn test_null_policy_grants_full_access() {
 }
 
 // ============================================================================
-// Test 4: Policy Enforces Kind Restrictions
+// Revoked OAuth with NULL policy_id (e.g. dangling-policy migration) must not grant access
+// ============================================================================
+
+#[tokio::test]
+async fn test_revoked_null_policy_row_denied_for_origin_validation() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (keys, pubkey) = create_test_user();
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(&pool, tenant_id, &pubkey, &keys, &key_manager).await;
+
+    let redirect_origin = format!("https://revoked-null-policy-{}.example.com", Uuid::new_v4());
+
+    let auth_id = create_test_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        None,
+        None,
+        &key_manager,
+    )
+    .await;
+
+    sqlx::query(
+        "UPDATE oauth_authorizations
+         SET revoked_at = NOW(), policy_id = NULL, updated_at = NOW()
+         WHERE id = $1",
+    )
+    .bind(auth_id)
+    .execute(&pool)
+    .await
+    .expect("Failed to revoke oauth row");
+
+    let unsigned_event =
+        EventBuilder::new(Kind::EncryptedDirectMessage, "Secret message").build(keys.public_key());
+
+    let result = keycast_api::api::http::auth::validate_signing_permissions(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        &unsigned_event,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "Revoked row with NULL policy_id must not grant access: {:?}",
+        result
+    );
+}
+
+// ============================================================================
+// Test 4: Valid policy with zero permissions remains permissive (backward compatibility)
+// ============================================================================
+
+#[tokio::test]
+async fn test_valid_empty_policy_grants_access() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (keys, pubkey) = create_test_user();
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(&pool, tenant_id, &pubkey, &keys, &key_manager).await;
+
+    // Create a real policy row but link no permissions.
+    let policy_id = create_test_policy(&pool, tenant_id, vec![]).await;
+    let redirect_origin = format!("https://empty-policy-{}.example.com", Uuid::new_v4());
+
+    create_test_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        Some(policy_id),
+        None,
+        &key_manager,
+    )
+    .await;
+
+    let unsigned_event =
+        EventBuilder::new(Kind::EncryptedDirectMessage, "No restrictions").build(keys.public_key());
+
+    let result = keycast_api::api::http::auth::validate_signing_permissions(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        &unsigned_event,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Valid policy with zero linked permissions should stay permissive: {:?}",
+        result
+    );
+}
+
+// ============================================================================
+// Test 5: Referenced OAuth policy cannot be deleted (prevents dangling policy_id)
+// ============================================================================
+
+#[tokio::test]
+async fn test_referenced_oauth_policy_delete_is_restricted() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (keys, pubkey) = create_test_user();
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(&pool, tenant_id, &pubkey, &keys, &key_manager).await;
+
+    let policy_id = create_test_policy(&pool, tenant_id, vec![]).await;
+    let redirect_origin = format!("https://fk-policy-{}.example.com", Uuid::new_v4());
+
+    create_test_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        Some(policy_id),
+        None,
+        &key_manager,
+    )
+    .await;
+
+    let delete_result = sqlx::query("DELETE FROM policies WHERE id = $1")
+        .bind(policy_id)
+        .execute(&pool)
+        .await;
+
+    assert!(
+        delete_result.is_err(),
+        "Deleting a policy referenced by oauth_authorizations should be restricted"
+    );
+}
+
+// ============================================================================
+// Test 6: Policy Enforces Kind Restrictions
 // ============================================================================
 
 #[tokio::test]
@@ -402,7 +546,7 @@ async fn test_policy_enforces_kind_restrictions() {
 }
 
 // ============================================================================
-// Test 5: Expired Authorization Rejected
+// Test 7: Expired Authorization Rejected
 // ============================================================================
 
 #[tokio::test]
@@ -454,7 +598,7 @@ async fn test_expired_authorization_rejected() {
 }
 
 // ============================================================================
-// Test 6: Encrypt Requires Authorization
+// Test 8: Encrypt Requires Authorization
 // ============================================================================
 
 #[tokio::test]
@@ -606,5 +750,20 @@ async fn test_ucan_with_bunker_pubkey_returns_some() {
         bunker_pubkey.unwrap(),
         bunker_pubkey_hex,
         "bunker_pubkey should match"
+    );
+}
+
+#[test]
+fn test_repository_database_error_maps_to_internal_not_forbidden() {
+    let auth_err: keycast_api::api::http::auth::AuthError =
+        RepositoryError::Database("temporary db outage".to_string()).into();
+
+    assert!(
+        matches!(
+            auth_err,
+            keycast_api::api::http::auth::AuthError::Internal(msg)
+            if msg.contains("temporary db outage")
+        ),
+        "Repository database errors must not be reclassified as Forbidden"
     );
 }

--- a/core/src/repositories/oauth_authorization.rs
+++ b/core/src/repositories/oauth_authorization.rs
@@ -194,7 +194,8 @@ impl OAuthAuthorizationRepository {
         let result: Option<(String,)> = sqlx::query_as(
             "SELECT oa.user_pubkey FROM oauth_authorizations oa
              JOIN users u ON oa.user_pubkey = u.pubkey
-             WHERE oa.bunker_public_key = $1 AND u.tenant_id = $2",
+             WHERE oa.bunker_public_key = $1 AND u.tenant_id = $2
+               AND oa.revoked_at IS NULL",
         )
         .bind(bunker_pubkey)
         .bind(tenant_id)
@@ -257,7 +258,8 @@ impl OAuthAuthorizationRepository {
             "SELECT oa.bunker_public_key FROM oauth_authorizations oa
              WHERE oa.user_pubkey = $1
              AND oa.redirect_origin = $2
-             AND oa.tenant_id = $3",
+             AND oa.tenant_id = $3
+             AND oa.revoked_at IS NULL",
         )
         .bind(user_pubkey)
         .bind(redirect_origin)
@@ -304,6 +306,7 @@ impl OAuthAuthorizationRepository {
              WHERE user_pubkey = $1
              AND redirect_origin = $2
              AND tenant_id = $3
+             AND revoked_at IS NULL
              AND (expires_at IS NULL OR expires_at > NOW())",
         )
         .bind(user_pubkey)
@@ -348,6 +351,7 @@ impl OAuthAuthorizationRepository {
              FROM oauth_authorizations oa
              JOIN users u ON oa.user_pubkey = u.pubkey
              WHERE oa.user_pubkey = $1 AND u.tenant_id = $2
+             AND oa.revoked_at IS NULL
              ORDER BY oa.created_at DESC
              LIMIT 1",
         )
@@ -412,7 +416,8 @@ impl OAuthAuthorizationRepository {
         sqlx::query_as(
             "SELECT id, user_pubkey, authorization_handle, expires_at, revoked_at, policy_id
              FROM oauth_authorizations
-             WHERE bunker_public_key = $1 AND tenant_id = $2",
+             WHERE bunker_public_key = $1 AND tenant_id = $2
+               AND revoked_at IS NULL",
         )
         .bind(bunker_pubkey)
         .bind(tenant_id)

--- a/core/src/types/authorization.rs
+++ b/core/src/types/authorization.rs
@@ -24,6 +24,10 @@ pub enum AuthorizationError {
     InvalidSecret,
     #[error("Unauthorized by permission")]
     Unauthorized,
+    #[error("OAuth authorization references missing policy_id {0}")]
+    DanglingPolicy(i32),
+    #[error("OAuth authorization has been revoked")]
+    Revoked,
     #[error("Unsupported request")]
     UnsupportedRequest,
 }

--- a/core/src/types/oauth_authorization.rs
+++ b/core/src/types/oauth_authorization.rs
@@ -59,11 +59,25 @@ impl OAuthAuthorization {
         pool: &PgPool,
         _tenant_id: i64,
     ) -> Result<Vec<crate::types::permission::Permission>, AuthorizationError> {
+        if self.revoked_at.is_some() {
+            return Err(AuthorizationError::Revoked);
+        }
         // If no policy, return empty vec (allow all)
         let policy_id = match self.policy_id {
             Some(id) => id,
             None => return Ok(vec![]),
         };
+
+        // Distinguish "valid policy with no permissions" from "dangling policy_id".
+        let policy_exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM policies WHERE id = $1)")
+                .bind(policy_id)
+                .fetch_one(pool)
+                .await
+                .map_err(AuthorizationError::Database)?;
+        if !policy_exists {
+            return Err(AuthorizationError::DanglingPolicy(policy_id));
+        }
 
         // Load permissions from database
         // Tenant isolation is enforced at authorization lookup level

--- a/database/migrations/20260504124000_add_oauth_policy_fk.sql
+++ b/database/migrations/20260504124000_add_oauth_policy_fk.sql
@@ -1,0 +1,26 @@
+-- Fail closed for dangling oauth_authorizations.policy_id references.
+-- 1) Revoke active OAuth authorizations pointing at missing policies.
+-- 2) Clear dangling policy_id for all affected rows so FK can be added safely.
+-- 3) Add FK to prevent future dangling references.
+--
+-- Affected rows end up with policy_id NULL and revoked_at set. Application code
+-- must treat NULL policy_id as full access only when revoked_at IS NULL; otherwise
+-- a revoked row could be mistaken for an active unrestricted authorization.
+
+UPDATE oauth_authorizations oa
+SET revoked_at = CASE
+        WHEN oa.revoked_at IS NULL THEN NOW()
+        ELSE oa.revoked_at
+    END,
+    policy_id = NULL,
+    updated_at = NOW()
+WHERE oa.policy_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM policies p
+      WHERE p.id = oa.policy_id
+  );
+
+ALTER TABLE ONLY public.oauth_authorizations
+    ADD CONSTRAINT oauth_authorizations_policy_id_fkey
+    FOREIGN KEY (policy_id) REFERENCES public.policies(id) ON DELETE RESTRICT;

--- a/signer/src/signer_daemon.rs
+++ b/signer/src/signer_daemon.rs
@@ -10,8 +10,9 @@ use keycast_core::encryption::KeyManager;
 use keycast_core::metrics::METRICS;
 use keycast_core::signing_handler::SigningHandler;
 use keycast_core::signing_session::canonicalize_event_author;
-use keycast_core::types::authorization::Authorization;
+use keycast_core::types::authorization::{Authorization, AuthorizationError};
 use keycast_core::types::oauth_authorization::OAuthAuthorization;
+use keycast_core::types::permission::Permission;
 use moka::future::Cache;
 use nostr_sdk::prelude::*;
 use secrecy::{ExposeSecret, SecretString};
@@ -63,6 +64,31 @@ pub struct Nip46Handler {
 }
 
 impl Nip46Handler {
+    async fn load_permissions_for_validation(&self) -> SignerResult<Vec<Permission>> {
+        if self.is_oauth {
+            let oauth_auth =
+                OAuthAuthorization::find(&self.pool, self.tenant_id, self.authorization_id).await?;
+            return match oauth_auth.permissions(&self.pool, self.tenant_id).await {
+                Ok(permissions) => Ok(permissions),
+                Err(AuthorizationError::DanglingPolicy(policy_id)) => {
+                    Err(SignerError::permission_denied(format!(
+                        "OAuth authorization {} references missing policy_id {}",
+                        self.authorization_id, policy_id
+                    )))
+                }
+                Err(AuthorizationError::Revoked) => Err(SignerError::permission_denied(
+                    "OAuth authorization has been revoked",
+                )),
+                Err(e) => Err(e.into()),
+            };
+        }
+
+        let auth = Authorization::find(&self.pool, self.tenant_id, self.authorization_id).await?;
+        auth.permissions(&self.pool, self.tenant_id)
+            .await
+            .map_err(Into::into)
+    }
+
     /// Constructor for testing only - do not use in production code
     #[doc(hidden)]
     pub fn new_for_test(
@@ -150,16 +176,7 @@ impl Nip46Handler {
         &self,
         unsigned_event: &UnsignedEvent,
     ) -> SignerResult<()> {
-        // Load permissions based on authorization type
-        let permissions = if self.is_oauth {
-            let oauth_auth =
-                OAuthAuthorization::find(&self.pool, self.tenant_id, self.authorization_id).await?;
-            oauth_auth.permissions(&self.pool, self.tenant_id).await?
-        } else {
-            let auth =
-                Authorization::find(&self.pool, self.tenant_id, self.authorization_id).await?;
-            auth.permissions(&self.pool, self.tenant_id).await?
-        };
+        let permissions = self.load_permissions_for_validation().await?;
 
         // If no permissions configured, allow all (backward compatibility)
         if permissions.is_empty() {
@@ -195,16 +212,7 @@ impl Nip46Handler {
         recipient_pubkey: &PublicKey,
     ) -> SignerResult<()> {
         self.check_user_active().await?;
-        // Load permissions based on authorization type
-        let permissions = if self.is_oauth {
-            let oauth_auth =
-                OAuthAuthorization::find(&self.pool, self.tenant_id, self.authorization_id).await?;
-            oauth_auth.permissions(&self.pool, self.tenant_id).await?
-        } else {
-            let auth =
-                Authorization::find(&self.pool, self.tenant_id, self.authorization_id).await?;
-            auth.permissions(&self.pool, self.tenant_id).await?
-        };
+        let permissions = self.load_permissions_for_validation().await?;
 
         // If no permissions configured, allow all (backward compatibility)
         if permissions.is_empty() {
@@ -242,16 +250,7 @@ impl Nip46Handler {
         sender_pubkey: &PublicKey,
     ) -> SignerResult<()> {
         self.check_user_active().await?;
-        // Load permissions based on authorization type
-        let permissions = if self.is_oauth {
-            let oauth_auth =
-                OAuthAuthorization::find(&self.pool, self.tenant_id, self.authorization_id).await?;
-            oauth_auth.permissions(&self.pool, self.tenant_id).await?
-        } else {
-            let auth =
-                Authorization::find(&self.pool, self.tenant_id, self.authorization_id).await?;
-            auth.permissions(&self.pool, self.tenant_id).await?
-        };
+        let permissions = self.load_permissions_for_validation().await?;
 
         // If no permissions configured, allow all (backward compatibility)
         if permissions.is_empty() {

--- a/signer/tests/permission_validation_tests.rs
+++ b/signer/tests/permission_validation_tests.rs
@@ -6,7 +6,7 @@
 use chrono::{Duration, Utc};
 use keycast_core::encryption::{file_key_manager::FileKeyManager, KeyManager};
 use keycast_core::signing_handler::SigningHandler;
-use keycast_core::types::authorization::Authorization;
+use keycast_core::types::authorization::{Authorization, AuthorizationError};
 use keycast_core::types::oauth_authorization::OAuthAuthorization;
 use keycast_signer::Nip46Handler;
 use nostr_sdk::prelude::*;
@@ -489,6 +489,42 @@ async fn test_7_oauth_no_policy_allows_all() {
     assert!(
         result.is_ok(),
         "OAuth with no policy should allow all operations"
+    );
+}
+
+#[tokio::test]
+async fn test_7b_oauth_revoked_null_policy_denies_refetched_permissions() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    let (oauth_auth, user_keys) = create_oauth_authorization(&pool, 1, None, &key_manager).await;
+
+    let handler = Nip46Handler::new_for_test(
+        user_keys.clone(),
+        user_keys.clone(),
+        oauth_auth.secret_hash.clone(),
+        oauth_auth.id,
+        1,
+        true,
+        pool.clone(),
+    );
+
+    sqlx::query(
+        "UPDATE oauth_authorizations SET revoked_at = NOW(), policy_id = NULL WHERE id = $1",
+    )
+    .bind(oauth_auth.id)
+    .execute(&pool)
+    .await
+    .expect("Failed to revoke oauth authorization");
+
+    let unsigned = EventBuilder::new(Kind::EncryptedDirectMessage, "Test message")
+        .build(user_keys.public_key());
+
+    let result = handler.sign_event_direct(unsigned).await;
+    assert!(
+        result.is_err(),
+        "Refetched revoked OAuth row must not hit NULL-policy allow-all path: {:?}",
+        result
     );
 }
 
@@ -1173,36 +1209,26 @@ async fn test_19_content_filter_blocks_encrypt_of_blocked_plaintext() {
     );
 }
 
-/// Regression: an OAuth authorization with a dangling `policy_id` (no matching row in
-/// `policies`) currently degrades to "no permissions = allow". This test pins that behavior.
-/// See divinevideo/keycast#141 for the open question of whether this should fail closed.
+/// OAuth authorization permissions must fail closed when `policy_id` does not exist.
 #[tokio::test]
-async fn test_20_oauth_invalid_policy_id_allows_signing() {
+async fn test_20_oauth_invalid_policy_id_is_denied() {
     let pool = setup_test_db().await;
     let key_manager = FileKeyManager::new().expect("Failed to create key manager");
 
-    // OAuth authorizations can reference a non-existent policy_id.
-    // Current behavior treats missing policy permissions as unrestricted access.
+    // Create a valid OAuth authorization first, then simulate a dangling policy reference
+    // in-memory to avoid violating DB-level foreign key constraints.
     let invalid_policy_id = i32::MAX;
-    let (oauth_auth, user_keys) =
-        create_oauth_authorization(&pool, 1, Some(invalid_policy_id), &key_manager).await;
+    let (mut oauth_auth, _user_keys) =
+        create_oauth_authorization(&pool, 1, None, &key_manager).await;
+    oauth_auth.policy_id = Some(invalid_policy_id);
 
-    let handler = Nip46Handler::new_for_test(
-        user_keys.clone(),
-        user_keys.clone(),
-        oauth_auth.secret_hash.clone(),
-        oauth_auth.id,
-        1,
-        true,
-        pool.clone(),
-    );
-
-    let unsigned = EventBuilder::new(Kind::EncryptedDirectMessage, "Test message")
-        .build(user_keys.public_key());
-    let result = handler.sign_event_direct(unsigned).await;
-
+    let result = oauth_auth.permissions(&pool, 1).await;
     assert!(
-        result.is_ok(),
-        "OAuth authorization with invalid policy_id should follow current permissive behavior"
+        matches!(
+            result,
+            Err(AuthorizationError::DanglingPolicy(policy_id)) if policy_id == invalid_policy_id
+        ),
+        "OAuth authorization with dangling policy_id must fail closed, got: {:?}",
+        result
     );
 }


### PR DESCRIPTION
## Summary

- fail-closed handling for missing policy_id;
- migration cleanup to make FK addition safe;
- regression test coverage update.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- A follow-up for #131 and #132

## Related Issue

- Closes #141

## Testing

- [x] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] Manual verification completed

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

