### PR TITLE
fix(ci): pin sqlx-cli install

### DIFF
--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -73,7 +73,7 @@ jobs:
           ./scripts/generate_key.sh
 
           # Run migrations
-          cargo install sqlx-cli --no-default-features --features postgres
+          cargo install sqlx-cli --version 0.8.6 --no-default-features --features postgres
           sqlx migrate run --database-url $DATABASE_URL --source database/migrations
 
       - name: Run tests


### PR DESCRIPTION
## Summary

CI is failing before tests run because it installs the latest sqlx-cli.
sqlx-cli 0.9.0 now requires Rust 1.94+, while this repo pins Rust 1.93.0.
This change pins the CI install to sqlx-cli 0.8.6, which works with the repo toolchain and still supports the migration command CI runs.

## What Changed

The workflow now installs a known-compatible sqlx-cli version instead of whatever crates.io marks latest.
This keeps CI stable until the repo intentionally upgrades Rust.

- Changed the Build, Test & Push workflow from unpinned sqlx-cli install to `--version 0.8.6`.

## Testing

I reproduced the failing command with Rust 1.93.0, then verified the pinned command with the same toolchain.
The pre-push hook also ran the repository checks before pushing this branch.

- `rustup run 1.93.0 cargo install sqlx-cli --no-default-features --features postgres --root /tmp/opencode/sqlx-cli-unpinned-test --force` failed with the Rust 1.94 requirement for sqlx-cli 0.9.0.
- `rustup run 1.93.0 cargo install sqlx-cli --version 0.8.6 --no-default-features --features postgres --root /tmp/opencode/sqlx-cli-ci-pin-test --force` passed and reported `sqlx-cli 0.8.6`.
- Pre-push hook ran formatting, clippy, tests, and release build successfully.

## Risks

Risk is low because this only pins the migration CLI used by CI setup.
The repo already uses sqlx 0.8.x dependencies, and this does not change application code.

- Future sqlx-cli upgrades should happen together with an intentional Rust toolchain upgrade.