### PR TITLE
fix: persist request_id on registered_client admin audit rows

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -2,12 +2,14 @@
 // ABOUTME: Used for Vine import and support workflows
 
 use axum::extract::{Path, Query, State};
+use axum::http::HeaderMap;
 use axum::Json;
 use chrono::{Duration, Utc};
 use nostr_sdk::{FromBech32, Keys};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use super::auth_observability::request_id_from_headers;
 use super::routes::AuthState;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extractors::UcanAuth;
@@ -1548,6 +1550,7 @@ async fn record_registered_client_audit(
     actor_pubkey: &str,
     action: &'static str,
     client: &RegisteredClient,
+    request_id: Option<String>,
 ) {
     let metadata = serde_json::json!({
         "name": client.name,
@@ -1562,6 +1565,7 @@ async fn record_registered_client_audit(
             target_resource_type: "registered_client".to_string(),
             target_resource_id: Some(client.id.to_string()),
             target_client_id: Some(client.client_id.clone()),
+            request_id,
             metadata_json: metadata,
         })
         .await
@@ -1585,6 +1589,7 @@ async fn record_registered_client_update_audit(
     actor_pubkey: &str,
     before: &RegisteredClient,
     after: &RegisteredClient,
+    request_id: Option<String>,
 ) {
     let metadata = serde_json::json!({
         "before": {
@@ -1605,6 +1610,7 @@ async fn record_registered_client_update_audit(
             target_resource_type: "registered_client".to_string(),
             target_resource_id: Some(after.id.to_string()),
             target_client_id: Some(after.client_id.clone()),
+            request_id,
             metadata_json: metadata,
         })
         .await
@@ -1650,11 +1656,14 @@ pub async fn create_registered_client(
     tenant: crate::api::tenant::TenantExtractor,
     State(auth_state): State<AuthState>,
     auth: UcanAuth,
+    headers: HeaderMap,
     Json(req): Json<CreateRegisteredClientRequest>,
 ) -> ApiResult<Json<RegisteredClientView>> {
     if !is_full_admin(&auth) {
         return Err(ApiError::forbidden("Full admin access required"));
     }
+
+    let request_id = request_id_from_headers(&headers);
 
     let repo = RegisteredClientRepository::new(auth_state.state.db.clone());
     let created = repo
@@ -1672,6 +1681,7 @@ pub async fn create_registered_client(
         &auth.pubkey,
         "registered_client.create",
         &created,
+        request_id,
     )
     .await;
 
@@ -1698,12 +1708,15 @@ pub async fn update_registered_client(
     tenant: crate::api::tenant::TenantExtractor,
     State(auth_state): State<AuthState>,
     auth: UcanAuth,
+    headers: HeaderMap,
     Path(id): Path<i32>,
     Json(req): Json<UpdateRegisteredClientRequest>,
 ) -> ApiResult<Json<RegisteredClientView>> {
     if !is_full_admin(&auth) {
         return Err(ApiError::forbidden("Full admin access required"));
     }
+
+    let request_id = request_id_from_headers(&headers);
 
     if req.name.is_none() && req.allowed_redirect_uris.is_none() {
         return Err(ApiError::bad_request(
@@ -1727,6 +1740,7 @@ pub async fn update_registered_client(
         &auth.pubkey,
         &update.before,
         &update.after,
+        request_id,
     )
     .await;
 
@@ -1744,11 +1758,14 @@ pub async fn delete_registered_client(
     tenant: crate::api::tenant::TenantExtractor,
     State(auth_state): State<AuthState>,
     auth: UcanAuth,
+    headers: HeaderMap,
     Path(id): Path<i32>,
 ) -> ApiResult<Json<serde_json::Value>> {
     if !is_full_admin(&auth) {
         return Err(ApiError::forbidden("Full admin access required"));
     }
+
+    let request_id = request_id_from_headers(&headers);
 
     let repo = RegisteredClientRepository::new(auth_state.state.db.clone());
     let deleted = repo.delete(id, tenant.0.id).await.map_err(map_repo_error)?;
@@ -1758,6 +1775,7 @@ pub async fn delete_registered_client(
         &auth.pubkey,
         "registered_client.delete",
         &deleted,
+        request_id,
     )
     .await;
 

--- a/api/tests/registered_clients_admin_http_test.rs
+++ b/api/tests/registered_clients_admin_http_test.rs
@@ -8,7 +8,7 @@ mod common;
 use axum::{
     body::Body,
     extract::{Path, State},
-    http::{Request, StatusCode},
+    http::{HeaderMap, Request, StatusCode},
     routing::{get, patch, post},
     Json, Router,
 };
@@ -174,19 +174,22 @@ fn build_app(auth_state: AuthState, config: AuthConfig) -> Router {
                         .await
                 }
             })
-            .post(move |Json(body): Json<CreateRegisteredClientRequest>| {
-                let state = create_state.clone();
-                let cfg = create_cfg.clone();
-                async move {
-                    create_registered_client(
-                        create_test_tenant(),
-                        State(state),
-                        cfg.into_auth(),
-                        Json(body),
-                    )
-                    .await
-                }
-            }),
+            .post(
+                move |headers: HeaderMap, Json(body): Json<CreateRegisteredClientRequest>| {
+                    let state = create_state.clone();
+                    let cfg = create_cfg.clone();
+                    async move {
+                        create_registered_client(
+                            create_test_tenant(),
+                            State(state),
+                            cfg.into_auth(),
+                            headers,
+                            Json(body),
+                        )
+                        .await
+                    }
+                },
+            ),
         )
         .route(
             "/admin/registered-clients/test",
@@ -205,7 +208,9 @@ fn build_app(auth_state: AuthState, config: AuthConfig) -> Router {
         .route(
             "/admin/registered-clients/:id",
             patch(
-                move |Path(id): Path<i32>, Json(body): Json<UpdateRegisteredClientRequest>| {
+                move |headers: HeaderMap,
+                      Path(id): Path<i32>,
+                      Json(body): Json<UpdateRegisteredClientRequest>| {
                     let state = update_state.clone();
                     let cfg = update_cfg.clone();
                     async move {
@@ -213,6 +218,7 @@ fn build_app(auth_state: AuthState, config: AuthConfig) -> Router {
                             create_test_tenant(),
                             State(state),
                             cfg.into_auth(),
+                            headers,
                             Path(id),
                             Json(body),
                         )
@@ -220,7 +226,7 @@ fn build_app(auth_state: AuthState, config: AuthConfig) -> Router {
                     }
                 },
             )
-            .delete(move |Path(id): Path<i32>| {
+            .delete(move |headers: HeaderMap, Path(id): Path<i32>| {
                 let state = delete_state.clone();
                 let cfg = delete_cfg.clone();
                 async move {
@@ -228,6 +234,7 @@ fn build_app(auth_state: AuthState, config: AuthConfig) -> Router {
                         create_test_tenant(),
                         State(state),
                         cfg.into_auth(),
+                        headers,
                         Path(id),
                     )
                     .await

--- a/api/tests/registered_clients_audit_test.rs
+++ b/api/tests/registered_clients_audit_test.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
+use axum::http::{HeaderMap, HeaderValue};
 use axum::Json;
 use chrono::Utc;
 use keycast_api::{
@@ -127,13 +128,14 @@ struct AuditRow {
     target_resource_type: String,
     target_resource_id: Option<String>,
     target_client_id: Option<String>,
+    request_id: Option<String>,
     metadata_json: serde_json::Value,
 }
 
 async fn read_audit_rows(pool: &PgPool, tenant_id: i64, actor_pubkey: &str) -> Vec<AuditRow> {
     sqlx::query_as::<_, AuditRow>(
         "SELECT actor_pubkey, action, target_resource_type, target_resource_id,
-                target_client_id, metadata_json
+                target_client_id, request_id, metadata_json
          FROM admin_audit_events
          WHERE tenant_id = $1 AND actor_pubkey = $2
          ORDER BY occurred_at ASC, id ASC",
@@ -159,11 +161,19 @@ async fn create_update_delete_each_writes_admin_audit_event() {
 
     let state = make_auth_state(pool.clone());
 
+    let expected_request_id = format!("audit-req-{}", Uuid::new_v4());
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "x-request-id",
+        HeaderValue::from_str(&expected_request_id).expect("ascii request id"),
+    );
+
     // CREATE
     let created = create_registered_client(
         make_tenant(tenant_id),
         State(state.clone()),
         make_admin_auth(&actor_pubkey),
+        headers.clone(),
         Json(CreateRegisteredClientRequest {
             client_id: client_id.clone(),
             name: "Audit HTTP".to_string(),
@@ -179,6 +189,7 @@ async fn create_update_delete_each_writes_admin_audit_event() {
         make_tenant(tenant_id),
         State(state.clone()),
         make_admin_auth(&actor_pubkey),
+        headers.clone(),
         Path(created.id),
         Json(UpdateRegisteredClientRequest {
             name: Some("Audit HTTP renamed".to_string()),
@@ -193,6 +204,7 @@ async fn create_update_delete_each_writes_admin_audit_event() {
         make_tenant(tenant_id),
         State(state),
         make_admin_auth(&actor_pubkey),
+        headers,
         Path(created.id),
     )
     .await
@@ -219,6 +231,10 @@ async fn create_update_delete_each_writes_admin_audit_event() {
             Some(created.id.to_string()).as_deref()
         );
         assert_eq!(row.target_client_id.as_deref(), Some(client_id.as_str()));
+        assert_eq!(
+            row.request_id.as_deref(),
+            Some(expected_request_id.as_str())
+        );
     }
 
     // Spot-check metadata payloads carry the state we expect.

--- a/core/src/repositories/admin_audit_event.rs
+++ b/core/src/repositories/admin_audit_event.rs
@@ -15,6 +15,7 @@ pub struct AdminAuditEventRecord {
     pub target_resource_type: String,
     pub target_resource_id: Option<String>,
     pub target_client_id: Option<String>,
+    pub request_id: Option<String>,
     pub metadata_json: Value,
 }
 
@@ -28,6 +29,7 @@ pub struct AdminAuditEventRow {
     pub target_resource_type: String,
     pub target_resource_id: Option<String>,
     pub target_client_id: Option<String>,
+    pub request_id: Option<String>,
     pub metadata_json: Value,
 }
 
@@ -53,8 +55,9 @@ impl AdminAuditEventRepository {
                 target_resource_type,
                 target_resource_id,
                 target_client_id,
+                request_id,
                 metadata_json
-             ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
              RETURNING
                 id,
                 occurred_at,
@@ -64,6 +67,7 @@ impl AdminAuditEventRepository {
                 target_resource_type,
                 target_resource_id,
                 target_client_id,
+                request_id,
                 metadata_json",
         )
         .bind(record.tenant_id)
@@ -72,6 +76,7 @@ impl AdminAuditEventRepository {
         .bind(record.target_resource_type)
         .bind(record.target_resource_id)
         .bind(record.target_client_id)
+        .bind(record.request_id)
         .bind(record.metadata_json)
         .fetch_one(&self.pool)
         .await
@@ -93,6 +98,7 @@ impl AdminAuditEventRepository {
                 target_resource_type,
                 target_resource_id,
                 target_client_id,
+                request_id,
                 metadata_json
              FROM admin_audit_events
              WHERE tenant_id = $1

--- a/core/tests/admin_audit_event_repository_test.rs
+++ b/core/tests/admin_audit_event_repository_test.rs
@@ -48,6 +48,7 @@ async fn records_and_lists_admin_audit_event() {
             target_resource_type: "registered_client".to_string(),
             target_resource_id: Some("123".to_string()),
             target_client_id: Some(target_client_id.clone()),
+            request_id: Some("req-audit-1".to_string()),
             metadata_json: json!({
                 "name": "Audit Test",
                 "allowed_redirect_uris": ["https://example.com/cb"]
@@ -66,6 +67,7 @@ async fn records_and_lists_admin_audit_event() {
         inserted.target_client_id.as_deref(),
         Some(target_client_id.as_str())
     );
+    assert_eq!(inserted.request_id.as_deref(), Some("req-audit-1"));
     assert_eq!(inserted.metadata_json["name"], "Audit Test");
 
     let listed = repo
@@ -80,6 +82,7 @@ async fn records_and_lists_admin_audit_event() {
         listed[0].target_client_id.as_deref(),
         Some(target_client_id.as_str())
     );
+    assert_eq!(listed[0].request_id.as_deref(), Some("req-audit-1"));
 }
 
 #[tokio::test]
@@ -100,6 +103,7 @@ async fn list_recent_returns_newest_first_and_respects_tenant_scope() {
             target_resource_type: "registered_client".to_string(),
             target_resource_id: Some("1".to_string()),
             target_client_id: Some("client-a".to_string()),
+            request_id: None,
             metadata_json: json!({}),
         })
         .await
@@ -112,6 +116,7 @@ async fn list_recent_returns_newest_first_and_respects_tenant_scope() {
         target_resource_type: "registered_client".to_string(),
         target_resource_id: Some("9".to_string()),
         target_client_id: Some("client-b".to_string()),
+        request_id: Some("req-b".to_string()),
         metadata_json: json!({}),
     })
     .await
@@ -128,4 +133,5 @@ async fn list_recent_returns_newest_first_and_respects_tenant_scope() {
     let b_list = repo.list_recent(tenant_b, 10).await.unwrap();
     assert_eq!(b_list.len(), 1);
     assert_eq!(b_list[0].target_client_id.as_deref(), Some("client-b"));
+    assert_eq!(b_list[0].request_id.as_deref(), Some("req-b"));
 }

--- a/database/migrations/20260505160000_add_request_id_to_admin_audit_events.sql
+++ b/database/migrations/20260505160000_add_request_id_to_admin_audit_events.sql
@@ -1,0 +1,7 @@
+-- Correlate admin_audit_events with request-scoped auth observability (x-request-id).
+ALTER TABLE admin_audit_events
+    ADD COLUMN IF NOT EXISTS request_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_admin_audit_events_tenant_request_occurred
+    ON admin_audit_events (tenant_id, request_id, occurred_at DESC)
+    WHERE request_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- Admin CRUD for registered OAuth clients now stores the incoming requests;
- Rows are now lined up with request-scoped logs and auth events.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- A follow-up for #178 

## Related Issue

- Closes #185 

## Testing

- [x] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] Manual verification completed

## Visuals

- [x] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

