### PR TITLE
chore: wire keycast service token secret

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -68,7 +68,7 @@ steps:
       - '--network=default'
       - '--subnet=default'
       - '--vpc-egress=private-ranges-only'
-      - '--set-secrets=DATABASE_URL=keycast-database-url:latest,SERVER_NSEC=keycast-ucan-secret:latest,SENDGRID_API_KEY=keycast-sendgrid-api-key:latest,REDIS_URL=keycast-redis-url:latest'
+      - '--set-secrets=DATABASE_URL=keycast-database-url:latest,SERVER_NSEC=keycast-ucan-secret:latest,SENDGRID_API_KEY=keycast-sendgrid-api-key:latest,REDIS_URL=keycast-redis-url:latest,KEYCAST_SERVICE_TOKEN=keycast-service-token:latest'
       - '--set-env-vars=^;^NODE_ENV=production;USE_GCP_KMS=true;GCP_PROJECT_ID=${PROJECT_ID};ALLOWED_ORIGINS=https://login.divine.video,https://divine.video,https://*.openvine-app.pages.dev;ALLOWED_TENANT_DOMAINS=login.divine.video;REQUIRE_REGISTERED_OAUTH_CLIENTS=false;APP_URL=https://login.divine.video;FROM_EMAIL=noreply@divine.video;RUST_LOG=info;ENABLE_EXAMPLES=true;SQLX_STATEMENT_CACHE=100;SQLX_POOL_SIZE=50;ALLOWED_PUBKEYS=89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5,76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa;BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol;ENABLE_DIVINE_NAMES=true'
 
   # Smoke tests - verify deployment


### PR DESCRIPTION
## Summary

Cloud Run Keycast needs the service token secret available at runtime.
This change wires the existing Secret Manager secret into the Cloud Build deploy command as KEYCAST_SERVICE_TOKEN.
That lets the service-token admin status endpoints authorize relay-manager calls after the next Cloud Run deploy.

## What Changed

The Cloud Run deploy configuration now maps the Secret Manager secret into the service environment.
No secret value is committed.

- Added KEYCAST_SERVICE_TOKEN=keycast-service-token:latest to the Cloud Run --set-secrets list in cloudbuild.yaml.

## Testing

The push hook ran the repository checks before pushing the branch.
The change is deployment configuration only, so no runtime deploy was performed from this PR.

- cargo fmt check ran via pre-push hook
- cargo clippy ran via pre-push hook
- cargo test ran via pre-push hook
- release build ran via pre-push hook

## Risks

Risk is low because this only exposes an already-created Secret Manager secret to Cloud Run.
The new env var is only used by the service-token account-status endpoints.

- Requires a Cloud Run redeploy after merge before KEYCAST_SERVICE_TOKEN is present at runtime.
- Requires the Secret Manager secret keycast-service-token to exist in openvine-co.