### PR TITLE
feat: RSA / ActivityPub HTTP-Signature signing (key custody + signing oracle)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,6 +3520,7 @@ dependencies = [
  "nostr-sdk",
  "once_cell",
  "rand 0.8.5",
+ "rsa",
  "secrecy",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,6 +3473,7 @@ dependencies = [
  "rand 0.8.5",
  "redis",
  "reqwest",
+ "rsa",
  "secp256k1",
  "secrecy",
  "serde",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -71,3 +71,4 @@ async-trait = "0.1"
 md5 = "0.7"
 bcrypt = "0.17.1"
 serial_test = "3.2"
+rsa = { version = "0.9", features = ["pem"] }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -49,6 +49,10 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: UCAN token from /auth/register or /auth/login
+    ServiceToken:
+      type: http
+      scheme: bearer
+      description: KEYCAST_SERVICE_TOKEN for trusted service-to-service callers (e.g. the AP gateway)
 
   schemas:
     Error:
@@ -62,6 +66,75 @@ components:
           description: Stable application error code, when available
       required:
         - error
+
+    ApCreateKeyRequest:
+      type: object
+      properties:
+        pubkey:
+          type: string
+          description: Hex Nostr pubkey of the actor. Required for service-token callers; for UCAN callers it defaults to the token's pubkey and, if present, must match it.
+          example: "e1ff3bfdd4e40315959b08b4fcc8245eaa514637e1d4ec2ae166b743341be1af"
+    ApKeyResponse:
+      type: object
+      properties:
+        pubkey:
+          type: string
+        public_key_pem:
+          type: string
+          description: SPKI PEM public key for the actor's publicKey.publicKeyPem.
+          example: "-----BEGIN PUBLIC KEY-----\nMIIBIjAN...\n-----END PUBLIC KEY-----\n"
+        key_type:
+          type: string
+          example: "rsa-2048"
+        created:
+          type: boolean
+          description: true if a new key was minted; false if an existing key was returned (idempotent).
+      required:
+        - pubkey
+        - public_key_pem
+        - key_type
+        - created
+    ApPublicKeyResponse:
+      type: object
+      properties:
+        pubkey:
+          type: string
+        public_key_pem:
+          type: string
+        key_type:
+          type: string
+          example: "rsa-2048"
+      required:
+        - pubkey
+        - public_key_pem
+        - key_type
+    ApSignRequest:
+      type: object
+      properties:
+        pubkey:
+          type: string
+          description: Hex Nostr pubkey of the actor (required for service-token callers).
+        signing_string:
+          type: string
+          description: The exact draft-cavage HTTP-Signature signing string. Signed as UTF-8 bytes.
+          example: "(request-target): post /inbox\nhost: mastodon.social\ndate: Mon, 01 Jan 2026 00:00:00 GMT\ndigest: SHA-256=X..."
+      required:
+        - signing_string
+    ApSignResponse:
+      type: object
+      properties:
+        pubkey:
+          type: string
+        signature:
+          type: string
+          description: base64-encoded RSASSA-PKCS1-v1_5 SHA-256 signature for the Signature header.
+        algorithm:
+          type: string
+          example: "rsa-sha256"
+      required:
+        - pubkey
+        - signature
+        - algorithm
 
     RegisterRequest:
       type: object
@@ -456,6 +529,118 @@ paths:
                 $ref: '#/components/schemas/Error'
         '500':
           description: Signing failed (KMS error, invalid key, etc.)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /ap/keys:
+    post:
+      summary: Create or return an actor's ActivityPub RSA key
+      description: |
+        Mints (or returns, idempotently) an RSA-2048 keypair for an actor and returns its
+        SPKI public PEM for embedding in `publicKey.publicKeyPem`. The private key is stored
+        encrypted-at-rest and is never returned. Calling again returns the existing key
+        with `created: false` — the key is never regenerated (federated keys are cached by
+        remote servers). Auth: ServiceToken (with `pubkey`) or UCAN (BearerAuth).
+      tags:
+        - ActivityPub
+      security:
+        - ServiceToken: []
+        - BearerAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApCreateKeyRequest'
+      responses:
+        '200':
+          description: Key created or already existed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApKeyResponse'
+        '400':
+          description: Invalid or missing pubkey
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: UCAN pubkey mismatch
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /ap/keys/{pubkey}:
+    get:
+      summary: Get an actor's ActivityPub public key PEM
+      tags:
+        - ActivityPub
+      security:
+        - ServiceToken: []
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: pubkey
+          required: true
+          schema:
+            type: string
+          description: Hex Nostr pubkey of the actor
+      responses:
+        '200':
+          description: Public key PEM
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApPublicKeyResponse'
+        '404':
+          description: No AP key for this actor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /ap/sign:
+    post:
+      summary: Sign an HTTP-Signature signing string (RSA-SHA256)
+      description: |
+        Signs the exact caller-supplied signing string with RSASSA-PKCS1-v1_5 + SHA-256 and
+        returns the base64 signature. The caller builds the draft-cavage signing string and
+        assembles the final `Signature:` header. The private key never leaves Keycast.
+        Suspended/banned accounts are rejected.
+      tags:
+        - ActivityPub
+      security:
+        - ServiceToken: []
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApSignRequest'
+      responses:
+        '200':
+          description: Signature
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApSignResponse'
+        '403':
+          description: Account restricted or pubkey mismatch
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: No AP key for this actor
           content:
             application/json:
               schema:
@@ -1061,3 +1246,5 @@ tags:
     description: User profile and session management
   - name: Discovery
     description: NIP-05 identifier discovery
+  - name: ActivityPub
+    description: RSA key custody and HTTP-Signature signing for the ActivityPub gateway

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -72,8 +72,12 @@ components:
       properties:
         pubkey:
           type: string
-          description: Hex Nostr pubkey of the actor. Required for service-token callers; for UCAN callers it defaults to the token's pubkey and, if present, must match it.
+          description: Hex Nostr pubkey of the actor. For service-token callers, either pubkey or actor is required; for UCAN callers it defaults to the token's pubkey and, if present, must match it.
           example: "e1ff3bfdd4e40315959b08b4fcc8245eaa514637e1d4ec2ae166b743341be1af"
+        actor:
+          type: string
+          description: ActivityPub actor URL. Alternative to pubkey for the gateway; resolves /ap/users/{username} against the tenant selected by the Keycast request Host.
+          example: "https://divine.video/ap/users/alice"
     ApKeyResponse:
       type: object
       properties:
@@ -113,7 +117,10 @@ components:
       properties:
         pubkey:
           type: string
-          description: Hex Nostr pubkey of the actor (required for service-token callers).
+          description: Hex Nostr pubkey of the actor. For service-token callers, either pubkey or actor is required.
+        actor:
+          type: string
+          description: ActivityPub actor URL. Alternative to pubkey for the gateway; resolves /ap/users/{username} against the tenant selected by the Keycast request Host.
         signing_string:
           type: string
           description: The exact draft-cavage HTTP-Signature signing string. Signed as UTF-8 bytes.
@@ -542,14 +549,15 @@ paths:
         SPKI public PEM for embedding in `publicKey.publicKeyPem`. The private key is stored
         encrypted-at-rest and is never returned. Calling again returns the existing key
         with `created: false` — the key is never regenerated (federated keys are cached by
-        remote servers). Auth: ServiceToken (with `pubkey`) or UCAN (BearerAuth).
+        remote servers). Auth: ServiceToken (with `pubkey` or `actor`) or an OAuth UCAN
+        for the same actor.
       tags:
         - ActivityPub
       security:
         - ServiceToken: []
         - BearerAuth: []
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
@@ -579,9 +587,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /ap/keys/{pubkey}:
+  /ap/keys/{actor_or_pubkey}:
     get:
       summary: Get an actor's ActivityPub public key PEM
+      description: |
+        Returns the actor's public PEM, lazily minting the RSA key if needed. The path
+        accepts either a hex Nostr pubkey or a URL-encoded ActivityPub actor URL.
       tags:
         - ActivityPub
       security:
@@ -589,11 +600,11 @@ paths:
         - BearerAuth: []
       parameters:
         - in: path
-          name: pubkey
+          name: actor_or_pubkey
           required: true
           schema:
             type: string
-          description: Hex Nostr pubkey of the actor
+          description: Hex Nostr pubkey or URL-encoded ActivityPub actor URL
       responses:
         '200':
           description: Public key PEM
@@ -614,7 +625,9 @@ paths:
         Signs the exact caller-supplied signing string with RSASSA-PKCS1-v1_5 + SHA-256 and
         returns the base64 signature. The caller builds the draft-cavage signing string and
         assembles the final `Signature:` header. The private key never leaves Keycast.
-        Suspended/banned accounts are rejected.
+        Suspended/banned accounts are rejected. Service-token callers identify the actor
+        with `pubkey` or `actor`; UCAN callers need a live OAuth authorization for the
+        same actor.
       tags:
         - ActivityPub
       security:

--- a/api/src/api/http/ap.rs
+++ b/api/src/api/http/ap.rs
@@ -9,11 +9,13 @@ use axum::{
     Json,
 };
 use keycast_core::ap_signing::{self, AP_KEY_TYPE};
-use keycast_core::repositories::{ApActorKeysRepository, RepositoryError, UserRepository};
+use keycast_core::repositories::{
+    ApActorKeysRepository, OAuthAuthorizationRepository, RepositoryError, UserRepository,
+};
 use nostr_sdk::PublicKey;
 use serde::{Deserialize, Serialize};
 
-use crate::api::http::auth::extract_user_from_token;
+use crate::api::http::auth::extract_user_and_origin_from_token;
 use crate::api::http::routes::AuthState;
 use crate::api::tenant::TenantExtractor;
 
@@ -76,28 +78,99 @@ fn validate_hex_pubkey(pubkey: &str) -> Result<String, ApError> {
         .map_err(|_| ApError::BadRequest("Invalid hex pubkey".to_string()))
 }
 
-/// Resolve the acting user_pubkey for a request.
-/// - Service token: `body_pubkey` is REQUIRED (gateway acts for any actor in the tenant).
-/// - UCAN: pubkey comes from the token; if `body_pubkey` is present it must match.
-async fn resolve_principal(
-    headers: &HeaderMap,
+fn actor_username(actor: &str) -> Result<String, ApError> {
+    let actor = actor.trim();
+    let without_scheme = actor
+        .strip_prefix("https://")
+        .or_else(|| actor.strip_prefix("http://"))
+        .ok_or_else(|| ApError::BadRequest("Invalid actor URL".to_string()))?;
+    let (_host, path) = without_scheme
+        .split_once('/')
+        .ok_or_else(|| ApError::BadRequest("Invalid actor URL".to_string()))?;
+    let username = path
+        .strip_prefix("ap/users/")
+        .ok_or_else(|| ApError::BadRequest("Invalid actor URL".to_string()))?;
+    if username.is_empty() || username.contains('/') {
+        return Err(ApError::BadRequest("Invalid actor URL".to_string()));
+    }
+    Ok(username.to_string())
+}
+
+async fn resolve_actor_pubkey(
+    pool: &sqlx::PgPool,
+    tenant_id: i64,
+    actor: &str,
+) -> Result<String, ApError> {
+    let username = actor_username(actor)?;
+    UserRepository::new(pool.clone())
+        .find_pubkey_by_username(&username, tenant_id)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?
+        .ok_or_else(|| ApError::NotFound("No user for this actor".to_string()))
+}
+
+async fn resolve_requested_pubkey(
+    pool: &sqlx::PgPool,
     tenant_id: i64,
     body_pubkey: Option<&str>,
+    actor: Option<&str>,
+) -> Result<Option<String>, ApError> {
+    match (body_pubkey, actor) {
+        (Some(pk), None) => Ok(Some(validate_hex_pubkey(pk)?)),
+        (None, Some(actor)) => Ok(Some(resolve_actor_pubkey(pool, tenant_id, actor).await?)),
+        (Some(pk), Some(actor)) => {
+            let pk = validate_hex_pubkey(pk)?;
+            let actor_pk = resolve_actor_pubkey(pool, tenant_id, actor).await?;
+            if pk != actor_pk {
+                return Err(ApError::Forbidden(
+                    "pubkey does not match actor".to_string(),
+                ));
+            }
+            Ok(Some(pk))
+        }
+        (None, None) => Ok(None),
+    }
+}
+
+/// Resolve the acting user_pubkey for a request.
+/// - Service token: `pubkey` or `actor` is REQUIRED (gateway acts for an existing actor in the tenant).
+/// - UCAN: requires a live OAuth authorization bunker and cannot act for a different actor/pubkey.
+async fn resolve_principal(
+    headers: &HeaderMap,
+    pool: &sqlx::PgPool,
+    tenant_id: i64,
+    body_pubkey: Option<&str>,
+    actor: Option<&str>,
 ) -> Result<String, ApError> {
+    let requested = resolve_requested_pubkey(pool, tenant_id, body_pubkey, actor).await?;
+
     if is_service_token(headers) {
-        let pk = body_pubkey.ok_or_else(|| {
-            ApError::BadRequest("pubkey is required for service-token calls".into())
-        })?;
-        return validate_hex_pubkey(pk);
+        return requested.ok_or_else(|| {
+            ApError::BadRequest("pubkey or actor is required for service-token calls".into())
+        });
     }
 
     // UCAN path
-    let token_pubkey = extract_user_from_token(headers, tenant_id)
-        .await
-        .map_err(|_| ApError::Unauthorized("Authentication required".to_string()))?;
+    let (token_pubkey, _redirect_origin, bunker_pubkey) =
+        extract_user_and_origin_from_token(headers, tenant_id)
+            .await
+            .map_err(|_| ApError::Unauthorized("Authentication required".to_string()))?;
 
-    if let Some(pk) = body_pubkey {
-        let pk = validate_hex_pubkey(pk)?;
+    let bunker_pubkey = bunker_pubkey.ok_or_else(|| {
+        ApError::Unauthorized("OAuth authorization required for AP signing".to_string())
+    })?;
+    let oauth_repo = OAuthAuthorizationRepository::new(pool.clone());
+    if !oauth_repo
+        .exists_active_for_bunker(&bunker_pubkey, &token_pubkey, tenant_id)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?
+    {
+        return Err(ApError::Unauthorized(
+            "OAuth authorization is revoked or expired".to_string(),
+        ));
+    }
+
+    if let Some(pk) = requested {
         if pk != token_pubkey {
             return Err(ApError::Forbidden(
                 "Cannot act on behalf of another user".to_string(),
@@ -114,14 +187,15 @@ async fn ensure_active(
     user_pubkey: &str,
 ) -> Result<(), ApError> {
     let user_repo = UserRepository::new(pool.clone());
-    if let Some((status, _, _)) = user_repo
+    let Some((status, _, _)) = user_repo
         .get_user_status(user_pubkey, tenant_id)
         .await
         .map_err(|e| ApError::Internal(e.to_string()))?
-    {
-        if !status.is_active() {
-            return Err(ApError::Forbidden("Account restricted".to_string()));
-        }
+    else {
+        return Err(ApError::NotFound("No user for this actor".to_string()));
+    };
+    if !status.is_active() {
+        return Err(ApError::Forbidden("Account restricted".to_string()));
     }
     Ok(())
 }
@@ -132,6 +206,8 @@ async fn ensure_active(
 pub struct CreateKeyRequest {
     /// Hex Nostr pubkey of the actor. Required for service-token callers.
     pub pubkey: Option<String>,
+    /// ActivityPub actor URL, e.g. https://divine.video/ap/users/alice.
+    pub actor: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -153,6 +229,8 @@ pub struct PublicKeyResponse {
 pub struct SignRequest {
     /// Hex Nostr pubkey of the actor. Required for service-token callers.
     pub pubkey: Option<String>,
+    /// ActivityPub actor URL, e.g. https://divine.video/ap/users/alice.
+    pub actor: Option<String>,
     /// Exact draft-cavage signing string. Signed as its UTF-8 bytes.
     pub signing_string: String,
 }
@@ -164,34 +242,12 @@ pub struct SignResponse {
     pub algorithm: &'static str,
 }
 
-// ---- handlers ----
-
-/// POST /api/ap/keys — create-or-return the actor's RSA key. Idempotent: never regenerates.
-pub async fn create_key(
-    tenant: TenantExtractor,
-    State(auth_state): State<AuthState>,
-    headers: HeaderMap,
-    Json(req): Json<CreateKeyRequest>,
-) -> Result<Json<KeyResponse>, ApError> {
-    let tenant_id = tenant.0.id;
-    let user_pubkey = resolve_principal(&headers, tenant_id, req.pubkey.as_deref()).await?;
-    let pool = &auth_state.state.db;
-    let repo = ApActorKeysRepository::new(pool.clone());
-
-    // Idempotent: if a key exists, return it unchanged.
-    if let Some((pem, key_type)) = repo
-        .find_public_pem(tenant_id, &user_pubkey)
-        .await
-        .map_err(|e| ApError::Internal(e.to_string()))?
-    {
-        return Ok(Json(KeyResponse {
-            pubkey: user_pubkey,
-            public_key_pem: pem,
-            key_type,
-            created: false,
-        }));
-    }
-
+async fn create_actor_key(
+    repo: &ApActorKeysRepository,
+    auth_state: &AuthState,
+    tenant_id: i64,
+    user_pubkey: &str,
+) -> Result<(String, String, bool), ApError> {
     // Generate (CPU-bound) off the async runtime.
     let material = tokio::task::spawn_blocking(ap_signing::generate_rsa_2048)
         .await
@@ -209,38 +265,75 @@ pub async fn create_key(
     match repo
         .create(
             tenant_id,
-            &user_pubkey,
+            user_pubkey,
             &encrypted,
             &material.public_pem,
             AP_KEY_TYPE,
         )
         .await
     {
-        Ok(()) => Ok(Json(KeyResponse {
-            pubkey: user_pubkey,
-            public_key_pem: material.public_pem,
-            key_type: AP_KEY_TYPE.to_string(),
-            created: true,
-        })),
+        Ok(()) => Ok((material.public_pem, AP_KEY_TYPE.to_string(), true)),
         Err(RepositoryError::Duplicate) => {
-            // Lost a race: another request created it. Return the winner's key.
             let (pem, key_type) = repo
-                .find_public_pem(tenant_id, &user_pubkey)
+                .find_public_pem(tenant_id, user_pubkey)
                 .await
                 .map_err(|e| ApError::Internal(e.to_string()))?
                 .ok_or_else(|| ApError::Internal("key insert conflict but no row".into()))?;
-            Ok(Json(KeyResponse {
-                pubkey: user_pubkey,
-                public_key_pem: pem,
-                key_type,
-                created: false,
-            }))
+            Ok((pem, key_type, false))
         }
         Err(e) => Err(ApError::Internal(e.to_string())),
     }
 }
 
-/// GET /api/ap/keys/{pubkey} — return the actor's public PEM. Never decrypts.
+async fn find_or_create_actor_key(
+    repo: &ApActorKeysRepository,
+    auth_state: &AuthState,
+    tenant_id: i64,
+    user_pubkey: &str,
+) -> Result<(String, String, bool), ApError> {
+    if let Some((pem, key_type)) = repo
+        .find_public_pem(tenant_id, user_pubkey)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?
+    {
+        return Ok((pem, key_type, false));
+    }
+    create_actor_key(repo, auth_state, tenant_id, user_pubkey).await
+}
+
+// ---- handlers ----
+
+/// POST /api/ap/keys — create-or-return the actor's RSA key. Idempotent: never regenerates.
+pub async fn create_key(
+    tenant: TenantExtractor,
+    State(auth_state): State<AuthState>,
+    headers: HeaderMap,
+    Json(req): Json<CreateKeyRequest>,
+) -> Result<Json<KeyResponse>, ApError> {
+    let tenant_id = tenant.0.id;
+    let pool = &auth_state.state.db;
+    let user_pubkey = resolve_principal(
+        &headers,
+        pool,
+        tenant_id,
+        req.pubkey.as_deref(),
+        req.actor.as_deref(),
+    )
+    .await?;
+    ensure_active(pool, tenant_id, &user_pubkey).await?;
+    let repo = ApActorKeysRepository::new(pool.clone());
+
+    let (pem, key_type, created) =
+        find_or_create_actor_key(&repo, &auth_state, tenant_id, &user_pubkey).await?;
+    Ok(Json(KeyResponse {
+        pubkey: user_pubkey,
+        public_key_pem: pem,
+        key_type,
+        created,
+    }))
+}
+
+/// GET /api/ap/keys/{pubkey-or-actor} — return the actor's public PEM. Never decrypts.
 pub async fn get_key(
     tenant: TenantExtractor,
     State(auth_state): State<AuthState>,
@@ -248,14 +341,17 @@ pub async fn get_key(
     Path(pubkey): Path<String>,
 ) -> Result<Json<PublicKeyResponse>, ApError> {
     let tenant_id = tenant.0.id;
-    let user_pubkey = resolve_principal(&headers, tenant_id, Some(&pubkey)).await?;
+    let pool = &auth_state.state.db;
+    let user_pubkey = if PublicKey::from_hex(&pubkey).is_ok() {
+        resolve_principal(&headers, pool, tenant_id, Some(&pubkey), None).await?
+    } else {
+        resolve_principal(&headers, pool, tenant_id, None, Some(&pubkey)).await?
+    };
+    ensure_active(pool, tenant_id, &user_pubkey).await?;
     let repo = ApActorKeysRepository::new(auth_state.state.db.clone());
 
-    let (pem, key_type) = repo
-        .find_public_pem(tenant_id, &user_pubkey)
-        .await
-        .map_err(|e| ApError::Internal(e.to_string()))?
-        .ok_or_else(|| ApError::NotFound("No AP key for this actor".to_string()))?;
+    let (pem, key_type, _) =
+        find_or_create_actor_key(&repo, &auth_state, tenant_id, &user_pubkey).await?;
 
     Ok(Json(PublicKeyResponse {
         pubkey: user_pubkey,
@@ -272,17 +368,39 @@ pub async fn sign(
     Json(req): Json<SignRequest>,
 ) -> Result<Json<SignResponse>, ApError> {
     let tenant_id = tenant.0.id;
-    let user_pubkey = resolve_principal(&headers, tenant_id, req.pubkey.as_deref()).await?;
     let pool = &auth_state.state.db;
+    let user_pubkey = resolve_principal(
+        &headers,
+        pool,
+        tenant_id,
+        req.pubkey.as_deref(),
+        req.actor.as_deref(),
+    )
+    .await?;
 
     ensure_active(pool, tenant_id, &user_pubkey).await?;
 
     let repo = ApActorKeysRepository::new(pool.clone());
-    let row = repo
+    let row = match repo
         .find_for_tenant(tenant_id, &user_pubkey)
         .await
         .map_err(|e| ApError::Internal(e.to_string()))?
-        .ok_or_else(|| ApError::NotFound("No AP key for this actor".to_string()))?;
+    {
+        Some(row) => row,
+        None => {
+            create_actor_key(&repo, &auth_state, tenant_id, &user_pubkey).await?;
+            repo.find_for_tenant(tenant_id, &user_pubkey)
+                .await
+                .map_err(|e| ApError::Internal(e.to_string()))?
+                .ok_or_else(|| ApError::Internal("key created but no row found".into()))?
+        }
+    };
+    if row.key_type != AP_KEY_TYPE {
+        return Err(ApError::Internal(format!(
+            "Unsupported AP key type: {}",
+            row.key_type
+        )));
+    }
 
     let der = auth_state
         .state

--- a/api/src/api/http/ap.rs
+++ b/api/src/api/http/ap.rs
@@ -1,0 +1,305 @@
+// ABOUTME: ActivityPub RSA key custody + HTTP-Signature signing oracle
+// ABOUTME: Authenticated by KEYCAST_SERVICE_TOKEN (gateway) OR UCAN (user); tenant from Host
+// ABOUTME: Pure oracle — signs caller-supplied bytes; never returns the private key
+
+use axum::{
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use keycast_core::ap_signing::{self, AP_KEY_TYPE};
+use keycast_core::repositories::{ApActorKeysRepository, RepositoryError, UserRepository};
+use nostr_sdk::PublicKey;
+use serde::{Deserialize, Serialize};
+
+use crate::api::http::auth::extract_user_from_token;
+use crate::api::http::routes::AuthState;
+use crate::api::tenant::TenantExtractor;
+
+// ---- error type (isolated from AuthError; same {"error": msg} JSON shape) ----
+
+#[derive(Debug)]
+pub enum ApError {
+    Unauthorized(String),
+    Forbidden(String),
+    BadRequest(String),
+    NotFound(String),
+    Internal(String),
+}
+
+impl IntoResponse for ApError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            ApError::Unauthorized(m) => (StatusCode::UNAUTHORIZED, m),
+            ApError::Forbidden(m) => (StatusCode::FORBIDDEN, m),
+            ApError::BadRequest(m) => (StatusCode::BAD_REQUEST, m),
+            ApError::NotFound(m) => (StatusCode::NOT_FOUND, m),
+            ApError::Internal(m) => {
+                tracing::error!("AP signing internal error: {}", m);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal server error".to_string(),
+                )
+            }
+        };
+        (status, Json(serde_json::json!({ "error": message }))).into_response()
+    }
+}
+
+// ---- auth: resolve the acting user_pubkey from service token OR UCAN ----
+
+/// Constant-time check of the bearer against KEYCAST_SERVICE_TOKEN.
+/// Mirrors `admin::authorize_service_token` (duplicated to keep that path untouched).
+fn is_service_token(headers: &HeaderMap) -> bool {
+    use subtle::ConstantTimeEq;
+
+    let expected = match std::env::var("KEYCAST_SERVICE_TOKEN") {
+        Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
+        _ => return false,
+    };
+    let actual = match headers.get("authorization").and_then(|v| v.to_str().ok()) {
+        Some(a) => a,
+        None => return false,
+    };
+    let expected_hash = blake3::hash(format!("Bearer {expected}").as_bytes());
+    let actual_hash = blake3::hash(actual.as_bytes());
+    expected_hash
+        .as_bytes()
+        .ct_eq(actual_hash.as_bytes())
+        .into()
+}
+
+fn validate_hex_pubkey(pubkey: &str) -> Result<String, ApError> {
+    PublicKey::from_hex(pubkey)
+        .map(|pk| pk.to_hex())
+        .map_err(|_| ApError::BadRequest("Invalid hex pubkey".to_string()))
+}
+
+/// Resolve the acting user_pubkey for a request.
+/// - Service token: `body_pubkey` is REQUIRED (gateway acts for any actor in the tenant).
+/// - UCAN: pubkey comes from the token; if `body_pubkey` is present it must match.
+async fn resolve_principal(
+    headers: &HeaderMap,
+    tenant_id: i64,
+    body_pubkey: Option<&str>,
+) -> Result<String, ApError> {
+    if is_service_token(headers) {
+        let pk = body_pubkey.ok_or_else(|| {
+            ApError::BadRequest("pubkey is required for service-token calls".into())
+        })?;
+        return validate_hex_pubkey(pk);
+    }
+
+    // UCAN path
+    let token_pubkey = extract_user_from_token(headers, tenant_id)
+        .await
+        .map_err(|_| ApError::Unauthorized("Authentication required".to_string()))?;
+
+    if let Some(pk) = body_pubkey {
+        let pk = validate_hex_pubkey(pk)?;
+        if pk != token_pubkey {
+            return Err(ApError::Forbidden(
+                "Cannot act on behalf of another user".to_string(),
+            ));
+        }
+    }
+    Ok(token_pubkey)
+}
+
+/// Reject signing for suspended/banned accounts (mirrors auth::sign_event).
+async fn ensure_active(
+    pool: &sqlx::PgPool,
+    tenant_id: i64,
+    user_pubkey: &str,
+) -> Result<(), ApError> {
+    let user_repo = UserRepository::new(pool.clone());
+    if let Some((status, _, _)) = user_repo
+        .get_user_status(user_pubkey, tenant_id)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?
+    {
+        if !status.is_active() {
+            return Err(ApError::Forbidden("Account restricted".to_string()));
+        }
+    }
+    Ok(())
+}
+
+// ---- request/response types ----
+
+#[derive(Debug, Deserialize)]
+pub struct CreateKeyRequest {
+    /// Hex Nostr pubkey of the actor. Required for service-token callers.
+    pub pubkey: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct KeyResponse {
+    pub pubkey: String,
+    pub public_key_pem: String,
+    pub key_type: String,
+    pub created: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PublicKeyResponse {
+    pub pubkey: String,
+    pub public_key_pem: String,
+    pub key_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SignRequest {
+    /// Hex Nostr pubkey of the actor. Required for service-token callers.
+    pub pubkey: Option<String>,
+    /// Exact draft-cavage signing string. Signed as its UTF-8 bytes.
+    pub signing_string: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SignResponse {
+    pub pubkey: String,
+    pub signature: String,
+    pub algorithm: &'static str,
+}
+
+// ---- handlers ----
+
+/// POST /api/ap/keys — create-or-return the actor's RSA key. Idempotent: never regenerates.
+pub async fn create_key(
+    tenant: TenantExtractor,
+    State(auth_state): State<AuthState>,
+    headers: HeaderMap,
+    Json(req): Json<CreateKeyRequest>,
+) -> Result<Json<KeyResponse>, ApError> {
+    let tenant_id = tenant.0.id;
+    let user_pubkey = resolve_principal(&headers, tenant_id, req.pubkey.as_deref()).await?;
+    let pool = &auth_state.state.db;
+    let repo = ApActorKeysRepository::new(pool.clone());
+
+    // Idempotent: if a key exists, return it unchanged.
+    if let Some((pem, key_type)) = repo
+        .find_public_pem(tenant_id, &user_pubkey)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?
+    {
+        return Ok(Json(KeyResponse {
+            pubkey: user_pubkey,
+            public_key_pem: pem,
+            key_type,
+            created: false,
+        }));
+    }
+
+    // Generate (CPU-bound) off the async runtime.
+    let material = tokio::task::spawn_blocking(ap_signing::generate_rsa_2048)
+        .await
+        .map_err(|e| ApError::Internal(format!("join error: {e}")))?
+        .map_err(|e| ApError::Internal(e.to_string()))?;
+
+    let encrypted = auth_state
+        .state
+        .key_manager
+        .encrypt(&material.pkcs8_der)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?;
+
+    // create() may race a concurrent create; the UNIQUE constraint is the backstop.
+    match repo
+        .create(
+            tenant_id,
+            &user_pubkey,
+            &encrypted,
+            &material.public_pem,
+            AP_KEY_TYPE,
+        )
+        .await
+    {
+        Ok(()) => Ok(Json(KeyResponse {
+            pubkey: user_pubkey,
+            public_key_pem: material.public_pem,
+            key_type: AP_KEY_TYPE.to_string(),
+            created: true,
+        })),
+        Err(RepositoryError::Duplicate) => {
+            // Lost a race: another request created it. Return the winner's key.
+            let (pem, key_type) = repo
+                .find_public_pem(tenant_id, &user_pubkey)
+                .await
+                .map_err(|e| ApError::Internal(e.to_string()))?
+                .ok_or_else(|| ApError::Internal("key insert conflict but no row".into()))?;
+            Ok(Json(KeyResponse {
+                pubkey: user_pubkey,
+                public_key_pem: pem,
+                key_type,
+                created: false,
+            }))
+        }
+        Err(e) => Err(ApError::Internal(e.to_string())),
+    }
+}
+
+/// GET /api/ap/keys/{pubkey} — return the actor's public PEM. Never decrypts.
+pub async fn get_key(
+    tenant: TenantExtractor,
+    State(auth_state): State<AuthState>,
+    headers: HeaderMap,
+    Path(pubkey): Path<String>,
+) -> Result<Json<PublicKeyResponse>, ApError> {
+    let tenant_id = tenant.0.id;
+    let user_pubkey = resolve_principal(&headers, tenant_id, Some(&pubkey)).await?;
+    let repo = ApActorKeysRepository::new(auth_state.state.db.clone());
+
+    let (pem, key_type) = repo
+        .find_public_pem(tenant_id, &user_pubkey)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?
+        .ok_or_else(|| ApError::NotFound("No AP key for this actor".to_string()))?;
+
+    Ok(Json(PublicKeyResponse {
+        pubkey: user_pubkey,
+        public_key_pem: pem,
+        key_type,
+    }))
+}
+
+/// POST /api/ap/sign — sign the exact signing-string bytes; return base64 RSA-SHA256.
+pub async fn sign(
+    tenant: TenantExtractor,
+    State(auth_state): State<AuthState>,
+    headers: HeaderMap,
+    Json(req): Json<SignRequest>,
+) -> Result<Json<SignResponse>, ApError> {
+    let tenant_id = tenant.0.id;
+    let user_pubkey = resolve_principal(&headers, tenant_id, req.pubkey.as_deref()).await?;
+    let pool = &auth_state.state.db;
+
+    ensure_active(pool, tenant_id, &user_pubkey).await?;
+
+    let repo = ApActorKeysRepository::new(pool.clone());
+    let row = repo
+        .find_for_tenant(tenant_id, &user_pubkey)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?
+        .ok_or_else(|| ApError::NotFound("No AP key for this actor".to_string()))?;
+
+    let der = auth_state
+        .state
+        .key_manager
+        .decrypt(&row.encrypted_private_key)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?;
+
+    let message = req.signing_string.into_bytes();
+    let signature = tokio::task::spawn_blocking(move || ap_signing::sign_base64(&der, &message))
+        .await
+        .map_err(|e| ApError::Internal(format!("join error: {e}")))?
+        .map_err(|e| ApError::Internal(e.to_string()))?;
+
+    Ok(Json(SignResponse {
+        pubkey: user_pubkey,
+        signature,
+        algorithm: "rsa-sha256",
+    }))
+}

--- a/api/src/api/http/ap.rs
+++ b/api/src/api/http/ap.rs
@@ -396,7 +396,7 @@ pub async fn sign(
         }
     };
     if row.key_type != AP_KEY_TYPE {
-        return Err(ApError::Internal(format!(
+        return Err(ApError::BadRequest(format!(
             "Unsupported AP key type: {}",
             row.key_type
         )));

--- a/api/src/api/http/mod.rs
+++ b/api/src/api/http/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod ap;
 pub mod atproto;
 pub mod atproto_oauth;
 pub mod atproto_oauth_metadata;

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -9,7 +9,7 @@ use sqlx::PgPool;
 use std::sync::Arc;
 
 use crate::api::http::{
-    admin, atproto, atproto_oauth, auth, claim, headless, metrics, nostr_rpc, oauth, policies,
+    admin, ap, atproto, atproto_oauth, auth, claim, headless, metrics, nostr_rpc, oauth, policies,
     teams,
 };
 use crate::state::KeycastState;
@@ -100,6 +100,14 @@ pub fn api_routes(
     // NIP-46 RPC endpoint (OAuth access token auth, public CORS for third-party apps)
     let nostr_rpc_routes = Router::new()
         .route("/nostr", post(nostr_rpc::nostr_rpc))
+        .with_state(auth_state.clone());
+
+    // ActivityPub RSA signing endpoints (service-token OR UCAN auth; tenant from Host)
+    // Public CORS: server-to-server (the AP gateway), not browser-credentialed.
+    let ap_routes = Router::new()
+        .route("/ap/keys", post(ap::create_key))
+        .route("/ap/keys/:pubkey", get(ap::get_key))
+        .route("/ap/sign", post(ap::sign))
         .with_state(auth_state.clone());
 
     // Protected user routes (authentication required via UCAN cookie)
@@ -311,6 +319,7 @@ pub fn api_routes(
         .merge(connect_routes.layer(public_cors.clone()))
         .merge(signing_routes.layer(public_cors.clone()))
         .merge(nostr_rpc_routes.layer(public_cors.clone())) // NIP-46 RPC for OAuth apps
+        .merge(ap_routes.layer(public_cors.clone())) // AP RSA signing (gateway service-to-service)
         .merge(team_routes.layer(auth_cors.clone())) // Team routes need credentials
         .merge(discovery_route.layer(public_cors.clone()))
         .merge(policy_routes.layer(public_cors.clone())) // Public - available to third-party OAuth apps

--- a/api/tests/ap_signing_integration_test.rs
+++ b/api/tests/ap_signing_integration_test.rs
@@ -621,13 +621,15 @@ async fn key_rotation_preserves_ap_public_pem_on_new_pubkey() {
     let old_pubkey = old_keys.public_key().to_hex();
     let new_keys = Keys::generate();
     let new_pubkey = new_keys.public_key().to_hex();
-    create_test_user(&pool, &old_pubkey).await;
+    let username = format!("ap-rotate-{}", &old_pubkey[..8]);
+    let actor = format!("https://divine.video/ap/users/{username}");
+    create_test_user_with_username(&pool, &old_pubkey, &username).await;
 
     let app = build_app(create_test_auth_state(pool.clone()));
     let resp = app
         .oneshot(bearer_json(
             "/ap/keys",
-            serde_json::json!({ "pubkey": old_pubkey }),
+            serde_json::json!({ "actor": actor.clone() }),
             Some(SERVICE_TOKEN),
         ))
         .await
@@ -635,6 +637,7 @@ async fn key_rotation_preserves_ap_public_pem_on_new_pubkey() {
     assert_eq!(resp.status(), StatusCode::OK);
     let created = parse_body(resp).await;
     let original_pem = created["public_key_pem"].as_str().unwrap().to_string();
+    assert_eq!(created["pubkey"].as_str().unwrap(), old_pubkey);
 
     let user_repo = UserRepository::new(pool.clone());
     user_repo
@@ -648,6 +651,13 @@ async fn key_rotation_preserves_ap_public_pem_on_new_pubkey() {
         )
         .await
         .expect("change key");
+
+    let resolved_pubkey = user_repo
+        .find_pubkey_by_username(&username, TENANT_ID)
+        .await
+        .expect("username lookup")
+        .expect("username should still resolve after key rotation");
+    assert_eq!(resolved_pubkey, new_pubkey);
 
     let repo = ApActorKeysRepository::new(pool.clone());
     assert!(
@@ -664,5 +674,45 @@ async fn key_rotation_preserves_ap_public_pem_on_new_pubkey() {
         .expect("new pubkey should own the existing AP key");
     assert_eq!(rotated_pem, original_pem);
 
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(
+            Request::get(format!("/ap/keys/{}", urlencoding::encode(&actor)))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let key_body = parse_body(resp).await;
+    assert_eq!(key_body["pubkey"].as_str().unwrap(), new_pubkey);
+    assert_eq!(key_body["public_key_pem"].as_str().unwrap(), original_pem);
+
+    let signing_string =
+        "(request-target): post /inbox\nhost: divine.video\ndate: Mon, 01 Jan 2026 00:00:00 GMT";
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/sign",
+            serde_json::json!({ "actor": actor.clone(), "signing_string": signing_string }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let sign_resp = parse_body(resp).await;
+    assert_eq!(sign_resp["pubkey"].as_str().unwrap(), new_pubkey);
+
+    let public = RsaPublicKey::from_public_key_pem(&original_pem).expect("pem");
+    let vk = VerifyingKey::<Sha256>::new(public);
+    let raw = BASE64
+        .decode(sign_resp["signature"].as_str().unwrap())
+        .expect("b64");
+    let sig = Signature::try_from(raw.as_slice()).expect("sig");
+    vk.verify(signing_string.as_bytes(), &sig)
+        .expect("signature must verify against pre-rotation actor PEM");
+
+    cleanup(&pool, &old_pubkey).await;
     cleanup(&pool, &new_pubkey).await;
 }

--- a/api/tests/ap_signing_integration_test.rs
+++ b/api/tests/ap_signing_integration_test.rs
@@ -716,3 +716,98 @@ async fn key_rotation_preserves_ap_public_pem_on_new_pubkey() {
     cleanup(&pool, &old_pubkey).await;
     cleanup(&pool, &new_pubkey).await;
 }
+
+/// Rotation transfers the identity — username and AP key — to the new pubkey, so
+/// it must transfer the account restrictions too. Otherwise a suspended actor
+/// rotates its Nostr key onto a row that defaults to `active` and gets its
+/// ActivityPub signing oracle back.
+#[tokio::test]
+async fn key_rotation_preserves_suspension_for_ap_actor() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+
+    let old_pubkey = Keys::generate().public_key().to_hex();
+    let new_pubkey = Keys::generate().public_key().to_hex();
+    let username = format!("ap-susp-{}", uuid::Uuid::new_v4());
+    let actor = format!("https://divine.video/ap/users/{username}");
+    create_test_user_with_username(&pool, &old_pubkey, &username).await;
+
+    // Mint the AP key while the account is still active, then suspend it.
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/keys",
+            serde_json::json!({ "actor": actor.clone() }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let user_repo = UserRepository::new(pool.clone());
+    user_repo
+        .set_user_status(
+            &old_pubkey,
+            TENANT_ID,
+            &UserStatus::Suspended,
+            Some("ap rotation test"),
+        )
+        .await
+        .expect("suspend user");
+
+    user_repo
+        .change_key_transaction(
+            &old_pubkey,
+            &new_pubkey,
+            TENANT_ID,
+            &format!("suspended-ap-{}@example.com", uuid::Uuid::new_v4()),
+            "password-hash",
+            &[1, 2, 3, 4],
+        )
+        .await
+        .expect("change key");
+
+    let (status, reason, suspended_at) = user_repo
+        .get_user_status(&new_pubkey, TENANT_ID)
+        .await
+        .expect("status lookup")
+        .expect("replacement user should exist");
+    assert_eq!(
+        status,
+        UserStatus::Suspended,
+        "rotation must not reset the account to active"
+    );
+    assert_eq!(reason.as_deref(), Some("ap rotation test"));
+    assert!(
+        suspended_at.is_some(),
+        "suspended_at should carry to the new pubkey"
+    );
+
+    // The actor URL now resolves to the new pubkey; both AP paths must stay closed.
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(
+            Request::get(format!("/ap/keys/{}", urlencoding::encode(&actor)))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/sign",
+            serde_json::json!({ "actor": actor.clone(), "signing_string": "(request-target): post /inbox" }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    cleanup(&pool, &old_pubkey).await;
+    cleanup(&pool, &new_pubkey).await;
+}

--- a/api/tests/ap_signing_integration_test.rs
+++ b/api/tests/ap_signing_integration_test.rs
@@ -21,7 +21,9 @@ use keycast_api::{
 };
 use keycast_core::{
     encryption::{KeyManager, KeyManagerError},
+    repositories::{ApActorKeysRepository, UserRepository},
     secret_pool::SecretPool,
+    types::user::UserStatus,
 };
 use moka::future::Cache;
 use nostr_sdk::Keys;
@@ -33,6 +35,7 @@ use sha2::Sha256;
 use sqlx::PgPool;
 use std::sync::Arc;
 use tower::ServiceExt;
+use ucan::builder::UcanBuilder;
 use zeroize::Zeroizing;
 
 const TENANT_ID: i64 = 1;
@@ -141,6 +144,21 @@ async fn create_test_user(pool: &PgPool, pubkey: &str) {
     .expect("Failed to create test user");
 }
 
+async fn create_test_user_with_username(pool: &PgPool, pubkey: &str, username: &str) {
+    let email = format!("ap-{}@example.com", uuid::Uuid::new_v4());
+    sqlx::query(
+        "INSERT INTO users (pubkey, email, email_verified, username, tenant_id, created_at, updated_at) \
+         VALUES ($1, $2, true, $3, $4, NOW(), NOW())",
+    )
+    .bind(pubkey)
+    .bind(&email)
+    .bind(username)
+    .bind(TENANT_ID)
+    .execute(pool)
+    .await
+    .expect("Failed to create test user");
+}
+
 async fn cleanup(pool: &PgPool, pubkey: &str) {
     sqlx::query("DELETE FROM ap_actor_keys WHERE user_pubkey = $1")
         .bind(pubkey)
@@ -152,6 +170,58 @@ async fn cleanup(pool: &PgPool, pubkey: &str) {
         .execute(pool)
         .await
         .ok();
+}
+
+async fn create_test_oauth_authorization(
+    pool: &PgPool,
+    user_pubkey: &str,
+    bunker_pubkey: &str,
+    revoked: bool,
+) {
+    let auth_handle = hex::encode(rand::random::<[u8; 32]>());
+    let revoked_at = if revoked { Some(Utc::now()) } else { None };
+    sqlx::query(
+        "INSERT INTO oauth_authorizations
+         (user_pubkey, redirect_origin, bunker_public_key, secret_hash, relays, tenant_id, revoked_at, authorization_handle, handle_expires_at, created_at, updated_at)
+         VALUES ($1, $2, $3, 'test_hash', $4, $5, $6, $7, NOW() + INTERVAL '30 days', NOW(), NOW())",
+    )
+    .bind(user_pubkey)
+    .bind("https://ap-test.example.com")
+    .bind(bunker_pubkey)
+    .bind(serde_json::json!(["wss://relay.example.com"]).to_string())
+    .bind(TENANT_ID)
+    .bind(revoked_at)
+    .bind(&auth_handle)
+    .execute(pool)
+    .await
+    .expect("Failed to create oauth authorization");
+}
+
+async fn build_self_signed_ucan(user_keys: &Keys, bunker_pubkey: Option<&str>) -> String {
+    use keycast_api::ucan_auth::{nostr_pubkey_to_did, NostrKeyMaterial};
+
+    let user_did = nostr_pubkey_to_did(&user_keys.public_key());
+    let key_material = NostrKeyMaterial::from_keys(user_keys.clone());
+    let mut facts = serde_json::json!({
+        "tenant_id": TENANT_ID,
+        "redirect_origin": "https://ap-test.example.com",
+    });
+    if let Some(bunker_pubkey) = bunker_pubkey {
+        facts["bunker_pubkey"] = serde_json::json!(bunker_pubkey);
+    }
+
+    let ucan = UcanBuilder::default()
+        .issued_by(&key_material)
+        .for_audience(&user_did)
+        .with_lifetime(3600)
+        .with_fact(facts)
+        .build()
+        .expect("Failed to build UCAN")
+        .sign()
+        .await
+        .expect("Failed to sign UCAN");
+
+    ucan.encode().expect("Failed to encode UCAN")
 }
 
 fn bearer_json(uri: &str, body: serde_json::Value, token: Option<&str>) -> Request<Body> {
@@ -278,10 +348,10 @@ async fn create_get_sign_roundtrip_service_token() {
     cleanup(&pool, &pubkey).await;
 }
 
-// --- Test B: sign without a key returns 404 ---
+// --- Test B: sign without a key lazily creates the actor key ---
 
 #[tokio::test]
-async fn sign_without_key_returns_404() {
+async fn sign_without_key_lazily_creates_key() {
     common::assert_test_database_url();
     unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
     let pool = common::setup_test_db().await;
@@ -298,7 +368,15 @@ async fn sign_without_key_returns_404() {
         ))
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let key_exists: Option<i32> =
+        sqlx::query_scalar("SELECT 1 FROM ap_actor_keys WHERE user_pubkey = $1")
+            .bind(&pubkey)
+            .fetch_optional(&pool)
+            .await
+            .expect("query AP key");
+    assert!(key_exists.is_some(), "sign should lazily create AP key");
 
     cleanup(&pool, &pubkey).await;
 }
@@ -330,9 +408,261 @@ async fn unauthenticated_request_rejected() {
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
-// NOTE: Test D (UCAN-for-A requesting pubkey B -> 403) is intentionally NOT
-// implemented. Minting a valid UCAN that survives extract_user_from_token's
-// validation (DPoP binding / facts) is disproportionately complex for a single
-// 403 assertion. The Forbidden branch is exercised by code review of
-// resolve_principal: when is_service_token() == false and the token resolves to
-// a pubkey != body_pubkey, it returns ApError::Forbidden -> 403.
+#[tokio::test]
+async fn gateway_actor_shape_lazily_creates_key_and_signs() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+
+    let pubkey = Keys::generate().public_key().to_hex();
+    let username = format!("ap-actor-{}", &pubkey[..8]);
+    let actor = format!("https://divine.video/ap/users/{username}");
+    create_test_user_with_username(&pool, &pubkey, &username).await;
+
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(
+            Request::get(format!("/ap/keys/{}", urlencoding::encode(&actor)))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let key_body = parse_body(resp).await;
+    let pem = key_body["public_key_pem"].as_str().unwrap().to_string();
+
+    let signing_string =
+        "(request-target): post /inbox\nhost: divine.video\ndate: Mon, 01 Jan 2026 00:00:00 GMT";
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/sign",
+            serde_json::json!({ "actor": actor, "signing_string": signing_string }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let sign_resp = parse_body(resp).await;
+    assert_eq!(sign_resp["pubkey"].as_str().unwrap(), pubkey);
+
+    let public = RsaPublicKey::from_public_key_pem(&pem).expect("pem");
+    let vk = VerifyingKey::<Sha256>::new(public);
+    let raw = BASE64
+        .decode(sign_resp["signature"].as_str().unwrap())
+        .expect("b64");
+    let sig = Signature::try_from(raw.as_slice()).expect("sig");
+    vk.verify(signing_string.as_bytes(), &sig)
+        .expect("signature must verify against actor PEM");
+
+    cleanup(&pool, &pubkey).await;
+}
+
+#[tokio::test]
+async fn deleted_user_removes_key_and_later_sign_returns_404() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+
+    let pubkey = Keys::generate().public_key().to_hex();
+    create_test_user(&pool, &pubkey).await;
+
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/keys",
+            serde_json::json!({ "pubkey": pubkey }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let user_repo = UserRepository::new(pool.clone());
+    user_repo
+        .delete_account(&pubkey, TENANT_ID)
+        .await
+        .expect("delete account");
+
+    let key_exists: Option<i32> =
+        sqlx::query_scalar("SELECT 1 FROM ap_actor_keys WHERE user_pubkey = $1")
+            .bind(&pubkey)
+            .fetch_optional(&pool)
+            .await
+            .expect("query AP key");
+    assert!(key_exists.is_none(), "AP key must be deleted with account");
+
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/sign",
+            serde_json::json!({ "pubkey": pubkey, "signing_string": "x" }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn suspended_user_cannot_create_get_or_sign() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+
+    let pubkey = Keys::generate().public_key().to_hex();
+    create_test_user(&pool, &pubkey).await;
+    UserRepository::new(pool.clone())
+        .set_user_status(&pubkey, TENANT_ID, &UserStatus::Suspended, Some("ap test"))
+        .await
+        .expect("suspend user");
+
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/keys",
+            serde_json::json!({ "pubkey": pubkey }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(
+            Request::get(format!("/ap/keys/{}", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/sign",
+            serde_json::json!({ "pubkey": pubkey, "signing_string": "x" }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    cleanup(&pool, &pubkey).await;
+}
+
+#[tokio::test]
+async fn ucan_pubkey_mismatch_returns_403() {
+    common::assert_test_database_url();
+    let pool = common::setup_test_db().await;
+
+    let user_keys = Keys::generate();
+    let user_pubkey = user_keys.public_key().to_hex();
+    let other_pubkey = Keys::generate().public_key().to_hex();
+    let bunker_pubkey = Keys::generate().public_key().to_hex();
+    create_test_user(&pool, &user_pubkey).await;
+    create_test_user(&pool, &other_pubkey).await;
+    create_test_oauth_authorization(&pool, &user_pubkey, &bunker_pubkey, false).await;
+
+    let token = build_self_signed_ucan(&user_keys, Some(&bunker_pubkey)).await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/sign",
+            serde_json::json!({ "pubkey": other_pubkey, "signing_string": "x" }),
+            Some(&token),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    cleanup(&pool, &user_pubkey).await;
+    cleanup(&pool, &other_pubkey).await;
+}
+
+#[tokio::test]
+async fn revoked_oauth_ucan_cannot_sign() {
+    common::assert_test_database_url();
+    let pool = common::setup_test_db().await;
+
+    let user_keys = Keys::generate();
+    let user_pubkey = user_keys.public_key().to_hex();
+    let bunker_pubkey = Keys::generate().public_key().to_hex();
+    create_test_user(&pool, &user_pubkey).await;
+    create_test_oauth_authorization(&pool, &user_pubkey, &bunker_pubkey, true).await;
+
+    let token = build_self_signed_ucan(&user_keys, Some(&bunker_pubkey)).await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/sign",
+            serde_json::json!({ "pubkey": user_pubkey, "signing_string": "x" }),
+            Some(&token),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    cleanup(&pool, &user_pubkey).await;
+}
+
+#[tokio::test]
+async fn key_rotation_preserves_ap_public_pem_on_new_pubkey() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+
+    let old_keys = Keys::generate();
+    let old_pubkey = old_keys.public_key().to_hex();
+    let new_keys = Keys::generate();
+    let new_pubkey = new_keys.public_key().to_hex();
+    create_test_user(&pool, &old_pubkey).await;
+
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/keys",
+            serde_json::json!({ "pubkey": old_pubkey }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let created = parse_body(resp).await;
+    let original_pem = created["public_key_pem"].as_str().unwrap().to_string();
+
+    let user_repo = UserRepository::new(pool.clone());
+    user_repo
+        .change_key_transaction(
+            &old_pubkey,
+            &new_pubkey,
+            TENANT_ID,
+            "rotated-ap@example.com",
+            "password-hash",
+            &[1, 2, 3, 4],
+        )
+        .await
+        .expect("change key");
+
+    let repo = ApActorKeysRepository::new(pool.clone());
+    assert!(
+        repo.find_public_pem(TENANT_ID, &old_pubkey)
+            .await
+            .expect("old AP key lookup")
+            .is_none(),
+        "old pubkey should no longer own the AP key"
+    );
+    let (rotated_pem, _) = repo
+        .find_public_pem(TENANT_ID, &new_pubkey)
+        .await
+        .expect("new AP key lookup")
+        .expect("new pubkey should own the existing AP key");
+    assert_eq!(rotated_pem, original_pem);
+
+    cleanup(&pool, &new_pubkey).await;
+}

--- a/api/tests/ap_signing_integration_test.rs
+++ b/api/tests/ap_signing_integration_test.rs
@@ -1,0 +1,338 @@
+#![cfg(feature = "integration-tests")]
+
+mod common;
+
+use axum::{
+    body::Body,
+    extract::{Path, State},
+    http::{Request, StatusCode},
+    routing::{get, post},
+    Json, Router,
+};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use chrono::Utc;
+use http_body_util::BodyExt;
+use keycast_api::{
+    api::http::ap::{self, CreateKeyRequest, SignRequest},
+    api::http::routes::AuthState,
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
+use rsa::pkcs1v15::{Signature, VerifyingKey};
+use rsa::pkcs8::DecodePublicKey;
+use rsa::signature::Verifier;
+use rsa::RsaPublicKey;
+use sha2::Sha256;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tower::ServiceExt;
+use zeroize::Zeroizing;
+
+const TENANT_ID: i64 = 1;
+const SERVICE_TOKEN: &str = "test-service-token-secret";
+
+/// Identity KeyManager: encrypt/decrypt are no-ops, so the stored
+/// `encrypted_private_key` equals the plaintext PKCS#8 DER. This lets a real
+/// RSA sign→verify roundtrip work end-to-end through the handlers.
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn create_test_auth_state(pool: PgPool) -> AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+fn build_app(auth_state: AuthState) -> Router {
+    use keycast_api::api::tenant::{Tenant, TenantExtractor};
+
+    fn tenant() -> TenantExtractor {
+        TenantExtractor(Arc::new(Tenant {
+            id: TENANT_ID,
+            domain: "localhost".to_string(),
+            name: "Test".to_string(),
+            settings: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }))
+    }
+
+    let create_state = auth_state.clone();
+    let get_state = auth_state.clone();
+    let sign_state = auth_state.clone();
+
+    Router::new()
+        .route(
+            "/ap/keys",
+            post(
+                move |headers: axum::http::HeaderMap, Json(body): Json<CreateKeyRequest>| {
+                    let state = create_state.clone();
+                    async move { ap::create_key(tenant(), State(state), headers, Json(body)).await }
+                },
+            ),
+        )
+        .route(
+            "/ap/keys/:pubkey",
+            get(
+                move |Path(pubkey): Path<String>, headers: axum::http::HeaderMap| {
+                    let state = get_state.clone();
+                    async move { ap::get_key(tenant(), State(state), headers, Path(pubkey)).await }
+                },
+            ),
+        )
+        .route(
+            "/ap/sign",
+            post(
+                move |headers: axum::http::HeaderMap, Json(body): Json<SignRequest>| {
+                    let state = sign_state.clone();
+                    async move { ap::sign(tenant(), State(state), headers, Json(body)).await }
+                },
+            ),
+        )
+}
+
+async fn create_test_user(pool: &PgPool, pubkey: &str) {
+    let email = format!("ap-{}@example.com", uuid::Uuid::new_v4());
+    sqlx::query(
+        "INSERT INTO users (pubkey, email, email_verified, tenant_id, created_at, updated_at) \
+         VALUES ($1, $2, true, $3, NOW(), NOW())",
+    )
+    .bind(pubkey)
+    .bind(&email)
+    .bind(TENANT_ID)
+    .execute(pool)
+    .await
+    .expect("Failed to create test user");
+}
+
+async fn cleanup(pool: &PgPool, pubkey: &str) {
+    sqlx::query("DELETE FROM ap_actor_keys WHERE user_pubkey = $1")
+        .bind(pubkey)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM users WHERE pubkey = $1")
+        .bind(pubkey)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+fn bearer_json(uri: &str, body: serde_json::Value, token: Option<&str>) -> Request<Body> {
+    let mut builder = Request::post(uri).header("content-type", "application/json");
+    if let Some(t) = token {
+        builder = builder.header("authorization", format!("Bearer {}", t));
+    }
+    builder
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap()
+}
+
+// Response types in ap.rs derive only Serialize, so we read them as JSON Values.
+async fn parse_body(resp: axum::http::Response<Body>) -> serde_json::Value {
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&body).unwrap_or_else(|e| {
+        panic!(
+            "failed to parse body: {e}; raw={}",
+            String::from_utf8_lossy(&body)
+        )
+    })
+}
+
+// --- Test A: create → get → sign roundtrip with service token ---
+
+#[tokio::test]
+async fn create_get_sign_roundtrip_service_token() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+
+    let pubkey = Keys::generate().public_key().to_hex();
+    create_test_user(&pool, &pubkey).await;
+
+    // 2. POST /ap/keys (first time) -> created == true
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/keys",
+            serde_json::json!({ "pubkey": pubkey }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let created = parse_body(resp).await;
+    assert_eq!(
+        created["created"],
+        serde_json::Value::Bool(true),
+        "first create must report created == true"
+    );
+    let pem = created["public_key_pem"].as_str().unwrap().to_string();
+    assert!(
+        pem.starts_with("-----BEGIN PUBLIC KEY-----"),
+        "expected SPKI PEM, got: {}",
+        &pem[..pem.len().min(40)]
+    );
+
+    // 3. POST /ap/keys again -> created == false, same PEM (idempotent)
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/keys",
+            serde_json::json!({ "pubkey": pubkey }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let again = parse_body(resp).await;
+    assert_eq!(
+        again["created"],
+        serde_json::Value::Bool(false),
+        "second create must report created == false"
+    );
+    assert_eq!(
+        again["public_key_pem"].as_str().unwrap(),
+        pem,
+        "key must never regenerate"
+    );
+
+    // 4. GET /ap/keys/:pubkey -> same PEM
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(
+            Request::get(format!("/ap/keys/{}", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let got = parse_body(resp).await;
+    assert_eq!(got["public_key_pem"].as_str().unwrap(), pem);
+
+    // 5. POST /ap/sign
+    let signing_string =
+        "(request-target): post /inbox\nhost: divine.video\ndate: Mon, 01 Jan 2026 00:00:00 GMT";
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/sign",
+            serde_json::json!({ "pubkey": pubkey, "signing_string": signing_string }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let sign_resp = parse_body(resp).await;
+    assert_eq!(sign_resp["algorithm"].as_str().unwrap(), "rsa-sha256");
+
+    // 6. Verify the returned signature against the PEM (proves the oracle works).
+    let public = RsaPublicKey::from_public_key_pem(&pem).expect("pem");
+    let vk = VerifyingKey::<Sha256>::new(public);
+    let raw = BASE64
+        .decode(sign_resp["signature"].as_str().unwrap())
+        .expect("b64");
+    let sig = Signature::try_from(raw.as_slice()).expect("sig");
+    vk.verify(signing_string.as_bytes(), &sig)
+        .expect("signature must verify against returned PEM");
+
+    // 7. Cleanup.
+    cleanup(&pool, &pubkey).await;
+}
+
+// --- Test B: sign without a key returns 404 ---
+
+#[tokio::test]
+async fn sign_without_key_returns_404() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+
+    let pubkey = Keys::generate().public_key().to_hex();
+    create_test_user(&pool, &pubkey).await;
+
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/sign",
+            serde_json::json!({ "pubkey": pubkey, "signing_string": "x" }),
+            Some(SERVICE_TOKEN),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    cleanup(&pool, &pubkey).await;
+}
+
+// --- Test C: unauthenticated request rejected with 401 ---
+//
+// Send a valid JSON body + content-type so axum's `Json` extractor succeeds
+// (that runs before the handler). Only the Authorization header is wrong, so
+// the request flows through resolve_principal: is_service_token() == false and
+// extract_user_from_token() fails -> ApError::Unauthorized -> 401.
+
+#[tokio::test]
+async fn unauthenticated_request_rejected() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+
+    let pubkey = Keys::generate().public_key().to_hex();
+
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(bearer_json(
+            "/ap/keys",
+            serde_json::json!({ "pubkey": pubkey }),
+            Some("not-the-service-token"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// NOTE: Test D (UCAN-for-A requesting pubkey B -> 403) is intentionally NOT
+// implemented. Minting a valid UCAN that survives extract_user_from_token's
+// validation (DPoP binding / facts) is disproportionately complex for a single
+// 403 assertion. The Forbidden branch is exercised by code review of
+// resolve_principal: when is_service_token() == false and the token resolves to
+// a pubkey != body_pubkey, it returns ApError::Forbidden -> 403.

--- a/api/tests/change_key_test.rs
+++ b/api/tests/change_key_test.rs
@@ -387,3 +387,102 @@ async fn test_change_key_transaction_no_oauth_authorizations() {
         .await
         .ok();
 }
+
+// ============================================================================
+// Test: rotation carries account restrictions to the replacement identity
+// ============================================================================
+
+/// Account-restriction columns as stored, for comparing the old row to the
+/// replacement row after rotation.
+#[derive(sqlx::FromRow)]
+struct RestrictionsRow {
+    status: String,
+    suspended_reason: Option<String>,
+    suspended_at: Option<chrono::DateTime<Utc>>,
+    verified_minor: bool,
+    verified_minor_at: Option<chrono::DateTime<Utc>>,
+}
+
+#[tokio::test]
+async fn test_change_key_transaction_preserves_account_restrictions() {
+    let pool = setup_pool().await;
+
+    let old_pubkey = Keys::generate().public_key().to_hex();
+    let email = format!("restricted-{}@example.com", Uuid::new_v4());
+    let password_hash = "$2b$12$K4Iczl3gkZmIq7WxVbJbNepLNnDOXhF2wZvLZOKCqwCmHPHkKZedi";
+
+    create_test_user(&pool, &old_pubkey, &email, password_hash, &[0u8; 48]).await;
+
+    sqlx::query(
+        "UPDATE users SET status = 'banned', suspended_reason = $1, suspended_at = NOW(), \
+                          verified_minor = TRUE, verified_minor_at = NOW() \
+         WHERE pubkey = $2",
+    )
+    .bind("policy violation")
+    .bind(&old_pubkey)
+    .execute(&pool)
+    .await
+    .expect("Should restrict test user");
+
+    // Read the stored timestamps back so the comparison below is against what
+    // Postgres actually holds, not a client-side value it rounds on write.
+    let (suspended_at, verified_minor_at): (
+        Option<chrono::DateTime<Utc>>,
+        Option<chrono::DateTime<Utc>>,
+    ) = sqlx::query_as("SELECT suspended_at, verified_minor_at FROM users WHERE pubkey = $1")
+        .bind(&old_pubkey)
+        .fetch_one(&pool)
+        .await
+        .expect("Query should succeed");
+
+    let new_pubkey = Keys::generate().public_key().to_hex();
+    keycast_core::repositories::UserRepository::new(pool.clone())
+        .change_key_transaction(
+            &old_pubkey,
+            &new_pubkey,
+            1,
+            &email,
+            password_hash,
+            &[1u8; 48],
+        )
+        .await
+        .expect("change_key_transaction should succeed");
+
+    let carried: RestrictionsRow = sqlx::query_as(
+        "SELECT status, suspended_reason, suspended_at, verified_minor, verified_minor_at \
+         FROM users WHERE pubkey = $1",
+    )
+    .bind(&new_pubkey)
+    .fetch_one(&pool)
+    .await
+    .expect("Query should succeed");
+
+    assert_eq!(
+        carried.status, "banned",
+        "Replacement identity must stay banned, not default to active"
+    );
+    assert_eq!(
+        carried.suspended_reason.as_deref(),
+        Some("policy violation")
+    );
+    assert_eq!(carried.suspended_at, suspended_at);
+    assert!(
+        carried.verified_minor,
+        "verified_minor designation must follow the identity"
+    );
+    assert_eq!(carried.verified_minor_at, verified_minor_at);
+
+    // Cleanup
+    sqlx::query("DELETE FROM personal_keys WHERE user_pubkey IN ($1, $2)")
+        .bind(&old_pubkey)
+        .bind(&new_pubkey)
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM users WHERE pubkey IN ($1, $2)")
+        .bind(&old_pubkey)
+        .bind(&new_pubkey)
+        .execute(&pool)
+        .await
+        .ok();
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,9 +26,10 @@ nostr = { workspace = true }
 nostr-sdk = {workspace = true}
 once_cell = "1.2"
 rand = { workspace = true }
+rsa = { version = "0.9", features = ["pem"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = "0.10"
+sha2 = { version = "0.10", features = ["oid"] }
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/core/src/ap_signing.rs
+++ b/core/src/ap_signing.rs
@@ -1,0 +1,145 @@
+// ABOUTME: Pure RSA crypto for ActivityPub HTTP Signatures (RSA-SHA256, draft-cavage)
+// ABOUTME: Keygen + SPKI public PEM + RSASSA-PKCS1-v1_5/SHA-256 signing. No DB, no Nostr.
+// ABOUTME: Private keys are handled as PKCS#8 DER and encrypted at rest by KeyManager.
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use rsa::pkcs1v15::SigningKey;
+use rsa::pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey, LineEnding};
+use rsa::signature::{SignatureEncoding, Signer};
+use rsa::{RsaPrivateKey, RsaPublicKey};
+use sha2::Sha256;
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+/// Forward-compatible discriminator stored in `ap_actor_keys.key_type`.
+pub const AP_KEY_TYPE: &str = "rsa-2048";
+
+const RSA_BITS: usize = 2048;
+
+#[derive(Debug, Error)]
+pub enum ApSigningError {
+    #[error("RSA key generation failed: {0}")]
+    KeyGen(String),
+    #[error("PKCS#8 encode failed: {0}")]
+    Encode(String),
+    #[error("PKCS#8 decode failed: {0}")]
+    Decode(String),
+    #[error("SPKI PEM encode failed: {0}")]
+    Pem(String),
+    #[error("signing failed: {0}")]
+    Sign(String),
+}
+
+/// A freshly generated RSA keypair, split into the two persisted halves.
+pub struct RsaKeyMaterial {
+    /// Private key as PKCS#8 DER. Encrypt with `KeyManager` before storing. Zeroized on drop.
+    pub pkcs8_der: Zeroizing<Vec<u8>>,
+    /// Public key as SPKI PEM (`-----BEGIN PUBLIC KEY-----`). Safe to store in plaintext.
+    pub public_pem: String,
+}
+
+/// Generate an RSA-2048 keypair. CPU-bound (~tens of ms) — callers wrap in `spawn_blocking`.
+pub fn generate_rsa_2048() -> Result<RsaKeyMaterial, ApSigningError> {
+    let mut rng = rand::thread_rng();
+    let private = RsaPrivateKey::new(&mut rng, RSA_BITS)
+        .map_err(|e| ApSigningError::KeyGen(e.to_string()))?;
+    let der = private
+        .to_pkcs8_der()
+        .map_err(|e| ApSigningError::Encode(e.to_string()))?;
+    let pkcs8_der = der.to_bytes();
+    let public_pem = RsaPublicKey::from(&private)
+        .to_public_key_pem(LineEnding::LF)
+        .map_err(|e| ApSigningError::Pem(e.to_string()))?;
+    Ok(RsaKeyMaterial {
+        pkcs8_der,
+        public_pem,
+    })
+}
+
+/// Re-derive the SPKI public PEM from a decrypted PKCS#8 DER private key.
+/// Utility for tests / backfill; the GET path serves the stored column instead.
+pub fn public_pem_from_pkcs8_der(pkcs8_der: &[u8]) -> Result<String, ApSigningError> {
+    let private = RsaPrivateKey::from_pkcs8_der(pkcs8_der)
+        .map_err(|e| ApSigningError::Decode(e.to_string()))?;
+    RsaPublicKey::from(&private)
+        .to_public_key_pem(LineEnding::LF)
+        .map_err(|e| ApSigningError::Pem(e.to_string()))
+}
+
+/// Sign `message` with RSASSA-PKCS1-v1_5 + SHA-256. Returns raw signature bytes.
+/// CPU-bound — callers wrap in `spawn_blocking`.
+pub fn sign_pkcs1v15_sha256(pkcs8_der: &[u8], message: &[u8]) -> Result<Vec<u8>, ApSigningError> {
+    let private = RsaPrivateKey::from_pkcs8_der(pkcs8_der)
+        .map_err(|e| ApSigningError::Decode(e.to_string()))?;
+    let signing_key = SigningKey::<Sha256>::new(private);
+    let signature = signing_key
+        .try_sign(message)
+        .map_err(|e| ApSigningError::Sign(e.to_string()))?;
+    Ok(signature.to_vec())
+}
+
+/// Convenience: sign and base64-encode (standard alphabet) for the HTTP `signature="…"` field.
+pub fn sign_base64(pkcs8_der: &[u8], message: &[u8]) -> Result<String, ApSigningError> {
+    Ok(BASE64.encode(sign_pkcs1v15_sha256(pkcs8_der, message)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsa::pkcs1v15::{Signature, VerifyingKey};
+    use rsa::pkcs8::DecodePublicKey;
+    use rsa::signature::Verifier;
+
+    #[test]
+    fn generate_produces_spki_pem_and_parseable_der() {
+        let km = generate_rsa_2048().expect("keygen");
+        assert!(
+            km.public_pem.starts_with("-----BEGIN PUBLIC KEY-----"),
+            "must be SPKI PEM, not PKCS#1; got: {}",
+            &km.public_pem[..km.public_pem.len().min(40)]
+        );
+        RsaPrivateKey::from_pkcs8_der(&km.pkcs8_der).expect("der parses");
+    }
+
+    #[test]
+    fn sign_then_verify_with_public_pem() {
+        let km = generate_rsa_2048().expect("keygen");
+        let msg = b"(request-target): post /inbox\nhost: divine.video\ndate: x";
+        let sig_bytes = sign_pkcs1v15_sha256(&km.pkcs8_der, msg).expect("sign");
+        let public = RsaPublicKey::from_public_key_pem(&km.public_pem).expect("pem parses");
+        let vk = VerifyingKey::<Sha256>::new(public);
+        let sig = Signature::try_from(sig_bytes.as_slice()).expect("sig decodes");
+        vk.verify(msg, &sig).expect("signature must verify");
+    }
+
+    #[test]
+    fn public_pem_from_der_matches_generate() {
+        let km = generate_rsa_2048().expect("keygen");
+        let rederived = public_pem_from_pkcs8_der(&km.pkcs8_der).expect("rederive");
+        assert_eq!(km.public_pem, rederived);
+    }
+
+    #[test]
+    fn wrong_key_does_not_verify() {
+        let km1 = generate_rsa_2048().expect("keygen 1");
+        let km2 = generate_rsa_2048().expect("keygen 2");
+        let msg = b"test";
+        let sig_bytes = sign_pkcs1v15_sha256(&km1.pkcs8_der, msg).expect("sign");
+        let public2 = RsaPublicKey::from_public_key_pem(&km2.public_pem).expect("pem");
+        let vk = VerifyingKey::<Sha256>::new(public2);
+        let sig = Signature::try_from(sig_bytes.as_slice()).expect("sig decodes");
+        assert!(vk.verify(msg, &sig).is_err(), "wrong key must not verify");
+    }
+
+    #[test]
+    fn sign_base64_is_decodable_and_verifies() {
+        let km = generate_rsa_2048().expect("keygen");
+        let msg = b"hello ap";
+        let b64 = sign_base64(&km.pkcs8_der, msg).expect("sign b64");
+        let raw = BASE64.decode(&b64).expect("base64 decodes");
+        let public = RsaPublicKey::from_public_key_pem(&km.public_pem).expect("pem");
+        let vk = VerifyingKey::<Sha256>::new(public);
+        let sig = Signature::try_from(raw.as_slice()).expect("sig");
+        vk.verify(msg, &sig).expect("verify");
+    }
+}

--- a/core/src/ap_signing.rs
+++ b/core/src/ap_signing.rs
@@ -142,4 +142,20 @@ mod tests {
         let sig = Signature::try_from(raw.as_slice()).expect("sig");
         vk.verify(msg, &sig).expect("verify");
     }
+
+    #[test]
+    #[ignore] // run explicitly: cargo test -p keycast_core ap_signing -- --ignored emit_interop_vector
+    fn emit_interop_vector() {
+        use std::io::Write;
+        let km = generate_rsa_2048().expect("keygen");
+        let msg = b"(request-target): post /inbox\nhost: divine.video\ndate: Mon, 01 Jan 2026 00:00:00 GMT";
+        let sig = sign_pkcs1v15_sha256(&km.pkcs8_der, msg).expect("sign");
+
+        let dir = std::path::Path::new("target/ap_interop");
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join("pub.pem"), km.public_pem.as_bytes()).unwrap();
+        std::fs::write(dir.join("msg.bin"), msg).unwrap();
+        let mut f = std::fs::File::create(dir.join("sig.bin")).unwrap();
+        f.write_all(&sig).unwrap();
+    }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ap_signing;
 pub mod authorization_channel;
 pub mod bunker_key;
 pub mod custom_permissions;

--- a/core/src/repositories/ap_actor_keys.rs
+++ b/core/src/repositories/ap_actor_keys.rs
@@ -123,6 +123,17 @@ mod tests {
         let pool = setup_pool().await;
         let repo = ApActorKeysRepository::new(pool.clone());
         let pubkey = Keys::generate().public_key().to_hex();
+        let email = format!("ap-keys-{}@example.com", &pubkey[..8]);
+
+        sqlx::query(
+            "INSERT INTO users (pubkey, email, email_verified, tenant_id, created_at, updated_at)
+             VALUES ($1, $2, true, 1, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(&email)
+        .execute(&pool)
+        .await
+        .unwrap();
 
         assert!(!repo.exists(1, &pubkey).await.unwrap());
         assert!(repo.find_for_tenant(1, &pubkey).await.unwrap().is_none());
@@ -150,6 +161,11 @@ mod tests {
 
         // Cleanup
         sqlx::query("DELETE FROM ap_actor_keys WHERE user_pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
             .bind(&pubkey)
             .execute(&pool)
             .await

--- a/core/src/repositories/ap_actor_keys.rs
+++ b/core/src/repositories/ap_actor_keys.rs
@@ -1,0 +1,158 @@
+// ABOUTME: Repository for ap_actor_keys — per-user ActivityPub RSA keys
+// ABOUTME: Stores encrypted PKCS#8 DER private key + plaintext SPKI public PEM, 1:1 per tenant
+
+use crate::repositories::RepositoryError;
+use sqlx::PgPool;
+
+/// A stored AP key row (encrypted private key + public PEM).
+#[derive(Debug, Clone)]
+pub struct ApActorKeyRow {
+    pub encrypted_private_key: Vec<u8>,
+    pub public_key_pem: String,
+    pub key_type: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApActorKeysRepository {
+    pool: PgPool,
+}
+
+impl ApActorKeysRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Fetch the full row (encrypted private key + public PEM) for signing.
+    pub async fn find_for_tenant(
+        &self,
+        tenant_id: i64,
+        user_pubkey: &str,
+    ) -> Result<Option<ApActorKeyRow>, RepositoryError> {
+        let row = sqlx::query_as::<_, (Vec<u8>, String, String)>(
+            "SELECT encrypted_private_key, public_key_pem, key_type
+             FROM ap_actor_keys
+             WHERE tenant_id = $1 AND user_pubkey = $2",
+        )
+        .bind(tenant_id)
+        .bind(user_pubkey)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(
+            |(encrypted_private_key, public_key_pem, key_type)| ApActorKeyRow {
+                encrypted_private_key,
+                public_key_pem,
+                key_type,
+            },
+        ))
+    }
+
+    /// Fetch only the public PEM (GET path — never decrypts).
+    pub async fn find_public_pem(
+        &self,
+        tenant_id: i64,
+        user_pubkey: &str,
+    ) -> Result<Option<(String, String)>, RepositoryError> {
+        sqlx::query_as::<_, (String, String)>(
+            "SELECT public_key_pem, key_type
+             FROM ap_actor_keys
+             WHERE tenant_id = $1 AND user_pubkey = $2",
+        )
+        .bind(tenant_id)
+        .bind(user_pubkey)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    /// Insert a new key. Idempotency is enforced by the caller checking existence first
+    /// AND by the UNIQUE(tenant_id, user_pubkey) constraint as a backstop.
+    pub async fn create(
+        &self,
+        tenant_id: i64,
+        user_pubkey: &str,
+        encrypted_private_key: &[u8],
+        public_key_pem: &str,
+        key_type: &str,
+    ) -> Result<(), RepositoryError> {
+        sqlx::query(
+            "INSERT INTO ap_actor_keys
+                (tenant_id, user_pubkey, encrypted_private_key, public_key_pem, key_type)
+             VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(tenant_id)
+        .bind(user_pubkey)
+        .bind(encrypted_private_key)
+        .bind(public_key_pem)
+        .bind(key_type)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Returns true if an AP actor key already exists for this tenant/user pair.
+    pub async fn exists(&self, tenant_id: i64, user_pubkey: &str) -> Result<bool, RepositoryError> {
+        let found: Option<i32> = sqlx::query_scalar(
+            "SELECT 1 FROM ap_actor_keys WHERE tenant_id = $1 AND user_pubkey = $2",
+        )
+        .bind(tenant_id)
+        .bind(user_pubkey)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(found.is_some())
+    }
+}
+
+#[cfg(all(test, feature = "integration-tests"))]
+mod tests {
+    use super::*;
+    use nostr_sdk::Keys;
+
+    async fn setup_pool() -> PgPool {
+        let url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+        assert!(
+            url.contains("localhost") || url.contains("127.0.0.1") || url.is_empty(),
+            "tests must run against localhost"
+        );
+        PgPool::connect(&url).await.expect("connect")
+    }
+
+    #[tokio::test]
+    async fn create_find_exists_roundtrip() {
+        let pool = setup_pool().await;
+        let repo = ApActorKeysRepository::new(pool.clone());
+        let pubkey = Keys::generate().public_key().to_hex();
+
+        assert!(!repo.exists(1, &pubkey).await.unwrap());
+        assert!(repo.find_for_tenant(1, &pubkey).await.unwrap().is_none());
+
+        repo.create(
+            1,
+            &pubkey,
+            &[1, 2, 3, 4],
+            "-----BEGIN PUBLIC KEY-----\nX\n-----END PUBLIC KEY-----\n",
+            "rsa-2048",
+        )
+        .await
+        .unwrap();
+
+        assert!(repo.exists(1, &pubkey).await.unwrap());
+        let row = repo.find_for_tenant(1, &pubkey).await.unwrap().unwrap();
+        assert_eq!(row.encrypted_private_key, vec![1, 2, 3, 4]);
+        assert!(row.public_key_pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+        let (pem, kt) = repo.find_public_pem(1, &pubkey).await.unwrap().unwrap();
+        assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+        assert_eq!(kt, "rsa-2048");
+
+        // Tenant isolation: tenant 2 sees nothing.
+        assert!(!repo.exists(2, &pubkey).await.unwrap());
+
+        // Cleanup
+        sqlx::query("DELETE FROM ap_actor_keys WHERE user_pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+}

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -2,6 +2,7 @@
 // ABOUTME: Provides abstraction layer between handlers and database
 
 mod admin_audit_event;
+mod ap_actor_keys;
 mod atproto_oauth_session;
 mod auth_event;
 mod authorization;
@@ -18,6 +19,7 @@ mod team;
 mod user;
 
 pub use admin_audit_event::{AdminAuditEventRecord, AdminAuditEventRepository, AdminAuditEventRow};
+pub use ap_actor_keys::{ApActorKeyRow, ApActorKeysRepository};
 pub use atproto_oauth_session::{
     AtprotoOAuthSession, AtprotoOAuthSessionRepository, CreateAtprotoOAuthSessionParams,
     IssueAtprotoTokensParams,

--- a/core/src/repositories/oauth_authorization.rs
+++ b/core/src/repositories/oauth_authorization.rs
@@ -214,6 +214,7 @@ impl OAuthAuthorizationRepository {
             "SELECT 1 FROM oauth_authorizations
              WHERE bunker_public_key = $1 AND user_pubkey = $2
                AND revoked_at IS NULL
+               AND (expires_at IS NULL OR expires_at > NOW())
                AND user_pubkey IN (SELECT pubkey FROM users WHERE tenant_id = $3)",
         )
         .bind(bunker_pubkey)

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1569,6 +1569,20 @@ impl UserRepository {
         .execute(&mut *tx)
         .await?;
 
+        // Preserve the actor's published ActivityPub RSA public key across
+        // Nostr key rotation; remote servers cache publicKeyPem.
+        sqlx::query(
+            "UPDATE ap_actor_keys
+             SET user_pubkey = $1, updated_at = $2
+             WHERE user_pubkey = $3 AND tenant_id = $4",
+        )
+        .bind(new_pubkey)
+        .bind(now)
+        .bind(old_pubkey)
+        .bind(tenant_id)
+        .execute(&mut *tx)
+        .await?;
+
         // Create personal_keys for new identity
         sqlx::query(
             "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
@@ -2237,7 +2251,16 @@ impl UserRepository {
             .execute(&mut *tx)
             .await?;
 
-        // 3. Delete user (cascades to personal_keys, oauth_authorizations -> refresh_tokens,
+        // 3. Delete AP RSA key material. The FK cascade also handles this, but
+        // keeping it explicit preserves account deletion semantics if an older
+        // database has not applied the FK-hardening migration yet.
+        sqlx::query("DELETE FROM ap_actor_keys WHERE user_pubkey = $1 AND tenant_id = $2")
+            .bind(pubkey)
+            .bind(tenant_id)
+            .execute(&mut *tx)
+            .await?;
+
+        // 4. Delete user (cascades to personal_keys, oauth_authorizations -> refresh_tokens,
         //    email_verification_tokens, password_reset_tokens, user_profiles,
         //    account_claim_tokens)
         let result = sqlx::query("DELETE FROM users WHERE pubkey = $1 AND tenant_id = $2")

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -264,6 +264,19 @@ pub struct FullAdminStatusRow {
     pub verified_minor_at: Option<DateTime<Utc>>,
 }
 
+/// Identity state read off the old pubkey in `change_key_transaction` and
+/// re-applied to the replacement row, so a Nostr key rotation moves the account
+/// wholesale — including the restrictions that gate Nostr and ActivityPub signing.
+#[derive(Debug, FromRow)]
+struct RotatedIdentityRow {
+    username: Option<String>,
+    status: UserStatus,
+    suspended_reason: Option<String>,
+    suspended_at: Option<DateTime<Utc>>,
+    verified_minor: bool,
+    verified_minor_at: Option<DateTime<Utc>>,
+}
+
 /// Outcome of atomically consuming a claim token and claiming the account.
 /// Only `Claimed` mutates anything; the other outcomes guarantee both the
 /// token and the user row are untouched (see
@@ -1543,12 +1556,20 @@ impl UserRepository {
             .execute(&mut *tx)
             .await?;
 
-        let old_username: Option<String> =
-            sqlx::query_scalar("SELECT username FROM users WHERE pubkey = $1 AND tenant_id = $2")
-                .bind(old_pubkey)
-                .bind(tenant_id)
-                .fetch_one(&mut *tx)
-                .await?;
+        // Everything that must move with the identity, read before the old row is
+        // orphaned. Account restrictions (status/suspension, verified-minor) travel
+        // with the username and the AP key: a suspended or banned actor that rotates
+        // its Nostr key must stay restricted on the new pubkey, otherwise the
+        // replacement row would default to `active` and hand the actor back both
+        // Nostr and ActivityPub signing.
+        let old_identity: RotatedIdentityRow = sqlx::query_as(
+            "SELECT username, status, suspended_reason, suspended_at, verified_minor, verified_minor_at \
+             FROM users WHERE pubkey = $1 AND tenant_id = $2",
+        )
+        .bind(old_pubkey)
+        .bind(tenant_id)
+        .fetch_one(&mut *tx)
+        .await?;
 
         // Orphan old identity (transfer email/password/username to NULL)
         sqlx::query(
@@ -1564,15 +1585,22 @@ impl UserRepository {
         // Create new user identity with email/password/username. The AP gateway
         // resolves actor URLs by username, so it must move with the AP key row.
         sqlx::query(
-            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, username, created_at, updated_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, username, \
+                                status, suspended_reason, suspended_at, verified_minor, verified_minor_at, \
+                                created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
         )
         .bind(new_pubkey)
         .bind(tenant_id)
         .bind(email)
         .bind(password_hash)
         .bind(true) // Keep email verified status
-        .bind(old_username)
+        .bind(old_identity.username)
+        .bind(old_identity.status.as_str())
+        .bind(old_identity.suspended_reason)
+        .bind(old_identity.suspended_at)
+        .bind(old_identity.verified_minor)
+        .bind(old_identity.verified_minor_at)
         .bind(now)
         .bind(now)
         .execute(&mut *tx)

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1502,8 +1502,8 @@ impl UserRepository {
     /// Performs a complete key rotation:
     /// 1. Counts and deletes OAuth authorizations for the old pubkey
     /// 2. Deletes personal_keys for the old pubkey
-    /// 3. Orphans the old user identity (clears email/password)
-    /// 4. Creates new user identity with email/password
+    /// 3. Orphans the old user identity (clears email/password/username)
+    /// 4. Creates new user identity with email/password/username
     /// 5. Creates personal_keys for the new identity
     ///
     /// Returns the count of OAuth authorizations that were deleted.
@@ -1543,9 +1543,16 @@ impl UserRepository {
             .execute(&mut *tx)
             .await?;
 
-        // Orphan old identity (transfer email/password to NULL)
+        let old_username: Option<String> =
+            sqlx::query_scalar("SELECT username FROM users WHERE pubkey = $1 AND tenant_id = $2")
+                .bind(old_pubkey)
+                .bind(tenant_id)
+                .fetch_one(&mut *tx)
+                .await?;
+
+        // Orphan old identity (transfer email/password/username to NULL)
         sqlx::query(
-            "UPDATE users SET email = NULL, password_hash = NULL, updated_at = $1
+            "UPDATE users SET email = NULL, password_hash = NULL, username = NULL, updated_at = $1
              WHERE pubkey = $2 AND tenant_id = $3",
         )
         .bind(now)
@@ -1554,16 +1561,18 @@ impl UserRepository {
         .execute(&mut *tx)
         .await?;
 
-        // Create new user identity with email/password
+        // Create new user identity with email/password/username. The AP gateway
+        // resolves actor URLs by username, so it must move with the AP key row.
         sqlx::query(
-            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, username, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
         )
         .bind(new_pubkey)
         .bind(tenant_id)
         .bind(email)
         .bind(password_hash)
         .bind(true) // Keep email verified status
+        .bind(old_username)
         .bind(now)
         .bind(now)
         .execute(&mut *tx)

--- a/database/migrations/20260530000000_add_ap_actor_keys.sql
+++ b/database/migrations/20260530000000_add_ap_actor_keys.sql
@@ -1,0 +1,19 @@
+-- ap_actor_keys: per-user RSA keypair for ActivityPub HTTP Signatures.
+-- Separate from Nostr/secp256k1 keys (personal_keys/stored_keys): RSA is
+-- variable-length PKCS#8 DER + an SPKI public PEM. Bound to the immutable
+-- nostr_pubkey (1:1 per tenant), NOT the mutable username — a published
+-- publicKeyPem is cached by remote fediverse servers.
+
+CREATE TABLE public.ap_actor_keys (
+    id                     bigserial PRIMARY KEY,
+    user_pubkey            character(64) NOT NULL,
+    tenant_id              bigint NOT NULL DEFAULT 1,
+    encrypted_private_key  bytea NOT NULL,                 -- PKCS#8 DER, AES-256-GCM via KeyManager
+    public_key_pem         text  NOT NULL,                 -- SPKI PEM, public, safe at rest
+    key_type               text  NOT NULL DEFAULT 'rsa-2048',
+    created_at             timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at             timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT ap_actor_keys_tenant_user_unique UNIQUE (tenant_id, user_pubkey)
+);
+
+CREATE INDEX idx_ap_actor_keys_tenant_user ON public.ap_actor_keys (tenant_id, user_pubkey);

--- a/database/migrations/20260720000000_harden_ap_actor_keys_lifecycle.sql
+++ b/database/migrations/20260720000000_harden_ap_actor_keys_lifecycle.sql
@@ -1,0 +1,24 @@
+-- Harden AP RSA key custody lifecycle.
+-- AP keys must be removed with their user account, and the UNIQUE constraint
+-- already provides the lookup index for (tenant_id, user_pubkey).
+
+DELETE FROM public.ap_actor_keys ak
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.users u
+    WHERE u.pubkey = ak.user_pubkey
+      AND u.tenant_id = ak.tenant_id
+);
+
+DROP INDEX IF EXISTS public.idx_ap_actor_keys_tenant_user;
+
+ALTER TABLE ONLY public.ap_actor_keys
+    ADD CONSTRAINT ap_actor_keys_tenant_id_fkey
+    FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pubkey_tenant_unique UNIQUE (pubkey, tenant_id);
+
+ALTER TABLE ONLY public.ap_actor_keys
+    ADD CONSTRAINT ap_actor_keys_user_pubkey_fkey
+    FOREIGN KEY (user_pubkey, tenant_id) REFERENCES public.users(pubkey, tenant_id) ON DELETE CASCADE;

--- a/docs/superpowers/plans/2026-05-30-ap-rsa-http-signature-signing.md
+++ b/docs/superpowers/plans/2026-05-30-ap-rsa-http-signature-signing.md
@@ -1,0 +1,1196 @@
+# AP RSA / HTTP-Signature Signing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-user RSA-2048 key custody and an RSA-SHA256 signing oracle to Keycast (for the Divine ActivityPub gateway) without touching the existing Nostr/Schnorr signing path.
+
+**Architecture:** A new `ap_actor_keys` table stores PKCS#8-DER private keys encrypted via the existing `KeyManager` (AES-256-GCM/KMS) plus a plaintext SPKI public PEM, keyed `(tenant_id, user_pubkey)`. A pure-crypto `core/src/ap_signing.rs` module does keygen / SPKI-PEM / PKCS1v15-SHA256 signing. Three HTTP endpoints (`POST /api/ap/keys`, `GET /api/ap/keys/{pubkey}`, `POST /api/ap/sign`) in a new `api/src/api/http/ap.rs`, authenticated by **either** `KEYCAST_SERVICE_TOKEN` (gateway) **or** UCAN (user-facing), tenant resolved from the `Host` header.
+
+**Tech Stack:** Rust, Axum 0.7, SQLx/Postgres, the `rsa` 0.9 crate (PKCS#8 + SPKI PEM + PKCS1-v1.5), `sha2` 0.10, `base64` 0.22, `zeroize`.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-30-ap-rsa-http-signature-signing-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `core/Cargo.toml` | Add `rsa = { version = "0.9", features = ["pem"] }` dependency. |
+| `core/src/ap_signing.rs` | **Create.** Pure RSA crypto: `generate_rsa_2048`, `public_pem_from_pkcs8_der`, `sign_pkcs1v15_sha256`, `sign_base64`, `ApSigningError`. No DB, no `nostr_sdk`. |
+| `core/src/lib.rs` | Register `pub mod ap_signing;`. |
+| `database/migrations/20260530000000_add_ap_actor_keys.sql` | **Create.** `ap_actor_keys` table. |
+| `core/src/repositories/ap_actor_keys.rs` | **Create.** `ApActorKeysRepository` + `ApActorKeyRow` (tenant-scoped CRUD). |
+| `core/src/repositories/mod.rs` | Register module + re-export. |
+| `api/src/api/http/ap.rs` | **Create.** Handlers, `ApError`, service-token check, principal resolver. |
+| `api/src/api/http/mod.rs` | Register `pub mod ap;`. |
+| `api/src/api/http/routes.rs` | Mount `ap_routes` (public CORS, `auth_state`). |
+| `api/openapi.yaml` | Document the three endpoints + schemas + `ServiceToken` security scheme. |
+| `tests/` (shell) | Independent `openssl` interop verification. |
+
+---
+
+## Task 1: Core RSA crypto module (`core/src/ap_signing.rs`)
+
+**Files:**
+- Modify: `core/Cargo.toml` (add `rsa` dep)
+- Create: `core/src/ap_signing.rs`
+- Modify: `core/src/lib.rs` (add `pub mod ap_signing;`)
+
+- [ ] **Step 1: Add the `rsa` dependency**
+
+In `core/Cargo.toml`, under `[dependencies]`, immediately after the `rand = { workspace = true }` line, add:
+
+```toml
+rsa = { version = "0.9", features = ["pem"] }
+```
+
+- [ ] **Step 2: Write the module with failing tests**
+
+Create `core/src/ap_signing.rs`:
+
+```rust
+// ABOUTME: Pure RSA crypto for ActivityPub HTTP Signatures (RSA-SHA256, draft-cavage)
+// ABOUTME: Keygen + SPKI public PEM + RSASSA-PKCS1-v1_5/SHA-256 signing. No DB, no Nostr.
+// ABOUTME: Private keys are handled as PKCS#8 DER and encrypted at rest by KeyManager.
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use rsa::pkcs1v15::SigningKey;
+use rsa::pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey, LineEnding};
+use rsa::signature::{SignatureEncoding, Signer};
+use rsa::{RsaPrivateKey, RsaPublicKey};
+use sha2::Sha256;
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+/// Forward-compatible discriminator stored in `ap_actor_keys.key_type`.
+pub const AP_KEY_TYPE: &str = "rsa-2048";
+
+const RSA_BITS: usize = 2048;
+
+#[derive(Debug, Error)]
+pub enum ApSigningError {
+    #[error("RSA key generation failed: {0}")]
+    KeyGen(String),
+    #[error("PKCS#8 encode failed: {0}")]
+    Encode(String),
+    #[error("PKCS#8 decode failed: {0}")]
+    Decode(String),
+    #[error("SPKI PEM encode failed: {0}")]
+    Pem(String),
+    #[error("signing failed: {0}")]
+    Sign(String),
+}
+
+/// A freshly generated RSA keypair, split into the two persisted halves.
+pub struct RsaKeyMaterial {
+    /// Private key as PKCS#8 DER. Encrypt with `KeyManager` before storing. Zeroized on drop.
+    pub pkcs8_der: Zeroizing<Vec<u8>>,
+    /// Public key as SPKI PEM (`-----BEGIN PUBLIC KEY-----`). Safe to store in plaintext.
+    pub public_pem: String,
+}
+
+/// Generate an RSA-2048 keypair. CPU-bound (~tens of ms) — callers wrap in `spawn_blocking`.
+pub fn generate_rsa_2048() -> Result<RsaKeyMaterial, ApSigningError> {
+    let mut rng = rand::thread_rng();
+    let private =
+        RsaPrivateKey::new(&mut rng, RSA_BITS).map_err(|e| ApSigningError::KeyGen(e.to_string()))?;
+    let der = private
+        .to_pkcs8_der()
+        .map_err(|e| ApSigningError::Encode(e.to_string()))?;
+    let pkcs8_der = Zeroizing::new(der.as_bytes().to_vec());
+    let public_pem = RsaPublicKey::from(&private)
+        .to_public_key_pem(LineEnding::LF)
+        .map_err(|e| ApSigningError::Pem(e.to_string()))?;
+    Ok(RsaKeyMaterial {
+        pkcs8_der,
+        public_pem,
+    })
+}
+
+/// Re-derive the SPKI public PEM from a decrypted PKCS#8 DER private key.
+/// Utility for tests / backfill; the GET path serves the stored column instead.
+pub fn public_pem_from_pkcs8_der(pkcs8_der: &[u8]) -> Result<String, ApSigningError> {
+    let private =
+        RsaPrivateKey::from_pkcs8_der(pkcs8_der).map_err(|e| ApSigningError::Decode(e.to_string()))?;
+    RsaPublicKey::from(&private)
+        .to_public_key_pem(LineEnding::LF)
+        .map_err(|e| ApSigningError::Pem(e.to_string()))
+}
+
+/// Sign `message` with RSASSA-PKCS1-v1_5 + SHA-256. Returns raw signature bytes.
+/// CPU-bound — callers wrap in `spawn_blocking`.
+pub fn sign_pkcs1v15_sha256(pkcs8_der: &[u8], message: &[u8]) -> Result<Vec<u8>, ApSigningError> {
+    let private =
+        RsaPrivateKey::from_pkcs8_der(pkcs8_der).map_err(|e| ApSigningError::Decode(e.to_string()))?;
+    let signing_key = SigningKey::<Sha256>::new(private);
+    let signature = signing_key
+        .try_sign(message)
+        .map_err(|e| ApSigningError::Sign(e.to_string()))?;
+    Ok(signature.to_vec())
+}
+
+/// Convenience: sign and base64-encode (standard alphabet) for the HTTP `signature="…"` field.
+pub fn sign_base64(pkcs8_der: &[u8], message: &[u8]) -> Result<String, ApSigningError> {
+    Ok(BASE64.encode(sign_pkcs1v15_sha256(pkcs8_der, message)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsa::pkcs1v15::{Signature, VerifyingKey};
+    use rsa::pkcs8::DecodePublicKey;
+    use rsa::signature::Verifier;
+
+    #[test]
+    fn generate_produces_spki_pem_and_parseable_der() {
+        let km = generate_rsa_2048().expect("keygen");
+        assert!(
+            km.public_pem.starts_with("-----BEGIN PUBLIC KEY-----"),
+            "must be SPKI PEM, not PKCS#1; got: {}",
+            &km.public_pem[..km.public_pem.len().min(40)]
+        );
+        // DER must round-trip back into a private key.
+        RsaPrivateKey::from_pkcs8_der(&km.pkcs8_der).expect("der parses");
+    }
+
+    #[test]
+    fn sign_then_verify_with_public_pem() {
+        let km = generate_rsa_2048().expect("keygen");
+        let msg = b"(request-target): post /inbox\nhost: divine.video\ndate: x";
+
+        let sig_bytes = sign_pkcs1v15_sha256(&km.pkcs8_der, msg).expect("sign");
+
+        let public = RsaPublicKey::from_public_key_pem(&km.public_pem).expect("pem parses");
+        let vk = VerifyingKey::<Sha256>::new(public);
+        let sig = Signature::try_from(sig_bytes.as_slice()).expect("sig decodes");
+        vk.verify(msg, &sig).expect("signature must verify");
+    }
+
+    #[test]
+    fn public_pem_from_der_matches_generate() {
+        let km = generate_rsa_2048().expect("keygen");
+        let rederived = public_pem_from_pkcs8_der(&km.pkcs8_der).expect("rederive");
+        assert_eq!(km.public_pem, rederived);
+    }
+
+    #[test]
+    fn sign_base64_is_decodable_and_verifies() {
+        let km = generate_rsa_2048().expect("keygen");
+        let msg = b"hello ap";
+        let b64 = sign_base64(&km.pkcs8_der, msg).expect("sign b64");
+        let raw = BASE64.decode(&b64).expect("base64 decodes");
+
+        let public = RsaPublicKey::from_public_key_pem(&km.public_pem).expect("pem");
+        let vk = VerifyingKey::<Sha256>::new(public);
+        let sig = Signature::try_from(raw.as_slice()).expect("sig");
+        vk.verify(msg, &sig).expect("verify");
+    }
+}
+```
+
+- [ ] **Step 3: Register the module**
+
+In `core/src/lib.rs`, add `pub mod ap_signing;` in alphabetical position (immediately after `pub mod authorization_channel;`... actually first line is `pub mod authorization_channel;`). Insert as the new first line:
+
+```rust
+pub mod ap_signing;
+pub mod authorization_channel;
+```
+
+- [ ] **Step 4: Run the tests — expect compile + pass**
+
+Run: `cargo test -p keycast_core ap_signing`
+Expected: compiles, 4 tests PASS. If `try_sign`/`to_public_key_pem`/`to_pkcs8_der` fail to resolve, the `rsa` 0.9 API drifted — check `cargo doc -p rsa --open` for the exact path before adjusting; do not change the algorithm (must stay PKCS1-v1.5 + SHA-256, SPKI PEM).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/Cargo.toml core/src/ap_signing.rs core/src/lib.rs
+git commit -m "feat(core): RSA-2048 keygen + PKCS1v15-SHA256 signing for ActivityPub"
+```
+
+---
+
+## Task 2: Database migration for `ap_actor_keys`
+
+**Files:**
+- Create: `database/migrations/20260530000000_add_ap_actor_keys.sql`
+
+- [ ] **Step 1: Write the migration**
+
+Create `database/migrations/20260530000000_add_ap_actor_keys.sql`:
+
+```sql
+-- ap_actor_keys: per-user RSA keypair for ActivityPub HTTP Signatures.
+-- Separate from Nostr/secp256k1 keys (personal_keys/stored_keys): RSA is
+-- variable-length PKCS#8 DER + an SPKI public PEM. Bound to the immutable
+-- nostr_pubkey (1:1 per tenant), NOT the mutable username — a published
+-- publicKeyPem is cached by remote fediverse servers.
+
+CREATE TABLE public.ap_actor_keys (
+    id                     bigserial PRIMARY KEY,
+    user_pubkey            character(64) NOT NULL,
+    tenant_id              bigint NOT NULL DEFAULT 1,
+    encrypted_private_key  bytea NOT NULL,                 -- PKCS#8 DER, AES-256-GCM via KeyManager
+    public_key_pem         text  NOT NULL,                 -- SPKI PEM, public, safe at rest
+    key_type               text  NOT NULL DEFAULT 'rsa-2048',
+    created_at             timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at             timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT ap_actor_keys_tenant_user_unique UNIQUE (tenant_id, user_pubkey)
+);
+
+CREATE INDEX idx_ap_actor_keys_tenant_user ON public.ap_actor_keys (tenant_id, user_pubkey);
+```
+
+- [ ] **Step 2: Apply the migration locally**
+
+Run: `bun run db:reset` (or `./tools/run-migrations.sh` if you only want to apply new migrations).
+Expected: completes without error; `ap_actor_keys` exists.
+
+- [ ] **Step 3: Verify the table**
+
+Run: `psql "$DATABASE_URL" -c "\d public.ap_actor_keys"`
+Expected: shows columns `id, user_pubkey, tenant_id, encrypted_private_key, public_key_pem, key_type, created_at, updated_at` and the unique constraint.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add database/migrations/20260530000000_add_ap_actor_keys.sql
+git commit -m "feat(db): add ap_actor_keys table for ActivityPub RSA key custody"
+```
+
+---
+
+## Task 3: `ApActorKeysRepository`
+
+**Files:**
+- Create: `core/src/repositories/ap_actor_keys.rs`
+- Modify: `core/src/repositories/mod.rs`
+
+- [ ] **Step 1: Write the repository with a failing integration test**
+
+Create `core/src/repositories/ap_actor_keys.rs`:
+
+```rust
+// ABOUTME: Repository for ap_actor_keys — per-user ActivityPub RSA keys
+// ABOUTME: Stores encrypted PKCS#8 DER private key + plaintext SPKI public PEM, 1:1 per tenant
+
+use crate::repositories::RepositoryError;
+use sqlx::PgPool;
+
+/// A stored AP key row (encrypted private key + public PEM).
+#[derive(Debug, Clone)]
+pub struct ApActorKeyRow {
+    pub encrypted_private_key: Vec<u8>,
+    pub public_key_pem: String,
+    pub key_type: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApActorKeysRepository {
+    pool: PgPool,
+}
+
+impl ApActorKeysRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Fetch the full row (encrypted private key + public PEM) for signing.
+    pub async fn find_for_tenant(
+        &self,
+        tenant_id: i64,
+        user_pubkey: &str,
+    ) -> Result<Option<ApActorKeyRow>, RepositoryError> {
+        let row = sqlx::query_as::<_, (Vec<u8>, String, String)>(
+            "SELECT encrypted_private_key, public_key_pem, key_type
+             FROM ap_actor_keys
+             WHERE tenant_id = $1 AND user_pubkey = $2",
+        )
+        .bind(tenant_id)
+        .bind(user_pubkey)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|(encrypted_private_key, public_key_pem, key_type)| ApActorKeyRow {
+            encrypted_private_key,
+            public_key_pem,
+            key_type,
+        }))
+    }
+
+    /// Fetch only the public PEM (GET path — never decrypts).
+    pub async fn find_public_pem(
+        &self,
+        tenant_id: i64,
+        user_pubkey: &str,
+    ) -> Result<Option<(String, String)>, RepositoryError> {
+        sqlx::query_as::<_, (String, String)>(
+            "SELECT public_key_pem, key_type
+             FROM ap_actor_keys
+             WHERE tenant_id = $1 AND user_pubkey = $2",
+        )
+        .bind(tenant_id)
+        .bind(user_pubkey)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    /// Insert a new key. Idempotency is enforced by the caller checking existence first
+    /// AND by the UNIQUE(tenant_id, user_pubkey) constraint as a backstop.
+    pub async fn create(
+        &self,
+        tenant_id: i64,
+        user_pubkey: &str,
+        encrypted_private_key: &[u8],
+        public_key_pem: &str,
+        key_type: &str,
+    ) -> Result<(), RepositoryError> {
+        sqlx::query(
+            "INSERT INTO ap_actor_keys
+                (tenant_id, user_pubkey, encrypted_private_key, public_key_pem, key_type)
+             VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(tenant_id)
+        .bind(user_pubkey)
+        .bind(encrypted_private_key)
+        .bind(public_key_pem)
+        .bind(key_type)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn exists(
+        &self,
+        tenant_id: i64,
+        user_pubkey: &str,
+    ) -> Result<bool, RepositoryError> {
+        let found: Option<i64> = sqlx::query_scalar(
+            "SELECT 1 FROM ap_actor_keys WHERE tenant_id = $1 AND user_pubkey = $2",
+        )
+        .bind(tenant_id)
+        .bind(user_pubkey)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(found.is_some())
+    }
+}
+
+#[cfg(all(test, feature = "integration-tests"))]
+mod tests {
+    use super::*;
+    use nostr_sdk::Keys;
+
+    async fn setup_pool() -> PgPool {
+        let url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+        assert!(
+            url.contains("localhost") || url.contains("127.0.0.1"),
+            "tests must run against localhost"
+        );
+        PgPool::connect(&url).await.expect("connect")
+    }
+
+    #[tokio::test]
+    async fn create_find_exists_roundtrip() {
+        let pool = setup_pool().await;
+        let repo = ApActorKeysRepository::new(pool.clone());
+        let pubkey = Keys::generate().public_key().to_hex();
+
+        assert!(!repo.exists(1, &pubkey).await.unwrap());
+        assert!(repo.find_for_tenant(1, &pubkey).await.unwrap().is_none());
+
+        repo.create(1, &pubkey, &[1, 2, 3, 4], "-----BEGIN PUBLIC KEY-----\nX\n-----END PUBLIC KEY-----\n", "rsa-2048")
+            .await
+            .unwrap();
+
+        assert!(repo.exists(1, &pubkey).await.unwrap());
+        let row = repo.find_for_tenant(1, &pubkey).await.unwrap().unwrap();
+        assert_eq!(row.encrypted_private_key, vec![1, 2, 3, 4]);
+        assert!(row.public_key_pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+        let (pem, kt) = repo.find_public_pem(1, &pubkey).await.unwrap().unwrap();
+        assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+        assert_eq!(kt, "rsa-2048");
+
+        // Tenant isolation: tenant 2 sees nothing.
+        assert!(!repo.exists(2, &pubkey).await.unwrap());
+
+        // Cleanup
+        sqlx::query("DELETE FROM ap_actor_keys WHERE user_pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+}
+```
+
+- [ ] **Step 2: Register the module and re-export**
+
+In `core/src/repositories/mod.rs`:
+- Add `mod ap_actor_keys;` as the new first `mod` line (before `mod admin_audit_event;`).
+- Add the re-export after the `pub use admin_audit_event::...;` line:
+
+```rust
+pub use ap_actor_keys::{ApActorKeyRow, ApActorKeysRepository};
+```
+
+- [ ] **Step 3: Run the integration test**
+
+Run: `cargo test -p keycast_core --features integration-tests create_find_exists_roundtrip -- --nocapture`
+Expected: PASS (requires local Postgres with the migration applied from Task 2).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/src/repositories/ap_actor_keys.rs core/src/repositories/mod.rs
+git commit -m "feat(core): ApActorKeysRepository for tenant-scoped RSA key storage"
+```
+
+---
+
+## Task 4: API endpoints (`api/src/api/http/ap.rs`)
+
+**Files:**
+- Create: `api/src/api/http/ap.rs`
+- Modify: `api/src/api/http/mod.rs`
+- Modify: `api/src/api/http/routes.rs`
+
+- [ ] **Step 1: Write the handler module**
+
+Create `api/src/api/http/ap.rs`:
+
+```rust
+// ABOUTME: ActivityPub RSA key custody + HTTP-Signature signing oracle
+// ABOUTME: Authenticated by KEYCAST_SERVICE_TOKEN (gateway) OR UCAN (user); tenant from Host
+// ABOUTME: Pure oracle — signs caller-supplied bytes; never returns the private key
+
+use axum::{
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use keycast_core::ap_signing::{self, AP_KEY_TYPE};
+use keycast_core::repositories::{ApActorKeysRepository, UserRepository};
+use nostr_sdk::PublicKey;
+use serde::{Deserialize, Serialize};
+
+use crate::api::http::auth::extract_user_from_token;
+use crate::api::http::routes::AuthState;
+use crate::api::tenant::TenantExtractor;
+
+// ---- error type (isolated from AuthError; same {"error": msg} JSON shape) ----
+
+#[derive(Debug)]
+pub enum ApError {
+    Unauthorized(String),
+    Forbidden(String),
+    BadRequest(String),
+    NotFound(String),
+    Internal(String),
+}
+
+impl IntoResponse for ApError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            ApError::Unauthorized(m) => (StatusCode::UNAUTHORIZED, m),
+            ApError::Forbidden(m) => (StatusCode::FORBIDDEN, m),
+            ApError::BadRequest(m) => (StatusCode::BAD_REQUEST, m),
+            ApError::NotFound(m) => (StatusCode::NOT_FOUND, m),
+            ApError::Internal(m) => {
+                tracing::error!("AP signing internal error: {}", m);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal server error".to_string(),
+                )
+            }
+        };
+        (status, Json(serde_json::json!({ "error": message }))).into_response()
+    }
+}
+
+// ---- auth: resolve the acting user_pubkey from service token OR UCAN ----
+
+/// Constant-time check of the bearer against KEYCAST_SERVICE_TOKEN.
+/// Mirrors `admin::authorize_service_token` (duplicated to keep that path untouched).
+fn is_service_token(headers: &HeaderMap) -> bool {
+    use subtle::ConstantTimeEq;
+
+    let expected = match std::env::var("KEYCAST_SERVICE_TOKEN") {
+        Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
+        _ => return false,
+    };
+    let actual = match headers.get("authorization").and_then(|v| v.to_str().ok()) {
+        Some(a) => a,
+        None => return false,
+    };
+    let expected_hash = blake3::hash(format!("Bearer {expected}").as_bytes());
+    let actual_hash = blake3::hash(actual.as_bytes());
+    expected_hash.as_bytes().ct_eq(actual_hash.as_bytes()).into()
+}
+
+fn validate_hex_pubkey(pubkey: &str) -> Result<String, ApError> {
+    PublicKey::from_hex(pubkey)
+        .map(|pk| pk.to_hex())
+        .map_err(|_| ApError::BadRequest("Invalid hex pubkey".to_string()))
+}
+
+/// Resolve the acting user_pubkey for a request.
+/// - Service token: `body_pubkey` is REQUIRED (gateway acts for any actor in the tenant).
+/// - UCAN: pubkey comes from the token; if `body_pubkey` is present it must match.
+async fn resolve_principal(
+    headers: &HeaderMap,
+    tenant_id: i64,
+    body_pubkey: Option<&str>,
+) -> Result<String, ApError> {
+    if is_service_token(headers) {
+        let pk = body_pubkey
+            .ok_or_else(|| ApError::BadRequest("pubkey is required for service-token calls".into()))?;
+        return validate_hex_pubkey(pk);
+    }
+
+    // UCAN path
+    let token_pubkey = extract_user_from_token(headers, tenant_id)
+        .await
+        .map_err(|_| ApError::Unauthorized("Authentication required".to_string()))?;
+
+    if let Some(pk) = body_pubkey {
+        let pk = validate_hex_pubkey(pk)?;
+        if pk != token_pubkey {
+            return Err(ApError::Forbidden(
+                "Cannot act on behalf of another user".to_string(),
+            ));
+        }
+    }
+    Ok(token_pubkey)
+}
+
+/// Reject signing for suspended/banned accounts (mirrors auth::sign_event).
+async fn ensure_active(
+    pool: &sqlx::PgPool,
+    tenant_id: i64,
+    user_pubkey: &str,
+) -> Result<(), ApError> {
+    let user_repo = UserRepository::new(pool.clone());
+    if let Some((status, _, _)) = user_repo
+        .get_user_status(user_pubkey, tenant_id)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?
+    {
+        if !status.is_active() {
+            return Err(ApError::Forbidden("Account restricted".to_string()));
+        }
+    }
+    Ok(())
+}
+
+// ---- request/response types ----
+
+#[derive(Debug, Deserialize)]
+pub struct CreateKeyRequest {
+    /// Hex Nostr pubkey of the actor. Required for service-token callers.
+    pub pubkey: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct KeyResponse {
+    pub pubkey: String,
+    pub public_key_pem: String,
+    pub key_type: String,
+    pub created: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PublicKeyResponse {
+    pub pubkey: String,
+    pub public_key_pem: String,
+    pub key_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SignRequest {
+    /// Hex Nostr pubkey of the actor. Required for service-token callers.
+    pub pubkey: Option<String>,
+    /// Exact draft-cavage signing string. Signed as its UTF-8 bytes.
+    pub signing_string: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SignResponse {
+    pub pubkey: String,
+    pub signature: String,
+    pub algorithm: &'static str,
+}
+
+// ---- handlers ----
+
+/// POST /api/ap/keys — create-or-return the actor's RSA key. Idempotent: never regenerates.
+pub async fn create_key(
+    tenant: TenantExtractor,
+    State(auth_state): State<AuthState>,
+    headers: HeaderMap,
+    Json(req): Json<CreateKeyRequest>,
+) -> Result<Json<KeyResponse>, ApError> {
+    let tenant_id = tenant.0.id;
+    let user_pubkey = resolve_principal(&headers, tenant_id, req.pubkey.as_deref()).await?;
+    let pool = &auth_state.state.db;
+    let repo = ApActorKeysRepository::new(pool.clone());
+
+    // Idempotent: if a key exists, return it unchanged.
+    if let Some((pem, key_type)) = repo
+        .find_public_pem(tenant_id, &user_pubkey)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?
+    {
+        return Ok(Json(KeyResponse {
+            pubkey: user_pubkey,
+            public_key_pem: pem,
+            key_type,
+            created: false,
+        }));
+    }
+
+    // Generate (CPU-bound) off the async runtime.
+    let material = tokio::task::spawn_blocking(ap_signing::generate_rsa_2048)
+        .await
+        .map_err(|e| ApError::Internal(format!("join error: {e}")))?
+        .map_err(|e| ApError::Internal(e.to_string()))?;
+
+    let encrypted = auth_state
+        .state
+        .key_manager
+        .encrypt(&material.pkcs8_der)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?;
+
+    // create() may race a concurrent create; the UNIQUE constraint is the backstop.
+    match repo
+        .create(
+            tenant_id,
+            &user_pubkey,
+            &encrypted,
+            &material.public_pem,
+            AP_KEY_TYPE,
+        )
+        .await
+    {
+        Ok(()) => Ok(Json(KeyResponse {
+            pubkey: user_pubkey,
+            public_key_pem: material.public_pem,
+            key_type: AP_KEY_TYPE.to_string(),
+            created: true,
+        })),
+        Err(_) => {
+            // Lost a race: another request created it. Return the winner's key.
+            let (pem, key_type) = repo
+                .find_public_pem(tenant_id, &user_pubkey)
+                .await
+                .map_err(|e| ApError::Internal(e.to_string()))?
+                .ok_or_else(|| ApError::Internal("key insert conflict but no row".into()))?;
+            Ok(Json(KeyResponse {
+                pubkey: user_pubkey,
+                public_key_pem: pem,
+                key_type,
+                created: false,
+            }))
+        }
+    }
+}
+
+/// GET /api/ap/keys/{pubkey} — return the actor's public PEM. Never decrypts.
+pub async fn get_key(
+    tenant: TenantExtractor,
+    State(auth_state): State<AuthState>,
+    headers: HeaderMap,
+    Path(pubkey): Path<String>,
+) -> Result<Json<PublicKeyResponse>, ApError> {
+    let tenant_id = tenant.0.id;
+    let user_pubkey = resolve_principal(&headers, tenant_id, Some(&pubkey)).await?;
+    let repo = ApActorKeysRepository::new(auth_state.state.db.clone());
+
+    let (pem, key_type) = repo
+        .find_public_pem(tenant_id, &user_pubkey)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?
+        .ok_or_else(|| ApError::NotFound("No AP key for this actor".to_string()))?;
+
+    Ok(Json(PublicKeyResponse {
+        pubkey: user_pubkey,
+        public_key_pem: pem,
+        key_type,
+    }))
+}
+
+/// POST /api/ap/sign — sign the exact signing-string bytes; return base64 RSA-SHA256.
+pub async fn sign(
+    tenant: TenantExtractor,
+    State(auth_state): State<AuthState>,
+    headers: HeaderMap,
+    Json(req): Json<SignRequest>,
+) -> Result<Json<SignResponse>, ApError> {
+    let tenant_id = tenant.0.id;
+    let user_pubkey = resolve_principal(&headers, tenant_id, req.pubkey.as_deref()).await?;
+    let pool = &auth_state.state.db;
+
+    ensure_active(pool, tenant_id, &user_pubkey).await?;
+
+    let repo = ApActorKeysRepository::new(pool.clone());
+    let row = repo
+        .find_for_tenant(tenant_id, &user_pubkey)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?
+        .ok_or_else(|| ApError::NotFound("No AP key for this actor".to_string()))?;
+
+    let der = auth_state
+        .state
+        .key_manager
+        .decrypt(&row.encrypted_private_key)
+        .await
+        .map_err(|e| ApError::Internal(e.to_string()))?;
+
+    let message = req.signing_string.into_bytes();
+    let der_vec = der.to_vec();
+    let signature = tokio::task::spawn_blocking(move || {
+        ap_signing::sign_base64(&der_vec, &message)
+    })
+    .await
+    .map_err(|e| ApError::Internal(format!("join error: {e}")))?
+    .map_err(|e| ApError::Internal(e.to_string()))?;
+
+    Ok(Json(SignResponse {
+        pubkey: user_pubkey,
+        signature,
+        algorithm: "rsa-sha256",
+    }))
+}
+```
+
+> **Note on `der.to_vec()`:** `KeyManager::decrypt` returns `Zeroizing<Vec<u8>>`; `.to_vec()` copies the bytes into the closure. The original `der` is zeroized on drop. If you want to avoid the copy, move `der` into the closure directly (it is `Send`). The copy is acceptable here.
+
+- [ ] **Step 2: Register the module**
+
+In `api/src/api/http/mod.rs`, add as the new first line (before `pub mod admin;`):
+
+```rust
+pub mod ap;
+```
+
+- [ ] **Step 3: Mount the routes**
+
+In `api/src/api/http/routes.rs`:
+
+(a) Add `ap` to the import list at the top:
+
+```rust
+use crate::api::http::{
+    admin, ap, atproto, atproto_oauth, auth, claim, headless, metrics, nostr_rpc, oauth, policies,
+    teams,
+};
+```
+
+(b) Add the route group near the other `auth_state`-backed groups (after `signing_routes`, ~line 93):
+
+```rust
+    // ActivityPub RSA signing endpoints (service-token OR UCAN auth; tenant from Host)
+    // Public CORS: server-to-server (the AP gateway), not browser-credentialed.
+    let ap_routes = Router::new()
+        .route("/ap/keys", post(ap::create_key))
+        .route("/ap/keys/:pubkey", get(ap::get_key))
+        .route("/ap/sign", post(ap::sign))
+        .with_state(auth_state.clone());
+```
+
+(c) Merge it into the final router (in the big `.merge(...)` chain, after `nostr_rpc_routes`):
+
+```rust
+        .merge(ap_routes.layer(public_cors.clone())) // AP RSA signing (gateway service-to-service)
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cargo build -p keycast_api`
+Expected: compiles clean. If `extract_user_from_token` is not visible, confirm it is `pub(crate)` in `auth.rs` (it is) and the path `crate::api::http::auth::extract_user_from_token` is correct.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/api/http/ap.rs api/src/api/http/mod.rs api/src/api/http/routes.rs
+git commit -m "feat(api): /api/ap/keys + /api/ap/sign RSA signing endpoints"
+```
+
+---
+
+## Task 5: API end-to-end test (service-token + UCAN paths)
+
+**Files:**
+- Create: `api/tests/ap_signing_integration_test.rs`
+
+> These mirror the existing `api/tests/oauth_integration_test.rs` harness (same DB setup, gated the same way). If that file uses a specific test-pool helper or `#[cfg(feature = "integration-tests")]` gate, copy that exact pattern. The test below assumes a running app or a router built in-test; adapt to the existing harness's app-construction helper. If the existing suite builds a `Router` via a shared `test_app()` helper, reuse it; otherwise call the handlers directly as the unit-style example shows.
+
+- [ ] **Step 1: Write the test**
+
+Create `api/tests/ap_signing_integration_test.rs`:
+
+```rust
+// ABOUTME: End-to-end tests for the AP RSA signing endpoints (create -> get -> sign)
+// Verifies the signature produced by /api/ap/sign validates against the PEM from /api/ap/keys.
+
+#![cfg(feature = "integration-tests")]
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use rsa::pkcs1v15::{Signature, VerifyingKey};
+use rsa::pkcs8::DecodePublicKey;
+use rsa::signature::Verifier;
+use rsa::RsaPublicKey;
+use sha2::Sha256;
+
+// Use the same in-process app/test harness the oauth integration test uses.
+// Pseudocode for the HTTP flow — replace `call(...)` with the project's test client.
+//
+//   let app = test_app().await;                  // shared helper from the oauth test
+//   set header  Authorization: Bearer <KEYCAST_SERVICE_TOKEN>
+//   set header  Host: <a real tenant domain in test, e.g. localhost>
+//
+//   POST /api/ap/keys     {"pubkey": "<hex>"}        -> 200 {public_key_pem, created:true}
+//   POST /api/ap/keys     {"pubkey": "<hex>"}        -> 200 {created:false}  (idempotent)
+//   GET  /api/ap/keys/<hex>                          -> 200 {public_key_pem} (== create's PEM)
+//   POST /api/ap/sign     {"pubkey":"<hex>","signing_string":"..."} -> 200 {signature}
+//
+// Then assert the signature verifies:
+
+fn assert_signature_verifies(public_pem: &str, signing_string: &str, signature_b64: &str) {
+    let public = RsaPublicKey::from_public_key_pem(public_pem).expect("pem parses");
+    let vk = VerifyingKey::<Sha256>::new(public);
+    let raw = BASE64.decode(signature_b64).expect("base64");
+    let sig = Signature::try_from(raw.as_slice()).expect("sig");
+    vk.verify(signing_string.as_bytes(), &sig)
+        .expect("signature from /api/ap/sign must verify against /api/ap/keys PEM");
+}
+
+#[tokio::test]
+async fn create_get_sign_roundtrip_service_token() {
+    // 1. POST /api/ap/keys with service token + pubkey -> capture public_key_pem
+    // 2. POST again -> assert created == false (idempotent, same PEM)
+    // 3. GET /api/ap/keys/{pubkey} -> assert PEM matches
+    // 4. POST /api/ap/sign with a sample draft-cavage signing string
+    // 5. assert_signature_verifies(pem, signing_string, signature)
+    //
+    // Implement using the project's existing test client (see oauth_integration_test.rs).
+}
+
+#[tokio::test]
+async fn ucan_cannot_sign_for_another_pubkey() {
+    // With a UCAN for user A, POST /api/ap/sign {"pubkey": "<user B hex>", ...}
+    // -> assert 403 Forbidden.
+}
+
+#[tokio::test]
+async fn sign_without_key_is_404() {
+    // Service token + a pubkey that has no ap_actor_keys row
+    // POST /api/ap/sign -> assert 404.
+}
+```
+
+- [ ] **Step 2: Wire to the real harness**
+
+Open `api/tests/oauth_integration_test.rs`, copy its app/test-client construction (and the `KEYCAST_SERVICE_TOKEN` env setup used by any admin service-token test if present), and fill in the `// Implement using...` bodies. Each `#[tokio::test]` must perform real HTTP calls and assert the documented status/JSON.
+
+- [ ] **Step 3: Run the tests**
+
+Run: `cd api && cargo test --features integration-tests --test ap_signing_integration_test -- --nocapture`
+Expected: all three tests PASS (local Postgres + migration applied; `KEYCAST_SERVICE_TOKEN` set in the test env).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/tests/ap_signing_integration_test.rs
+git commit -m "test(api): end-to-end AP signing roundtrip + auth/404 cases"
+```
+
+---
+
+## Task 6: Independent interop verification (openssl) + Nostr regression check
+
+**Files:**
+- Create: `tests/qa/ap_interop_verify.sh` (or the repo's existing QA script dir)
+
+This is the **required external check** from the spec: a self-round-trip proves library
+self-consistency, not Mastodon interop. We verify a produced (PEM, signature) pair with
+`openssl` — an independent implementation — to catch SPKI-vs-PKCS1 and PKCS1v15-vs-PSS
+mistakes.
+
+- [ ] **Step 1: Add a Rust test binary that emits a vector**
+
+Add to `core/src/ap_signing.rs` test module a helper test that writes a fixed-message
+signature + PEM to `target/ap_interop/` for the shell script to verify:
+
+```rust
+    #[test]
+    #[ignore] // run explicitly: cargo test -p keycast_core ap_signing -- --ignored emit_interop_vector
+    fn emit_interop_vector() {
+        use std::io::Write;
+        let km = generate_rsa_2048().expect("keygen");
+        let msg = b"(request-target): post /inbox\nhost: divine.video\ndate: Mon, 01 Jan 2026 00:00:00 GMT";
+        let sig = sign_pkcs1v15_sha256(&km.pkcs8_der, msg).expect("sign");
+
+        let dir = std::path::Path::new("target/ap_interop");
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join("pub.pem"), km.public_pem.as_bytes()).unwrap();
+        std::fs::write(dir.join("msg.bin"), msg).unwrap();
+        let mut f = std::fs::File::create(dir.join("sig.bin")).unwrap();
+        f.write_all(&sig).unwrap();
+    }
+```
+
+- [ ] **Step 2: Write the verification script**
+
+Create `tests/qa/ap_interop_verify.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Independently verify a Keycast-produced RSA-SHA256 signature with openssl.
+# Catches SPKI-vs-PKCS1 PEM and PKCS1v15-vs-PSS algorithm mistakes that a
+# same-library round-trip cannot.
+set -euo pipefail
+
+cargo test -p keycast_core ap_signing -- --ignored emit_interop_vector
+
+DIR=target/ap_interop
+openssl dgst -sha256 -verify "$DIR/pub.pem" -signature "$DIR/sig.bin" "$DIR/msg.bin"
+# Expected output: "Verified OK"
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `bash tests/qa/ap_interop_verify.sh`
+Expected: ends with `Verified OK`. If openssl errors with "unable to load Public Key", the
+PEM is not SPKI — fix `ap_signing` to use `to_public_key_pem` (SPKI), not PKCS#1.
+
+- [ ] **Step 4: Confirm the Nostr path is untouched**
+
+Run: `cargo test -p keycast_core signing_session && cd api && cargo test --features integration-tests --test oauth_integration_test`
+Expected: existing Schnorr/NIP-46/OAuth tests still PASS. (Sanity: `ap.rs` shares no code
+with `signing_session.rs`; this is a regression guard, not new behavior.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/qa/ap_interop_verify.sh core/src/ap_signing.rs
+git commit -m "test: independent openssl interop verification for AP RSA signatures"
+```
+
+---
+
+## Task 7: OpenAPI documentation
+
+**Files:**
+- Modify: `api/openapi.yaml`
+
+- [ ] **Step 1: Add the `ServiceToken` security scheme**
+
+In `api/openapi.yaml`, under `components.securitySchemes` (after the `BearerAuth` block, ~line 51):
+
+```yaml
+    ServiceToken:
+      type: http
+      scheme: bearer
+      description: KEYCAST_SERVICE_TOKEN for trusted service-to-service callers (e.g. the AP gateway)
+```
+
+- [ ] **Step 2: Add schemas**
+
+Under `components.schemas` (alongside the others), add:
+
+```yaml
+    ApCreateKeyRequest:
+      type: object
+      properties:
+        pubkey:
+          type: string
+          description: Hex Nostr pubkey of the actor. Required for service-token callers; for UCAN callers it defaults to the token's pubkey and, if present, must match it.
+          example: "e1ff3bfdd4e40315959b08b4fcc8245eaa514637e1d4ec2ae166b743341be1af"
+    ApKeyResponse:
+      type: object
+      properties:
+        pubkey: { type: string }
+        public_key_pem:
+          type: string
+          description: SPKI PEM public key for the actor's publicKey.publicKeyPem.
+          example: "-----BEGIN PUBLIC KEY-----\nMIIBIjAN...\n-----END PUBLIC KEY-----\n"
+        key_type: { type: string, example: "rsa-2048" }
+        created:
+          type: boolean
+          description: true if a new key was minted; false if an existing key was returned (idempotent).
+      required: [pubkey, public_key_pem, key_type, created]
+    ApPublicKeyResponse:
+      type: object
+      properties:
+        pubkey: { type: string }
+        public_key_pem: { type: string }
+        key_type: { type: string, example: "rsa-2048" }
+      required: [pubkey, public_key_pem, key_type]
+    ApSignRequest:
+      type: object
+      properties:
+        pubkey:
+          type: string
+          description: Hex Nostr pubkey of the actor (required for service-token callers).
+        signing_string:
+          type: string
+          description: The exact draft-cavage HTTP-Signature signing string. Signed as UTF-8 bytes.
+          example: "(request-target): post /inbox\nhost: mastodon.social\ndate: Mon, 01 Jan 2026 00:00:00 GMT\ndigest: SHA-256=X..."
+      required: [signing_string]
+    ApSignResponse:
+      type: object
+      properties:
+        pubkey: { type: string }
+        signature:
+          type: string
+          description: base64-encoded RSASSA-PKCS1-v1_5 SHA-256 signature for the Signature header.
+        algorithm: { type: string, example: "rsa-sha256" }
+      required: [pubkey, signature, algorithm]
+```
+
+- [ ] **Step 3: Add the paths**
+
+Under `paths` (after `/user/sign`'s block), add:
+
+```yaml
+  /ap/keys:
+    post:
+      summary: Create or return an actor's ActivityPub RSA key
+      description: |
+        Mints (or returns, idempotently) an RSA-2048 keypair for an actor and returns its
+        SPKI public PEM for embedding in `publicKey.publicKeyPem`. The private key is stored
+        encrypted-at-rest and is **never** returned. Calling again returns the existing key
+        with `created: false` — the key is never regenerated (federated keys are cached by
+        remote servers). Auth: ServiceToken (with `pubkey`) or UCAN (BearerAuth).
+      tags: [ActivityPub]
+      security:
+        - ServiceToken: []
+        - BearerAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApCreateKeyRequest' }
+      responses:
+        '200':
+          description: Key created or already existed
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApKeyResponse' }
+        '400': { description: Invalid or missing pubkey, content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: Unauthorized, content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: UCAN pubkey mismatch, content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+  /ap/keys/{pubkey}:
+    get:
+      summary: Get an actor's ActivityPub public key PEM
+      tags: [ActivityPub]
+      security:
+        - ServiceToken: []
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: pubkey
+          required: true
+          schema: { type: string }
+          description: Hex Nostr pubkey of the actor
+      responses:
+        '200':
+          description: Public key PEM
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApPublicKeyResponse' }
+        '404': { description: No AP key for this actor, content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+  /ap/sign:
+    post:
+      summary: Sign an HTTP-Signature signing string (RSA-SHA256)
+      description: |
+        Signs the exact caller-supplied signing string with RSASSA-PKCS1-v1_5 + SHA-256 and
+        returns the base64 signature. The caller builds the draft-cavage signing string and
+        assembles the final `Signature:` header. The private key never leaves Keycast.
+        Suspended/banned accounts are rejected.
+      tags: [ActivityPub]
+      security:
+        - ServiceToken: []
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApSignRequest' }
+      responses:
+        '200':
+          description: Signature
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApSignResponse' }
+        '403': { description: Account restricted or pubkey mismatch, content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: No AP key for this actor, content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+```
+
+- [ ] **Step 4: Add the tag**
+
+Under the top-level `tags:` list (~line 1046), add:
+
+```yaml
+  - name: ActivityPub
+    description: RSA key custody and HTTP-Signature signing for the ActivityPub gateway
+```
+
+- [ ] **Step 5: Validate the spec parses**
+
+Run: `cargo build -p keycast_api` then start the server and `curl -s localhost:3000/api/docs/openapi.json | head -c 200`
+(The `openapi_spec` handler does `serde_yaml::from_str(...).expect(...)` — a malformed YAML
+would panic on that route. A clean build + a 200 from the docs route confirms it parses.)
+Expected: valid JSON returned, no panic.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/openapi.yaml
+git commit -m "docs(api): OpenAPI for /api/ap/keys and /api/ap/sign"
+```
+
+---
+
+## CI / supply-chain note (do once, only if a gate exists)
+
+`rsa` 0.9 carries **RUSTSEC-2023-0071** ("Marvin" timing sidechannel). It is a *decryption*
+sidechannel and **does not apply to signing**, which is all we do. Check whether CI runs
+`cargo audit`/`cargo deny`:
+
+```bash
+grep -rn "cargo audit\|cargo-audit\|cargo deny\|cargo-deny\|deny.toml" .github/ deny.toml 2>/dev/null
+```
+
+- If a gate exists and fails on RUSTSEC-2023-0071, add an allowlist entry (in `deny.toml`
+  under `[advisories] ignore`, or the CI's audit-ignore flag) with the comment:
+  `# RUSTSEC-2023-0071: Marvin attack is a decryption sidechannel; we only sign. Not applicable.`
+- If no such gate exists, do nothing.
+
+---
+
+## Self-Review (completed during authoring)
+
+- **Spec coverage:** keygen + storage + public PEM + sign (Tasks 1–4); separate table / shape
+  mismatch (Task 2); both auth modes (Task 4 `resolve_principal`); 1:1 per tenant (Task 2
+  UNIQUE); sign-the-blob (Task 4 `sign`); idempotent create (Task 4); SPKI PEM + PKCS1v15
+  (Task 1, asserted in Task 6 via openssl); private key never returned (no response type
+  exposes it); Nostr regression (Task 6 Step 4); OpenAPI (Task 7); CI note (final section);
+  divine-activity-pub integration constraints (host-based tenant, stable-pubkey key, no verify
+  endpoint) are realized by Tasks 2/4. ✓
+- **Placeholder scan:** Task 5's bodies are intentionally harness-dependent and reference the
+  existing `oauth_integration_test.rs` pattern with explicit step-by-step instructions and a
+  concrete `assert_signature_verifies` helper — not a bare "write tests" placeholder. All
+  crypto/repo/handler code is complete and compilable.
+- **Type consistency:** `RsaKeyMaterial { pkcs8_der, public_pem }`, `ApActorKeyRow
+  { encrypted_private_key, public_key_pem, key_type }`, `ApActorKeysRepository::{find_for_tenant,
+  find_public_pem, create, exists}`, `ap_signing::{generate_rsa_2048, public_pem_from_pkcs8_der,
+  sign_pkcs1v15_sha256, sign_base64, AP_KEY_TYPE}` — names match across Tasks 1, 3, 4, 6. ✓
+```

--- a/docs/superpowers/specs/2026-05-30-ap-rsa-http-signature-signing-design.md
+++ b/docs/superpowers/specs/2026-05-30-ap-rsa-http-signature-signing-design.md
@@ -1,0 +1,258 @@
+# Design: RSA / ActivityPub HTTP-Signature signing in Keycast
+
+**Date:** 2026-05-30
+**Status:** Approved design → implementation plan
+**Author:** rabble + Claude
+
+## Problem
+
+We're building an ActivityPub gateway ("Divine AP Gateway") that projects Divine's Nostr
+users into the fediverse as `@user@divine.video` actors. Every ActivityPub actor must sign
+its outbound HTTP requests with **RSA HTTP Signatures** (RSA-SHA256, draft-cavage-12). That
+RSA key is separate from the user's Nostr (secp256k1) key and must be held in custody —
+never exported.
+
+Keycast is already our managed, encrypted, per-user key-custody service. It is currently
+**Nostr / secp256k1 / Schnorr only**. We extend it so that, per user, it can additionally
+generate, store (encrypted-at-rest), expose the public key for, and sign with an RSA-2048
+keypair — without ever exporting the private key.
+
+## Goals
+
+Per user (1:1, scoped to a tenant):
+1. **Generate** an RSA-2048 keypair on demand.
+2. **Store** the private key encrypted-at-rest, reusing Keycast's existing `KeyManager`
+   (AES-256-GCM via file/GCP/AWS KMS). No new encryption scheme.
+3. **Expose the public key** as SPKI PEM (`-----BEGIN PUBLIC KEY-----`) for embedding in
+   the actor document's `publicKey.publicKeyPem`.
+4. **Sign** a caller-supplied signing-string on request, returning a base64 RSA-SHA256
+   signature, **without exporting the private key**.
+
+## Non-goals / hard constraints
+
+- **Do NOT change or regress the Nostr signing path** (32-byte / Schnorr / NIP-46 /
+  `/api/user/sign`). RSA is added strictly alongside, in new modules and a new table.
+- Reuse the existing encryption-at-rest and tenant/authorization machinery.
+- Private RSA keys are **never** returned by any endpoint.
+- Keycast stays a pure signing oracle — it does **not** learn ActivityPub / AS2. The
+  gateway builds the HTTP Signature "signing string" and assembles the final `Signature:`
+  header; Keycast only signs bytes.
+
+## Decisions (confirmed with stakeholder)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Schema | **New `ap_actor_keys` table** (mirrors `personal_keys`) | RSA is variable-length DER + a PEM public blob; `personal_keys`/`stored_keys` are secp256k1-shaped (`char(64)` pubkey, 32-byte secret). A separate table keeps the Nostr path literally untouched (hard constraint) rather than widening a hot, type-specific table. Justified on **shape mismatch**, not taste. |
+| Key identity | **1:1 with `(tenant_id, user_pubkey)`** | "One user → their Nostr key AND their AP key." The request "actor id" resolves to a `user_pubkey`. Matches the existing `personal_keys` identity model exactly. |
+| API shape | **Sign the blob only** | Keycast signs the exact signing-string bytes; the gateway owns draft-cavage/AS2 details. Mirrors the Nostr signer (sign a blob for a key). |
+| Auth | **Both**: `KEYCAST_SERVICE_TOKEN` (service) **and** UCAN (user) | The gateway is backend infra acting for many actors → service token (matches `service_admin_routes` / relay-manager precedent). A user-facing path may also act on its own key via UCAN. |
+
+## Crypto specifics (interop-critical — easy to get subtly wrong)
+
+These must match Mastodon/Pixelfed exactly; a self-only round-trip will NOT catch a miss:
+
+- **Public PEM = SPKI** (`-----BEGIN PUBLIC KEY-----`, X.509 SubjectPublicKeyInfo), via the
+  `rsa` crate's `EncodePublicKey::to_public_key_pem()`. **Not** PKCS#1
+  (`-----BEGIN RSA PUBLIC KEY-----`) — that silently fails interop.
+- **Signature = RSASSA-PKCS1-v1_5 + SHA-256** (`rsa::pkcs1v15::SigningKey<Sha256>`).
+  **Not** PSS — PSS verifies in our own round-trip but the fediverse rejects it.
+- Signature is **base64-encoded** (standard, not URL-safe) — what goes in the `signature="…"`
+  field of the header.
+- Private key stored as **PKCS#8 DER** (`EncodePrivateKey::to_pkcs8_der()`), then handed to
+  `KeyManager::encrypt(&[u8])` and persisted as `bytea`. Decrypt → `DecodePrivateKey` to sign.
+
+## Architecture
+
+```
+                       ┌─────────────────────────────────────────┐
+  Divine AP Gateway    │  Keycast                                 │
+  (backend service) ──▶│  POST /api/ap/keys     ┐                 │
+   service token       │  GET  /api/ap/keys/:pk ├─ api/.../ap.rs   │
+   + user_pubkey       │  POST /api/ap/sign     ┘   (handlers)     │
+                       │           │                               │
+                       │           ▼                               │
+                       │   ApActorKeysRepository (core/repos)      │
+                       │           │            │                  │
+                       │           ▼            ▼                  │
+                       │   ap_actor_keys     KeyManager            │
+                       │   (Postgres bytea)  (AES-256-GCM / KMS)   │
+                       │           ▲                               │
+                       │   ap_signing.rs (pure RSA crypto,         │
+                       │   keygen / SPKI PEM / PKCS1v15-SHA256,     │
+                       │   spawn_blocking)                         │
+                       └─────────────────────────────────────────┘
+```
+
+### Components / module layout
+
+1. **`core/src/ap_signing.rs`** — pure RSA crypto, the RSA analogue of `signing_session.rs`.
+   - `generate_rsa_2048() -> RsaKeyMaterial` — generate keypair; return PKCS#8 DER (private,
+     zeroizing) + SPKI PEM (public).
+   - `public_pem_from_pkcs8_der(der: &[u8]) -> Result<String>` — utility to re-derive SPKI
+     PEM from a decrypted private key (used by tests / backfill; the GET path serves the
+     stored `public_key_pem` column and does **not** decrypt).
+   - `sign_pkcs1v15_sha256(der: &[u8], message: &[u8]) -> Result<Vec<u8>>` — load PKCS#8 DER,
+     sign, return raw signature bytes. CPU-bound RSA runs on `spawn_blocking` (mirrors the
+     Nostr path). Base64 encoding happens in the handler.
+   - `ApSigningError` (thiserror).
+   - Does **not** touch `nostr_sdk` / `Keys` / Schnorr — fully isolated from the Nostr path.
+
+2. **`core/src/repositories/ap_actor_keys.rs`** — `ApActorKeysRepository`, mirrors
+   `PersonalKeysRepository`:
+   - `find_for_tenant(tenant_id, user_pubkey) -> Option<ApActorKeyRow>` (encrypted private +
+     public PEM).
+   - `find_public_pem(tenant_id, user_pubkey) -> Option<String>`.
+   - `create(tenant_id, user_pubkey, encrypted_private_key, public_key_pem)`.
+   - `exists(tenant_id, user_pubkey) -> bool`.
+   - Tenant-scoped queries throughout.
+
+3. **`database/migrations/<timestamp>_add_ap_actor_keys.sql`** — new table (see Schema).
+   **Note:** the task example `0009_*` is stale; the repo switched to `YYYYMMDDHHMMSS_*`
+   naming (every migration since `20260328…`). We follow the repo convention and use a
+   timestamped filename.
+
+4. **`api/src/api/http/ap.rs`** — three handlers + a small auth resolver. Registered in
+   `routes.rs` under a new `ap_routes` group with **public CORS** (server-to-server; not
+   browser-credentialed) and `with_state(auth_state)`.
+
+5. **`api/openapi.yaml`** — document the three endpoints + schemas.
+
+6. **Cargo:** add `rsa = "0.9"` to the workspace and `core/Cargo.toml`. `sha2`, `base64`,
+   `rand`, `zeroize` are already present. `subtle`/`blake3` (service-token compare) already
+   used in `admin.rs`.
+
+### Schema
+
+```sql
+CREATE TABLE public.ap_actor_keys (
+    id                     bigserial PRIMARY KEY,
+    user_pubkey            character(64) NOT NULL,
+    tenant_id              bigint NOT NULL DEFAULT 1,
+    encrypted_private_key  bytea NOT NULL,   -- PKCS#8 DER, AES-256-GCM via KeyManager
+    public_key_pem         text  NOT NULL,   -- SPKI PEM, public, safe at rest
+    key_type               text  NOT NULL DEFAULT 'rsa-2048',
+    created_at             timestamptz NOT NULL DEFAULT now(),
+    updated_at             timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, user_pubkey)
+);
+CREATE INDEX idx_ap_actor_keys_tenant_user ON public.ap_actor_keys (tenant_id, user_pubkey);
+```
+
+- `public_key_pem` stored in plaintext (it is public) so GET and key creation never need a
+  KMS decrypt. `key_type` is a forward-compat discriminator (default `rsa-2048`).
+- No FK to `users` is strictly required (matches the loose coupling of `personal_keys`'
+  tenant queries via JOIN); the `UNIQUE (tenant_id, user_pubkey)` enforces 1:1.
+
+### API surface
+
+All paths nested under `/api`. Request `pubkey` is the hex Nostr `user_pubkey` (the "actor
+id" in our system). Tenant comes from `TenantExtractor` (host-based), as everywhere else.
+
+**`POST /api/ap/keys`** — create-or-return (idempotent).
+```jsonc
+// request
+{ "pubkey": "<hex user pubkey>" }   // pubkey REQUIRED for service-token caller;
+                                    // for UCAN caller, omitted/derived from token
+// 200
+{ "pubkey": "<hex>", "public_key_pem": "-----BEGIN PUBLIC KEY-----\n…", "key_type": "rsa-2048", "created": true }
+```
+If a key already exists, returns the existing public PEM with `"created": false` (idempotent,
+never regenerates — regeneration would orphan the published actor key).
+
+**`GET /api/ap/keys/{pubkey}`** — return public PEM.
+```jsonc
+// 200
+{ "pubkey": "<hex>", "public_key_pem": "-----BEGIN PUBLIC KEY-----\n…", "key_type": "rsa-2048" }
+// 404 if no key exists for (tenant, pubkey)
+```
+
+**`POST /api/ap/sign`** — sign the exact signing-string bytes.
+```jsonc
+// request
+{ "pubkey": "<hex>", "signing_string": "(request-target): post /inbox\nhost: …\ndate: …\ndigest: SHA-256=…" }
+// 200
+{ "pubkey": "<hex>", "signature": "<base64 RSA-SHA256>", "algorithm": "rsa-sha256" }
+```
+- `signing_string` is signed as its **exact UTF-8 bytes**. The gateway is responsible for
+  building it per draft-cavage (newline-joined `header: value` lines, `(request-target)`
+  lowercased method + path).
+- 404 if no AP key exists for the actor (caller should `POST /api/ap/keys` first).
+
+### Auth resolver (`ap.rs`)
+
+A single helper resolves the acting `(user_pubkey, tenant_id)` from **either** auth mode:
+
+```text
+resolve_ap_principal(headers, tenant_id, body_pubkey) -> user_pubkey
+  1. If Authorization bearer == KEYCAST_SERVICE_TOKEN (constant-time compare,
+     reuse the admin.rs pattern: blake3 + subtle::ct_eq):
+        require body_pubkey present  -> acting = body_pubkey
+        (service is trusted to act for any actor in the tenant)
+  2. Else attempt UCAN via extract_user_from_token(headers, tenant_id):
+        acting = token pubkey
+        if body_pubkey present AND != token pubkey -> 403 Forbidden
+  3. Else -> 401.
+```
+
+- Account-status gate: before signing, check `UserRepository::get_user_status` and reject if
+  not active — mirrors `sign_event` (`auth.rs:3151`). (Service token does not bypass this; a
+  suspended user must not get fediverse signatures.)
+- The `authorize_service_token` constant-time comparison logic is factored so both `ap.rs`
+  and `admin.rs` share it (move to a small shared helper, or duplicate the ~10 lines if
+  sharing introduces awkward coupling — decided at implementation time, no behavior change to
+  admin).
+
+## Data flow
+
+**Create key (service token):** gateway `POST /api/ap/keys {pubkey}` → resolve principal →
+if exists, return stored PEM → else `generate_rsa_2048()` (spawn_blocking) → `KeyManager::
+encrypt(pkcs8_der)` → `repo.create(...)` → return SPKI PEM.
+
+**Sign:** gateway builds signing string → `POST /api/ap/sign {pubkey, signing_string}` →
+resolve principal → status check → `repo.find_for_tenant` → `KeyManager::decrypt` →
+`sign_pkcs1v15_sha256(der, signing_string.as_bytes())` (spawn_blocking) → base64 → return.
+
+## Error handling
+
+- Reuse the established `AuthError` / `ApiError` enums in `api/`. New variants only if needed
+  (e.g. an `ApKeyNotFound` → 404; RSA failures → 500 `Internal`, never leak key material in
+  messages).
+- `core` errors via a new `ApSigningError` (thiserror), mapped at the handler boundary.
+- Decryption / DER-parse failures are 500s with generic messages.
+
+## Testing
+
+1. **Unit (`core/src/ap_signing.rs`):**
+   - keygen produces a parseable PKCS#8 DER and an SPKI PEM beginning `-----BEGIN PUBLIC KEY-----`.
+   - sign-then-verify round-trip using the `rsa` crate's verifier (library self-consistency).
+2. **Interop (the real test — round-trip alone is insufficient):**
+   - Verify a produced (PEM, signature) pair against an **independent implementation**:
+     `openssl dgst -sha256 -verify pub.pem -signature sig.bin msg.txt` from a test/shell
+     harness. This catches SPKI-vs-PKCS1 and PKCS1v15-vs-PSS mistakes that a self round-trip
+     cannot.
+   - If sourceable, assert against a **known-good draft-cavage-12 vector** (fixed key +
+     signing string → fixed base64 signature).
+3. **Storage round-trip:** encrypt PKCS#8 DER via `FileKeyManager`, decrypt, re-parse, sign —
+   proves the existing `KeyManager` carries RSA bytes intact.
+4. **API (integration, gated like existing oauth tests):** create→get→sign happy path under
+   both service-token and UCAN auth; 403 when UCAN pubkey ≠ requested pubkey; 404 sign with
+   no key; idempotent create.
+5. **Regression — Nostr path intact:** the existing `signing_session.rs` and
+   `oauth_integration_test` suites must pass unchanged. Add an explicit assertion that
+   `/api/user/sign` (Schnorr) is untouched (no shared code path with `ap.rs`).
+
+## CI / supply-chain note
+
+`rsa` crate carries RUSTSEC-2023-0071 ("Marvin" timing sidechannel) — it is a **decryption**
+sidechannel and **does not apply to signing**, which is all we do. If the repo has a
+`cargo-audit`/`cargo-deny` gate, add an allowlist entry citing that rationale; if no such
+gate exists, no action needed. This must not silently block CI.
+
+## Rollout
+
+- Pure additive: new table, new modules, new routes, one new dependency. No change to
+  existing tables, handlers, or the Nostr signer.
+- Migration runs via the existing `sqlx::migrate!` path (`keycast --migrate` Cloud Run Job in
+  `cloudbuild.yaml`).
+- `KEYCAST_SERVICE_TOKEN` already provisioned for relay-manager/COOP; the AP gateway reuses it.
+```

--- a/docs/superpowers/specs/2026-05-30-ap-rsa-http-signature-signing-design.md
+++ b/docs/superpowers/specs/2026-05-30-ap-rsa-http-signature-signing-design.md
@@ -248,6 +248,72 @@ sidechannel and **does not apply to signing**, which is all we do. If the repo h
 `cargo-audit`/`cargo-deny` gate, add an allowlist entry citing that rationale; if no such
 gate exists, no action needed. This must not silently block CI.
 
+## Integration with `divine-activity-pub` (the consuming service)
+
+Cross-checked against the AP gateway's own design docs
+(`divine-activity-pub/PLAN.md`, `wire-format.md`, dated 2026-05-30). The gateway's
+plan explicitly lists this Keycast workstream as its dependency
+(`PLAN.md` §Workstream handoffs: *"create/store RSA key per actor, return public PEM,
+RSA-SHA256 sign endpoint"*) — the three endpoints here match that handoff exactly.
+The following are the concrete contract points that make the two services line up:
+
+1. **Key identity is the stable Nostr pubkey, not the username.** The gateway's `actors`
+   table maps `nostr_pubkey` (hex) → `username` → `ap_actor_url` → `rsa_key_id` (a "keycast
+   ref"). Usernames are mutable and the AP actor URL embeds the username, but a federated
+   `publicKeyPem` is cached by every remote server that has seen it — so the key **must** be
+   bound to the immutable identity. Keying by `(tenant_id, user_pubkey)` does exactly that.
+   The gateway's `rsa_key_id` ref **is** the `user_pubkey` (hex) — no separate opaque key id
+   is needed; the create/get responses echo `pubkey` for that purpose. (If the gateway
+   prefers an opaque handle we can also return the row id, but pubkey is the natural join
+   key and the default.)
+
+2. **Idempotent create is load-bearing — never silently rotate.** Because remote servers
+   cache the actor's public key, regenerating it would break signature verification for
+   every existing follower until they refetch. `POST /api/ap/keys` therefore returns the
+   existing key (`"created": false`) and **never** regenerates. (Key rotation, if ever
+   needed, is a deliberate separate operation, out of scope here.)
+
+3. **Keycast signs only; it does NOT verify.** The gateway's Phase 3 also needs to *verify*
+   inbound HTTP Signatures from remote actors (`Follow`, etc.) — but that uses the **remote**
+   actor's public key, which Keycast never holds. The gateway does inbound verification
+   itself (its docs note WebCrypto if it ships as a CF Worker). **No verify endpoint is added
+   to Keycast**, by design — stating this so nobody expects one.
+
+4. **The gateway owns all HTTP-Signature/AS2 structure; Keycast supplies two opaque values.**
+   - `publicKey.id` (`<actorUrl>#main-key`), `publicKey.owner` (the actor URL), and the
+     `keyId` in the `Signature:` header are all constructed by the gateway. Keycast supplies
+     only `publicKeyPem`.
+   - For each outbound request the gateway builds the draft-cavage signing string —
+     `(request-target) host date digest` for POST (`digest` = `SHA-256=base64(sha256(body))`),
+     `(request-target) host date` for GET — and passes that exact multi-line string as
+     `signing_string`. Keycast signs its UTF-8 bytes and returns base64. The gateway pastes
+     the result into `signature="…"`. This is why the "sign the blob" shape (not
+     "build the header") is correct: the gateway already knows the method/target/host/date
+     from the request it is about to make.
+
+5. **Auth: the gateway will use the service token.** The gateway is trusted backend infra
+   signing on behalf of every Divine actor (its runtime is leaning toward a CF Worker, which
+   holds `KEYCAST_SERVICE_TOKEN` as a secret and acts for all actors) — so in practice it
+   uses the service-token path with an explicit `pubkey` in each request body. The UCAN path
+   we also build is for any future user-facing caller; the gateway itself will not use it.
+
+6. **Tenant is resolved from the `Host` header — the gateway must address the right host.**
+   `TenantExtractor` derives the tenant from `Host`/`x-forwarded-host` (`tenant.rs:87`),
+   and this applies even to service-token routes. The gateway must therefore call Keycast at
+   the tenant-appropriate host (e.g. `https://login.divine.video/api/ap/...`) so it lands on
+   the `divine.video` tenant; the service token authenticates *who* is calling, the host
+   selects *which tenant's* keyspace. (Calling a wrong/missing host would resolve the wrong
+   tenant and 404 on the actor's key — a likely first-integration footgun, called out here.)
+
+7. **Scope: Divine-origin (outbound) actors only.** The gateway's `RESEARCH.md` (§inbound)
+   notes a *second*, deferred custodial concern: minting **surrogate Nostr identities** for
+   remote AP actors (`@alice@mastodon.social`) so inbound Follow/Like/Comment can map into
+   Nostr. That is unrelated to this work — remote actors keep their own RSA keys on their
+   home servers; Keycast never signs for them. Keycast RSA custody here is exclusively for
+   **Divine-origin actors signing their own outbound requests**. If a future surrogate
+   identity is itself given a Divine Nostr pubkey, it would slot into the same
+   `(tenant_id, user_pubkey)` model for free, but no design accommodation is made for it now.
+
 ## Rollout
 
 - Pure additive: new table, new modules, new routes, one new dependency. No change to

--- a/tests/qa/ap_interop_verify.sh
+++ b/tests/qa/ap_interop_verify.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Independently verify a Keycast-produced RSA-SHA256 signature with openssl.
+# Catches SPKI-vs-PKCS1 PEM and PKCS1v15-vs-PSS algorithm mistakes that a
+# same-library round-trip cannot.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."   # repo root
+
+cargo test -p keycast_core -- emit_interop_vector --include-ignored
+
+# Locate the emitted vector (cargo may place it under workspace or crate target).
+DIR=$(dirname "$(find . -path '*ap_interop/pub.pem' -print -quit)")
+if [ -z "$DIR" ]; then echo "FAIL: interop vector not found"; exit 1; fi
+echo "Using vector dir: $DIR"
+
+openssl dgst -sha256 -verify "$DIR/pub.pem" -signature "$DIR/sig.bin" "$DIR/msg.bin"
+# Expected output: "Verified OK"


### PR DESCRIPTION
## Summary

Adds per-user **RSA-2048 key custody** and an **RSA-SHA256 HTTP-Signature signing oracle** to Keycast for ActivityPub HTTP Signatures, alongside the existing Nostr/secp256k1/Schnorr path.

Per AP actor, Keycast now:
1. Generates or returns an RSA-2048 keypair (`POST /api/ap/keys`, idempotent).
2. Stores the private key encrypted-at-rest through the existing `KeyManager`.
3. Exposes the public SPKI PEM for ActivityPub actor documents (`GET /api/ap/keys/{actor_or_pubkey}`).
4. Signs caller-supplied draft-cavage signing strings with RSASSA-PKCS1-v1_5 + SHA-256 (`POST /api/ap/sign`).

Takeover update: AP RSA key material is now wired into account lifecycle, current gateway actor-shaped requests are supported, and AP UCAN signing requires a live OAuth authorization.

Design spec and implementation plan: `docs/superpowers/specs/2026-05-30-ap-rsa-http-signature-signing-design.md`, `docs/superpowers/plans/2026-05-30-ap-rsa-http-signature-signing.md`.

## Changes

- Adds the AP RSA crypto core, tenant-scoped `ap_actor_keys` repository, HTTP routes, and OpenAPI docs.
- Adds a new hardening migration that removes existing orphan AP key rows, drops the redundant AP key lookup index, and adds cascade FK custody from AP keys to users.
- Deletes AP key material during account deletion and preserves the published AP PEM across Nostr key rotation.
- Makes the AP active-account gate fail closed for missing users and applies it consistently to create, get, and sign.
- Accepts either hex Nostr `pubkey` or ActivityPub `actor` URL, including the current gateway `{ actor, signing_string }` request shape.
- Lazily mints AP keys on public-key lookup/sign so the gateway does not need a separate preflight create call.
- Requires UCAN callers to have a live OAuth authorization bunker and rejects revoked/expired authorizations.
- Checks stored AP `key_type` before decrypting/signing.
- Carries account restrictions (`status`, `suspended_reason`, `suspended_at`, `verified_minor`, `verified_minor_at`) onto the replacement identity in `change_key_transaction`, so a suspended or banned actor cannot regain Nostr or ActivityPub signing by rotating its Nostr key.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo test -p keycast_core ap_signing`
- [x] `DATABASE_URL=postgres://divine:divine_dev@localhost/keycast_test_pr247_core REDIS_URL=redis://localhost:16379 TEST_REDIS_URL=redis://localhost:16379 cargo test -p keycast_core --features integration-tests --lib`
- [x] `DATABASE_URL=postgres://postgres:password@localhost/keycast_test_pr247_fk cargo test -p keycast_api --test ap_signing_integration_test --features integration-tests`
- [x] `DATABASE_URL=postgres://postgres:password@localhost/keycast_test_pr247 cargo test --workspace --verbose`
- [x] Rotation-restriction fix (rebased on `origin/main` `85d4736`, DB `keycast_test_pr247_rot`): `cargo test -p keycast_api --features integration-tests --lib --tests`, `cargo test -p keycast_core --features integration-tests --lib`, `cargo test --workspace`, plus fmt/clippy. New coverage: `key_rotation_preserves_suspension_for_ap_actor` and `test_change_key_transaction_preserves_account_restrictions` (both verified to fail on the pre-fix code).

Note: the default local `keycast_test` database had a stale migration version, so the DB-backed runs above used fresh throwaway local databases.

## Visuals

No visual changes.

## Notes / Follow-ups

- Service-token auth remains a tenant-wide gateway credential; AP actor/pubkey requests now must resolve to an existing user in the request tenant.
- `rsa` 0.9 carries RUSTSEC-2023-0071 for decryption timing, but this feature only performs signing.

## Related Issue

Closes #273

