### PR TITLE
feat(api): detect UCAN session on nostr-login connect page

### DIFF
--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -2,7 +2,7 @@
 // ABOUTME: Implements authorization code flow that issues bunker URLs for NIP-46 remote signing
 
 use axum::{
-    extract::{Query, State},
+    extract::{Path, Query, State},
     http::{HeaderMap, StatusCode},
     response::{Html, IntoResponse, Redirect, Response},
     Form, Json,
@@ -3496,11 +3496,16 @@ fn parse_nostrconnect_uri(uri: &str) -> Result<(String, NostrConnectParams), OAu
 /// GET /connect/*nostrconnect
 /// Entry point from nostr-login popup - shows authorization page
 pub async fn connect_get(
-    State(_auth_state): State<super::routes::AuthState>,
-    axum::extract::Path(nostrconnect_uri): axum::extract::Path<String>,
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<super::routes::AuthState>,
+    headers: HeaderMap,
+    Path(nostrconnect_uri): Path<String>,
 ) -> Result<Response, OAuthError> {
     // Parse the nostrconnect:// URI
     let (client_pubkey, params) = parse_nostrconnect_uri(&nostrconnect_uri)?;
+
+    let tenant_id = tenant.0.id;
+    let pool = &auth_state.state.db;
 
     tracing::info!(
         "nostr-login connect request - client: {}..., app: {}, relay: {}",
@@ -3509,8 +3514,61 @@ pub async fn connect_get(
         params.relay
     );
 
-    // TODO: Check if user is logged in via session/UCAN
-    // For now, show a simple auth form
+    let user_pubkey = if let Some(token) = super::auth::extract_ucan_from_cookie(&headers) {
+        crate::ucan_auth::validate_ucan_token(&format!("Bearer {}", token), tenant_id)
+            .await
+            .ok()
+            .map(|(pubkey, _redirect_origin, _bunker_pubkey, _ucan)| pubkey)
+    } else {
+        None
+    };
+
+    let (session_pubkey, clear_cookie, account_email) = if let Some(ref pubkey) = user_pubkey {
+        let user_repo = UserRepository::new(pool.clone());
+        let account_status = user_repo.get_account_status(pubkey, tenant_id).await?;
+
+        match account_status {
+            None => {
+                tracing::warn!(
+                    "UCAN cookie has pubkey {} but user doesn't exist in tenant {}, clearing stale cookie",
+                    pubkey,
+                    tenant_id
+                );
+                (None, true, None)
+            }
+            Some((email, _verified)) => (Some(pubkey.clone()), false, email),
+        }
+    } else {
+        (None, false, None)
+    };
+
+    let session_body_attr = if session_pubkey.is_some() {
+        r#" data-keycast-session="signed-in""#
+    } else {
+        ""
+    };
+
+    let session_strip_html = if let Some(ref pk) = session_pubkey {
+        let identity_label = account_email
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .cloned()
+            .unwrap_or_else(|| {
+                let n = pk.len().min(16);
+                format!("{}…", &pk[..n])
+            });
+        format!(
+            r#"
+        <div class="session_strip">
+            <div class="account-label">Signed in as</div>
+            <div class="account-value">{}</div>
+        </div>
+"#,
+            escape_html(&identity_label)
+        )
+    } else {
+        String::new()
+    };
 
     let app_name = params.name.as_deref().unwrap_or("Unknown App");
     let permissions_raw = params.perms.as_deref().unwrap_or("sign_event");
@@ -3711,6 +3769,23 @@ pub async fn connect_get(
             border-radius: 0.75rem;
             line-height: 1.5;
         }}
+        .session_strip {{
+            border: 1px solid var(--border);
+            border-radius: 0.75rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background: var(--surface);
+        }}
+        .session_strip .account-label {{
+            font-size: 0.8rem;
+            color: var(--text-secondary);
+            margin-bottom: 0.35rem;
+        }}
+        .session_strip .account-value {{
+            font-size: 1rem;
+            font-weight: 600;
+            word-break: break-word;
+        }}
         /* Mobile: reduce padding for more working area */
         @media (max-width: 480px) {{
             body {{
@@ -3740,7 +3815,7 @@ pub async fn connect_get(
         }}
     </style>
 </head>
-<body>
+<body{session_body_attr}>
     <div class="container">
         <div class="header">
             <div class="logo">
@@ -3750,7 +3825,7 @@ pub async fn connect_get(
             <h1>Authorize Connection</h1>
             <p class="subtitle">An app wants to connect to your account</p>
         </div>
-
+{session_strip_html}
         <div class="card">
             <div class="app_header">
                 <div class="app_icon" id="app_icon">{app_icon_html}</div>
@@ -3866,9 +3941,21 @@ pub async fn connect_get(
         perms_attr = escape_attr(params.perms.as_deref().unwrap_or("")),
         permissions_raw_js = js_string_literal(&permissions_raw),
         brand = BRAND_NAME,
+        session_body_attr = session_body_attr,
+        session_strip_html = session_strip_html,
     );
 
-    Ok(Html(html).into_response())
+    if clear_cookie {
+        let clear_cookie_header =
+            "keycast_session=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0";
+        Ok((
+            [(axum::http::header::SET_COOKIE, clear_cookie_header)],
+            Html(html),
+        )
+            .into_response())
+    } else {
+        Ok(Html(html).into_response())
+    }
 }
 
 /// POST /oauth/connect

--- a/api/tests/connect_get_session_test.rs
+++ b/api/tests/connect_get_session_test.rs
@@ -1,0 +1,276 @@
+#![cfg(feature = "integration-tests")]
+
+mod common;
+
+use axum::{
+    body::Body,
+    extract::{Path, State},
+    http::{header, HeaderMap, Request, StatusCode},
+    routing::get,
+    Router,
+};
+use bcrypt::hash;
+use chrono::Utc;
+use http_body_util::BodyExt;
+use keycast_api::{
+    api::{
+        http::{auth::generate_server_signed_ucan, oauth::connect_get, routes::AuthState},
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::{Keys, ToBech32};
+use serial_test::serial;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tower::ServiceExt;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+const TENANT_ID: i64 = 1;
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+async fn cleanup_user(pool: &PgPool, pubkey: &str) {
+    let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+        .bind(pubkey)
+        .execute(pool)
+        .await;
+}
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn create_test_auth_state(pool: PgPool) -> AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+    let server_keys = Keys::generate();
+    std::env::set_var(
+        "SERVER_NSEC",
+        server_keys
+            .secret_key()
+            .to_bech32()
+            .expect("server nsec bech32"),
+    );
+
+    AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys,
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+fn create_test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: TENANT_ID,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+fn encoded_connect_uri(client_pk: &str) -> String {
+    let inner = format!(
+        "nostrconnect://{}?relay=wss://relay.example.com/ws&secret=testsecret",
+        client_pk
+    );
+    format!("/connect/{}", urlencoding::encode(&inner))
+}
+
+fn build_app(auth_state: AuthState) -> Router {
+    Router::new()
+        .route(
+            "/connect/*nostrconnect",
+            get(
+                |State(state): State<AuthState>, headers: HeaderMap, path: Path<String>| async move {
+                    connect_get(create_test_tenant(), State(state), headers, path).await
+                },
+            ),
+        )
+        .with_state(auth_state)
+}
+
+#[tokio::test]
+#[serial]
+async fn connect_get_without_cookie_has_no_session_marker() {
+    let pool = setup_pool().await;
+    let client_keys = Keys::generate();
+    let client_pk = client_keys.public_key().to_hex();
+    let auth_state = create_test_auth_state(pool);
+    let app = build_app(auth_state);
+
+    let uri = encoded_connect_uri(&client_pk);
+    let res = app
+        .oneshot(Request::builder().uri(&uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let body =
+        String::from_utf8(res.into_body().collect().await.unwrap().to_bytes().to_vec()).unwrap();
+    assert!(!body.contains(r#"data-keycast-session="signed-in""#));
+    assert!(!body.contains("Signed in as"));
+}
+
+#[tokio::test]
+#[serial]
+async fn connect_get_with_valid_session_shows_signed_in() {
+    let pool = setup_pool().await;
+    let user_keys = Keys::generate();
+    let user_pubkey = user_keys.public_key().to_hex();
+    let email = format!("connect-session-{}@example.com", Uuid::new_v4());
+
+    cleanup_user(&pool, &user_pubkey).await;
+
+    let password_hash = hash("pw", 4).expect("bcrypt");
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, true, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(TENANT_ID)
+    .bind(&email)
+    .bind(&password_hash)
+    .execute(&pool)
+    .await
+    .expect("insert user");
+
+    let auth_state = create_test_auth_state(pool.clone());
+    let server_keys = auth_state.state.server_keys.clone();
+    let session_token = generate_server_signed_ucan(
+        &user_keys.public_key(),
+        TENANT_ID,
+        &email,
+        "https://localhost",
+        None,
+        &server_keys,
+        true,
+        None,
+    )
+    .await
+    .expect("ucan");
+
+    let client_keys = Keys::generate();
+    let client_pk = client_keys.public_key().to_hex();
+    let app = build_app(auth_state);
+    let uri = encoded_connect_uri(&client_pk);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(&uri)
+                .header(header::COOKIE, format!("keycast_session={session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let body =
+        String::from_utf8(res.into_body().collect().await.unwrap().to_bytes().to_vec()).unwrap();
+    assert!(body.contains(r#"data-keycast-session="signed-in""#));
+    assert!(body.contains("Signed in as"));
+    assert!(body.contains(&email));
+
+    cleanup_user(&pool, &user_pubkey).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn connect_get_stale_ucan_clears_cookie() {
+    let pool = setup_pool().await;
+    let ghost_keys = Keys::generate();
+    let ghost_pubkey = ghost_keys.public_key().to_hex();
+    cleanup_user(&pool, &ghost_pubkey).await;
+
+    let auth_state = create_test_auth_state(pool.clone());
+    let server_keys = auth_state.state.server_keys.clone();
+    let session_token = generate_server_signed_ucan(
+        &ghost_keys.public_key(),
+        TENANT_ID,
+        "ghost@example.com",
+        "https://localhost",
+        None,
+        &server_keys,
+        true,
+        None,
+    )
+    .await
+    .expect("ucan");
+
+    let client_keys = Keys::generate();
+    let client_pk = client_keys.public_key().to_hex();
+    let app = build_app(auth_state);
+    let uri = encoded_connect_uri(&client_pk);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(&uri)
+                .header(header::COOKIE, format!("keycast_session={session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let clear = res.headers().get_all(header::SET_COOKIE).iter().any(|v| {
+        v.to_str()
+            .ok()
+            .is_some_and(|s| s.starts_with("keycast_session=") && s.contains("Max-Age=0"))
+    });
+    assert!(clear, "expected Set-Cookie clearing session");
+
+    let body =
+        String::from_utf8(res.into_body().collect().await.unwrap().to_bytes().to_vec()).unwrap();
+    assert!(!body.contains(r#"data-keycast-session="signed-in""#));
+}


### PR DESCRIPTION
## Summary

- `GET /connect/*nostrconnect` now validates Keycast's session, checks the user exists for the tenant;
- Integration tests cover.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Solving TODOs left in the code.

## Related Issue

- Closes #226

## Testing

- [x] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] Manual verification completed

## Visuals

- [x] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

