### PR TITLE
ci: unbreak main by dropping decommissioned test push and fixing e2e.yaml syntax

### DIFF
--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -140,17 +140,10 @@ jobs:
           repository: containers-poc
           region: ${{ env.GCP_REGION }}
 
-      - name: Push to Test
-        uses: divinevideo/divine-github-actions/docker-push-gcp@v1
-        with:
-          image-name: keycast:local
-          registry-image: keycast
-          tags: ${{ steps.tags.outputs.tags }}
-          wif-provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER_TEST }}
-          service-account: ${{ vars.SERVICE_ACCOUNT_TEST }}
-          project-id: ${{ vars.GCP_PROJECT_ID_TEST }}
-          repository: containers-test
-          region: ${{ env.GCP_REGION }}
+      # Test environment decommissioned (divine-iac-coreconfig #1006, 2026-06-17):
+      # dv-platform-test project is DELETE_REQUESTED and its github-actions-test
+      # WIF provider was removed, so a Push to Test step here is a guaranteed
+      # failure. Re-add only if a test environment is ever reprovisioned.
 
       - name: Push to Staging
         uses: divinevideo/divine-github-actions/docker-push-gcp@v1
@@ -186,7 +179,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Environments:**" >> $GITHUB_STEP_SUMMARY
           echo "- POC: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_POC }}/containers-poc/keycast\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Test: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_TEST }}/containers-test/keycast\`" >> $GITHUB_STEP_SUMMARY
           echo "- Staging: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_STAGING }}/containers-staging/keycast\`" >> $GITHUB_STEP_SUMMARY
           if [[ "${{ github.ref }}" == refs/tags/v* ]] || [[ "${{ inputs.include_production }}" == "true" ]]; then
             echo "- Production: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_PRODUCTION }}/containers-production/keycast\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -97,7 +97,8 @@ jobs:
           ./scripts/generate_key.sh
 
       - name: Run database migrations
-        run: "$KEYCAST_BINARY" --migrate
+        run: |
+          "$KEYCAST_BINARY" --migrate
 
       - name: Install e2e dependencies
         working-directory: e2e
@@ -113,7 +114,8 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Report Playwright cache status
-        run: echo "Playwright cache hit: ${{ steps.playwright-cache.outputs.cache-hit }}"
+        run: |
+          echo "Playwright cache hit: ${{ steps.playwright-cache.outputs.cache-hit }}"
 
       - name: Install Playwright browsers
         working-directory: e2e


### PR DESCRIPTION
## Summary
Fixes two chronic CI failures that hit every push to `main`. Both are CI-config/infra, not test-code issues.

## 1. `Build, Test & Push` → "Push to Test" failed
The `test` environment was decommissioned (`divine-iac-coreconfig` #1006, 2026-06-17). Verified live: `dv-platform-test` is `DELETE_REQUESTED` and its `github-actions-test` WIF **provider** was deleted, so the auth step fails with `invalid_target`. POC/Staging/Production are unaffected.

**Fix:** remove the dead `Push to Test` step and its summary line. Restoring the WIF would be pointless — the project is being deleted.

## 2. `e2e.yaml` failed instantly ("workflow file issue")
The workflow file was **invalid YAML**, so GitHub couldn't parse it → 0-job ghost failure on every push, and the nightly schedule silently stopped firing. Two errors:
- `run: "$KEYCAST_BINARY" --migrate` (#193) — a double-quoted scalar followed by trailing text.
- `run: echo "Playwright cache hit: ${{ ... }}"` (#194) — a plain scalar containing `: `.

**Fix:** convert both to block scalars (`run: |`).

## Test plan
- `actionlint` and `python -c "import yaml; yaml.safe_load(...)"` pass on both files (both failed before this change).
- Real validation: the post-merge `main` run should go green on both workflows, and the nightly `E2E Tests` schedule should dispatch again.

No visual/UI changes.
