### PR TITLE
ci(actions): use standard GitHub Actions runners

### DIFF
--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: postgres:16
@@ -97,7 +97,7 @@ jobs:
   docker:
     name: Build & Push
     needs: test
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     if: github.event_name != 'pull_request'
     permissions:
       id-token: write
@@ -203,7 +203,7 @@ jobs:
   deploy:
     name: Trigger Deploy
     needs: docker
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     if: github.event_name != 'pull_request'
     environment: staging
 

--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     services:
       postgres:
         image: postgres:16
@@ -97,7 +97,7 @@ jobs:
   docker:
     name: Build & Push
     needs: test
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     if: github.event_name != 'pull_request'
     permissions:
       id-token: write
@@ -203,7 +203,7 @@ jobs:
   deploy:
     name: Trigger Deploy
     needs: docker
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     if: github.event_name != 'pull_request'
     environment: staging
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   e2e:
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
 
     services:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   e2e:
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     timeout-minutes: 45
 
     services:


### PR DESCRIPTION
## Summary
- replace `ubuntu-24.04-16core` GitHub larger runner labels with standard `ubuntu-24.04` hosted runners
- reduce Actions spend while avoiding the unschedulable `ubuntu-24.04-4core` custom runner label

## Motivation
The Divine org has used 90% of its May 2026 Actions budget. The standard Ubuntu runner removes the 16-core larger-runner cost while keeping CI on a schedulable GitHub-hosted label.

## Linked issue
Closes #271

## Manual validation
- Verified changed workflow files no longer contain `ubuntu-24.04-16core`.
- Verified changed workflow files no longer contain `ubuntu-24.04-4core`.
- Verified changed workflow files now use `ubuntu-24.04`.