### PR TITLE
fix(auth): add EMAIL_ALREADY_EXISTS code to duplicate-email 409

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -57,6 +57,9 @@ components:
         error:
           type: string
           description: Error message
+        code:
+          type: string
+          description: Stable application error code, when available
       required:
         - error
 
@@ -342,7 +345,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegisterResponse'
         '400':
-          description: Invalid request (email already exists, weak password, invalid nsec)
+          description: Invalid request (weak password, invalid nsec)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Email already exists
           content:
             application/json:
               schema:

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1553,7 +1553,7 @@ pub async fn verify_email(
             let now = Utc::now();
             let mut tx = pool.begin().await?;
 
-            sqlx::query(
+            if let Err(err) = sqlx::query(
                 "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, email_verification_token, created_at, updated_at)
                  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
             )
@@ -1566,7 +1566,17 @@ pub async fn verify_email(
             .bind(now)
             .bind(now)
             .execute(&mut *tx)
-            .await?;
+            .await
+            {
+                if has_database_constraint(&err, USERS_EMAIL_TENANT_CONSTRAINT) {
+                    tx.rollback().await?;
+                    oauth_code_repo
+                        .delete_by_verification_token(&req.token, tenant_id)
+                        .await?;
+                    return Err(AuthError::EmailAlreadyExists);
+                }
+                return Err(err.into());
+            }
 
             sqlx::query(
                 "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
@@ -1588,7 +1598,7 @@ pub async fn verify_email(
             );
         } else {
             // BYOK flow: just create user, keys will come at token exchange
-            user_repo
+            if let Err(err) = user_repo
                 .create_with_password_verified(
                     &oauth_data.user_pubkey,
                     tenant_id,
@@ -1597,7 +1607,16 @@ pub async fn verify_email(
                     true,             // email_verified = true
                     Some(&req.token), // Keep token for idempotent re-verification
                 )
-                .await?;
+                .await
+            {
+                if matches!(err, keycast_core::repositories::RepositoryError::Duplicate) {
+                    oauth_code_repo
+                        .delete_by_verification_token(&req.token, tenant_id)
+                        .await?;
+                    return Err(AuthError::EmailAlreadyExists);
+                }
+                return Err(err.into());
+            }
 
             tracing::info!(
                 "Created user for BYOK OAuth registration: {}",
@@ -4561,7 +4580,7 @@ mod tests {
 
         let response = match verify_email(
             create_test_tenant(),
-            State(auth_state),
+            State(auth_state.clone()),
             HeaderMap::new(),
             Json(VerifyEmailRequest {
                 token: verification_token.clone(),
@@ -4576,6 +4595,38 @@ mod tests {
         assert_eq!(response.status(), StatusCode::CONFLICT);
         let body = response_json(response).await;
         assert_eq!(body["code"], super::EMAIL_ALREADY_EXISTS_CODE);
+
+        let pending_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE tenant_id = 1 AND pending_email_verification_token = $1",
+        )
+        .bind(&verification_token)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            pending_count.0, 0,
+            "duplicate-email verification should resolve the pending registration"
+        );
+
+        let retry_response = match verify_email(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            Json(VerifyEmailRequest {
+                token: verification_token.clone(),
+            }),
+        )
+        .await
+        {
+            Ok(response) => response.into_response(),
+            Err(err) => err.into_response(),
+        };
+        assert_ne!(
+            retry_response.status(),
+            StatusCode::CONFLICT,
+            "retrying the same token should not loop through duplicate-email insertion"
+        );
 
         cleanup_verify_email_test_data(&pool, &existing_pubkey, &verification_token).await;
         cleanup_verify_email_test_data(&pool, &pending_pubkey, &verification_token).await;

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -40,6 +40,9 @@ const MAX_NIP05_USERNAME_LENGTH: usize = 64;
 const USERS_EMAIL_TENANT_CONSTRAINT: &str = "idx_users_email_tenant";
 pub(crate) const INVALID_EMAIL_CODE: &str = "INVALID_EMAIL";
 pub(crate) const INVALID_EMAIL_MESSAGE: &str = "Please enter a valid email address.";
+pub(crate) const EMAIL_ALREADY_EXISTS_CODE: &str = "EMAIL_ALREADY_EXISTS";
+const EMAIL_ALREADY_EXISTS_MESSAGE: &str =
+    "This email is already registered. Please log in instead.";
 
 /// Get token expiry in seconds. Uses `TOKEN_EXPIRY_SECONDS` env var if set,
 /// otherwise defaults to 24 hours (86400 seconds).
@@ -443,10 +446,14 @@ impl IntoResponse for AuthError {
                     "Email conflict while verifying registration: constraint {}",
                     USERS_EMAIL_TENANT_CONSTRAINT
                 );
-                (
+                return (
                     StatusCode::CONFLICT,
-                    "This email is already registered. Please log in instead.".to_string(),
+                    Json(serde_json::json!({
+                        "error": EMAIL_ALREADY_EXISTS_MESSAGE,
+                        "code": EMAIL_ALREADY_EXISTS_CODE,
+                    })),
                 )
+                    .into_response();
             }
             AuthError::Database(e) => {
                 // Log the real error but return generic message to user
@@ -468,10 +475,16 @@ impl IntoResponse for AuthError {
                 StatusCode::UNAUTHORIZED,
                 "Invalid email or password. Please check your credentials and try again.".to_string(),
             ),
-            AuthError::EmailAlreadyExists => (
-                StatusCode::CONFLICT,
-                "This email is already registered. Please log in instead.".to_string(),
-            ),
+            AuthError::EmailAlreadyExists => {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": EMAIL_ALREADY_EXISTS_MESSAGE,
+                        "code": EMAIL_ALREADY_EXISTS_CODE,
+                    })),
+                )
+                    .into_response();
+            }
             AuthError::EmailNotVerified => (
                 StatusCode::FORBIDDEN,
                 "Please verify your email address before continuing. Check your inbox for the verification link.".to_string(),
@@ -4549,6 +4562,8 @@ mod tests {
         };
 
         assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["code"], super::EMAIL_ALREADY_EXISTS_CODE);
 
         cleanup_verify_email_test_data(&pool, &existing_pubkey, &verification_token).await;
         cleanup_verify_email_test_data(&pool, &pending_pubkey, &verification_token).await;

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -436,6 +436,17 @@ fn has_database_constraint(error: &sqlx::Error, expected_constraint: &str) -> bo
     }
 }
 
+fn coded_error_response(status: StatusCode, message: &str, code: &str) -> Response {
+    (
+        status,
+        Json(serde_json::json!({
+            "error": message,
+            "code": code,
+        })),
+    )
+        .into_response()
+}
+
 impl IntoResponse for AuthError {
     fn into_response(self) -> Response {
         let (status, message) = match self {
@@ -446,14 +457,11 @@ impl IntoResponse for AuthError {
                     "Email conflict while verifying registration: constraint {}",
                     USERS_EMAIL_TENANT_CONSTRAINT
                 );
-                return (
+                return coded_error_response(
                     StatusCode::CONFLICT,
-                    Json(serde_json::json!({
-                        "error": EMAIL_ALREADY_EXISTS_MESSAGE,
-                        "code": EMAIL_ALREADY_EXISTS_CODE,
-                    })),
-                )
-                    .into_response();
+                    EMAIL_ALREADY_EXISTS_MESSAGE,
+                    EMAIL_ALREADY_EXISTS_CODE,
+                );
             }
             AuthError::Database(e) => {
                 // Log the real error but return generic message to user
@@ -476,14 +484,11 @@ impl IntoResponse for AuthError {
                 "Invalid email or password. Please check your credentials and try again.".to_string(),
             ),
             AuthError::EmailAlreadyExists => {
-                return (
+                return coded_error_response(
                     StatusCode::CONFLICT,
-                    Json(serde_json::json!({
-                        "error": EMAIL_ALREADY_EXISTS_MESSAGE,
-                        "code": EMAIL_ALREADY_EXISTS_CODE,
-                    })),
-                )
-                    .into_response();
+                    EMAIL_ALREADY_EXISTS_MESSAGE,
+                    EMAIL_ALREADY_EXISTS_CODE,
+                );
             }
             AuthError::EmailNotVerified => (
                 StatusCode::FORBIDDEN,
@@ -530,14 +535,11 @@ impl IntoResponse for AuthError {
                 "This Nostr key is already registered. Please log in instead or use a different key.".to_string(),
             ),
             AuthError::InvalidEmail => {
-                return (
+                return coded_error_response(
                     StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "error": INVALID_EMAIL_MESSAGE,
-                        "code": INVALID_EMAIL_CODE,
-                    })),
-                )
-                    .into_response();
+                    INVALID_EMAIL_MESSAGE,
+                    INVALID_EMAIL_CODE,
+                );
             },
             AuthError::TokenExpired => (
                 StatusCode::UNAUTHORIZED,
@@ -4188,6 +4190,16 @@ mod tests {
         let body = response_json(response).await;
         assert_eq!(body["code"], super::INVALID_EMAIL_CODE);
         assert_eq!(body["error"], "Please enter a valid email address.");
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_email_response_has_stable_code() {
+        let response = super::AuthError::EmailAlreadyExists.into_response();
+
+        assert_eq!(response.status(), axum::http::StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["code"], super::EMAIL_ALREADY_EXISTS_CODE);
+        assert_eq!(body["error"], super::EMAIL_ALREADY_EXISTS_MESSAGE);
     }
 
     #[cfg(feature = "integration-tests")]


### PR DESCRIPTION
## Summary

- Adds a stable machine-readable `code` to duplicate-email 409 responses so clients can classify the conflict on a token instead of bare HTTP status or the human-readable message. Body becomes `{"error":"This email is already registered. Please log in instead.","code":"EMAIL_ALREADY_EXISTS"}`, following the existing `INVALID_EMAIL` precedent.
- Covers both duplicate-email paths in auth error rendering: the email-verification database constraint path and the direct `AuthError::EmailAlreadyExists` path used by duplicate registration.
- Factors coded auth error JSON through a small helper to avoid drift between duplicate-email and invalid-email responses.
- Updates OpenAPI to document the optional stable `code` field and the register `409` duplicate-email response.

## Motivation

The mobile duplicate-email recovery had no machine-readable signal to key off; it relied on bare 409 status. A stable `EMAIL_ALREADY_EXISTS` token lets clients classify the failure robustly without string-matching the human message.

The 503-to-409 behavior already shipped in #208; this completes #198 by giving the conflict a classifiable signal while keeping the existing status and message stable.

## Related Issue

Closes #198

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p keycast_api test_duplicate_email_response_has_stable_code`
- [x] `cargo test -p keycast_api test_register_rejects_malformed_email_with_stable_error`
- [x] `test_verify_email_duplicate_email_returns_conflict` was added for the integration path and passed in CI before the follow-up amendment
- [ ] Full `cargo test --workspace --verbose` not run locally after the amendment; CI runs the full suite

## Visuals

- [x] No visual change
