### PR TITLE
feat(rpc): nip17_unwrap_batch — server-side NIP-59 gift-wrap unwrap (server verb for #254)

### DIFF
--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -1050,4 +1050,62 @@ mod tests {
         let result = enforce_cached_dpop_binding(&handler, &headers, htu).await;
         assert!(result.is_ok());
     }
+
+    /// Build a kind:1059 gift wrap (from `sender` to `receiver`) carrying a kind:14
+    /// DM rumor with the given text, serialized to its JSON event value.
+    async fn gift_wrap_value(sender: &Keys, receiver: &PublicKey, text: &str) -> JsonValue {
+        let rumor =
+            nostr_sdk::EventBuilder::private_msg_rumor(*receiver, text).build(sender.public_key());
+        let wrap = nostr_sdk::EventBuilder::gift_wrap(
+            sender,
+            receiver,
+            rumor,
+            Vec::<nostr_sdk::Tag>::new(),
+        )
+        .await
+        .expect("gift wrap should build");
+        serde_json::to_value(&wrap).expect("serialize gift wrap")
+    }
+
+    /// `unwrap_gift_wrap_batch` chunks at `UNWRAP_BATCH_CONCURRENCY` (16). The
+    /// integration ordering test uses 4 items, so the multi-chunk path never runs.
+    /// This drives 40 items (> 2 chunks) through the function directly and asserts
+    /// every slot's content + authenticated sender stays index-aligned with the
+    /// request across chunk boundaries.
+    #[tokio::test]
+    async fn unwrap_gift_wrap_batch_preserves_order_across_chunks() {
+        let handler = Arc::new(create_test_handler_with_dpop(None));
+        let receiver = handler.public_key();
+
+        // 40 = 2 * UNWRAP_BATCH_CONCURRENCY + 8 -> spans three chunks (16, 16, 8).
+        const N: usize = 40;
+        assert!(N > UNWRAP_BATCH_CONCURRENCY, "must exceed one chunk");
+        let mut senders = Vec::with_capacity(N);
+        let mut items = Vec::with_capacity(N);
+        for i in 0..N {
+            let sender = Keys::generate();
+            items.push(gift_wrap_value(&sender, &receiver, &format!("ordered message {i}")).await);
+            senders.push(sender);
+        }
+
+        let results = unwrap_gift_wrap_batch(&handler, &items).await;
+        assert_eq!(results.len(), N, "one ordered slot per input");
+
+        for (i, slot) in results.iter().enumerate() {
+            assert!(
+                slot.get("error").is_none(),
+                "slot {i} should succeed, got {slot:?}"
+            );
+            assert_eq!(
+                slot["rumor"]["content"].as_str().unwrap(),
+                format!("ordered message {i}"),
+                "content out of order at slot {i}"
+            );
+            assert_eq!(
+                slot["sender"].as_str().unwrap(),
+                senders[i].public_key().to_hex(),
+                "authenticated sender out of order at slot {i}"
+            );
+        }
+    }
 }

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -1079,7 +1079,6 @@ mod tests {
 
         // 40 = 2 * UNWRAP_BATCH_CONCURRENCY + 8 -> spans three chunks (16, 16, 8).
         const N: usize = 40;
-        assert!(N > UNWRAP_BATCH_CONCURRENCY, "must exceed one chunk");
         let mut senders = Vec::with_capacity(N);
         let mut items = Vec::with_capacity(N);
         for i in 0..N {

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -777,7 +777,10 @@ fn unwrap_error_slot(code: &str) -> JsonValue {
 /// never fails the batch. Items run with bounded concurrency
 /// (`UNWRAP_BATCH_CONCURRENCY`); `chunks` + ordered await preserves request
 /// order (NIP-17 history is positional).
-async fn unwrap_gift_wrap_batch(handler: &Arc<HttpRpcHandler>, items: &[JsonValue]) -> Vec<JsonValue> {
+async fn unwrap_gift_wrap_batch(
+    handler: &Arc<HttpRpcHandler>,
+    items: &[JsonValue],
+) -> Vec<JsonValue> {
     let mut results: Vec<JsonValue> = Vec::with_capacity(items.len());
 
     for chunk in items.chunks(UNWRAP_BATCH_CONCURRENCY) {
@@ -804,7 +807,11 @@ async fn unwrap_gift_wrap_batch(handler: &Arc<HttpRpcHandler>, items: &[JsonValu
         }
         // Await in spawn order to keep the response index-aligned with the request.
         for handle in handles {
-            results.push(handle.await.unwrap_or_else(|_| unwrap_error_slot("internal")));
+            results.push(
+                handle
+                    .await
+                    .unwrap_or_else(|_| unwrap_error_slot("internal")),
+            );
         }
     }
 

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -30,10 +30,6 @@ use super::routes::AuthState;
 /// limit (gift wraps are ~1-2 KB each). Mirrors the `batch_lookup_users` cap.
 const MAX_UNWRAP_BATCH: usize = 100;
 
-/// Bounded fan-out width for unwrapping a batch. Caps in-flight blocking-pool
-/// tasks so one large batch can't starve the runtime.
-const UNWRAP_BATCH_CONCURRENCY: usize = 16;
-
 /// RPC request format (mirrors NIP-46)
 #[derive(Debug, Deserialize)]
 pub struct NostrRpcRequest {
@@ -774,47 +770,55 @@ fn unwrap_error_slot(code: &str) -> JsonValue {
 ///
 /// Each slot is `{"rumor": <kind14 unsigned event>, "sender": "<hex>"}` on
 /// success or `{"error": "<code>"}` on a per-item failure — one bad gift wrap
-/// never fails the batch. Items run with bounded concurrency
-/// (`UNWRAP_BATCH_CONCURRENCY`); `chunks` + ordered await preserves request
-/// order (NIP-17 history is positional).
+/// never fails the batch.
+///
+/// Every item is fanned out into a [`tokio::task::JoinSet`] so the per-item tasks
+/// are tied to THIS request's future: if the client disconnects, dropping the set
+/// aborts the still-pending tasks instead of leaving them to decrypt in the
+/// background. Abort cannot preempt a per-item `spawn_blocking` closure that has
+/// already started — that work is instead bounded, and its blocking-pool slot
+/// accounted for, by the global `UNWRAP_CRYPTO_PERMITS` semaphore held inside
+/// `HttpRpcHandler::nip17_unwrap`. That same semaphore is the single shared cap on
+/// concurrent unwrap crypto, so spawning every item at once only parks cheap async
+/// tasks on it and never floods the blocking pool. Results are reassembled by
+/// index, so the response stays positionally aligned with the request (NIP-17
+/// history is ordered) regardless of completion order.
 async fn unwrap_gift_wrap_batch(
     handler: &Arc<HttpRpcHandler>,
     items: &[JsonValue],
 ) -> Vec<JsonValue> {
-    let mut results: Vec<JsonValue> = Vec::with_capacity(items.len());
-
-    for chunk in items.chunks(UNWRAP_BATCH_CONCURRENCY) {
-        let mut handles = Vec::with_capacity(chunk.len());
-        for item in chunk {
-            let handler = handler.clone();
-            let item = item.clone();
-            handles.push(tokio::spawn(async move {
-                let event: Event = match serde_json::from_value(item) {
-                    Ok(e) => e,
-                    Err(_) => return unwrap_error_slot("invalid_event"),
-                };
-                match handler.nip17_unwrap(event).await {
-                    Ok(unwrapped) => match serde_json::to_value(&unwrapped.rumor) {
-                        Ok(rumor) => serde_json::json!({
-                            "rumor": rumor,
-                            "sender": unwrapped.sender.to_hex(),
-                        }),
-                        Err(_) => unwrap_error_slot("internal"),
-                    },
-                    Err(e) => unwrap_error_slot(e.code()),
-                }
-            }));
-        }
-        // Await in spawn order to keep the response index-aligned with the request.
-        for handle in handles {
-            results.push(
-                handle
-                    .await
-                    .unwrap_or_else(|_| unwrap_error_slot("internal")),
-            );
-        }
+    let mut set: tokio::task::JoinSet<(usize, JsonValue)> = tokio::task::JoinSet::new();
+    for (idx, item) in items.iter().enumerate() {
+        let handler = handler.clone();
+        let item = item.clone();
+        set.spawn(async move {
+            let event: Event = match serde_json::from_value(item) {
+                Ok(e) => e,
+                Err(_) => return (idx, unwrap_error_slot("invalid_event")),
+            };
+            let slot = match handler.nip17_unwrap(event).await {
+                Ok(unwrapped) => match serde_json::to_value(&unwrapped.rumor) {
+                    Ok(rumor) => serde_json::json!({
+                        "rumor": rumor,
+                        "sender": unwrapped.sender.to_hex(),
+                    }),
+                    Err(_) => unwrap_error_slot("internal"),
+                },
+                Err(e) => unwrap_error_slot(e.code()),
+            };
+            (idx, slot)
+        });
     }
 
+    // Pre-fill with internal-error slots so a task that fails to report a result
+    // (e.g. a JoinError from a panicked task) still yields a valid, index-aligned
+    // slot rather than a hole in the ordered response.
+    let mut results = vec![unwrap_error_slot("internal"); items.len()];
+    while let Some(joined) = set.join_next().await {
+        if let Ok((idx, slot)) = joined {
+            results[idx] = slot;
+        }
+    }
     results
 }
 
@@ -1067,18 +1071,20 @@ mod tests {
         serde_json::to_value(&wrap).expect("serialize gift wrap")
     }
 
-    /// `unwrap_gift_wrap_batch` chunks at `UNWRAP_BATCH_CONCURRENCY` (16). The
-    /// integration ordering test uses 4 items, so the multi-chunk path never runs.
-    /// This drives 40 items (> 2 chunks) through the function directly and asserts
-    /// every slot's content + authenticated sender stays index-aligned with the
-    /// request across chunk boundaries.
+    /// `unwrap_gift_wrap_batch` fans every item out concurrently and reassembles
+    /// results by index. The integration ordering test uses only 4 items, so this
+    /// drives a full `MAX_UNWRAP_BATCH` page through the function directly and
+    /// asserts every slot's content + authenticated sender stays index-aligned
+    /// with the request regardless of completion order.
     #[tokio::test]
-    async fn unwrap_gift_wrap_batch_preserves_order_across_chunks() {
+    async fn unwrap_gift_wrap_batch_preserves_order() {
         let handler = Arc::new(create_test_handler_with_dpop(None));
         let receiver = handler.public_key();
 
-        // 40 = 2 * UNWRAP_BATCH_CONCURRENCY + 8 -> spans three chunks (16, 16, 8).
-        const N: usize = 40;
+        // A full page (100), larger than the global unwrap crypto-permit pool, so
+        // items queue on the semaphore and complete out of order — exercising both
+        // the permit-queueing path and the index-reassembly that re-orders them.
+        const N: usize = MAX_UNWRAP_BATCH;
         let mut senders = Vec::with_capacity(N);
         let mut items = Vec::with_capacity(N);
         for i in 0..N {

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -15,7 +15,7 @@ use keycast_core::repositories::{
 };
 use keycast_core::signing_session::{parse_cache_key, CacheKey, SigningSession};
 use keycast_core::traits::CustomPermission;
-use nostr_sdk::{Keys, PublicKey, UnsignedEvent};
+use nostr_sdk::{Event, Keys, PublicKey, UnsignedEvent};
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -24,6 +24,15 @@ use std::sync::Arc;
 
 use super::auth::AuthError;
 use super::routes::AuthState;
+
+/// Maximum gift wraps accepted in a single `nip17_unwrap_batch` request.
+/// Bounds per-request work and keeps the body well under axum's 2 MB default
+/// limit (gift wraps are ~1-2 KB each). Mirrors the `batch_lookup_users` cap.
+const MAX_UNWRAP_BATCH: usize = 100;
+
+/// Bounded fan-out width for unwrapping a batch. Caps in-flight blocking-pool
+/// tasks so one large batch can't starve the runtime.
+const UNWRAP_BATCH_CONCURRENCY: usize = 16;
 
 /// RPC request format (mirrors NIP-46)
 #[derive(Debug, Deserialize)]
@@ -118,6 +127,9 @@ impl From<HandlerError> for RpcError {
 /// - nip04_decrypt: Decrypts ciphertext using NIP-04
 /// - nip44_encrypt: Encrypts plaintext using NIP-44
 /// - nip44_decrypt: Decrypts ciphertext using NIP-44
+/// - nip17_unwrap_batch: Unwraps a batch of NIP-59 gift wraps (1059→seal→rumor),
+///   returning ordered per-item `{rumor, sender}` / `{error}` slots. Amortizes the
+///   per-request auth/status overhead and collapses the client's 2 RPCs-per-DM.
 ///
 /// Uses BLAKE3 token cache - on cache hit, skips UCAN verification entirely.
 /// All operations use cached handler with in-memory permission validation (no DB hits).
@@ -207,6 +219,36 @@ pub async fn nostr_rpc(
 
             // Expose secret only at serialization boundary
             JsonValue::String(plaintext.expose_secret().to_string())
+        }
+
+        "nip17_unwrap_batch" => {
+            // Size cap keeps the request under axum's 2 MB default body limit and
+            // bounds per-request work (mirrors the batch_lookup_users cap precedent).
+            if req.params.is_empty() {
+                return Err(RpcError::InvalidParams("Empty gift wrap batch".into()));
+            }
+            if req.params.len() > MAX_UNWRAP_BATCH {
+                return Err(RpcError::InvalidParams(format!(
+                    "Maximum {} gift wraps per batch",
+                    MAX_UNWRAP_BATCH
+                )));
+            }
+
+            // Whole-batch validity gate: an expired/revoked authorization can
+            // decrypt nothing, so fail the batch rather than emitting N error
+            // slots (matches the single-method behavior).
+            if !handler.is_valid() {
+                return Err(RpcError::Auth(AuthError::InvalidToken));
+            }
+
+            // Server does BOTH gift-wrap decrypt layers internally, so the client
+            // makes one call per page instead of 2 sequential RPCs per message.
+            let results = unwrap_gift_wrap_batch(&handler, &req.params).await;
+
+            // One coalesced activity log for the whole batch (per-request semantics).
+            spawn_log_activity(pool.clone(), handler.is_oauth(), handler.authorization_id());
+
+            JsonValue::Array(results)
         }
 
         "nip04_encrypt" => {
@@ -721,6 +763,52 @@ fn parse_decrypt_params(params: &[JsonValue]) -> Result<(PublicKey, String), Rpc
         .map_err(|e| RpcError::InvalidParams(format!("Invalid pubkey: {}", e)))?;
 
     Ok((pubkey, ciphertext.to_string()))
+}
+
+/// Build the per-item error slot for the unwrap batch response.
+fn unwrap_error_slot(code: &str) -> JsonValue {
+    serde_json::json!({ "error": code })
+}
+
+/// Unwrap a batch of NIP-59 gift wraps into ordered, index-aligned result slots.
+///
+/// Each slot is `{"rumor": <kind14 unsigned event>, "sender": "<hex>"}` on
+/// success or `{"error": "<code>"}` on a per-item failure — one bad gift wrap
+/// never fails the batch. Items run with bounded concurrency
+/// (`UNWRAP_BATCH_CONCURRENCY`); `chunks` + ordered await preserves request
+/// order (NIP-17 history is positional).
+async fn unwrap_gift_wrap_batch(handler: &Arc<HttpRpcHandler>, items: &[JsonValue]) -> Vec<JsonValue> {
+    let mut results: Vec<JsonValue> = Vec::with_capacity(items.len());
+
+    for chunk in items.chunks(UNWRAP_BATCH_CONCURRENCY) {
+        let mut handles = Vec::with_capacity(chunk.len());
+        for item in chunk {
+            let handler = handler.clone();
+            let item = item.clone();
+            handles.push(tokio::spawn(async move {
+                let event: Event = match serde_json::from_value(item) {
+                    Ok(e) => e,
+                    Err(_) => return unwrap_error_slot("invalid_event"),
+                };
+                match handler.nip17_unwrap(event).await {
+                    Ok(unwrapped) => match serde_json::to_value(&unwrapped.rumor) {
+                        Ok(rumor) => serde_json::json!({
+                            "rumor": rumor,
+                            "sender": unwrapped.sender.to_hex(),
+                        }),
+                        Err(_) => unwrap_error_slot("internal"),
+                    },
+                    Err(e) => unwrap_error_slot(e.code()),
+                }
+            }));
+        }
+        // Await in spawn order to keep the response index-aligned with the request.
+        for handle in handles {
+            results.push(handle.await.unwrap_or_else(|_| unwrap_error_slot("internal")));
+        }
+    }
+
+    results
 }
 
 /// Spawn activity logging in background (non-blocking)

--- a/api/src/handlers/http_rpc_handler.rs
+++ b/api/src/handlers/http_rpc_handler.rs
@@ -367,27 +367,28 @@ impl HttpRpcHandler {
         }
 
         let keys = self.signing.keys().clone();
-        let unwrapped = tokio::task::spawn_blocking(move || -> Result<UnwrappedGift, UnwrapError> {
-            // Defense-in-depth: verify the outer wrap's own id+signature (parity
-            // with the client's getRumorEvent). from_gift_wrap does not do this.
-            gift_wrap
-                .verify()
-                .map_err(|_| UnwrapError::InvalidWrapSignature)?;
+        let unwrapped =
+            tokio::task::spawn_blocking(move || -> Result<UnwrappedGift, UnwrapError> {
+                // Defense-in-depth: verify the outer wrap's own id+signature (parity
+                // with the client's getRumorEvent). from_gift_wrap does not do this.
+                gift_wrap
+                    .verify()
+                    .map_err(|_| UnwrapError::InvalidWrapSignature)?;
 
-            // from_gift_wrap is async but its crypto is synchronous; drive it to
-            // completion on this blocking thread (same pattern as sign_event).
-            tokio::runtime::Handle::current()
-                .block_on(UnwrappedGift::from_gift_wrap(&keys, &gift_wrap))
-                .map_err(|e| match e {
-                    nip59::Error::NotGiftWrap => UnwrapError::NotGiftWrap,
-                    nip59::Error::SenderMismatch => UnwrapError::SenderMismatch,
-                    // Signer (wrong recipient / decrypt failure) and Event (malformed
-                    // seal/rumor json) both surface as a decrypt failure to the client.
-                    _ => UnwrapError::DecryptFailed,
-                })
-        })
-        .await
-        .map_err(|_| UnwrapError::Internal)??;
+                // from_gift_wrap is async but its crypto is synchronous; drive it to
+                // completion on this blocking thread (same pattern as sign_event).
+                tokio::runtime::Handle::current()
+                    .block_on(UnwrappedGift::from_gift_wrap(&keys, &gift_wrap))
+                    .map_err(|e| match e {
+                        nip59::Error::NotGiftWrap => UnwrapError::NotGiftWrap,
+                        nip59::Error::SenderMismatch => UnwrapError::SenderMismatch,
+                        // Signer (wrong recipient / decrypt failure) and Event (malformed
+                        // seal/rumor json) both surface as a decrypt failure to the client.
+                        _ => UnwrapError::DecryptFailed,
+                    })
+            })
+            .await
+            .map_err(|_| UnwrapError::Internal)??;
 
         // Enforce decrypt policy on the authenticated inner sender. Only
         // `encrypt_to_self` actually denies decrypt today; DM authorizations
@@ -629,13 +630,9 @@ mod tests {
 
     /// Build a kind:1059 gift wrap from `sender` to `receiver` carrying a
     /// kind:14 private DM rumor with the given text.
-    async fn build_gift_wrap(
-        sender: &Keys,
-        receiver: &PublicKey,
-        text: &str,
-    ) -> nostr_sdk::Event {
-        let rumor = nostr_sdk::EventBuilder::private_msg_rumor(*receiver, text)
-            .build(sender.public_key());
+    async fn build_gift_wrap(sender: &Keys, receiver: &PublicKey, text: &str) -> nostr_sdk::Event {
+        let rumor =
+            nostr_sdk::EventBuilder::private_msg_rumor(*receiver, text).build(sender.public_key());
         nostr_sdk::EventBuilder::gift_wrap(sender, receiver, rumor, Vec::<nostr_sdk::Tag>::new())
             .await
             .expect("gift wrap should build")

--- a/api/src/handlers/http_rpc_handler.rs
+++ b/api/src/handlers/http_rpc_handler.rs
@@ -380,6 +380,9 @@ impl HttpRpcHandler {
                 tokio::runtime::Handle::current()
                     .block_on(UnwrappedGift::from_gift_wrap(&keys, &gift_wrap))
                     .map_err(|e| match e {
+                        // Defensive/unreachable: the kind gate above already rejects
+                        // non-gift-wraps before we get here, so from_gift_wrap's own
+                        // kind check never fires. Mapped anyway for exhaustiveness.
                         nip59::Error::NotGiftWrap => UnwrapError::NotGiftWrap,
                         nip59::Error::SenderMismatch => UnwrapError::SenderMismatch,
                         // Signer (wrong recipient / decrypt failure) and Event (malformed
@@ -726,5 +729,68 @@ mod tests {
             .await
             .expect_err("encrypt_to_self should deny a DM from another sender");
         assert_eq!(err.code(), "permission_denied");
+    }
+
+    #[tokio::test]
+    async fn nip17_unwrap_rejects_sender_mismatch() {
+        // Pins the strict sender-mismatch behavior (NIP-59 requires rumor.pubkey ==
+        // seal signer). Built like nostr-sdk's own `test_sender_mismatch`: the rumor
+        // claims an impersonated author while the seal/wrap is signed by `sender`, so
+        // `from_gift_wrap` authenticates `sender` but the inner author disagrees.
+        let handler = create_test_handler(None, None);
+        let receiver = handler.public_key();
+        let sender = Keys::generate(); // signs the seal -> the authenticated sender
+        let impersonated = Keys::generate(); // rumor lies about its author
+
+        let rumor = nostr_sdk::EventBuilder::private_msg_rumor(receiver, "spoofed")
+            .build(impersonated.public_key());
+        let gift_wrap = nostr_sdk::EventBuilder::gift_wrap(
+            &sender,
+            &receiver,
+            rumor,
+            Vec::<nostr_sdk::Tag>::new(),
+        )
+        .await
+        .expect("gift wrap should build");
+
+        let err = handler
+            .nip17_unwrap(gift_wrap)
+            .await
+            .expect_err("rumor author disagreeing with the seal signer must be rejected");
+        assert_eq!(err.code(), "sender_mismatch");
+    }
+
+    #[tokio::test]
+    async fn nip17_unwrap_rejects_invalid_wrap_signature() {
+        // Exercises the OUTER-wrap defense-in-depth check, which `from_gift_wrap`
+        // does NOT perform (it verifies only the seal). We can't sign a broken wrap
+        // with EventBuilder, so we tamper a valid one: deserialization does not
+        // verify id/signature, so mutating `content` while leaving id+sig untouched
+        // yields a kind:1059 event whose recomputed id no longer matches -> verify()
+        // fails before any decrypt runs.
+        let handler = create_test_handler(None, None);
+        let receiver = handler.public_key();
+        let sender = Keys::generate();
+
+        let gift_wrap = build_gift_wrap(&sender, &receiver, "tamper me").await;
+        let mut json = serde_json::to_value(&gift_wrap).expect("serialize gift wrap");
+        let original = json["content"]
+            .as_str()
+            .expect("content string")
+            .to_string();
+        json["content"] = serde_json::Value::String(format!("{original}x"));
+        let tampered: Event =
+            serde_json::from_value(json).expect("deserialize does not verify, so this succeeds");
+        assert_eq!(
+            tampered.kind,
+            Kind::GiftWrap,
+            "tamper must keep kind:1059 so it passes the kind gate"
+        );
+
+        let err = handler
+            .nip17_unwrap(tampered)
+            .await
+            .expect_err("tampered outer wrap must fail the defense-in-depth verify");
+        assert_eq!(err.code(), "invalid_wrap_signature");
     }
 }

--- a/api/src/handlers/http_rpc_handler.rs
+++ b/api/src/handlers/http_rpc_handler.rs
@@ -7,7 +7,8 @@ use keycast_core::signing_session::{CacheKey, SigningSession};
 use keycast_core::traits::CustomPermission;
 use moka::future::Cache;
 use nostr_sdk::nips::nip04;
-use nostr_sdk::{Event, Keys, PublicKey, UnsignedEvent};
+use nostr_sdk::nips::nip59::{self, UnwrappedGift};
+use nostr_sdk::{Event, Keys, Kind, PublicKey, UnsignedEvent};
 use secrecy::SecretString;
 use std::sync::Arc;
 use thiserror::Error;
@@ -22,6 +23,45 @@ pub enum HandlerError {
     Signing(String),
     #[error("encryption error: {0}")]
     Encryption(String),
+}
+
+/// Per-item failure reason for the NIP-17 gift-wrap unwrap batch.
+///
+/// Each variant maps to a stable, machine-readable `code()` returned in the
+/// per-item `{"error": "<code>"}` response slot so one malformed gift wrap
+/// never fails the whole batch.
+#[derive(Debug, Error)]
+pub enum UnwrapError {
+    #[error("authorization expired or revoked")]
+    AuthorizationInvalid,
+    #[error("not a gift wrap event")]
+    NotGiftWrap,
+    #[error("invalid gift wrap signature")]
+    InvalidWrapSignature,
+    #[error("gift wrap decryption failed")]
+    DecryptFailed,
+    #[error("rumor author does not match seal signer")]
+    SenderMismatch,
+    #[error("permission denied")]
+    PermissionDenied,
+    #[error("internal error")]
+    Internal,
+}
+
+impl UnwrapError {
+    /// Stable wire code for the per-item error slot. Keep these strings stable —
+    /// clients branch on them (e.g. to route a slot into a retry queue).
+    pub fn code(&self) -> &'static str {
+        match self {
+            UnwrapError::AuthorizationInvalid => "authorization_invalid",
+            UnwrapError::NotGiftWrap => "not_gift_wrap",
+            UnwrapError::InvalidWrapSignature => "invalid_wrap_signature",
+            UnwrapError::DecryptFailed => "decrypt_failed",
+            UnwrapError::SenderMismatch => "sender_mismatch",
+            UnwrapError::PermissionDenied => "permission_denied",
+            UnwrapError::Internal => "internal",
+        }
+    }
 }
 
 /// HTTP RPC handler - caches authorization state AND permissions for spam protection
@@ -295,6 +335,69 @@ impl HttpRpcHandler {
             .map_err(|e| HandlerError::Encryption(e.to_string()))
     }
 
+    /// Unwrap a single NIP-59 gift wrap (kind 1059) → seal (kind 13) → rumor.
+    ///
+    /// This is the per-item primitive behind the `nip17_unwrap_batch` RPC. It
+    /// reproduces the security guarantees the divine-mobile client enforces in
+    /// `GiftWrapUtil.getRumorEvent`, delegating the protocol unwrap to the
+    /// vetted `nostr_sdk` implementation rather than hand-rolling NIP-59:
+    ///
+    /// 1. validity (expiration/revocation) is checked first (cached, no DB hit);
+    /// 2. the OUTER gift wrap's id+Schnorr signature is verified — defense in
+    ///    depth, since `UnwrappedGift::from_gift_wrap` verifies the *seal* but
+    ///    NOT the outer wrap;
+    /// 3. `UnwrappedGift::from_gift_wrap` decrypts the outer layer, **verifies
+    ///    the seal's signature** (the sole cryptographic anchor of the sender's
+    ///    identity), decrypts the inner layer, and rejects a rumor whose
+    ///    `pubkey` disagrees with the authenticated seal signer (`SenderMismatch`);
+    /// 4. the cached decrypt policy is enforced against the **authenticated**
+    ///    inner sender — `from_gift_wrap` decrypts internally, so without this an
+    ///    `encrypt_to_self`-restricted authorization could read others' DMs.
+    ///
+    /// CPU-bound work (two Schnorr verifies + two NIP-44 decrypts) runs on
+    /// `spawn_blocking`, mirroring `SigningSession::sign_event`.
+    pub async fn nip17_unwrap(&self, gift_wrap: Event) -> Result<UnwrappedGift, UnwrapError> {
+        if !self.is_valid() {
+            return Err(UnwrapError::AuthorizationInvalid);
+        }
+
+        // Cheap kind gate before doing any crypto (from_gift_wrap also checks this).
+        if gift_wrap.kind != Kind::GiftWrap {
+            return Err(UnwrapError::NotGiftWrap);
+        }
+
+        let keys = self.signing.keys().clone();
+        let unwrapped = tokio::task::spawn_blocking(move || -> Result<UnwrappedGift, UnwrapError> {
+            // Defense-in-depth: verify the outer wrap's own id+signature (parity
+            // with the client's getRumorEvent). from_gift_wrap does not do this.
+            gift_wrap
+                .verify()
+                .map_err(|_| UnwrapError::InvalidWrapSignature)?;
+
+            // from_gift_wrap is async but its crypto is synchronous; drive it to
+            // completion on this blocking thread (same pattern as sign_event).
+            tokio::runtime::Handle::current()
+                .block_on(UnwrappedGift::from_gift_wrap(&keys, &gift_wrap))
+                .map_err(|e| match e {
+                    nip59::Error::NotGiftWrap => UnwrapError::NotGiftWrap,
+                    nip59::Error::SenderMismatch => UnwrapError::SenderMismatch,
+                    // Signer (wrong recipient / decrypt failure) and Event (malformed
+                    // seal/rumor json) both surface as a decrypt failure to the client.
+                    _ => UnwrapError::DecryptFailed,
+                })
+        })
+        .await
+        .map_err(|_| UnwrapError::Internal)??;
+
+        // Enforce decrypt policy on the authenticated inner sender. Only
+        // `encrypt_to_self` actually denies decrypt today; DM authorizations
+        // have no policy (full access) and pass through.
+        self.validate_decrypt_permission(&unwrapped.rumor.content, &unwrapped.sender)
+            .map_err(|_| UnwrapError::PermissionDenied)?;
+
+        Ok(unwrapped)
+    }
+
     /// Encrypt plaintext using NIP-04 after checking validity and permissions
     /// (CPU-bound crypto runs on spawn_blocking)
     pub async fn nip04_encrypt(
@@ -520,5 +623,111 @@ mod tests {
         );
 
         assert_eq!(handler.expected_dpop_jkt(), Some("thumbprint-123"));
+    }
+
+    // -- nip17_unwrap (NIP-59 gift-wrap unwrap) ------------------------------
+
+    /// Build a kind:1059 gift wrap from `sender` to `receiver` carrying a
+    /// kind:14 private DM rumor with the given text.
+    async fn build_gift_wrap(
+        sender: &Keys,
+        receiver: &PublicKey,
+        text: &str,
+    ) -> nostr_sdk::Event {
+        let rumor = nostr_sdk::EventBuilder::private_msg_rumor(*receiver, text)
+            .build(sender.public_key());
+        nostr_sdk::EventBuilder::gift_wrap(sender, receiver, rumor, Vec::<nostr_sdk::Tag>::new())
+            .await
+            .expect("gift wrap should build")
+    }
+
+    #[tokio::test]
+    async fn nip17_unwrap_round_trips_gift_wrap() {
+        let handler = create_test_handler(None, None);
+        let receiver = handler.public_key();
+        let sender = Keys::generate();
+
+        let gift_wrap = build_gift_wrap(&sender, &receiver, "hello dm").await;
+
+        let unwrapped = handler
+            .nip17_unwrap(gift_wrap)
+            .await
+            .expect("unwrap should succeed");
+
+        assert_eq!(
+            unwrapped.sender,
+            sender.public_key(),
+            "sender must be the authenticated seal signer"
+        );
+        assert_eq!(unwrapped.rumor.content, "hello dm");
+        assert_eq!(unwrapped.rumor.kind, Kind::PrivateDirectMessage);
+    }
+
+    #[tokio::test]
+    async fn nip17_unwrap_rejects_non_gift_wrap() {
+        let handler = create_test_handler(None, None);
+        let sender = Keys::generate();
+        let event = nostr_sdk::EventBuilder::text_note("not a wrap")
+            .sign_with_keys(&sender)
+            .expect("sign");
+
+        let err = handler
+            .nip17_unwrap(event)
+            .await
+            .expect_err("non-gift-wrap should be rejected");
+        assert_eq!(err.code(), "not_gift_wrap");
+    }
+
+    #[tokio::test]
+    async fn nip17_unwrap_rejects_wrong_recipient() {
+        let handler = create_test_handler(None, None);
+        let other_receiver = Keys::generate();
+        let sender = Keys::generate();
+
+        // Wrap addressed to someone else: this handler's key cannot decrypt it.
+        let gift_wrap = build_gift_wrap(&sender, &other_receiver.public_key(), "secret").await;
+
+        let err = handler
+            .nip17_unwrap(gift_wrap)
+            .await
+            .expect_err("wrong recipient should fail to decrypt");
+        assert_eq!(err.code(), "decrypt_failed");
+    }
+
+    #[tokio::test]
+    async fn nip17_unwrap_denied_when_expired() {
+        let expires = Utc::now() - chrono::Duration::hours(1);
+        let handler = create_test_handler(Some(expires), None);
+        let receiver = handler.public_key();
+        let sender = Keys::generate();
+
+        let gift_wrap = build_gift_wrap(&sender, &receiver, "hi").await;
+
+        let err = handler
+            .nip17_unwrap(gift_wrap)
+            .await
+            .expect_err("expired authorization should be denied");
+        assert_eq!(err.code(), "authorization_invalid");
+    }
+
+    #[tokio::test]
+    async fn nip17_unwrap_denied_by_encrypt_to_self_policy() {
+        // I4: the unwrap path decrypts inside the SDK, so it must still enforce
+        // the decrypt policy on the authenticated inner sender. encrypt_to_self
+        // only permits decrypting messages from oneself, so a DM from another
+        // sender must be denied rather than silently bypassing the policy.
+        use keycast_core::custom_permissions::encrypt_to_self::EncryptToSelf;
+        let handler =
+            create_test_handler_with_permissions(None, None, vec![Box::new(EncryptToSelf {})]);
+        let receiver = handler.public_key();
+        let sender = Keys::generate(); // not the user -> encrypt_to_self denies
+
+        let gift_wrap = build_gift_wrap(&sender, &receiver, "from someone else").await;
+
+        let err = handler
+            .nip17_unwrap(gift_wrap)
+            .await
+            .expect_err("encrypt_to_self should deny a DM from another sender");
+        assert_eq!(err.code(), "permission_denied");
     }
 }

--- a/api/src/handlers/http_rpc_handler.rs
+++ b/api/src/handlers/http_rpc_handler.rs
@@ -9,9 +9,11 @@ use moka::future::Cache;
 use nostr_sdk::nips::nip04;
 use nostr_sdk::nips::nip59::{self, UnwrappedGift};
 use nostr_sdk::{Event, Keys, Kind, PublicKey, UnsignedEvent};
+use once_cell::sync::Lazy;
 use secrecy::SecretString;
 use std::sync::Arc;
 use thiserror::Error;
+use tokio::sync::Semaphore;
 
 #[derive(Debug, Error)]
 pub enum HandlerError {
@@ -63,6 +65,23 @@ impl UnwrapError {
         }
     }
 }
+
+/// Global cap on gift-wrap unwraps running crypto at once, shared across ALL
+/// requests. Each unwrap holds one permit for the full lifetime of its
+/// `spawn_blocking` crypto closure (see [`HttpRpcHandler::nip17_unwrap`]), so this
+/// is a hard ceiling on concurrent unwrap blocking-pool work even when requests
+/// cancel mid-batch — aborting a request cannot preempt a closure that has already
+/// started, and that closure keeps its permit until it returns. Sized well under
+/// tokio's default 512-thread blocking pool (shared with all signing) so a burst
+/// of large unwrap batches cannot crowd signing off the pool, while still letting
+/// a full 100-item page drain in a couple of waves.
+const UNWRAP_CRYPTO_CONCURRENCY: usize = 64;
+
+/// Process-wide permit pool enforcing [`UNWRAP_CRYPTO_CONCURRENCY`]. Held as an
+/// owned permit moved into each unwrap's `spawn_blocking` closure so the limit
+/// tracks crypto that is actually running, not async tasks that may be cancelled.
+static UNWRAP_CRYPTO_PERMITS: Lazy<Arc<Semaphore>> =
+    Lazy::new(|| Arc::new(Semaphore::new(UNWRAP_CRYPTO_CONCURRENCY)));
 
 /// HTTP RPC handler - caches authorization state AND permissions for spam protection
 ///
@@ -355,7 +374,10 @@ impl HttpRpcHandler {
     ///    `encrypt_to_self`-restricted authorization could read others' DMs.
     ///
     /// CPU-bound work (two Schnorr verifies + two NIP-44 decrypts) runs on
-    /// `spawn_blocking`, mirroring `SigningSession::sign_event`.
+    /// `spawn_blocking`, mirroring `SigningSession::sign_event`, under a permit
+    /// from the global [`UNWRAP_CRYPTO_PERMITS`] semaphore that bounds total
+    /// concurrent unwrap crypto so a burst of large batches cannot crowd signing
+    /// off the shared blocking pool.
     pub async fn nip17_unwrap(&self, gift_wrap: Event) -> Result<UnwrappedGift, UnwrapError> {
         if !self.is_valid() {
             return Err(UnwrapError::AuthorizationInvalid);
@@ -367,8 +389,28 @@ impl HttpRpcHandler {
         }
 
         let keys = self.signing.keys().clone();
+
+        // Bound total in-flight unwrap crypto across ALL requests with one shared
+        // semaphore. Acquire an OWNED permit and move it INTO the spawn_blocking
+        // closure so it is released only when the blocking crypto returns — not when
+        // the awaiting async task is dropped. This keeps the cap a TRUE bound under
+        // disconnect/cancel churn: aborting the per-request JoinSet drops the async
+        // task awaiting this handle, but cannot preempt an already-running
+        // spawn_blocking closure, which holds its permit (and its blocking-pool slot)
+        // until it finishes.
+        let permit = Arc::clone(&UNWRAP_CRYPTO_PERMITS)
+            .acquire_owned()
+            .await
+            // Defensive: acquire_owned only errors on a closed semaphore, and this
+            // process-wide static is never closed, so this branch is unreachable.
+            .map_err(|_| UnwrapError::Internal)?;
+
         let unwrapped =
             tokio::task::spawn_blocking(move || -> Result<UnwrappedGift, UnwrapError> {
+                // Hold the global crypto permit for the lifetime of this blocking
+                // closure; it releases on return, i.e. when the crypto truly completes.
+                let _permit = permit;
+
                 // Defense-in-depth: verify the outer wrap's own id+signature (parity
                 // with the client's getRumorEvent). from_gift_wrap does not do this.
                 gift_wrap

--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -1457,8 +1457,13 @@ async fn test_nip17_unwrap_batch_happy_path_and_partial_failure() {
         gift_wrap_param(&sender_b, &other_receiver.public_key(), "not for you").await;
     let garbage = json!({ "not": "an event" });
 
-    let token =
-        build_self_signed_ucan(&user_keys, tenant_id, &redirect_origin, Some(&bunker_pubkey)).await;
+    let token = build_self_signed_ucan(
+        &user_keys,
+        tenant_id,
+        &redirect_origin,
+        Some(&bunker_pubkey),
+    )
+    .await;
     let auth_state = create_test_auth_state(
         pool.clone(),
         Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
@@ -1525,8 +1530,13 @@ async fn test_nip17_unwrap_batch_size_cap_rejected() {
     )
     .await;
 
-    let token =
-        build_self_signed_ucan(&user_keys, tenant_id, &redirect_origin, Some(&bunker_pubkey)).await;
+    let token = build_self_signed_ucan(
+        &user_keys,
+        tenant_id,
+        &redirect_origin,
+        Some(&bunker_pubkey),
+    )
+    .await;
     let auth_state = create_test_auth_state(
         pool.clone(),
         Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
@@ -1585,8 +1595,13 @@ async fn test_suspended_user_denied_nip17_unwrap_batch() {
     let sender = Keys::generate();
     let wrap = gift_wrap_param(&sender, &receiver, "should be gated").await;
 
-    let token =
-        build_self_signed_ucan(&user_keys, tenant_id, &redirect_origin, Some(&bunker_pubkey)).await;
+    let token = build_self_signed_ucan(
+        &user_keys,
+        tenant_id,
+        &redirect_origin,
+        Some(&bunker_pubkey),
+    )
+    .await;
     let auth_state = create_test_auth_state(
         pool.clone(),
         Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),

--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -1398,3 +1398,215 @@ async fn test_suspended_user_allowed_get_public_key() {
         .expect("result should be a string");
     assert_eq!(result_pubkey, pubkey);
 }
+
+// ============================================================================
+// nip17_unwrap_batch (NIP-59 gift-wrap unwrap)
+// ============================================================================
+
+/// Build a kind:1059 gift wrap (from `sender` to `receiver`) carrying a kind:14
+/// DM rumor, serialized to its JSON event value for an RPC param.
+async fn gift_wrap_param(sender: &Keys, receiver: &PublicKey, text: &str) -> Value {
+    let rumor = EventBuilder::private_msg_rumor(*receiver, text).build(sender.public_key());
+    let wrap = EventBuilder::gift_wrap(sender, receiver, rumor, Vec::<Tag>::new())
+        .await
+        .expect("gift wrap should build");
+    serde_json::to_value(&wrap).expect("serialize gift wrap")
+}
+
+/// Happy path + partial failure: a batch with one decryptable wrap, one
+/// non-gift-wrap event, one wrap for a different recipient, and one unparseable
+/// item returns four ordered, index-aligned slots (success / per-item errors).
+#[tokio::test]
+#[serial]
+async fn test_nip17_unwrap_batch_happy_path_and_partial_failure() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (user_keys, pubkey) = create_test_user();
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(&pool, tenant_id, &pubkey, &user_keys, &key_manager).await;
+
+    let redirect_origin = format!("https://unwrap-{}.example.com", Uuid::new_v4());
+    let (_auth_id, bunker_pubkey) = create_test_oauth_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    let receiver = user_keys.public_key();
+    let sender_a = Keys::generate();
+    let sender_b = Keys::generate();
+    let other_receiver = Keys::generate();
+
+    // 0: valid wrap to the user; 1: non-gift-wrap (kind 1); 2: wrap addressed to
+    // someone else (undecryptable); 3: not an event at all.
+    let valid = gift_wrap_param(&sender_a, &receiver, "hello from A").await;
+    let non_wrap = serde_json::to_value(
+        EventBuilder::text_note("plain note")
+            .sign_with_keys(&sender_b)
+            .expect("sign"),
+    )
+    .expect("serialize note");
+    let wrong_recipient =
+        gift_wrap_param(&sender_b, &other_receiver.public_key(), "not for you").await;
+    let garbage = json!({ "not": "an event" });
+
+    let token =
+        build_self_signed_ucan(&user_keys, tenant_id, &redirect_origin, Some(&bunker_pubkey)).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+
+    let response = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state,
+        &format!("Bearer {}", token),
+        None,
+        NostrRpcRequest {
+            method: "nip17_unwrap_batch".to_string(),
+            params: vec![valid, non_wrap, wrong_recipient, garbage],
+        },
+    )
+    .await
+    .expect("batch unwrap should return success");
+
+    let results = response
+        .result
+        .as_ref()
+        .and_then(|v| v.as_array())
+        .expect("result should be an array");
+    assert_eq!(results.len(), 4, "one ordered slot per input");
+
+    // 0: success — rumor content + authenticated sender (the seal signer).
+    assert!(results[0].get("error").is_none());
+    assert_eq!(
+        results[0]["sender"].as_str().unwrap(),
+        sender_a.public_key().to_hex()
+    );
+    assert_eq!(
+        results[0]["rumor"]["content"].as_str().unwrap(),
+        "hello from A"
+    );
+
+    // 1-3: per-item errors, in order.
+    assert_eq!(results[1]["error"].as_str().unwrap(), "not_gift_wrap");
+    assert_eq!(results[2]["error"].as_str().unwrap(), "decrypt_failed");
+    assert_eq!(results[3]["error"].as_str().unwrap(), "invalid_event");
+}
+
+/// A batch over the `MAX_UNWRAP_BATCH` cap is rejected before any per-item work.
+#[tokio::test]
+#[serial]
+async fn test_nip17_unwrap_batch_size_cap_rejected() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (user_keys, pubkey) = create_test_user();
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(&pool, tenant_id, &pubkey, &user_keys, &key_manager).await;
+
+    let redirect_origin = format!("https://unwrap-cap-{}.example.com", Uuid::new_v4());
+    let (_auth_id, bunker_pubkey) = create_test_oauth_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    let token =
+        build_self_signed_ucan(&user_keys, tenant_id, &redirect_origin, Some(&bunker_pubkey)).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+
+    // 101 trivial params: the cap check fires before any unwrap work.
+    let params: Vec<Value> = (0..101).map(|_| json!({})).collect();
+
+    let err = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state,
+        &format!("Bearer {}", token),
+        None,
+        NostrRpcRequest {
+            method: "nip17_unwrap_batch".to_string(),
+            params,
+        },
+    )
+    .await
+    .expect_err("over-cap batch should be rejected");
+
+    match err {
+        RpcError::InvalidParams(msg) => assert!(msg.contains("Maximum")),
+        other => panic!("expected InvalidParams, got: {:?}", other),
+    }
+}
+
+/// A suspended user is gated out of the unwrap batch by the per-request status
+/// check (same gate as the single mutating methods).
+#[tokio::test]
+#[serial]
+async fn test_suspended_user_denied_nip17_unwrap_batch() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (user_keys, pubkey) = create_test_user();
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(&pool, tenant_id, &pubkey, &user_keys, &key_manager).await;
+
+    let redirect_origin = format!("https://unwrap-suspend-{}.example.com", Uuid::new_v4());
+    let (_auth_id, bunker_pubkey) = create_test_oauth_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    suspend_user(&pool, &pubkey, tenant_id).await;
+
+    let receiver = user_keys.public_key();
+    let sender = Keys::generate();
+    let wrap = gift_wrap_param(&sender, &receiver, "should be gated").await;
+
+    let token =
+        build_self_signed_ucan(&user_keys, tenant_id, &redirect_origin, Some(&bunker_pubkey)).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+
+    let err = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state,
+        &format!("Bearer {}", token),
+        None,
+        NostrRpcRequest {
+            method: "nip17_unwrap_batch".to_string(),
+            params: vec![wrap],
+        },
+    )
+    .await
+    .expect_err("suspended user should be denied unwrap batch");
+
+    match err {
+        RpcError::AccountSuspended(msg) => assert_eq!(msg, "Account restricted"),
+        other => panic!("expected AccountSuspended, got: {:?}", other),
+    }
+}


### PR DESCRIPTION
## Description

Adds a server-side gift-wrap unwrap verb, `nip17_unwrap_batch`, to `POST /api/nostr`.
It accepts an ordered list of kind:1059 gift wraps and returns ordered, index-aligned
per-item slots — `{rumor, sender}` on success or `{error}` on a per-item failure.

This is the keycast-side implementation of #254 (Approach B). NIP-17 DM history drain
currently costs **two sequential `nip44_decrypt` RPCs per message** (gift wrap → seal,
seal → rumor). By unwrapping both layers server-side, this collapses the drain to **one
call per page** and the per-request uncacheable user-status `SELECT` from **N → 1**. It
compounds the client-side parallelism already shipped in `divinevideo/divine-mobile#5426`.

### How it works

`HttpRpcHandler::nip17_unwrap`:
- delegates the unwrap to nostr-sdk's vetted `nip59::UnwrappedGift::from_gift_wrap`, which
  decrypts both layers, **verifies the seal's signature** (the sole cryptographic anchor of
  sender identity), and rejects a rumor whose author disagrees with the seal signer;
- additionally verifies the **outer** wrap's id + signature, for parity with the mobile
  client's defense-in-depth check (`from_gift_wrap` verifies only the seal);
- runs the crypto on `spawn_blocking` (same pattern as `sign_event`);
- enforces the cached decrypt policy on the **authenticated inner sender** — `from_gift_wrap`
  decrypts internally, so without this an `encrypt_to_self`-restricted authorization could read
  others' DMs.

The dispatch path bounds batch size (`MAX_UNWRAP_BATCH = 100`, well under axum's 2 MB default
body limit), bounds fan-out concurrency (`UNWRAP_BATCH_CONCURRENCY = 16`, pure-tokio — no new
dependency), preserves request order, returns per-item error slots so one malformed wrap never
fails the batch, gates suspended users via the existing per-request status check, and coalesces
the activity log to one write per request. The token's auth / DPoP enforcement happens once per
request, as for the single methods.

### Wire shape

```jsonc
// request
{ "method": "nip17_unwrap_batch",
  "params": [ <giftwrap_1059_event>, <giftwrap_1059_event>, ... ] }

// response (ordered, index-aligned with params)
{ "result": [
    { "rumor": { /* kind:14 unsigned event */ }, "sender": "<hex authenticated author>" },
    { "error": "sender_mismatch" }
] }
```

Per-item error codes: `invalid_event`, `not_gift_wrap`, `invalid_wrap_signature`,
`decrypt_failed`, `sender_mismatch`, `permission_denied`, `internal`.

## Behavioral note (reviewers please weigh in)

Sender-mismatch is handled **strictly**: when `rumor.pubkey != seal.pubkey`, the item returns a
`sender_mismatch` error slot. The current mobile client (`GiftWrapUtil.getRumorEvent`) is
**lenient** — it re-attributes the message to the authenticated seal pubkey and keeps it. For
remote-signer accounts on a new server, the rare mismatched-pubkey messages would therefore
become error slots (falling into the client's existing retry path) rather than being shown.
Strict is arguably more correct (NIP-59 requires the match), but this is a deliberate, reversible
choice — happy to add a metric and/or restore the lenient behavior if preferred.

## Verification

- New handler unit tests (run under default `cargo test`): round-trip, non-gift-wrap rejected,
  wrong-recipient rejected, expired-auth denied, and `encrypt_to_self` policy denies a DM from
  another sender.
- New integration tests (`--features integration-tests`, via `invoke_nostr_rpc` against a local
  Postgres): happy path + partial-failure ordering with authenticated sender, size-cap rejection,
  and suspended-user gate.
- Full `keycast_api` lib suite: 137 passed, 0 failed.

## Out of scope (follow-ups)

- **Client adoption** (`divine-mobile`): swap the remote-signer DM drain
  (`_parallelDecryptGiftWraps`, two RPCs/message) for chunked `nip17_unwrap_batch` calls with a
  method-not-found fallback. Tracked in a divine-mobile issue.
- **Benchmark**: extend the #255 harness to the unwrap verb to measure the end-to-end win.

## Related

Refs #254. Compounds `divinevideo/divine-mobile#5426`.