### PR TITLE
feat(rpc): allow admin-issued preload UCANs to sign for claimed users

### DIFF
--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -391,8 +391,9 @@ fn is_server_signed(ucan: &ucan::Ucan) -> bool {
 }
 
 /// Load handler for preloaded user (server-signed UCAN, no bunker_pubkey)
-/// These are users imported from Vine that haven't claimed their accounts yet.
-/// They have no policy restrictions - full access until account is claimed.
+/// Originally for unclaimed Vine imports; gate dropped to allow admin-issued
+/// preload UCANs to keep signing for accounts after claim — needed to publish
+/// additional legacy Vine archives discovered after handover.
 async fn load_preloaded_user_handler(
     auth_state: &AuthState,
     pool: &sqlx::PgPool,
@@ -402,17 +403,16 @@ async fn load_preloaded_user_handler(
 ) -> Result<Arc<HttpRpcHandler>, RpcError> {
     let key_manager = auth_state.state.key_manager.as_ref();
 
-    // Verify user exists and is unclaimed (email IS NULL)
+    // Verify user exists (encrypted key lookup below will also catch missing rows).
     let user_repo = UserRepository::new(pool.clone());
-    let is_unclaimed = user_repo
+    if user_repo
         .is_unclaimed(user_pubkey_hex, tenant_id)
         .await
-        .map_err(|e| RpcError::Internal(format!("Database error: {}", e)))?;
-
-    if is_unclaimed != Some(true) {
-        // User either doesn't exist or has already claimed their account
+        .map_err(|e| RpcError::Internal(format!("Database error: {}", e)))?
+        .is_none()
+    {
         tracing::warn!(
-            "Preloaded user RPC denied: user {} not unclaimed",
+            "Preloaded user RPC denied: user {} not found",
             &user_pubkey_hex[..8]
         );
         return Err(RpcError::Auth(AuthError::InvalidToken));
@@ -563,7 +563,8 @@ async fn get_handler(
         h
     } else if is_server_signed(&ucan) {
         // MODE 2: Preloaded user - server-signed UCAN without bunker_pubkey
-        // These are Vine-imported users who haven't claimed their accounts yet
+        // Used for Vine import; works for both unclaimed and claimed accounts so
+        // admins can publish additional legacy archives after handover.
         let h = load_preloaded_user_handler(
             auth_state,
             pool,

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -471,11 +471,11 @@ async fn load_preloaded_user_handler(
     // past the UCAN's lifetime until the entry was idle-evicted.
     let handler = Arc::new(HttpRpcHandler::new(
         session,
-        0,                // No authorization_id - this is direct access
-        ucan_expires_at,  // Stop signing when the UCAN expires (Daniel feedback)
-        None,             // Not revoked
-        vec![],           // No permissions = full access
-        false,            // Not OAuth (preloaded user mode)
+        0,               // No authorization_id - this is direct access
+        ucan_expires_at, // Stop signing when the UCAN expires (Daniel feedback)
+        None,            // Not revoked
+        vec![],          // No permissions = full access
+        false,           // Not OAuth (preloaded user mode)
         cache_key,
         cache_key, // Use same key for auth_handle
         dpop_cnf_jkt,

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -8,6 +8,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use chrono::{DateTime, Utc};
 use keycast_core::metrics::METRICS;
 use keycast_core::repositories::{
     OAuthAuthorizationRepository, PersonalKeysRepository, PolicyRepository, UserRepository,
@@ -394,13 +395,32 @@ fn is_server_signed(ucan: &ucan::Ucan) -> bool {
 /// Originally for unclaimed Vine imports; gate dropped to allow admin-issued
 /// preload UCANs to keep signing for accounts after claim — needed to publish
 /// additional legacy Vine archives discovered after handover.
+///
+/// Caller must pass the UCAN's `redirect_origin` and `exp` so we can (1) reject
+/// non-preload server-signed UCANs (admin sessions, claim UCANs, etc.) and (2)
+/// propagate the UCAN expiry into the cached handler so warm cache hits stop
+/// signing once the UCAN lifetime ends.
 async fn load_preloaded_user_handler(
     auth_state: &AuthState,
     pool: &sqlx::PgPool,
     user_pubkey_hex: &str,
     tenant_id: i64,
+    redirect_origin: &str,
+    ucan_expires_at: Option<DateTime<Utc>>,
     dpop_cnf_jkt: Option<String>,
 ) -> Result<Arc<HttpRpcHandler>, RpcError> {
+    // Only accept UCANs minted by generate_preload_ucan (admin.rs).
+    // Other server-signed UCANs (admin sessions, claim flow) must not be usable
+    // to sign as preload users via this path.
+    if redirect_origin != "preload" {
+        tracing::warn!(
+            "Preloaded user RPC denied: redirect_origin={} for user {}",
+            redirect_origin,
+            &user_pubkey_hex[..8]
+        );
+        return Err(RpcError::Auth(AuthError::InvalidToken));
+    }
+
     let key_manager = auth_state.state.key_manager.as_ref();
 
     // Verify user exists (encrypted key lookup below will also catch missing rows).
@@ -445,15 +465,17 @@ async fn load_preloaded_user_handler(
     // Create signing session
     let session = Arc::new(SigningSession::new(user_keys));
 
-    // Create handler with NO policy restrictions (empty permissions = full access)
-    // Preloaded users get full access until they claim their account
+    // Create handler with NO policy restrictions (empty permissions = full access).
+    // The cached handler's expiry is the UCAN's exp: cache hits short-circuit UCAN
+    // validation entirely, so without this, a warm cache entry would keep signing
+    // past the UCAN's lifetime until the entry was idle-evicted.
     let handler = Arc::new(HttpRpcHandler::new(
         session,
-        0,      // No authorization_id - this is direct access
-        None,   // No expiry (handled by token expiry)
-        None,   // Not revoked
-        vec![], // No permissions = full access
-        false,  // Not OAuth (preloaded user mode)
+        0,                // No authorization_id - this is direct access
+        ucan_expires_at,  // Stop signing when the UCAN expires (Daniel feedback)
+        None,             // Not revoked
+        vec![],           // No permissions = full access
+        false,            // Not OAuth (preloaded user mode)
         cache_key,
         cache_key, // Use same key for auth_handle
         dpop_cnf_jkt,
@@ -517,10 +539,15 @@ async fn get_handler(
     METRICS.inc_http_rpc_cache_miss();
 
     // Verify UCAN and extract bunker_pubkey (Schnorr signature verification ~1-2ms)
-    let (user_pubkey, _redirect_origin, bunker_pubkey, ucan) =
+    let (user_pubkey, redirect_origin, bunker_pubkey, ucan) =
         crate::ucan_auth::validate_ucan_token(auth_header, tenant_id)
             .await
             .map_err(|_| RpcError::Auth(AuthError::InvalidToken))?;
+
+    // Extract UCAN expiry (unix seconds → DateTime<Utc>) so cached preload
+    // handlers can be invalidated once the UCAN lifetime ends.
+    let ucan_expires_at: Option<DateTime<Utc>> =
+        DateTime::<Utc>::from_timestamp(*ucan.expires_at() as i64, 0);
 
     let dpop_cnf_jkt = crate::ucan_auth::extract_cnf_jkt_from_ucan(&ucan);
 
@@ -565,11 +592,15 @@ async fn get_handler(
         // MODE 2: Preloaded user - server-signed UCAN without bunker_pubkey
         // Used for Vine import; works for both unclaimed and claimed accounts so
         // admins can publish additional legacy archives after handover.
+        // The callee rejects server-signed UCANs whose redirect_origin != "preload"
+        // so admin-session / claim UCANs cannot fall through this path.
         let h = load_preloaded_user_handler(
             auth_state,
             pool,
             &user_pubkey,
             tenant_id,
+            &redirect_origin,
+            ucan_expires_at,
             dpop_cnf_jkt.clone(),
         )
         .await?;

--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -907,3 +907,261 @@ async fn test_cache_hit_dpop_bound_ucan_enforced_end_to_end() {
     .expect("Valid DPoP proof on cache hit should succeed");
     assert_eq!(response_4.result, Some(Value::String(pubkey)));
 }
+
+// ============================================================================
+// Preload UCAN regression tests (PR #232 / Daniel review feedback)
+// ============================================================================
+
+/// Build a preload UCAN (server-signed, redirect_origin: "preload", no bunker_pubkey).
+/// Mirrors `generate_preload_ucan` in admin.rs.
+async fn build_preload_ucan_with_lifetime(
+    user_pubkey: &nostr_sdk::PublicKey,
+    tenant_id: i64,
+    server_keys: &Keys,
+    lifetime_secs: u64,
+) -> String {
+    let server_key_material = NostrKeyMaterial::from_keys(server_keys.clone());
+    let user_did = nostr_pubkey_to_did(user_pubkey);
+
+    let facts = json!({
+        "tenant_id": tenant_id,
+        "redirect_origin": "preload",
+        "issued_by_admin": "deadbeef".to_string(),
+    });
+
+    let ucan = UcanBuilder::default()
+        .issued_by(&server_key_material)
+        .for_audience(&user_did)
+        .with_lifetime(lifetime_secs)
+        .with_fact(facts)
+        .build()
+        .expect("Failed to build preload UCAN")
+        .sign()
+        .await
+        .expect("Failed to sign preload UCAN");
+
+    ucan.encode().expect("Failed to encode preload UCAN")
+}
+
+/// Build a server-signed UCAN with a non-"preload" redirect_origin.
+/// Should be rejected by the signing path even though it's server-signed.
+async fn build_server_signed_non_preload_ucan(
+    user_pubkey: &nostr_sdk::PublicKey,
+    tenant_id: i64,
+    server_keys: &Keys,
+) -> String {
+    let server_key_material = NostrKeyMaterial::from_keys(server_keys.clone());
+    let user_did = nostr_pubkey_to_did(user_pubkey);
+
+    let facts = json!({
+        "tenant_id": tenant_id,
+        "redirect_origin": "admin",
+        "admin": true,
+        "admin_role": "full",
+    });
+
+    let ucan = UcanBuilder::default()
+        .issued_by(&server_key_material)
+        .for_audience(&user_did)
+        .with_lifetime(3600)
+        .with_fact(facts)
+        .build()
+        .expect("Failed to build admin UCAN")
+        .sign()
+        .await
+        .expect("Failed to sign admin UCAN");
+
+    ucan.encode().expect("Failed to encode admin UCAN")
+}
+
+/// Daniel review: cached preload handlers must stop at UCAN expiry.
+///
+/// Before the fix, `load_preloaded_user_handler` passed `expires_at: None` to
+/// the cached handler. On cache hit, `get_handler` short-circuits UCAN
+/// validation and only checks `handler.is_valid()`, so a warm cache entry kept
+/// signing past the UCAN's lifetime until idle eviction.
+///
+/// This test mints a preload UCAN with a 2-second lifetime, exercises a
+/// successful sign to populate the cache, sleeps past expiry, and asserts the
+/// second call (cache hit) is rejected and the entry evicted.
+#[tokio::test]
+#[serial]
+async fn test_warm_cache_preload_handler_rejected_after_ucan_expiry() {
+    // Server keys must match SERVER_NSEC env (read by validate_ucan_token /
+    // is_server_signed); set both to the same value.
+    let server_keys = Keys::generate();
+    std::env::set_var(
+        "SERVER_NSEC",
+        server_keys
+            .secret_key()
+            .to_bech32()
+            .expect("server nsec bech32"),
+    );
+
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (user_keys, pubkey_hex) = create_test_user();
+    let pubkey = user_keys.public_key();
+    let key_manager: Arc<Box<dyn KeyManager>> =
+        Arc::new(Box::new(FileKeyManager::new().expect("key manager")));
+
+    insert_user(&pool, tenant_id, &pubkey_hex).await;
+    create_personal_key(&pool, tenant_id, &pubkey_hex, &user_keys, &**key_manager).await;
+
+    // Build AuthState whose state.server_keys matches SERVER_NSEC so behavior is
+    // consistent across the request lifecycle.
+    let auth_state = {
+        let bcrypt_queue = BcryptQueue::new();
+        let secret_pool = SecretPool::new(1);
+        let tenant_cache = Cache::builder().max_capacity(10).build();
+        AuthState {
+            state: Arc::new(KeycastState {
+                db: pool.clone(),
+                key_manager: key_manager.clone(),
+                signer_handlers: None,
+                http_handler_cache: new_http_handler_cache(),
+                server_keys: server_keys.clone(),
+                tenant_cache,
+                bcrypt_sender: bcrypt_queue.sender(),
+                redis: None,
+                secret_pool: secret_pool.receiver(),
+            }),
+            auth_tx: None,
+        }
+    };
+
+    // Preload UCAN with 2s lifetime — long enough to validate on first request,
+    // short enough for the test to wait it out.
+    let token = build_preload_ucan_with_lifetime(&pubkey, tenant_id, &server_keys, 2).await;
+    let auth_header = format!("Bearer {}", token);
+    let cache_key = *blake3::hash(token.as_bytes()).as_bytes();
+
+    // First call: cache miss → UCAN validates → handler cached.
+    let response_1 = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state.clone(),
+        &auth_header,
+        None,
+        get_public_key_request(),
+    )
+    .await
+    .expect("First preload request should succeed");
+    assert_eq!(response_1.result, Some(Value::String(pubkey_hex.clone())));
+
+    // Cache should now contain the handler with expires_at carried from UCAN.
+    let cached = auth_state
+        .state
+        .http_handler_cache
+        .get(&cache_key)
+        .await
+        .expect("Handler should be in cache after first request");
+    assert!(
+        cached.is_valid(),
+        "Cached handler should still be valid before UCAN expiry"
+    );
+
+    // Wait past the UCAN's 2-second lifetime.
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    // Cached handler should now report invalid (expires_at < now).
+    assert!(
+        !cached.is_valid(),
+        "Cached handler should be invalid once UCAN exp has passed"
+    );
+
+    // Second call: cache hit → handler.is_valid() returns false → InvalidToken.
+    let err = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state.clone(),
+        &auth_header,
+        None,
+        get_public_key_request(),
+    )
+    .await
+    .expect_err("Cached request after UCAN expiry must be rejected");
+    match err {
+        RpcError::Auth(AuthError::InvalidToken) => {}
+        other => panic!("expected InvalidToken, got: {:?}", other),
+    }
+
+    // Cache entry must be evicted so subsequent requests don't keep hitting it.
+    assert!(
+        auth_state
+            .state
+            .http_handler_cache
+            .get(&cache_key)
+            .await
+            .is_none(),
+        "Invalid cached handler must be evicted"
+    );
+}
+
+/// Daniel review: signing path must accept *real* preload UCANs only.
+///
+/// Before the fix, MODE 2 routed any server-signed UCAN without a bunker_pubkey
+/// to `load_preloaded_user_handler`, which would happily decrypt the user's
+/// nsec and sign. That meant an admin-session UCAN (`redirect_origin: "admin"`)
+/// could be used to sign as any user.
+///
+/// This test mints a server-signed UCAN with `redirect_origin: "admin"` and
+/// verifies the signing path rejects it before touching the user's key.
+#[tokio::test]
+#[serial]
+async fn test_server_signed_non_preload_redirect_origin_rejected() {
+    let server_keys = Keys::generate();
+    std::env::set_var(
+        "SERVER_NSEC",
+        server_keys
+            .secret_key()
+            .to_bech32()
+            .expect("server nsec bech32"),
+    );
+
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (user_keys, pubkey_hex) = create_test_user();
+    let pubkey = user_keys.public_key();
+    let key_manager: Arc<Box<dyn KeyManager>> =
+        Arc::new(Box::new(FileKeyManager::new().expect("key manager")));
+
+    insert_user(&pool, tenant_id, &pubkey_hex).await;
+    create_personal_key(&pool, tenant_id, &pubkey_hex, &user_keys, &**key_manager).await;
+
+    let auth_state = {
+        let bcrypt_queue = BcryptQueue::new();
+        let secret_pool = SecretPool::new(1);
+        let tenant_cache = Cache::builder().max_capacity(10).build();
+        AuthState {
+            state: Arc::new(KeycastState {
+                db: pool.clone(),
+                key_manager: key_manager.clone(),
+                signer_handlers: None,
+                http_handler_cache: new_http_handler_cache(),
+                server_keys: server_keys.clone(),
+                tenant_cache,
+                bcrypt_sender: bcrypt_queue.sender(),
+                redis: None,
+                secret_pool: secret_pool.receiver(),
+            }),
+            auth_tx: None,
+        }
+    };
+
+    // UCAN is server-signed but redirect_origin = "admin" (not "preload").
+    let token = build_server_signed_non_preload_ucan(&pubkey, tenant_id, &server_keys).await;
+    let auth_header = format!("Bearer {}", token);
+
+    let err = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state,
+        &auth_header,
+        None,
+        get_public_key_request(),
+    )
+    .await
+    .expect_err("Server-signed non-preload UCAN must not sign for users");
+    match err {
+        RpcError::Auth(AuthError::InvalidToken) => {}
+        other => panic!("expected InvalidToken, got: {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary

- Drop the `is_unclaimed` gate in `load_preloaded_user_handler` (`api/src/api/http/nostr_rpc.rs`) so admin-issued preload UCANs continue to work after a user claims their account.
- Existence check preserved — non-existent users still rejected with `InvalidToken`.
- Updated docstrings on `load_preloaded_user_handler` and the MODE 2 branch in `get_handler` to reflect the new behavior.

## Why

We've discovered more classic Vine archives belonging to accounts that users have already claimed, and users want them published under their accounts. The mint side (`/api/admin/preload-user`) was already idempotent on `vine_id` and happily returned a fresh signing UCAN regardless of claim status; the signing endpoint at `nostr_rpc.rs` was the sole remaining block.

## Behavior change

Before: a server-signed preload UCAN could only sign for users where `email IS NULL`. Once a user claimed, their preload UCANs became dead.

After: the same preload UCAN works for both unclaimed and claimed users, until the UCAN itself expires (30 days) or gets evicted from cache.

The mint gate is unchanged: only `is_full_admin` callers can mint these UCANs, so the externally-reachable attack surface is the same.

## What this expands

A leaked admin token can now sign as any user (claimed or not) for as long as a 30-day preload UCAN lives. Before, claim was a user-side seal that closed that door. Acceptable for our small ops team and the Vine republish workflow, but the threat model genuinely changed.

## Follow-ups (not in this PR)

- #231 — add per-sign audit trail to `admin_audit_events` so we can answer "who signed what as whom" months after the fact. Schema + insertion-site notes are in the issue.
- Consider shortening preload UCAN TTL from 30d → 24h to cut the leaked-token window.
- `get_user_token` (pubkey-based admin endpoint at `admin.rs:344-393`) still has its own `is_unclaimed` block. Inconsistent with the new vine_id behavior, but the import script doesn't use that path so it's not blocking. Worth aligning later.

## Test plan

- [x] Build passes (`cargo build -p keycast_api`)
- [ ] Existing `admin_preload_test`, `admin_token_test`, `admin_batch_claim_test` still pass (they test mint-side and `is_unclaimed` repository behavior, both unchanged)
- [ ] Manual: in staging, mint a preload UCAN for a claimed test account, hit `/api/nostr` with `sign_event`, verify it returns a signed event instead of `InvalidToken`
- [ ] Manual: confirm preload UCAN for nonexistent pubkey still returns `InvalidToken`

🤖 Generated with [Claude Code](https://claude.com/claude-code)