### PR TITLE
ci: use 16-core GitHub runners

### DIFF
--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -30,8 +30,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-24.04-16core
     services:
       postgres:
         image: postgres:16
@@ -98,7 +97,7 @@ jobs:
   docker:
     name: Build & Push
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     if: github.event_name != 'pull_request'
     permissions:
       id-token: write
@@ -212,7 +211,7 @@ jobs:
   deploy:
     name: Trigger Deploy
     needs: docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     if: github.event_name != 'pull_request'
     environment: staging
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     timeout-minutes: 45
 
     services:


### PR DESCRIPTION
## Summary
- move Ubuntu GitHub Actions jobs from `ubuntu-latest` to the org hosted `ubuntu-24.04-16core` runner
- keep workflow logic unchanged; this only changes runner capacity

## Motivation
Reduce CI/build lead time across Divine repos. The org runner `ubuntu-24.04-16core` is configured as Ubuntu 24.04, 16 cores, 64 GB RAM, max 50 concurrent runners.

## Manual validation
- Parsed changed workflow YAML with Ruby
- Ran `git diff --check -- .github/workflows`