### PR TITLE
fix: reject malformed emails during registration

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -106,14 +106,17 @@ fn normalize_nip05_username(raw_username: &str) -> Result<String, AuthError> {
 }
 
 pub(crate) fn normalize_registration_email(email: &str) -> Result<String, &'static str> {
-    let normalized = email.trim().to_lowercase();
+    let trimmed = email.trim();
 
-    if normalized.is_empty()
-        || normalized.len() > 254
-        || normalized.bytes().any(|byte| byte <= b' ' || byte == 0x7f)
+    if trimmed.is_empty()
+        || trimmed.len() > 254
+        || !trimmed.is_ascii()
+        || trimmed.bytes().any(|byte| byte <= b' ' || byte == 0x7f)
     {
         return Err(INVALID_EMAIL_CODE);
     }
+
+    let normalized = trimmed.to_ascii_lowercase();
 
     let Some((local, domain)) = normalized.split_once('@') else {
         return Err(INVALID_EMAIL_CODE);
@@ -4364,6 +4367,8 @@ mod tests {
             "person@example-.com",
             "person(foo)@example.com",
             "person<evil>@example.com",
+            "\u{212a}@example.com",
+            "person@\u{212a}.example.com",
             "person@.example.com",
             "person@example.com.",
             ".person@example.com",

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -35,6 +35,7 @@ const PASSWORD_RESET_EXPIRY_HOURS: i64 = 1;
 const DEFAULT_NIP05_DOMAIN: &str = "divine.video";
 const MAX_NIP05_USERNAME_LENGTH: usize = 64;
 pub(crate) const INVALID_EMAIL_CODE: &str = "INVALID_EMAIL";
+pub(crate) const INVALID_EMAIL_MESSAGE: &str = "Please enter a valid email address.";
 
 /// Get token expiry in seconds. Uses `TOKEN_EXPIRY_SECONDS` env var if set,
 /// otherwise defaults to 24 hours (86400 seconds).
@@ -354,6 +355,7 @@ pub enum AuthError {
     TokenExpired,
     EmailSendFailed(String),
     DuplicateKey, // Nostr pubkey already registered (BYOK case)
+    InvalidEmail,
     BadRequest(String),
     Forbidden(String),   // User has no authorization for this origin
     RegistrationExpired, // Async bcrypt timed out (instance died)
@@ -435,6 +437,16 @@ impl IntoResponse for AuthError {
                 StatusCode::CONFLICT,
                 "This Nostr key is already registered. Please log in instead or use a different key.".to_string(),
             ),
+            AuthError::InvalidEmail => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": INVALID_EMAIL_MESSAGE,
+                        "code": INVALID_EMAIL_CODE,
+                    })),
+                )
+                    .into_response();
+            },
             AuthError::TokenExpired => (
                 StatusCode::UNAUTHORIZED,
                 "Verification code or token has expired. Please request a new one.".to_string(),
@@ -712,7 +724,7 @@ pub async fn register(
     let key_manager = auth_state.state.key_manager.as_ref();
     let tenant_id = tenant.0.id;
 
-    req.email = req.email.to_lowercase();
+    req.email = normalize_registration_email(&req.email).map_err(|_| AuthError::InvalidEmail)?;
 
     let instance_id = keycast_core::instance::instance_id();
 
@@ -3593,6 +3605,31 @@ mod tests {
         assert!(validate_origin("http://localhost.evil.com").is_err());
     }
 
+    #[tokio::test]
+    async fn test_register_rejects_malformed_email_with_stable_error() {
+        let response = match super::register(
+            create_unit_test_tenant(),
+            axum::extract::State(create_lazy_auth_state()),
+            axum::http::HeaderMap::new(),
+            axum::Json(super::RegisterRequest {
+                email: "person@gmail..com".to_string(),
+                password: "testpassword123".to_string(),
+                nsec: None,
+                relays: None,
+            }),
+        )
+        .await
+        {
+            Ok(response) => axum::response::IntoResponse::into_response(response),
+            Err(error) => axum::response::IntoResponse::into_response(error),
+        };
+
+        assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["code"], super::INVALID_EMAIL_CODE);
+        assert_eq!(body["error"], "Please enter a valid email address.");
+    }
+
     #[cfg(feature = "integration-tests")]
     use super::{verify_email, VerifyEmailRequest};
     #[cfg(feature = "integration-tests")]
@@ -3633,6 +3670,70 @@ mod tests {
     use uuid::Uuid;
     #[cfg(feature = "integration-tests")]
     use zeroize::Zeroizing;
+
+    struct LazyTestKeyManager;
+
+    #[async_trait::async_trait]
+    impl keycast_core::encryption::KeyManager for LazyTestKeyManager {
+        async fn encrypt(
+            &self,
+            plaintext_bytes: &[u8],
+        ) -> Result<Vec<u8>, keycast_core::encryption::KeyManagerError> {
+            Ok(plaintext_bytes.to_vec())
+        }
+
+        async fn decrypt(
+            &self,
+            ciphertext_bytes: &[u8],
+        ) -> Result<zeroize::Zeroizing<Vec<u8>>, keycast_core::encryption::KeyManagerError>
+        {
+            Ok(zeroize::Zeroizing::new(ciphertext_bytes.to_vec()))
+        }
+    }
+
+    fn create_lazy_auth_state() -> crate::api::http::routes::AuthState {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://postgres:password@localhost/keycast_test")
+            .expect("lazy pool should be created");
+        let bcrypt_queue = crate::bcrypt_queue::BcryptQueue::new();
+        let secret_pool = keycast_core::secret_pool::SecretPool::new(1);
+        let tenant_cache = moka::future::Cache::builder().max_capacity(10).build();
+        let key_manager: std::sync::Arc<Box<dyn keycast_core::encryption::KeyManager>> =
+            std::sync::Arc::new(Box::new(LazyTestKeyManager));
+
+        crate::api::http::routes::AuthState {
+            state: std::sync::Arc::new(crate::state::KeycastState {
+                db: pool,
+                key_manager,
+                signer_handlers: None,
+                http_handler_cache: crate::handlers::http_rpc_handler::new_http_handler_cache(),
+                server_keys: Keys::generate(),
+                tenant_cache,
+                bcrypt_sender: bcrypt_queue.sender(),
+                redis: None,
+                secret_pool: secret_pool.receiver(),
+            }),
+            auth_tx: None,
+        }
+    }
+
+    fn create_unit_test_tenant() -> crate::api::tenant::TenantExtractor {
+        crate::api::tenant::TenantExtractor(std::sync::Arc::new(crate::api::tenant::Tenant {
+            id: 1,
+            domain: "example.test".to_string(),
+            name: "Test Tenant".to_string(),
+            settings: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }))
+    }
+
+    async fn response_json(response: axum::response::Response) -> serde_json::Value {
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+        serde_json::from_slice(&body).expect("response body should be JSON")
+    }
 
     /// Helper to create test database connection
     /// Uses DATABASE_URL env var or defaults to localhost

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -121,6 +121,7 @@ pub(crate) fn normalize_registration_email(email: &str) -> Result<String, &'stat
 
     if local.is_empty()
         || domain.is_empty()
+        || local.len() > 64
         || local.contains('@')
         || domain.contains('@')
         || local.starts_with('.')
@@ -130,8 +131,34 @@ pub(crate) fn normalize_registration_email(email: &str) -> Result<String, &'stat
         || local.contains("..")
         || domain.contains("..")
         || !domain.contains('.')
+        || !local.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'/'
+                        | b'='
+                        | b'?'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'{'
+                        | b'|'
+                        | b'}'
+                        | b'~'
+                        | b'.'
+                )
+        })
         || domain.split('.').any(|label| {
             label.is_empty()
+                || label.len() > 63
                 || label.starts_with('-')
                 || label.ends_with('-')
                 || !label
@@ -4335,6 +4362,8 @@ mod tests {
             "person@gm!ail.com",
             "person@-example.com",
             "person@example-.com",
+            "person(foo)@example.com",
+            "person<evil>@example.com",
             "person@.example.com",
             "person@example.com.",
             ".person@example.com",
@@ -4349,5 +4378,17 @@ mod tests {
                 "{email} should be rejected"
             );
         }
+
+        let local_too_long = format!("{}@example.com", "a".repeat(65));
+        assert!(
+            super::normalize_registration_email(&local_too_long).is_err(),
+            "local part longer than 64 bytes should be rejected"
+        );
+
+        let domain_label_too_long = format!("person@{}.com", "a".repeat(64));
+        assert!(
+            super::normalize_registration_email(&domain_label_too_long).is_err(),
+            "domain labels longer than 63 bytes should be rejected"
+        );
     }
 }

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -130,7 +130,14 @@ pub(crate) fn normalize_registration_email(email: &str) -> Result<String, &'stat
         || local.contains("..")
         || domain.contains("..")
         || !domain.contains('.')
-        || domain.split('.').any(str::is_empty)
+        || domain.split('.').any(|label| {
+            label.is_empty()
+                || label.starts_with('-')
+                || label.ends_with('-')
+                || !label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
     {
         return Err(INVALID_EMAIL_CODE);
     }
@@ -4324,6 +4331,10 @@ mod tests {
     fn test_normalize_registration_email_rejects_malformed_addresses() {
         for email in [
             "person@gmail..com",
+            "person@exa_mple.com",
+            "person@gm!ail.com",
+            "person@-example.com",
+            "person@example-.com",
             "person@.example.com",
             "person@example.com.",
             ".person@example.com",

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -34,6 +34,7 @@ pub const EMAIL_VERIFICATION_EXPIRY_HOURS: i64 = 24;
 const PASSWORD_RESET_EXPIRY_HOURS: i64 = 1;
 const DEFAULT_NIP05_DOMAIN: &str = "divine.video";
 const MAX_NIP05_USERNAME_LENGTH: usize = 64;
+pub(crate) const INVALID_EMAIL_CODE: &str = "INVALID_EMAIL";
 
 /// Get token expiry in seconds. Uses `TOKEN_EXPIRY_SECONDS` env var if set,
 /// otherwise defaults to 24 hours (86400 seconds).
@@ -101,6 +102,39 @@ fn normalize_nip05_username(raw_username: &str) -> Result<String, AuthError> {
     }
 
     Ok(username)
+}
+
+pub(crate) fn normalize_registration_email(email: &str) -> Result<String, &'static str> {
+    let normalized = email.trim().to_lowercase();
+
+    if normalized.is_empty()
+        || normalized.len() > 254
+        || normalized.bytes().any(|byte| byte <= b' ' || byte == 0x7f)
+    {
+        return Err(INVALID_EMAIL_CODE);
+    }
+
+    let Some((local, domain)) = normalized.split_once('@') else {
+        return Err(INVALID_EMAIL_CODE);
+    };
+
+    if local.is_empty()
+        || domain.is_empty()
+        || local.contains('@')
+        || domain.contains('@')
+        || local.starts_with('.')
+        || local.ends_with('.')
+        || domain.starts_with('.')
+        || domain.ends_with('.')
+        || local.contains("..")
+        || domain.contains("..")
+        || !domain.contains('.')
+        || domain.split('.').any(str::is_empty)
+    {
+        return Err(INVALID_EMAIL_CODE);
+    }
+
+    Ok(normalized)
 }
 
 /// Generate UCAN token signed by user's key (self-signed)
@@ -4169,5 +4203,39 @@ mod tests {
             result.is_err(),
             "username longer than max boundary should be rejected"
         );
+    }
+
+    #[test]
+    fn test_normalize_registration_email_accepts_common_addresses() {
+        for email in [
+            "person@example.com",
+            "Person+tag@Example.COM",
+            "first.last@sub.example.co.uk",
+        ] {
+            assert!(
+                super::normalize_registration_email(email).is_ok(),
+                "{email} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_normalize_registration_email_rejects_malformed_addresses() {
+        for email in [
+            "person@gmail..com",
+            "person@.example.com",
+            "person@example.com.",
+            ".person@example.com",
+            "person.@example.com",
+            "personexample.com",
+            "person@localhost",
+            "person @example.com",
+            "",
+        ] {
+            assert!(
+                super::normalize_registration_email(email).is_err(),
+                "{email} should be rejected"
+            );
+        }
     }
 }

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -17,7 +17,10 @@ use nostr_sdk::Keys;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
-use super::auth::{generate_secure_token, EMAIL_VERIFICATION_EXPIRY_HOURS};
+use super::auth::{
+    generate_secure_token, normalize_registration_email, EMAIL_VERIFICATION_EXPIRY_HOURS,
+    INVALID_EMAIL_CODE, INVALID_EMAIL_MESSAGE,
+};
 use super::oauth::{extract_origin, parse_policy_scope};
 
 // ============================================================================
@@ -77,7 +80,8 @@ pub async fn headless_register(
     let key_manager = auth_state.state.key_manager.as_ref();
     let tenant_id = tenant.0.id;
 
-    req.email = req.email.to_lowercase();
+    req.email =
+        normalize_registration_email(&req.email).map_err(|_| HeadlessError::InvalidEmail)?;
 
     tracing::info!(
         event = "headless_registration_attempt",
@@ -618,6 +622,7 @@ pub async fn headless_authorize(
 pub enum HeadlessError {
     Unauthorized,
     EmailNotVerified,
+    InvalidEmail,
     InvalidRequest(String),
     Conflict(String),
     Internal(String),
@@ -639,6 +644,11 @@ impl IntoResponse for HeadlessError {
                 StatusCode::FORBIDDEN,
                 "Please verify your email address before signing in".to_string(),
                 "EMAIL_NOT_VERIFIED",
+            ),
+            HeadlessError::InvalidEmail => (
+                StatusCode::BAD_REQUEST,
+                INVALID_EMAIL_MESSAGE.to_string(),
+                INVALID_EMAIL_CODE,
             ),
             HeadlessError::InvalidRequest(msg) => (StatusCode::BAD_REQUEST, msg, "INVALID_REQUEST"),
             HeadlessError::Conflict(msg) => (StatusCode::CONFLICT, msg, "CONFLICT"),
@@ -699,5 +709,103 @@ impl From<keycast_core::repositories::RepositoryError> for HeadlessError {
             RepositoryError::NotFound(msg) => HeadlessError::InvalidRequest(msg),
             _ => HeadlessError::Internal(e.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr_sdk::Keys;
+
+    struct LazyTestKeyManager;
+
+    #[async_trait::async_trait]
+    impl keycast_core::encryption::KeyManager for LazyTestKeyManager {
+        async fn encrypt(
+            &self,
+            plaintext_bytes: &[u8],
+        ) -> Result<Vec<u8>, keycast_core::encryption::KeyManagerError> {
+            Ok(plaintext_bytes.to_vec())
+        }
+
+        async fn decrypt(
+            &self,
+            ciphertext_bytes: &[u8],
+        ) -> Result<zeroize::Zeroizing<Vec<u8>>, keycast_core::encryption::KeyManagerError>
+        {
+            Ok(zeroize::Zeroizing::new(ciphertext_bytes.to_vec()))
+        }
+    }
+
+    fn create_lazy_auth_state() -> crate::api::http::routes::AuthState {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://postgres:password@localhost/keycast_test")
+            .expect("lazy pool should be created");
+        let bcrypt_queue = crate::bcrypt_queue::BcryptQueue::new();
+        let secret_pool = keycast_core::secret_pool::SecretPool::new(1);
+        let tenant_cache = moka::future::Cache::builder().max_capacity(10).build();
+        let key_manager: std::sync::Arc<Box<dyn keycast_core::encryption::KeyManager>> =
+            std::sync::Arc::new(Box::new(LazyTestKeyManager));
+
+        crate::api::http::routes::AuthState {
+            state: std::sync::Arc::new(crate::state::KeycastState {
+                db: pool,
+                key_manager,
+                signer_handlers: None,
+                http_handler_cache: crate::handlers::http_rpc_handler::new_http_handler_cache(),
+                server_keys: Keys::generate(),
+                tenant_cache,
+                bcrypt_sender: bcrypt_queue.sender(),
+                redis: None,
+                secret_pool: secret_pool.receiver(),
+            }),
+            auth_tx: None,
+        }
+    }
+
+    fn create_unit_test_tenant() -> crate::api::tenant::TenantExtractor {
+        crate::api::tenant::TenantExtractor(std::sync::Arc::new(crate::api::tenant::Tenant {
+            id: 1,
+            domain: "example.test".to_string(),
+            name: "Test Tenant".to_string(),
+            settings: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }))
+    }
+
+    async fn response_json(response: axum::response::Response) -> serde_json::Value {
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+        serde_json::from_slice(&body).expect("response body should be JSON")
+    }
+
+    #[tokio::test]
+    async fn test_headless_register_rejects_malformed_email_with_stable_error() {
+        let response = match super::headless_register(
+            create_unit_test_tenant(),
+            axum::extract::State(create_lazy_auth_state()),
+            axum::Json(super::HeadlessRegisterRequest {
+                email: "person@gmail..com".to_string(),
+                password: "testpassword123".to_string(),
+                client_id: "TestClient".to_string(),
+                redirect_uri: "https://client.example/callback".to_string(),
+                nsec: None,
+                scope: None,
+                code_challenge: None,
+                code_challenge_method: None,
+                state: None,
+            }),
+        )
+        .await
+        {
+            Ok(response) => axum::response::IntoResponse::into_response(response),
+            Err(error) => axum::response::IntoResponse::into_response(error),
+        };
+
+        assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["code"], crate::api::http::auth::INVALID_EMAIL_CODE);
+        assert_eq!(body["error"], "Please enter a valid email address.");
     }
 }

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -23,7 +23,10 @@ use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 
 // Import constants and helpers from auth module
-use super::auth::{generate_secure_token, token_expiry_seconds, EMAIL_VERIFICATION_EXPIRY_HOURS};
+use super::auth::{
+    generate_secure_token, normalize_registration_email, token_expiry_seconds,
+    EMAIL_VERIFICATION_EXPIRY_HOURS, INVALID_EMAIL_CODE, INVALID_EMAIL_MESSAGE,
+};
 use super::html_safety::{escape_attr, escape_html, js_string_literal};
 use crate::brand::BRAND_NAME;
 
@@ -310,6 +313,7 @@ pub struct TokenResponse {
 #[derive(Debug)]
 pub enum OAuthError {
     Unauthorized,
+    InvalidEmail,
     InvalidRequest(String),
     InvalidGrant(String), // RFC 6749 - for invalid/expired refresh tokens or auth codes
     Database(sqlx::Error),
@@ -325,6 +329,16 @@ impl IntoResponse for OAuthError {
                 "Invalid email or password. Please check your credentials and try again."
                     .to_string(),
             ),
+            OAuthError::InvalidEmail => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": INVALID_EMAIL_MESSAGE,
+                        "code": INVALID_EMAIL_CODE,
+                    })),
+                )
+                    .into_response();
+            }
             OAuthError::InvalidRequest(msg) => {
                 (StatusCode::BAD_REQUEST, format!("Invalid request: {}", msg))
             }
@@ -3182,7 +3196,7 @@ pub async fn oauth_register(
     let pool = &auth_state.state.db;
     let tenant_id = tenant.0.id;
 
-    req.email = req.email.to_lowercase();
+    req.email = normalize_registration_email(&req.email).map_err(|_| OAuthError::InvalidEmail)?;
 
     tracing::info!(
         "OAuth popup registration for email: {} in tenant: {}, nsec: {}, pubkey: {}, client_id: {}",
@@ -4113,6 +4127,101 @@ pub async fn poll(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct LazyTestKeyManager;
+
+    #[async_trait::async_trait]
+    impl keycast_core::encryption::KeyManager for LazyTestKeyManager {
+        async fn encrypt(
+            &self,
+            plaintext_bytes: &[u8],
+        ) -> Result<Vec<u8>, keycast_core::encryption::KeyManagerError> {
+            Ok(plaintext_bytes.to_vec())
+        }
+
+        async fn decrypt(
+            &self,
+            ciphertext_bytes: &[u8],
+        ) -> Result<zeroize::Zeroizing<Vec<u8>>, keycast_core::encryption::KeyManagerError>
+        {
+            Ok(zeroize::Zeroizing::new(ciphertext_bytes.to_vec()))
+        }
+    }
+
+    fn create_lazy_auth_state() -> crate::api::http::routes::AuthState {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://postgres:password@localhost/keycast_test")
+            .expect("lazy pool should be created");
+        let bcrypt_queue = crate::bcrypt_queue::BcryptQueue::new();
+        let secret_pool = keycast_core::secret_pool::SecretPool::new(1);
+        let tenant_cache = moka::future::Cache::builder().max_capacity(10).build();
+        let key_manager: std::sync::Arc<Box<dyn keycast_core::encryption::KeyManager>> =
+            std::sync::Arc::new(Box::new(LazyTestKeyManager));
+
+        crate::api::http::routes::AuthState {
+            state: std::sync::Arc::new(crate::state::KeycastState {
+                db: pool,
+                key_manager,
+                signer_handlers: None,
+                http_handler_cache: crate::handlers::http_rpc_handler::new_http_handler_cache(),
+                server_keys: Keys::generate(),
+                tenant_cache,
+                bcrypt_sender: bcrypt_queue.sender(),
+                redis: None,
+                secret_pool: secret_pool.receiver(),
+            }),
+            auth_tx: None,
+        }
+    }
+
+    fn create_unit_test_tenant() -> crate::api::tenant::TenantExtractor {
+        crate::api::tenant::TenantExtractor(std::sync::Arc::new(crate::api::tenant::Tenant {
+            id: 1,
+            domain: "example.test".to_string(),
+            name: "Test Tenant".to_string(),
+            settings: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }))
+    }
+
+    async fn response_json(response: axum::response::Response) -> serde_json::Value {
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+        serde_json::from_slice(&body).expect("response body should be JSON")
+    }
+
+    #[tokio::test]
+    async fn test_oauth_register_rejects_malformed_email_with_stable_error() {
+        let response = match oauth_register(
+            create_unit_test_tenant(),
+            axum::extract::State(create_lazy_auth_state()),
+            axum::Json(OAuthRegisterRequest {
+                email: "person@-example.com".to_string(),
+                password: "testpassword123".to_string(),
+                client_id: "TestClient".to_string(),
+                redirect_uri: "https://client.example/callback".to_string(),
+                scope: None,
+                code_challenge: None,
+                code_challenge_method: None,
+                pubkey: None,
+                nsec: None,
+                relays: None,
+                state: None,
+            }),
+        )
+        .await
+        {
+            Ok(response) => axum::response::IntoResponse::into_response(response),
+            Err(error) => axum::response::IntoResponse::into_response(error),
+        };
+
+        assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["code"], crate::api::http::auth::INVALID_EMAIL_CODE);
+        assert_eq!(body["error"], crate::api::http::auth::INVALID_EMAIL_MESSAGE);
+    }
 
     #[test]
     fn test_extract_origin_https() {


### PR DESCRIPTION
## Summary

Users could get stuck after entering an email address that could not receive mail.
This change rejects malformed registration emails before signup state is stored or verification email is sent.
The same check now protects standard registration, headless registration, and OAuth popup registration.

## Motivation

The registration paths only lowercased email input before doing side-effect work.
The shared validator now checks the raw trimmed input as ASCII before lowercasing.
It rejects bad dot placement, invalid local characters, invalid domain labels, edge hyphens, length violations, and Unicode case-folding bypasses.

## Related Issue

- Closes #202

## Testing

I tested the validator, the affected registration paths, and the full Rust workspace.
Manual browser verification was not run because this has no visual change.
Fetching latest main failed because SSH auth is unavailable here; rebase against cached `origin/main` was up to date.

- [x] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [ ] Manual verification completed

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

## Risks

The validator is intentionally conservative.
It supports common deliverable ASCII addresses, but it does not support quoted local parts or internationalized domains.
That trade-off is safer for registration because users must receive a verification email to finish signup.