### PR TITLE
feat(api): add generate_admin_token example for minting admin UCANs

### DIFF
--- a/api/examples/generate_admin_token.rs
+++ b/api/examples/generate_admin_token.rs
@@ -1,0 +1,34 @@
+use keycast_api::ucan_auth::{did_to_nostr_pubkey, nostr_pubkey_to_did, NostrKeyMaterial};
+use nostr_sdk::Keys;
+use serde_json::json;
+use ucan::builder::UcanBuilder;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let server_nsec = std::env::var("SERVER_NSEC")?;
+    let admin_did = std::env::var("ADMIN_DID")?;
+    let tenant_id: i64 = std::env::var("TENANT_ID")?.parse()?;
+
+    let server_keys = Keys::parse(&server_nsec)?;
+    let admin_pubkey = did_to_nostr_pubkey(&admin_did)?;
+    let server_key_material = NostrKeyMaterial::from_keys(server_keys);
+
+    let facts = json!({
+        "tenant_id": tenant_id,
+        "redirect_origin": "admin",
+        "admin": true,
+        "admin_role": "full",
+    });
+
+    let ucan = UcanBuilder::default()
+        .issued_by(&server_key_material)
+        .for_audience(&nostr_pubkey_to_did(&admin_pubkey))
+        .with_lifetime(30 * 24 * 3600)
+        .with_fact(facts)
+        .build()?
+        .sign()
+        .await?;
+
+    println!("{}", ucan.encode()?);
+    Ok(())
+}


### PR DESCRIPTION
## What

Adds a standalone Cargo example, `api/examples/generate_admin_token.rs`, that mints a server-signed admin UCAN for a given DID + tenant.

- 30-day lifetime, `admin: true`, `admin_role: "full"`, `redirect_origin: "admin"`
- Reads `SERVER_NSEC`, `ADMIN_DID`, `TENANT_ID` from the environment
- Uses only the public `keycast_api::ucan_auth` surface (`did_to_nostr_pubkey`, `nostr_pubkey_to_did`, `NostrKeyMaterial`)

## Usage

```bash
SERVER_NSEC=... ADMIN_DID=did:... TENANT_ID=1 \
  cargo run -p keycast_api --example generate_admin_token
```

## Verification

`cargo check -p keycast_api --example generate_admin_token` compiles cleanly against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related Issue

Closes #272