### PR TITLE
fix: handle duplicate-email verify conflicts and clear pending oauth

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1494,6 +1494,30 @@ pub async fn verify_email(
         // Create user with email_verified=true (they just verified!)
         let user_repo = UserRepository::new(pool.clone());
         let user_already_exists = user_repo.exists(&oauth_data.user_pubkey, tenant_id).await?;
+        if let Some(existing_pubkey) = user_repo.find_pubkey_by_email(email, tenant_id).await? {
+            if existing_pubkey != oauth_data.user_pubkey {
+                tracing::info!(
+                    tenant_id = tenant_id,
+                    existing_pubkey = %existing_pubkey,
+                    pending_pubkey = %oauth_data.user_pubkey,
+                    "OAuth email verification conflict: email already belongs to another user"
+                );
+                if let Err(cleanup_err) = oauth_code_repo
+                    .delete_by_verification_token(&req.token, tenant_id)
+                    .await
+                {
+                    tracing::warn!(
+                        tenant_id = tenant_id,
+                        pending_pubkey = %oauth_data.user_pubkey,
+                        error = %cleanup_err,
+                        "Failed to clear pending OAuth verification after duplicate email conflict"
+                    );
+                }
+                return Err(AuthError::Conflict(
+                    "This email is already registered. Please log in instead.".to_string(),
+                ));
+            }
+        }
 
         if user_already_exists {
             tracing::info!(
@@ -1506,7 +1530,7 @@ pub async fn verify_email(
             let now = Utc::now();
             let mut tx = pool.begin().await?;
 
-            sqlx::query(
+            let insert_user_result = sqlx::query(
                 "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, email_verification_token, created_at, updated_at)
                  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
             )
@@ -1519,7 +1543,26 @@ pub async fn verify_email(
             .bind(now)
             .bind(now)
             .execute(&mut *tx)
-            .await?;
+            .await;
+            if let Err(err) = insert_user_result {
+                if has_database_constraint(&err, USERS_EMAIL_TENANT_CONSTRAINT) {
+                    if let Err(cleanup_err) = oauth_code_repo
+                        .delete_by_verification_token(&req.token, tenant_id)
+                        .await
+                    {
+                        tracing::warn!(
+                            tenant_id = tenant_id,
+                            pending_pubkey = %oauth_data.user_pubkey,
+                            error = %cleanup_err,
+                            "Failed to clear pending OAuth verification after duplicate email conflict"
+                        );
+                    }
+                    return Err(AuthError::Conflict(
+                        "This email is already registered. Please log in instead.".to_string(),
+                    ));
+                }
+                return Err(AuthError::Database(err));
+            }
 
             sqlx::query(
                 "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
@@ -1533,7 +1576,25 @@ pub async fn verify_email(
             .execute(&mut *tx)
             .await?;
 
-            tx.commit().await?;
+            if let Err(err) = tx.commit().await {
+                if has_database_constraint(&err, USERS_EMAIL_TENANT_CONSTRAINT) {
+                    if let Err(cleanup_err) = oauth_code_repo
+                        .delete_by_verification_token(&req.token, tenant_id)
+                        .await
+                    {
+                        tracing::warn!(
+                            tenant_id = tenant_id,
+                            pending_pubkey = %oauth_data.user_pubkey,
+                            error = %cleanup_err,
+                            "Failed to clear pending OAuth verification after duplicate email conflict"
+                        );
+                    }
+                    return Err(AuthError::Conflict(
+                        "This email is already registered. Please log in instead.".to_string(),
+                    ));
+                }
+                return Err(AuthError::Database(err));
+            }
 
             tracing::info!(
                 "Created user and personal_keys for OAuth registration: {}",
@@ -1541,7 +1602,7 @@ pub async fn verify_email(
             );
         } else {
             // BYOK flow: just create user, keys will come at token exchange
-            user_repo
+            let create_result = user_repo
                 .create_with_password_verified(
                     &oauth_data.user_pubkey,
                     tenant_id,
@@ -1550,7 +1611,28 @@ pub async fn verify_email(
                     true,             // email_verified = true
                     Some(&req.token), // Keep token for idempotent re-verification
                 )
-                .await?;
+                .await;
+            if let Err(err) = create_result {
+                match err {
+                    keycast_core::repositories::RepositoryError::Duplicate => {
+                        if let Err(cleanup_err) = oauth_code_repo
+                            .delete_by_verification_token(&req.token, tenant_id)
+                            .await
+                        {
+                            tracing::warn!(
+                                tenant_id = tenant_id,
+                                pending_pubkey = %oauth_data.user_pubkey,
+                                error = %cleanup_err,
+                                "Failed to clear pending OAuth verification after duplicate email conflict"
+                            );
+                        }
+                        return Err(AuthError::Conflict(
+                            "This email is already registered. Please log in instead.".to_string(),
+                        ));
+                    }
+                    other => return Err(other.into()),
+                }
+            }
 
             tracing::info!(
                 "Created user for BYOK OAuth registration: {}",
@@ -4103,7 +4185,7 @@ mod tests {
 
         let response = match verify_email(
             create_test_tenant(),
-            State(auth_state),
+            State(auth_state.clone()),
             HeaderMap::new(),
             Json(VerifyEmailRequest {
                 token: verification_token.clone(),
@@ -4116,6 +4198,38 @@ mod tests {
         };
 
         assert_eq!(response.status(), StatusCode::CONFLICT);
+
+        let pending_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE tenant_id = 1 AND pending_email_verification_token = $1",
+        )
+        .bind(&verification_token)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            pending_count.0, 0,
+            "duplicate-email conflict should clear pending registration state"
+        );
+
+        let second_response = match verify_email(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            Json(VerifyEmailRequest {
+                token: verification_token.clone(),
+            }),
+        )
+        .await
+        {
+            Ok(response) => response.into_response(),
+            Err(err) => err.into_response(),
+        };
+        assert_eq!(
+            second_response.status(),
+            StatusCode::UNAUTHORIZED,
+            "after conflict cleanup, retry should not loop on pending registration"
+        );
 
         cleanup_verify_email_test_data(&pool, &existing_pubkey, &verification_token).await;
         cleanup_verify_email_test_data(&pool, &pending_pubkey, &verification_token).await;


### PR DESCRIPTION
## Summary

- Handle duplicated-email collisions in OAuth/headless as a terminal 409 conflict instead of surfacing as a retryable server error;
- Clear pending OAuth verification state on duplicate-email conflict so the same verification token no longer gets stuck in a retry loop.
- add integration coverage to assert first-attempt conflict, pending-state cleanup, and non-looping behavior on retry.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Aiming to improve the repo

## Related Issue

- Closes #198

## Testing

- [x] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] Manual verification completed

## Visuals

- [x] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

