### PR TITLE
feat(admin): expose audit log via GET /admin/audit-events and UI

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -3,7 +3,7 @@
 
 use axum::extract::{Path, Query, State};
 use axum::Json;
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use nostr_sdk::{FromBech32, Keys};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -12,9 +12,10 @@ use super::routes::AuthState;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extractors::UcanAuth;
 use keycast_core::repositories::{
-    test_redirect_pattern, AdminAuditEventRecord, AdminAuditEventRepository, AuthEventRepository,
-    ClaimTokenRepository, OAuthAuthorizationRepository, RegisteredClient,
-    RegisteredClientRepository, RepositoryError, UserRepository,
+    test_redirect_pattern, AdminAuditEventListFilters, AdminAuditEventRecord,
+    AdminAuditEventRepository, AdminAuditEventRow, AuthEventRepository, ClaimTokenRepository,
+    OAuthAuthorizationRepository, RegisteredClient, RegisteredClientRepository, RepositoryError,
+    UserRepository,
 };
 use keycast_core::types::claim_token::generate_claim_token;
 
@@ -971,6 +972,99 @@ pub async fn get_user_lookup(
     }
 
     Ok(Json(UserLookupResponse { results, total }))
+}
+
+// ============================================================================
+// GET /api/admin/audit-events — read-only forensic log (support + full admin)
+// ============================================================================
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ListAdminAuditEventsQuery {
+    pub action: Option<String>,
+    pub target_client_id: Option<String>,
+    pub occurred_after: Option<String>,
+    pub occurred_before: Option<String>,
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminAuditEventView {
+    pub id: i64,
+    pub occurred_at: String,
+    pub tenant_id: i64,
+    pub actor_pubkey: String,
+    pub action: String,
+    pub target_resource_type: String,
+    pub target_resource_id: Option<String>,
+    pub target_client_id: Option<String>,
+    pub metadata_json: Value,
+}
+
+impl From<AdminAuditEventRow> for AdminAuditEventView {
+    fn from(row: AdminAuditEventRow) -> Self {
+        Self {
+            id: row.id,
+            occurred_at: row.occurred_at.to_rfc3339(),
+            tenant_id: row.tenant_id,
+            actor_pubkey: row.actor_pubkey,
+            action: row.action,
+            target_resource_type: row.target_resource_type,
+            target_resource_id: row.target_resource_id,
+            target_client_id: row.target_client_id,
+            metadata_json: row.metadata_json,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminAuditEventsResponse {
+    pub events: Vec<AdminAuditEventView>,
+}
+
+fn parse_occurred_bound(s: &str, label: &str) -> Result<DateTime<Utc>, ApiError> {
+    DateTime::parse_from_rfc3339(s.trim())
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|_| ApiError::bad_request(format!("Invalid {}: expected RFC3339", label)))
+}
+
+/// List admin audit events for the current tenant with optional filters.
+pub async fn list_admin_audit_events(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    Query(query): Query<ListAdminAuditEventsQuery>,
+) -> ApiResult<Json<AdminAuditEventsResponse>> {
+    if !is_support_admin(&auth).await {
+        return Err(ApiError::forbidden("Admin access required"));
+    }
+
+    let tenant_id = tenant.0.id;
+    let occurred_after = match query.occurred_after.as_deref() {
+        None | Some("") => None,
+        Some(s) => Some(parse_occurred_bound(s, "occurred_after")?),
+    };
+    let occurred_before = match query.occurred_before.as_deref() {
+        None | Some("") => None,
+        Some(s) => Some(parse_occurred_bound(s, "occurred_before")?),
+    };
+
+    let filters = AdminAuditEventListFilters {
+        action: query.action,
+        target_client_id: query.target_client_id,
+        occurred_after,
+        occurred_before,
+        limit: query.limit,
+    };
+
+    let repo = AdminAuditEventRepository::new(auth_state.state.db.clone());
+    let rows = repo
+        .list_filtered(tenant_id, filters)
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+
+    Ok(Json(AdminAuditEventsResponse {
+        events: rows.into_iter().map(Into::into).collect(),
+    }))
 }
 
 #[derive(Debug, Deserialize)]

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -204,6 +204,7 @@ pub fn api_routes(
         )
         .route("/admin/auth-debug", get(admin::get_auth_debug))
         .route("/admin/user-lookup", get(admin::get_user_lookup))
+        .route("/admin/audit-events", get(admin::list_admin_audit_events))
         .route(
             "/admin/support-admins",
             get(admin::list_support_admins).post(admin::add_support_admin),

--- a/api/tests/admin_audit_events_http_test.rs
+++ b/api/tests/admin_audit_events_http_test.rs
@@ -1,0 +1,222 @@
+// ABOUTME: HTTP-layer auth tests for GET /admin/audit-events
+// ABOUTME: Support and full admins allowed; non-admin forbidden
+
+#![cfg(feature = "integration-tests")]
+
+mod common;
+
+use axum::{
+    body::Body,
+    extract::{Query, State},
+    http::{Request, StatusCode},
+    routing::get,
+    Router,
+};
+use chrono::Utc;
+use http_body_util::BodyExt;
+use keycast_api::{
+    api::{
+        extractors::UcanAuth,
+        http::{
+            admin::{list_admin_audit_events, ListAdminAuditEventsQuery},
+            routes::AuthState,
+        },
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tower::ServiceExt;
+use zeroize::Zeroizing;
+
+const TENANT_ID: i64 = 1;
+
+#[derive(Clone)]
+struct AuthConfig {
+    pubkey: String,
+    admin_role: Option<String>,
+}
+
+impl AuthConfig {
+    fn full_admin() -> Self {
+        Self {
+            pubkey: Keys::generate().public_key().to_hex(),
+            admin_role: Some("full".to_string()),
+        }
+    }
+
+    fn support_admin() -> Self {
+        Self {
+            pubkey: Keys::generate().public_key().to_hex(),
+            admin_role: Some("support".to_string()),
+        }
+    }
+
+    fn non_admin() -> Self {
+        Self {
+            pubkey: Keys::generate().public_key().to_hex(),
+            admin_role: None,
+        }
+    }
+
+    fn into_auth(self) -> UcanAuth {
+        UcanAuth {
+            pubkey: self.pubkey,
+            admin_role: self.admin_role,
+        }
+    }
+}
+
+fn create_test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: TENANT_ID,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn create_test_auth_state(pool: PgPool) -> AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+fn build_app(auth_state: AuthState, config: AuthConfig) -> Router {
+    Router::new().route(
+        "/admin/audit-events",
+        get(move |Query(query): Query<ListAdminAuditEventsQuery>| {
+            let state = auth_state.clone();
+            let cfg = config.clone();
+            async move {
+                list_admin_audit_events(
+                    create_test_tenant(),
+                    State(state),
+                    cfg.into_auth(),
+                    Query(query),
+                )
+                .await
+            }
+        }),
+    )
+}
+
+fn request(method: &str, uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn read_body_string(response: axum::response::Response) -> String {
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn list_audit_events_allows_full_admin() {
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool), AuthConfig::full_admin());
+
+    let response = app
+        .oneshot(request("GET", "/admin/audit-events"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_string(response).await;
+    let v: serde_json::Value = serde_json::from_str(&body).expect("JSON");
+    assert!(v.get("events").is_some());
+}
+
+#[tokio::test]
+async fn list_audit_events_allows_support_admin() {
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool), AuthConfig::support_admin());
+
+    let response = app
+        .oneshot(request("GET", "/admin/audit-events"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn list_audit_events_rejects_non_admin() {
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool), AuthConfig::non_admin());
+
+    let response = app
+        .oneshot(request("GET", "/admin/audit-events"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert!(
+        read_body_string(response)
+            .await
+            .contains("Admin access required"),
+        "non-admin should get the support-admin gate message"
+    );
+}
+
+#[tokio::test]
+async fn list_audit_events_rejects_bad_occurred_after() {
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool), AuthConfig::full_admin());
+
+    let response = app
+        .oneshot(request(
+            "GET",
+            "/admin/audit-events?occurred_after=not-a-date",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/core/src/repositories/admin_audit_event.rs
+++ b/core/src/repositories/admin_audit_event.rs
@@ -1,7 +1,8 @@
 // ABOUTME: Repository for durable admin-action audit events
 // ABOUTME: Append-only forensic log capturing actor, action, target, and metadata
 
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
+use chrono::Utc;
 use serde_json::Value;
 use sqlx::{FromRow, PgPool};
 
@@ -29,6 +30,17 @@ pub struct AdminAuditEventRow {
     pub target_resource_id: Option<String>,
     pub target_client_id: Option<String>,
     pub metadata_json: Value,
+}
+
+/// Optional filters for listing audit events within a single tenant.
+#[derive(Debug, Clone, Default)]
+pub struct AdminAuditEventListFilters {
+    pub action: Option<String>,
+    pub target_client_id: Option<String>,
+    pub occurred_after: Option<DateTime<Utc>>,
+    pub occurred_before: Option<DateTime<Utc>>,
+    /// When `None`, defaults to 50. Clamped to 1..=200 in [`AdminAuditEventRepository::list_filtered`].
+    pub limit: Option<i64>,
 }
 
 #[derive(Debug, Clone)]
@@ -100,6 +112,56 @@ impl AdminAuditEventRepository {
              LIMIT $2",
         )
         .bind(tenant_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    pub async fn list_filtered(
+        &self,
+        tenant_id: i64,
+        filters: AdminAuditEventListFilters,
+    ) -> Result<Vec<AdminAuditEventRow>, RepositoryError> {
+        let limit = filters.limit.unwrap_or(50).clamp(1, 200);
+        let action = filters
+            .action
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string);
+        let target_client_id = filters
+            .target_client_id
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string);
+
+        sqlx::query_as::<_, AdminAuditEventRow>(
+            "SELECT
+                id,
+                occurred_at,
+                tenant_id,
+                actor_pubkey,
+                action,
+                target_resource_type,
+                target_resource_id,
+                target_client_id,
+                metadata_json
+             FROM admin_audit_events
+             WHERE tenant_id = $1
+               AND ($2::text IS NULL OR action = $2)
+               AND ($3::text IS NULL OR target_client_id = $3)
+               AND ($4::timestamptz IS NULL OR occurred_at >= $4)
+               AND ($5::timestamptz IS NULL OR occurred_at <= $5)
+             ORDER BY occurred_at DESC, id DESC
+             LIMIT $6",
+        )
+        .bind(tenant_id)
+        .bind(action.as_deref())
+        .bind(target_client_id.as_deref())
+        .bind(filters.occurred_after)
+        .bind(filters.occurred_before)
         .bind(limit)
         .fetch_all(&self.pool)
         .await

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -17,7 +17,10 @@ mod stored_key;
 mod team;
 mod user;
 
-pub use admin_audit_event::{AdminAuditEventRecord, AdminAuditEventRepository, AdminAuditEventRow};
+pub use admin_audit_event::{
+    AdminAuditEventListFilters, AdminAuditEventRecord, AdminAuditEventRepository,
+    AdminAuditEventRow,
+};
 pub use atproto_oauth_session::{
     AtprotoOAuthSession, AtprotoOAuthSessionRepository, CreateAtprotoOAuthSessionParams,
     IssueAtprotoTokensParams,

--- a/core/tests/admin_audit_event_repository_test.rs
+++ b/core/tests/admin_audit_event_repository_test.rs
@@ -1,4 +1,7 @@
-use keycast_core::repositories::{AdminAuditEventRecord, AdminAuditEventRepository};
+use chrono::{TimeZone, Utc};
+use keycast_core::repositories::{
+    AdminAuditEventListFilters, AdminAuditEventRecord, AdminAuditEventRepository,
+};
 use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -128,4 +131,101 @@ async fn list_recent_returns_newest_first_and_respects_tenant_scope() {
     let b_list = repo.list_recent(tenant_b, 10).await.unwrap();
     assert_eq!(b_list.len(), 1);
     assert_eq!(b_list[0].target_client_id.as_deref(), Some("client-b"));
+}
+
+#[tokio::test]
+async fn list_filtered_by_action_client_and_occurred_range() {
+    let pool = setup_pool().await;
+    let repo = AdminAuditEventRepository::new(pool.clone());
+
+    let tenant_id: i64 = 9_300_000 + (Uuid::new_v4().as_u128() as i64).rem_euclid(1_000_000);
+    let actor = format!("{:0>64}", Uuid::new_v4().simple());
+
+    let t_early = Utc.with_ymd_and_hms(2024, 1, 10, 12, 0, 0).unwrap();
+    let t_mid = Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap();
+    let t_late = Utc.with_ymd_and_hms(2024, 12, 1, 12, 0, 0).unwrap();
+
+    for (occurred_at, action, client) in [
+        (t_early, "registered_client.create", "client-early"),
+        (t_mid, "registered_client.update", "client-mid"),
+        (t_late, "registered_client.delete", "client-mid"),
+    ] {
+        sqlx::query(
+            r#"INSERT INTO admin_audit_events (
+                occurred_at, tenant_id, actor_pubkey, action,
+                target_resource_type, target_resource_id, target_client_id, metadata_json
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"#,
+        )
+        .bind(occurred_at)
+        .bind(tenant_id)
+        .bind(&actor)
+        .bind(action)
+        .bind("registered_client")
+        .bind::<Option<String>>(None)
+        .bind(client)
+        .bind(json!({}))
+        .execute(&pool)
+        .await
+        .expect("insert audit row");
+    }
+
+    let by_action = repo
+        .list_filtered(
+            tenant_id,
+            AdminAuditEventListFilters {
+                action: Some("registered_client.update".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(by_action.len(), 1);
+    assert_eq!(by_action[0].action, "registered_client.update");
+
+    let by_client = repo
+        .list_filtered(
+            tenant_id,
+            AdminAuditEventListFilters {
+                target_client_id: Some("client-mid".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(by_client.len(), 2);
+    assert!(by_client
+        .iter()
+        .all(|r| r.target_client_id.as_deref() == Some("client-mid")));
+
+    let t_window_start = Utc.with_ymd_and_hms(2024, 6, 14, 0, 0, 0).unwrap();
+    let t_window_end = Utc.with_ymd_and_hms(2024, 6, 16, 23, 59, 59).unwrap();
+
+    let by_window = repo
+        .list_filtered(
+            tenant_id,
+            AdminAuditEventListFilters {
+                occurred_after: Some(t_window_start),
+                occurred_before: Some(t_window_end),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(by_window.len(), 1);
+    assert_eq!(by_window[0].action, "registered_client.update");
+
+    let combined = repo
+        .list_filtered(
+            tenant_id,
+            AdminAuditEventListFilters {
+                action: Some("registered_client.delete".to_string()),
+                target_client_id: Some("client-mid".to_string()),
+                limit: Some(10),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(combined.len(), 1);
+    assert_eq!(combined[0].action, "registered_client.delete");
 }

--- a/web/src/routes/admin/+page.svelte
+++ b/web/src/routes/admin/+page.svelte
@@ -239,6 +239,10 @@
 					<ArrowSquareOut size={16} />
 					Registered OAuth Clients
 				</a>
+				<a href="/support-admin/audit-events" class="header-link">
+					<ArrowSquareOut size={16} />
+					Admin audit log
+				</a>
 				<a href="/support-admin" class="header-link">
 					<ArrowSquareOut size={16} />
 					Support Tools
@@ -374,10 +378,16 @@
 				</div>
 			</div>
 
-			<a href="/admin/registered-clients" class="btn-primary" style="text-decoration: none; display: inline-flex; align-items: center; gap: 0.5rem;">
-				<ArrowSquareOut size={16} />
-				Open Registered Clients
-			</a>
+			<div class="section-actions">
+				<a href="/admin/registered-clients" class="btn-primary" style="text-decoration: none; display: inline-flex; align-items: center; gap: 0.5rem;">
+					<ArrowSquareOut size={16} />
+					Open Registered Clients
+				</a>
+				<a href="/support-admin/audit-events" class="btn-secondary" style="text-decoration: none; display: inline-flex; align-items: center; gap: 0.5rem;">
+					<ArrowSquareOut size={16} />
+					Admin audit log
+				</a>
+			</div>
 		</div>
 
 		<!-- Documentation Section -->
@@ -728,6 +738,31 @@
 	.btn-primary:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+	}
+
+	.section-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+		align-items: center;
+	}
+
+	.btn-secondary {
+		padding: 0.75rem 1.5rem;
+		background: transparent;
+		color: var(--color-divine-text);
+		border: 1px solid var(--color-divine-border);
+		border-radius: 9999px;
+		font-size: 0.875rem;
+		font-weight: 600;
+		cursor: pointer;
+		transition: all 0.2s;
+		align-self: flex-start;
+	}
+
+	.btn-secondary:hover {
+		border-color: var(--color-divine-green);
+		color: var(--color-divine-green);
 	}
 
 	/* Documentation styles */

--- a/web/src/routes/support-admin/+page.svelte
+++ b/web/src/routes/support-admin/+page.svelte
@@ -5,7 +5,7 @@
 	import { goto } from '$app/navigation';
 	import Loader from '$lib/components/Loader.svelte';
 	import InvalidateClaimTokenModal from '$lib/components/InvalidateClaimTokenModal.svelte';
-	import { ShieldCheck, Warning, MagnifyingGlass, User, Key, Calendar, Globe, Copy, Check, CheckCircle, XCircle, Link, CaretDown, CaretRight } from 'phosphor-svelte';
+	import { ShieldCheck, Warning, MagnifyingGlass, User, Key, Calendar, Globe, Copy, Check, CheckCircle, XCircle, Link, CaretDown, CaretRight, List } from 'phosphor-svelte';
 	import { nip19 } from 'nostr-tools';
 	import { toast } from 'svelte-hot-french-toast';
 
@@ -244,6 +244,10 @@
 				<span class="admin-label">Support Admin</span>
 				<span class="admin-badge">{adminRole === 'full' ? 'Full Admin' : 'Support'}</span>
 			</div>
+			<a href="/support-admin/audit-events" class="audit-nav-link">
+				<List size={18} weight="duotone" />
+				Audit log
+			</a>
 		</div>
 
 		<div class="tools-section">
@@ -540,6 +544,25 @@
 		border-radius: 9999px;
 		background: color-mix(in srgb, var(--color-divine-purple, #8b5cf6) 20%, transparent);
 		color: var(--color-divine-purple, #8b5cf6);
+	}
+
+	.audit-nav-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 0.9rem;
+		font-weight: 500;
+		color: var(--color-divine-green, #22c55e);
+		text-decoration: none;
+		padding: 0.4rem 0.75rem;
+		border-radius: 8px;
+		border: 1px solid var(--color-divine-border);
+		transition: background 0.15s, border-color 0.15s;
+	}
+
+	.audit-nav-link:hover {
+		background: color-mix(in srgb, var(--color-divine-green, #22c55e) 12%, transparent);
+		border-color: color-mix(in srgb, var(--color-divine-green, #22c55e) 35%, var(--color-divine-border));
 	}
 
 	.tools-section {

--- a/web/src/routes/support-admin/audit-events/+page.svelte
+++ b/web/src/routes/support-admin/audit-events/+page.svelte
@@ -1,0 +1,563 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { BRAND } from '$lib/brand';
+	import { KeycastApi } from '$lib/keycast_api.svelte';
+	import { goto } from '$app/navigation';
+	import { toast } from 'svelte-hot-french-toast';
+	import {
+		ArrowLeft,
+		Warning,
+		CaretDown,
+		CaretRight,
+		List,
+		MagnifyingGlass
+	} from 'phosphor-svelte';
+
+	const api = new KeycastApi();
+
+	interface AuditEventRow {
+		id: number;
+		occurred_at: string;
+		tenant_id: number;
+		actor_pubkey: string;
+		action: string;
+		target_resource_type: string;
+		target_resource_id: string | null;
+		target_client_id: string | null;
+		metadata_json: unknown;
+	}
+
+	let status = $state<'loading' | 'not-admin' | 'ready'>('loading');
+
+	let filterAction = $state('');
+	let filterClientId = $state('');
+	let filterOccurredAfter = $state('');
+	let filterOccurredBefore = $state('');
+	let filterLimit = $state('50');
+
+	let events = $state<AuditEventRow[]>([]);
+	let isLoading = $state(false);
+	let listError = $state<string | null>(null);
+	let expandedId = $state<number | null>(null);
+
+	onMount(async () => {
+		try {
+			const response = await api.get<{ is_admin: boolean; role: string | null }>('/admin/status');
+			if (!response.is_admin) {
+				status = 'not-admin';
+				return;
+			}
+		} catch {
+			goto('/login?redirect=/support-admin/audit-events', { replaceState: true });
+			return;
+		}
+		status = 'ready';
+		await fetchEvents();
+	});
+
+	function buildQueryParams(): Record<string, string> {
+		const params: Record<string, string> = {};
+		const action = filterAction.trim();
+		const clientId = filterClientId.trim();
+		if (action) params.action = action;
+		if (clientId) params.target_client_id = clientId;
+		if (filterOccurredAfter.trim()) {
+			const d = new Date(filterOccurredAfter);
+			if (!Number.isNaN(d.getTime())) params.occurred_after = d.toISOString();
+		}
+		if (filterOccurredBefore.trim()) {
+			const d = new Date(filterOccurredBefore);
+			if (!Number.isNaN(d.getTime())) params.occurred_before = d.toISOString();
+		}
+		const lim = Math.min(200, Math.max(1, parseInt(filterLimit, 10) || 50));
+		params.limit = String(lim);
+		return params;
+	}
+
+	async function fetchEvents() {
+		isLoading = true;
+		listError = null;
+		try {
+			const result = await api.get<{ events: AuditEventRow[] }>('/admin/audit-events', {
+				params: buildQueryParams()
+			});
+			events = result.events;
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : 'Failed to load audit events';
+			listError = msg;
+			toast.error(msg);
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	function formatWhen(iso: string): string {
+		return new Date(iso).toLocaleString('en-US', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit'
+		});
+	}
+
+	function truncateActor(hex: string): string {
+		if (hex.length <= 16) return hex;
+		return `${hex.slice(0, 8)}…${hex.slice(-6)}`;
+	}
+
+	function prettyJson(value: unknown): string {
+		try {
+			return JSON.stringify(value, null, 2);
+		} catch {
+			return String(value);
+		}
+	}
+
+	function hasBeforeAfter(
+		m: unknown
+	): m is { before: unknown; after: unknown } {
+		return (
+			typeof m === 'object' &&
+			m !== null &&
+			'before' in m &&
+			'after' in m
+		);
+	}
+
+	function toggleExpand(id: number) {
+		expandedId = expandedId === id ? null : id;
+	}
+</script>
+
+<svelte:head>
+	<title>Admin audit log - {BRAND.name}</title>
+</svelte:head>
+
+{#if status === 'loading'}
+	<div class="page">
+		<div class="loading">Loading...</div>
+	</div>
+{:else if status === 'not-admin'}
+	<div class="page">
+		<div class="access-denied">
+			<Warning size={48} weight="fill" />
+			<h2>Access Denied</h2>
+			<p>Admin access is required to view the audit log.</p>
+		</div>
+	</div>
+{:else}
+	<div class="page">
+		<div class="header">
+			<a href="/support-admin" class="back-link">
+				<ArrowLeft size={16} />
+				Back to Support Admin
+			</a>
+			<h1>Admin audit log</h1>
+			<p class="subtitle">
+				Read-only forensic trail for admin actions on this tenant (e.g. registered OAuth clients).
+				Updates show before/after snapshots when available.
+			</p>
+		</div>
+
+		<div class="section">
+			<div class="section-header">
+				<div class="section-icon"><MagnifyingGlass size={24} weight="duotone" /></div>
+				<div>
+					<h2>Filters</h2>
+					<p>Scope is always the current tenant. Times use your local timezone; the API receives RFC3339.</p>
+				</div>
+			</div>
+
+			<form
+				class="filter-form"
+				onsubmit={(e) => {
+					e.preventDefault();
+					fetchEvents();
+				}}
+			>
+				<label>
+					<span class="label">Action</span>
+					<input type="text" bind:value={filterAction} placeholder="e.g. registered_client.update" disabled={isLoading} />
+				</label>
+				<label>
+					<span class="label">Target client id</span>
+					<input type="text" bind:value={filterClientId} placeholder="OAuth client_id" disabled={isLoading} />
+				</label>
+				<label>
+					<span class="label">Occurred after</span>
+					<input type="datetime-local" bind:value={filterOccurredAfter} disabled={isLoading} />
+				</label>
+				<label>
+					<span class="label">Occurred before</span>
+					<input type="datetime-local" bind:value={filterOccurredBefore} disabled={isLoading} />
+				</label>
+				<label>
+					<span class="label">Limit</span>
+					<input type="number" min="1" max="200" bind:value={filterLimit} disabled={isLoading} />
+				</label>
+				<button type="submit" class="btn-primary" disabled={isLoading}>
+					<List size={18} />
+					{isLoading ? 'Loading…' : 'Apply filters'}
+				</button>
+			</form>
+		</div>
+
+		<div class="section">
+			<div class="section-header">
+				<div class="section-icon"><List size={24} weight="duotone" /></div>
+				<div>
+					<h2>Events</h2>
+					<p>Newest first. Expand a row for full metadata.</p>
+				</div>
+			</div>
+
+			{#if listError}
+				<div class="list-error">
+					<Warning size={16} />
+					<span>{listError}</span>
+				</div>
+			{/if}
+
+			{#if !isLoading && events.length === 0}
+				<p class="empty-text">No events match the current filters.</p>
+			{:else}
+				<div class="table-wrap">
+					<table class="events-table">
+						<thead>
+							<tr>
+								<th class="col-expand"></th>
+								<th>When</th>
+								<th>Action</th>
+								<th>Actor</th>
+								<th>Client</th>
+								<th>Resource</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each events as row (row.id)}
+								<tr>
+									<td class="col-expand">
+										<button
+											type="button"
+											class="expand-btn"
+											onclick={() => toggleExpand(row.id)}
+											aria-expanded={expandedId === row.id}
+										>
+											{#if expandedId === row.id}
+												<CaretDown size={14} weight="bold" />
+											{:else}
+												<CaretRight size={14} weight="bold" />
+											{/if}
+										</button>
+									</td>
+									<td class="date-cell">{formatWhen(row.occurred_at)}</td>
+									<td><code>{row.action}</code></td>
+									<td class="mono" title={row.actor_pubkey}>{truncateActor(row.actor_pubkey)}</td>
+									<td><code>{row.target_client_id ?? '—'}</code></td>
+									<td class="resource-cell">
+										<code>{row.target_resource_type}</code>
+										{#if row.target_resource_id}
+											<span class="rid">#{row.target_resource_id}</span>
+										{/if}
+									</td>
+								</tr>
+								{#if expandedId === row.id}
+									<tr class="detail-row">
+										<td colspan="6">
+											{#if hasBeforeAfter(row.metadata_json)}
+												<div class="diff-grid">
+													<div class="diff-col">
+														<span class="diff-label">Before</span>
+														<pre class="json-block">{prettyJson(row.metadata_json.before)}</pre>
+													</div>
+													<div class="diff-col">
+														<span class="diff-label">After</span>
+														<pre class="json-block">{prettyJson(row.metadata_json.after)}</pre>
+													</div>
+												</div>
+											{:else}
+												<span class="diff-label">Metadata</span>
+												<pre class="json-block">{prettyJson(row.metadata_json)}</pre>
+											{/if}
+										</td>
+									</tr>
+								{/if}
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.page {
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 1.5rem 1.25rem 3rem;
+	}
+
+	.loading,
+	.access-denied {
+		text-align: center;
+		padding: 3rem 1rem;
+		color: var(--color-text-muted, #94a3b8);
+	}
+
+	.access-denied h2 {
+		margin: 1rem 0 0.5rem;
+		color: var(--color-text, #f1f5f9);
+	}
+
+	.header {
+		margin-bottom: 1.75rem;
+	}
+
+	.back-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		color: var(--color-accent, #8b5cf6);
+		text-decoration: none;
+		font-size: 0.9rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.back-link:hover {
+		text-decoration: underline;
+	}
+
+	h1 {
+		font-size: 1.65rem;
+		font-weight: 700;
+		margin: 0 0 0.35rem;
+		color: var(--color-text, #f1f5f9);
+	}
+
+	.subtitle {
+		color: var(--color-text-muted, #94a3b8);
+		font-size: 0.95rem;
+		line-height: 1.5;
+		margin: 0;
+	}
+
+	.section {
+		background: var(--color-surface-elevated, rgba(15, 23, 42, 0.6));
+		border: 1px solid var(--color-border, rgba(148, 163, 184, 0.15));
+		border-radius: 0.65rem;
+		padding: 1.25rem 1.35rem;
+		margin-bottom: 1.25rem;
+	}
+
+	.section-header {
+		display: flex;
+		gap: 0.85rem;
+		align-items: flex-start;
+		margin-bottom: 1rem;
+	}
+
+	.section-header h2 {
+		font-size: 1.05rem;
+		font-weight: 600;
+		margin: 0 0 0.2rem;
+		color: var(--color-text, #f1f5f9);
+	}
+
+	.section-header p {
+		margin: 0;
+		font-size: 0.85rem;
+		color: var(--color-text-muted, #94a3b8);
+	}
+
+	.section-icon {
+		color: var(--color-accent, #8b5cf6);
+		flex-shrink: 0;
+	}
+
+	.filter-form {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+		gap: 1rem;
+		align-items: end;
+	}
+
+	.filter-form label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		font-size: 0.85rem;
+		color: var(--color-text-muted, #94a3b8);
+	}
+
+	.filter-form input {
+		padding: 0.5rem 0.65rem;
+		border-radius: 0.4rem;
+		border: 1px solid var(--color-border, rgba(148, 163, 184, 0.25));
+		background: var(--color-bg, #0f172a);
+		color: var(--color-text, #f1f5f9);
+		font-size: 0.9rem;
+	}
+
+	.label {
+		font-weight: 500;
+	}
+
+	.btn-primary {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.55rem 1rem;
+		background: var(--color-accent, #8b5cf6);
+		color: white;
+		border: none;
+		border-radius: 0.4rem;
+		font-size: 0.9rem;
+		font-weight: 600;
+		cursor: pointer;
+		height: fit-content;
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		opacity: 0.92;
+	}
+
+	.btn-primary:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.list-error {
+		display: flex;
+		gap: 0.4rem;
+		align-items: center;
+		color: #fca5a5;
+		font-size: 0.9rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.empty-text {
+		color: var(--color-text-muted, #94a3b8);
+		font-style: italic;
+		margin: 0;
+	}
+
+	.table-wrap {
+		overflow-x: auto;
+	}
+
+	.events-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.88rem;
+	}
+
+	.events-table th,
+	.events-table td {
+		padding: 0.6rem 0.65rem;
+		border-bottom: 1px solid var(--color-border, rgba(148, 163, 184, 0.12));
+		text-align: left;
+		vertical-align: top;
+	}
+
+	.events-table th {
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--color-text-muted, #94a3b8);
+		font-weight: 600;
+	}
+
+	.col-expand {
+		width: 2rem;
+		padding-right: 0;
+	}
+
+	.expand-btn {
+		background: transparent;
+		border: none;
+		color: var(--color-text-muted, #94a3b8);
+		cursor: pointer;
+		padding: 0.2rem;
+		border-radius: 0.25rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.expand-btn:hover {
+		color: var(--color-text, #f1f5f9);
+		background: rgba(148, 163, 184, 0.12);
+	}
+
+	.date-cell {
+		white-space: nowrap;
+		font-size: 0.82rem;
+		color: var(--color-text-muted, #94a3b8);
+	}
+
+	.mono {
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		font-size: 0.82rem;
+	}
+
+	.events-table code {
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		font-size: 0.82em;
+		background: rgba(148, 163, 184, 0.12);
+		padding: 0.1rem 0.3rem;
+		border-radius: 0.25rem;
+	}
+
+	.resource-cell {
+		font-size: 0.85rem;
+	}
+
+	.rid {
+		margin-left: 0.35rem;
+		color: var(--color-text-muted, #94a3b8);
+	}
+
+	.detail-row td {
+		background: rgba(148, 163, 184, 0.06);
+		padding-top: 0.85rem;
+		padding-bottom: 0.85rem;
+	}
+
+	.diff-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 1rem;
+	}
+
+	@media (max-width: 720px) {
+		.diff-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.diff-label {
+		display: block;
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--color-text-muted, #94a3b8);
+		margin-bottom: 0.4rem;
+	}
+
+	.json-block {
+		margin: 0;
+		padding: 0.75rem;
+		background: var(--color-bg, #0f172a);
+		border: 1px solid var(--color-border, rgba(148, 163, 184, 0.2));
+		border-radius: 0.4rem;
+		font-size: 0.78rem;
+		line-height: 1.45;
+		overflow-x: auto;
+		max-height: 320px;
+		overflow-y: auto;
+	}
+</style>


### PR DESCRIPTION
## Summary

- Adds filtered listing of admin events for support/full admins;
  - GET endpoint;
  - read-only page;
- Test coverage.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- A follow-up for #170 

## Related Issue

- Closes #179

## Testing

- [x] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] Manual verification completed

## Visuals

- [x] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

