### PR TITLE
chore: Return conflict for username-taken profile updates

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -75,26 +75,28 @@ fn normalize_nip05_username(raw_username: &str) -> Result<String, AuthError> {
     let username = raw_username.trim().to_lowercase();
 
     if username.is_empty() {
-        return Err(AuthError::Internal("Username cannot be empty".to_string()));
+        return Err(AuthError::BadRequest(
+            "Username cannot be empty".to_string(),
+        ));
     }
 
     if !username
         .chars()
         .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_' || c == '.')
     {
-        return Err(AuthError::Internal(
+        return Err(AuthError::BadRequest(
             "Username can only contain a-z, 0-9, hyphens, underscores, and dots".to_string(),
         ));
     }
 
     if username.starts_with('-') || username.ends_with('-') {
-        return Err(AuthError::Internal(
+        return Err(AuthError::BadRequest(
             "Username cannot start or end with a hyphen".to_string(),
         ));
     }
 
     if username.len() > MAX_NIP05_USERNAME_LENGTH {
-        return Err(AuthError::Internal(format!(
+        return Err(AuthError::BadRequest(format!(
             "Username must be at most {} characters",
             MAX_NIP05_USERNAME_LENGTH
         )));
@@ -328,6 +330,7 @@ pub enum AuthError {
         message: String,
         retry_after: Option<u32>,
     },
+    Conflict(String),
 }
 
 impl IntoResponse for AuthError {
@@ -407,6 +410,10 @@ impl IntoResponse for AuthError {
             ),
             AuthError::BadRequest(msg) => (
                 StatusCode::BAD_REQUEST,
+                msg,
+            ),
+            AuthError::Conflict(msg) => (
+                StatusCode::CONFLICT,
                 msg,
             ),
             AuthError::Forbidden(msg) => (
@@ -2232,7 +2239,7 @@ pub async fn update_profile(
                             username,
                             error_msg
                         );
-                        return Err(AuthError::Internal(error_msg));
+                        return Err(AuthError::Conflict(error_msg));
                     }
                 }
                 Err(e) => {
@@ -2253,7 +2260,7 @@ pub async fn update_profile(
             .check_username_available(&username, &user_pubkey, tenant_id)
             .await?
         {
-            return Err(AuthError::Internal("Username already taken".to_string()));
+            return Err(AuthError::Conflict("Username is already taken".to_string()));
         }
 
         // Sync to divine-name-server (if enabled)

--- a/api/tests/update_profile_divine_name_test.rs
+++ b/api/tests/update_profile_divine_name_test.rs
@@ -1,10 +1,12 @@
 mod common;
 
 use axum::{
-    extract::State,
+    extract::{Path, State},
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
+    routing::get,
     Json,
+    Router,
 };
 use http_body_util::BodyExt;
 use keycast_api::api::http::{auth, routes::AuthState};
@@ -19,8 +21,11 @@ use keycast_core::secret_pool::SecretPool;
 use moka::future::Cache;
 use nostr_sdk::Keys;
 use serde_json::json;
+use serial_test::serial;
 use sqlx::PgPool;
 use std::sync::Arc;
+use tokio::task::JoinHandle;
+use tokio::net::TcpListener;
 use ucan::builder::UcanBuilder;
 use zeroize::Zeroizing;
 
@@ -93,6 +98,54 @@ async fn build_test_ucan(keys: &Keys, tenant_id: i64) -> String {
         .expect("failed to sign test UCAN")
         .encode()
         .expect("failed to encode test UCAN")
+}
+
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(ref value) = self.previous {
+            std::env::set_var(self.key, value);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
+async fn mock_name_check(Path(username): Path<String>) -> Json<serde_json::Value> {
+    Json(json!({
+        "ok": true,
+        "available": false,
+        "reason": format!("{username} is reserved"),
+    }))
+}
+
+async fn start_name_check_server() -> (String, JoinHandle<()>) {
+    let app = Router::new().route("/api/username/check/:username", get(mock_name_check));
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve divine name check app");
+    });
+
+    (format!("http://{}", address), handle)
 }
 
 #[tokio::test]
@@ -240,6 +293,66 @@ async fn update_profile_username_conflict_returns_conflict_status() {
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(body["error"], "Username is already taken");
+}
+
+#[tokio::test]
+#[serial]
+async fn update_profile_divine_name_conflict_returns_conflict_status() {
+    let pool = common::setup_test_db().await;
+
+    let user_keys = Keys::generate();
+    let user_pubkey = user_keys.public_key().to_hex();
+    let tenant_id = 1_i64;
+    let username = "reserved-handle".to_string();
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let token = build_test_ucan(&user_keys, tenant_id).await;
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::AUTHORIZATION,
+        format!("Bearer {token}")
+            .parse()
+            .expect("authorization header should parse"),
+    );
+
+    let (base_url, server_handle) = start_name_check_server().await;
+    let _divine_name_server = EnvGuard::set("DIVINE_NAME_SERVER_URL", &base_url);
+    let _enable_divine_names = EnvGuard::set("ENABLE_DIVINE_NAMES", "1");
+
+    let response = auth::update_profile(
+        create_test_tenant(tenant_id),
+        State(create_test_auth_state(pool)),
+        headers,
+        Json(auth::ProfileData {
+            username: Some(username.clone()),
+            name: None,
+            about: None,
+            picture: None,
+            banner: None,
+            nip05: None,
+            website: None,
+            lud16: None,
+        }),
+    )
+    .await
+    .into_response();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body["error"], format!("{username} is reserved"));
+
+    server_handle.abort();
 }
 
 #[tokio::test]

--- a/api/tests/update_profile_divine_name_test.rs
+++ b/api/tests/update_profile_divine_name_test.rs
@@ -1,7 +1,99 @@
 mod common;
 
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    Json,
+};
+use http_body_util::BodyExt;
+use keycast_api::api::http::{auth, routes::AuthState};
+use keycast_api::api::tenant::{Tenant, TenantExtractor};
+use keycast_api::bcrypt_queue::BcryptQueue;
+use keycast_api::handlers::http_rpc_handler::new_http_handler_cache;
+use keycast_api::state::KeycastState;
+use keycast_api::ucan_auth::{nostr_pubkey_to_did, NostrKeyMaterial};
+use keycast_core::encryption::{KeyManager, KeyManagerError};
 use keycast_core::repositories::UserRepository;
+use keycast_core::secret_pool::SecretPool;
+use moka::future::Cache;
 use nostr_sdk::Keys;
+use serde_json::json;
+use sqlx::PgPool;
+use std::sync::Arc;
+use ucan::builder::UcanBuilder;
+use zeroize::Zeroizing;
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn create_test_auth_state(pool: PgPool) -> AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+fn create_test_tenant(tenant_id: i64) -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: tenant_id,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    }))
+}
+
+async fn build_test_ucan(keys: &Keys, tenant_id: i64) -> String {
+    let key_material = NostrKeyMaterial::from_keys(keys.clone());
+    let user_did = nostr_pubkey_to_did(&keys.public_key());
+    let facts = json!({
+        "tenant_id": tenant_id,
+        "redirect_origin": "https://example.test"
+    });
+
+    UcanBuilder::default()
+        .issued_by(&key_material)
+        .for_audience(&user_did)
+        .with_lifetime(3600)
+        .with_fact(facts)
+        .build()
+        .expect("failed to build test UCAN")
+        .sign()
+        .await
+        .expect("failed to sign test UCAN")
+        .encode()
+        .expect("failed to encode test UCAN")
+}
 
 #[tokio::test]
 async fn update_profile_claims_name_without_enabling_atproto() {
@@ -78,6 +170,76 @@ async fn username_conflict_is_detected_in_local_repository_check() {
         !available_for_second,
         "username should be marked unavailable"
     );
+}
+
+#[tokio::test]
+async fn update_profile_username_conflict_returns_conflict_status() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+
+    let first_keys = Keys::generate();
+    let second_keys = Keys::generate();
+    let first_user = first_keys.public_key().to_hex();
+    let second_user = second_keys.public_key().to_hex();
+    let tenant_id = 1_i64;
+    let username = format!("profile-conflict-{}", &first_user[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())",
+    )
+    .bind(&first_user)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert first user");
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())",
+    )
+    .bind(&second_user)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert second user");
+
+    repo.update_username(&first_user, &username, tenant_id)
+        .await
+        .expect("failed to set first username");
+
+    let token = build_test_ucan(&second_keys, tenant_id).await;
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::AUTHORIZATION,
+        format!("Bearer {token}")
+            .parse()
+            .expect("authorization header should parse"),
+    );
+
+    let response = auth::update_profile(
+        create_test_tenant(tenant_id),
+        State(create_test_auth_state(pool)),
+        headers,
+        Json(auth::ProfileData {
+            username: Some(username),
+            name: None,
+            about: None,
+            picture: None,
+            banner: None,
+            nip05: None,
+            website: None,
+            lud16: None,
+        }),
+    )
+    .await
+    .into_response();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body["error"], "Username is already taken");
 }
 
 #[tokio::test]

--- a/api/tests/update_profile_divine_name_test.rs
+++ b/api/tests/update_profile_divine_name_test.rs
@@ -5,8 +5,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
     routing::get,
-    Json,
-    Router,
+    Json, Router,
 };
 use http_body_util::BodyExt;
 use keycast_api::api::http::{auth, routes::AuthState};
@@ -24,8 +23,8 @@ use serde_json::json;
 use serial_test::serial;
 use sqlx::PgPool;
 use std::sync::Arc;
-use tokio::task::JoinHandle;
 use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
 use ucan::builder::UcanBuilder;
 use zeroize::Zeroizing;
 

--- a/api/tests/update_profile_divine_name_test.rs
+++ b/api/tests/update_profile_divine_name_test.rs
@@ -226,6 +226,7 @@ async fn username_conflict_is_detected_in_local_repository_check() {
 }
 
 #[tokio::test]
+#[serial]
 async fn update_profile_username_conflict_returns_conflict_status() {
     let pool = common::setup_test_db().await;
     let repo = UserRepository::new(pool.clone());


### PR DESCRIPTION
## Summary

Profile saves used to return a generic 503 when the requested username was already taken.
This change returns 409 with a clear message so the client can tell the user to choose another username.
It also stops treating normal username validation failures as internal server errors.

## Motivation

The root cause was that expected profile username failures used `AuthError::Internal`.
That error path logs the problem and renders a generic service-unavailable response.
This change adds an expected conflict path and keeps real service failures on the existing internal paths.

## Related Issue

- Closes #199

## Testing

I tested the profile path that was returning the wrong status, then ran the full Rust checks.
The workspace tests used the local stack Postgres database on port 15432.
Rebase preflight could not run because fetching `origin/main` failed with SSH publickey permission denied.

- [x] `DATABASE_URL=postgres://postgres:password@localhost:15432/keycast_test cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [ ] Manual verification completed

## Visuals

There is no UI or web-facing visual change.

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

## Risks

The risk is low because the change only affects expected profile username errors.
Database errors, token errors, and unavailable dependency fallbacks still use their existing paths.
The external name-service not-available response is now also treated as a username conflict because it is an expected availability failure.