### PR TITLE
refactor(api): remove EmailService

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -647,17 +647,11 @@ pub async fn batch_create_claim_tokens(
     let user_repo = UserRepository::new(pool.clone());
     let claim_token_repo = ClaimTokenRepository::new(pool.clone());
 
-    // Create email service once outside the loop
-    let email_service =
-        req.delivery_email
-            .as_ref()
-            .and_then(|_| match crate::email_service::EmailService::new() {
-                Ok(svc) => Some(svc),
-                Err(e) => {
-                    tracing::error!("Failed to create email service: {}", e);
-                    None
-                }
-            });
+    // Create email sender reference when batch delivery is requested
+    let email_sender_for_delivery = req
+        .delivery_email
+        .as_ref()
+        .map(|_| auth_state.state.email_sender.clone());
 
     let mut tokens = Vec::new();
     let mut skipped = Vec::new();
@@ -740,8 +734,10 @@ pub async fn batch_create_claim_tokens(
         let claim_url = format!("{}/api/claim?token={}", app_url, token);
 
         // Send email if requested
-        if let (Some(email), Some(svc)) = (&req.delivery_email, &email_service) {
-            if let Err(e) = svc.send_claim_email(email, &claim_url).await {
+        if let (Some(email), Some(sender)) =
+            (&req.delivery_email, email_sender_for_delivery.as_ref())
+        {
+            if let Err(e) = sender.send_claim_email(email, &claim_url).await {
                 tracing::warn!(
                     "Failed to send claim email for vine_id={} to {}: {}",
                     vine_id,
@@ -750,8 +746,6 @@ pub async fn batch_create_claim_tokens(
                 );
                 errors.push(format!("vine_id {}: email delivery failed: {}", vine_id, e));
             }
-        } else if req.delivery_email.is_some() && email_service.is_none() {
-            errors.push(format!("vine_id {}: email service unavailable", vine_id));
         }
 
         tokens.push(BatchClaimTokenEntry {

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -905,24 +905,15 @@ pub async fn register(
     METRICS.inc_registration();
 
     // Send verification email (required - user must verify before login)
-    match crate::email_service::EmailService::new() {
-        Ok(email_service) => {
-            if let Err(e) = email_service
-                .send_verification_email(&req.email, &verification_token)
-                .await
-            {
-                tracing::error!("Failed to send verification email to {}: {}", req.email, e);
-                // Continue even if email fails - user can resend later
-            } else {
-                tracing::info!("Sent verification email to {}", req.email);
-            }
-        }
-        Err(e) => {
-            tracing::warn!(
-                "Email service unavailable, skipping verification email: {}",
-                e
-            );
-        }
+    let email_sender = auth_state.state.email_sender.clone();
+    if let Err(e) = email_sender
+        .send_verification_email(&req.email, &verification_token)
+        .await
+    {
+        tracing::error!("Failed to send verification email to {}: {}", req.email, e);
+        // Continue even if email fails - user can resend later
+    } else {
+        tracing::info!("Sent verification email to {}", req.email);
     }
 
     tracing::info!(
@@ -1875,10 +1866,11 @@ pub struct ResendVerificationResponse {
 /// Always returns success to prevent email enumeration attacks.
 pub async fn resend_verification(
     tenant: crate::api::tenant::TenantExtractor,
-    State(pool): State<PgPool>,
+    State(auth_state): State<super::routes::AuthState>,
     headers: HeaderMap,
     Json(mut req): Json<ResendVerificationRequest>,
 ) -> Json<ResendVerificationResponse> {
+    let pool = auth_state.state.db.clone();
     let tenant_id = tenant.0.id;
     if let Some(ref mut email) = req.email {
         *email = email.to_lowercase();
@@ -1966,27 +1958,21 @@ pub async fn resend_verification(
     }
 
     // Send verification email (don't await to prevent timing attacks)
+    let email_sender = auth_state.state.email_sender.clone();
     let email_clone = email.clone();
     let token_clone = verification_token.clone();
     tokio::spawn(async move {
-        match crate::email_service::EmailService::new() {
-            Ok(email_service) => {
-                if let Err(e) = email_service
-                    .send_verification_email(&email_clone, &token_clone)
-                    .await
-                {
-                    tracing::error!(
-                        "Failed to send verification email to {}: {}",
-                        email_clone,
-                        e
-                    );
-                } else {
-                    tracing::info!("Sent verification email to {}", email_clone);
-                }
-            }
-            Err(e) => {
-                tracing::warn!("Email service unavailable: {}", e);
-            }
+        if let Err(e) = email_sender
+            .send_verification_email(&email_clone, &token_clone)
+            .await
+        {
+            tracing::error!(
+                "Failed to send verification email to {}: {}",
+                email_clone,
+                e
+            );
+        } else {
+            tracing::info!("Sent verification email to {}", email_clone);
         }
     });
 
@@ -1996,10 +1982,11 @@ pub async fn resend_verification(
 /// Request password reset email
 pub async fn forgot_password(
     tenant: crate::api::tenant::TenantExtractor,
-    State(pool): State<PgPool>,
+    State(auth_state): State<super::routes::AuthState>,
     headers: HeaderMap,
     Json(mut req): Json<ForgotPasswordRequest>,
 ) -> Result<Json<ForgotPasswordResponse>, AuthError> {
+    let pool = auth_state.state.db.clone();
     let tenant_id = tenant.0.id;
     let endpoint = "/api/auth/forgot-password";
     req.email = req.email.to_lowercase();
@@ -2062,32 +2049,20 @@ pub async fn forgot_password(
         .set_password_reset_token(&public_key, tenant_id, &reset_token, reset_expires)
         .await?;
 
-    // Send password reset email (optional - don't fail if email service unavailable)
-    match crate::email_service::EmailService::new() {
-        Ok(email_service) => {
-            if let Err(e) = email_service
-                .send_password_reset_email(&req.email, &reset_token)
-                .await
-            {
-                METRICS.inc_auth_email_send_failure("password_reset");
-                reason_code = Some("email_send_failed");
-                tracing::error!(
-                    "Failed to send password reset email to {}: {}",
-                    req.email,
-                    e
-                );
-            } else {
-                tracing::info!("Sent password reset email to {}", req.email);
-            }
-        }
-        Err(e) => {
-            METRICS.inc_auth_email_send_failure("password_reset");
-            reason_code = Some("email_send_failed");
-            tracing::warn!(
-                "Email service unavailable, skipping password reset email: {}",
-                e
-            );
-        }
+    let email_sender = auth_state.state.email_sender.clone();
+    if let Err(e) = email_sender
+        .send_password_reset_email(&req.email, &reset_token)
+        .await
+    {
+        METRICS.inc_auth_email_send_failure("password_reset");
+        reason_code = Some("email_send_failed");
+        tracing::error!(
+            "Failed to send password reset email to {}: {}",
+            req.email,
+            e
+        );
+    } else {
+        tracing::info!("Sent password reset email to {}", req.email);
     }
 
     super::auth_observability::record_auth_event_and_log(
@@ -2120,10 +2095,11 @@ pub async fn forgot_password(
 /// Reset password with token
 pub async fn reset_password(
     tenant: crate::api::tenant::TenantExtractor,
-    State(pool): State<PgPool>,
+    State(auth_state): State<super::routes::AuthState>,
     headers: HeaderMap,
     Json(req): Json<ResetPasswordRequest>,
 ) -> Result<Json<ResetPasswordResponse>, AuthError> {
+    let pool = auth_state.state.db.clone();
     let tenant_id = tenant.0.id;
     let endpoint = "/api/auth/reset-password";
     tracing::info!(
@@ -3830,6 +3806,7 @@ mod tests {
                 bcrypt_sender: bcrypt_queue.sender(),
                 redis: None,
                 secret_pool: secret_pool.receiver(),
+                email_sender: std::sync::Arc::new(crate::email_service::DevEmailSender::new()),
             }),
             auth_tx: None,
         }
@@ -3935,6 +3912,7 @@ mod tests {
                 bcrypt_sender: bcrypt_queue.sender(),
                 redis: None,
                 secret_pool: secret_pool.receiver(),
+                email_sender: std::sync::Arc::new(crate::email_service::DevEmailSender::new()),
             }),
             auth_tx: None,
         }

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -209,24 +209,15 @@ pub async fn headless_register(
         .await?;
 
     // Send verification email
-    match crate::email_service::EmailService::new() {
-        Ok(email_service) => {
-            if let Err(e) = email_service
-                .send_verification_email(&req.email, &verification_token)
-                .await
-            {
-                tracing::error!("Failed to send verification email to {}: {}", req.email, e);
-                // Continue - user can request resend later
-            } else {
-                tracing::info!("Sent verification email to {}", req.email);
-            }
-        }
-        Err(e) => {
-            tracing::warn!(
-                "Email service unavailable, skipping verification email: {}",
-                e
-            );
-        }
+    let email_sender = auth_state.state.email_sender.clone();
+    if let Err(e) = email_sender
+        .send_verification_email(&req.email, &verification_token)
+        .await
+    {
+        tracing::error!("Failed to send verification email to {}: {}", req.email, e);
+        // Continue - user can request resend later
+    } else {
+        tracing::info!("Sent verification email to {}", req.email);
     }
 
     // Track successful registration
@@ -757,6 +748,7 @@ mod tests {
                 bcrypt_sender: bcrypt_queue.sender(),
                 redis: None,
                 secret_pool: secret_pool.receiver(),
+                email_sender: std::sync::Arc::new(crate::email_service::DevEmailSender::new()),
             }),
             auth_tx: None,
         }

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -2599,27 +2599,18 @@ async fn handle_authorization_code_grant(
         );
 
         // Send verification email (optional - don't fail if email service unavailable)
-        match crate::email_service::EmailService::new() {
-            Ok(email_service) => {
-                if let Err(e) = email_service
-                    .send_verification_email(pending_email_val, &verification_token)
-                    .await
-                {
-                    tracing::error!(
-                        "Failed to send verification email to {}: {}",
-                        pending_email_val,
-                        e
-                    );
-                } else {
-                    tracing::info!("Sent verification email to {}", pending_email_val);
-                }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "Email service unavailable, skipping verification email: {}",
-                    e
-                );
-            }
+        let email_sender = auth_state.state.email_sender.clone();
+        if let Err(e) = email_sender
+            .send_verification_email(pending_email_val, &verification_token)
+            .await
+        {
+            tracing::error!(
+                "Failed to send verification email to {}: {}",
+                pending_email_val,
+                e
+            );
+        } else {
+            tracing::info!("Sent verification email to {}", pending_email_val);
         }
 
         pending_email_val.clone()
@@ -3357,24 +3348,15 @@ pub async fn oauth_register(
     );
 
     // Send verification email (required - user must verify before OAuth flow completes)
-    match crate::email_service::EmailService::new() {
-        Ok(email_service) => {
-            if let Err(e) = email_service
-                .send_verification_email(&req.email, &verification_token)
-                .await
-            {
-                tracing::error!("Failed to send verification email to {}: {}", req.email, e);
-                // Continue even if email fails - user can resend later
-            } else {
-                tracing::info!("Sent verification email to {}", req.email);
-            }
-        }
-        Err(e) => {
-            tracing::warn!(
-                "Email service unavailable, skipping verification email: {}",
-                e
-            );
-        }
+    let email_sender = auth_state.state.email_sender.clone();
+    if let Err(e) = email_sender
+        .send_verification_email(&req.email, &verification_token)
+        .await
+    {
+        tracing::error!("Failed to send verification email to {}: {}", req.email, e);
+        // Continue even if email fails - user can resend later
+    } else {
+        tracing::info!("Sent verification email to {}", req.email);
     }
 
     // DO NOT issue UCAN or set session cookie - user must verify email first
@@ -4169,6 +4151,7 @@ mod tests {
                 bcrypt_sender: bcrypt_queue.sender(),
                 redis: None,
                 secret_pool: secret_pool.receiver(),
+                email_sender: std::sync::Arc::new(crate::email_service::DevEmailSender::new()),
             }),
             auth_tx: None,
         }

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -61,7 +61,7 @@ pub fn api_routes(
         .route("/auth/forgot-password", post(auth::forgot_password))
         .route("/auth/reset-password", post(auth::reset_password))
         .route("/auth/resend-verification", post(auth::resend_verification))
-        .with_state(pool.clone());
+        .with_state(auth_state.clone());
 
     // OAuth routes (no authentication required for initial authorize request)
     // Public CORS - third parties use authorization_code grant (never see passwords)

--- a/api/src/email_service.rs
+++ b/api/src/email_service.rs
@@ -521,44 +521,6 @@ pub fn create_email_sender() -> Result<Arc<dyn EmailSender>, String> {
     Ok(Arc::new(DevEmailSender::new()))
 }
 
-/// Legacy EmailService for backward compatibility during migration
-/// TODO: Remove once all usages are migrated to the trait
-pub struct EmailService {
-    inner: Arc<dyn EmailSender>,
-}
-
-impl EmailService {
-    pub fn new() -> Result<Self, String> {
-        Ok(Self {
-            inner: create_email_sender()?,
-        })
-    }
-
-    pub async fn send_verification_email(
-        &self,
-        to_email: &str,
-        verification_token: &str,
-    ) -> Result<(), String> {
-        self.inner
-            .send_verification_email(to_email, verification_token)
-            .await
-    }
-
-    pub async fn send_password_reset_email(
-        &self,
-        to_email: &str,
-        reset_token: &str,
-    ) -> Result<(), String> {
-        self.inner
-            .send_password_reset_email(to_email, reset_token)
-            .await
-    }
-
-    pub async fn send_claim_email(&self, to_email: &str, claim_url: &str) -> Result<(), String> {
-        self.inner.send_claim_email(to_email, claim_url).await
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -1,5 +1,6 @@
 use crate::api::tenant::Tenant;
 use crate::bcrypt_queue::BcryptSender;
+use crate::email_service::EmailSender;
 use crate::handlers::http_rpc_handler::HttpHandlerCache;
 use crate::redis::PrefixedRedis;
 use keycast_core::encryption::KeyManager;
@@ -46,6 +47,8 @@ pub struct KeycastState {
     /// Pre-computed secret pool for instant authorization creation
     /// Background producer generates (secret, bcrypt_hash) pairs ahead of time
     pub secret_pool: SecretPoolReceiver,
+    /// Shared email sender (SendGrid in production, dev logger in development)
+    pub email_sender: Arc<dyn EmailSender>,
 }
 
 pub static KEYCAST_STATE: OnceCell<Arc<KeycastState>> = OnceCell::new();

--- a/api/tests/auth_debug_test.rs
+++ b/api/tests/auth_debug_test.rs
@@ -75,6 +75,7 @@ fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthS
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            email_sender: Arc::new(keycast_api::email_service::DevEmailSender::new()),
         }),
         auth_tx: None,
     }

--- a/api/tests/headless_auth_test.rs
+++ b/api/tests/headless_auth_test.rs
@@ -104,6 +104,7 @@ fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthS
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            email_sender: Arc::new(keycast_api::email_service::DevEmailSender::new()),
         }),
         auth_tx: None,
     }

--- a/api/tests/login_observability_test.rs
+++ b/api/tests/login_observability_test.rs
@@ -86,6 +86,7 @@ fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthS
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            email_sender: Arc::new(keycast_api::email_service::DevEmailSender::new()),
         }),
         auth_tx: None,
     }

--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -127,6 +127,7 @@ fn create_test_auth_state(pool: PgPool, key_manager: Arc<Box<dyn KeyManager>>) -
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            email_sender: Arc::new(keycast_api::email_service::DevEmailSender::new()),
         }),
         auth_tx: None,
     }

--- a/api/tests/password_reset_observability_test.rs
+++ b/api/tests/password_reset_observability_test.rs
@@ -10,18 +10,29 @@ use axum::{
 };
 use bcrypt::{hash, verify};
 use chrono::{Duration, Utc};
-use keycast_api::api::{
-    http::{
-        auth::{forgot_password, reset_password, ForgotPasswordRequest, ResetPasswordRequest},
-        auth_observability::request_id_middleware,
+use keycast_api::{
+    api::{
+        http::{
+            auth::{forgot_password, reset_password, ForgotPasswordRequest, ResetPasswordRequest},
+            auth_observability::request_id_middleware,
+        },
+        tenant::{Tenant, TenantExtractor},
     },
-    tenant::{Tenant, TenantExtractor},
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
 };
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
 use nostr_sdk::Keys;
 use sqlx::PgPool;
 use std::sync::Arc;
 use tower::ServiceExt;
 use uuid::Uuid;
+use zeroize::Zeroizing;
 
 mod common;
 
@@ -52,6 +63,45 @@ fn create_test_tenant() -> TenantExtractor {
     }))
 }
 
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    keycast_api::api::http::routes::AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+            email_sender: Arc::new(keycast_api::email_service::DevEmailSender::new()),
+        }),
+        auth_tx: None,
+    }
+}
+
 async fn cleanup_by_email(pool: &PgPool, email: &str) {
     let _ = sqlx::query("DELETE FROM auth_events WHERE email = $1")
         .bind(email)
@@ -72,16 +122,21 @@ async fn test_forgot_password_records_accepted_event_for_missing_email() {
     cleanup_by_email(&pool, &email).await;
 
     let app = {
-        let pool = pool.clone();
+        let auth_state = create_test_auth_state(pool.clone());
         Router::new()
             .route(
                 "/auth/forgot-password",
                 post(
                     move |headers: HeaderMap, Json(req): Json<ForgotPasswordRequest>| {
-                        let pool = pool.clone();
+                        let auth_state = auth_state.clone();
                         async move {
-                            forgot_password(create_test_tenant(), State(pool), headers, Json(req))
-                                .await
+                            forgot_password(
+                                create_test_tenant(),
+                                State(auth_state),
+                                headers,
+                                Json(req),
+                            )
+                            .await
                         }
                     },
                 ),
@@ -162,16 +217,21 @@ async fn test_reset_password_records_success_event_and_updates_hash() {
     .expect("Should create resettable user");
 
     let app = {
-        let pool = pool.clone();
+        let auth_state = create_test_auth_state(pool.clone());
         Router::new()
             .route(
                 "/auth/reset-password",
                 post(
                     move |headers: HeaderMap, Json(req): Json<ResetPasswordRequest>| {
-                        let pool = pool.clone();
+                        let auth_state = auth_state.clone();
                         async move {
-                            reset_password(create_test_tenant(), State(pool), headers, Json(req))
-                                .await
+                            reset_password(
+                                create_test_tenant(),
+                                State(auth_state),
+                                headers,
+                                Json(req),
+                            )
+                            .await
                         }
                     },
                 ),

--- a/api/tests/registered_clients_admin_http_test.rs
+++ b/api/tests/registered_clients_admin_http_test.rs
@@ -136,6 +136,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            email_sender: Arc::new(keycast_api::email_service::DevEmailSender::new()),
         }),
         auth_tx: None,
     }

--- a/api/tests/registered_clients_audit_test.rs
+++ b/api/tests/registered_clients_audit_test.rs
@@ -83,6 +83,7 @@ fn make_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            email_sender: Arc::new(keycast_api::email_service::DevEmailSender::new()),
         }),
         auth_tx: None,
     }

--- a/api/tests/update_profile_divine_name_test.rs
+++ b/api/tests/update_profile_divine_name_test.rs
@@ -61,6 +61,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            email_sender: Arc::new(keycast_api::email_service::DevEmailSender::new()),
         }),
         auth_tx: None,
     }

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -715,6 +715,10 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     let _secret_pool_producer = secret_pool.spawn_producer();
     tracing::info!("✔︎ Secret pool initialized (capacity: 100, bcrypt cost: 10)");
 
+    let email_sender = keycast_api::email_service::create_email_sender()
+        .map_err(|e| format!("Email configuration: {}", e))?;
+    tracing::info!("✔︎ Email sender initialized");
+
     // Create API state with http_handler_cache for on-demand loading
     // Note: api no longer depends on signer's handler cache (decoupled)
     let api_state = Arc::new(keycast_api::state::KeycastState {
@@ -727,6 +731,7 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         bcrypt_sender,
         redis: Some(prefixed_redis),
         secret_pool: secret_pool_receiver,
+        email_sender,
     });
 
     // Set global state for routes that use it


### PR DESCRIPTION
## Summary

- Email sensing now uses one `Arc<dyn EmailSender>` created at startup;
- Legacy `EmailService` was removed;
- Tests were updated.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Improving code quality

## Related Issue

- Closes #225

## Testing

- [x] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] Manual verification completed

## Visuals

- [x] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

