### PR TITLE
feat(minor-safety): expose verified_minor on GET /user/account

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -374,6 +374,13 @@ pub struct AccountStatusResponse {
     pub account_status: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suspended_reason: Option<String>,
+    /// True for an approved minor (13-15) account (Keycast `users.verified_minor`).
+    /// Returned independently of `account_status`: an approved minor is `active`, so gating
+    /// this behind the non-active check (like `account_status`) would hide the protected-minor
+    /// state from clients. Always present so a `false` reliably signals "not a protected minor".
+    pub verified_minor: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verified_minor_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -2345,11 +2352,18 @@ pub async fn get_account_status(
 
     let user_repo = UserRepository::new(pool.clone());
     let user = user_repo
-        .get_account_status(&user_pubkey, tenant_id)
+        .get_account_status_with_minor(&user_pubkey, tenant_id)
         .await?;
 
     match user {
-        Some((email, email_verified, status, suspended_reason)) => {
+        Some((
+            email,
+            email_verified,
+            status,
+            suspended_reason,
+            verified_minor,
+            verified_minor_at,
+        )) => {
             let account_status = if status.is_active() {
                 None
             } else {
@@ -2366,6 +2380,10 @@ pub async fn get_account_status(
                 public_key: user_pubkey,
                 account_status,
                 suspended_reason: reason,
+                // Unconditional, unlike account_status: an approved minor is `active`, so the
+                // protected-minor flag must surface even on an otherwise-normal active account.
+                verified_minor,
+                verified_minor_at,
             }))
         }
         None => Err(AuthError::UserNotFound),

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -383,6 +383,39 @@ pub struct AccountStatusResponse {
     pub verified_minor_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+impl AccountStatusResponse {
+    /// Builds the `GET /user/account` response from a user's account row.
+    ///
+    /// `verified_minor` / `verified_minor_at` are surfaced **unconditionally** (an
+    /// approved minor is `active`), whereas `account_status` / `suspended_reason` are
+    /// only populated when the account is *not* active. Extracted so this branching —
+    /// the load-bearing behavior of this endpoint — is unit-testable without a DB.
+    fn from_account_row(
+        public_key: String,
+        email: Option<String>,
+        email_verified: Option<bool>,
+        status: keycast_core::types::user::UserStatus,
+        suspended_reason: Option<String>,
+        verified_minor: bool,
+        verified_minor_at: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Self {
+        let active = status.is_active();
+        AccountStatusResponse {
+            email: email.unwrap_or_default(),
+            email_verified: email_verified.unwrap_or(false),
+            public_key,
+            account_status: if active {
+                None
+            } else {
+                Some(status.as_str().to_string())
+            },
+            suspended_reason: if active { None } else { suspended_reason },
+            verified_minor,
+            verified_minor_at,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ProfileData {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2363,29 +2396,15 @@ pub async fn get_account_status(
             suspended_reason,
             verified_minor,
             verified_minor_at,
-        )) => {
-            let account_status = if status.is_active() {
-                None
-            } else {
-                Some(status.as_str().to_string())
-            };
-            let reason = if status.is_active() {
-                None
-            } else {
-                suspended_reason
-            };
-            Ok(Json(AccountStatusResponse {
-                email: email.unwrap_or_default(),
-                email_verified: email_verified.unwrap_or(false),
-                public_key: user_pubkey,
-                account_status,
-                suspended_reason: reason,
-                // Unconditional, unlike account_status: an approved minor is `active`, so the
-                // protected-minor flag must surface even on an otherwise-normal active account.
-                verified_minor,
-                verified_minor_at,
-            }))
-        }
+        )) => Ok(Json(AccountStatusResponse::from_account_row(
+            user_pubkey,
+            email,
+            email_verified,
+            status,
+            suspended_reason,
+            verified_minor,
+            verified_minor_at,
+        ))),
         None => Err(AuthError::UserNotFound),
     }
 }
@@ -3760,7 +3779,48 @@ pub async fn delete_account(
 #[cfg(test)]
 mod tests {
     use super::validate_origin;
+    use super::AccountStatusResponse;
     use axum::response::IntoResponse;
+
+    #[test]
+    fn account_status_active_minor_surfaces_flag_without_status() {
+        let resp = AccountStatusResponse::from_account_row(
+            "pk".to_string(),
+            Some("a@b.com".to_string()),
+            Some(true),
+            keycast_core::types::user::UserStatus::Active,
+            None,
+            true,
+            Some(chrono::Utc::now()),
+        );
+        // verified_minor surfaces even though the account is active (not gated).
+        assert!(resp.verified_minor);
+        assert!(resp.verified_minor_at.is_some());
+        assert!(resp.account_status.is_none());
+        assert!(resp.suspended_reason.is_none());
+        assert_eq!(resp.email, "a@b.com");
+        assert!(resp.email_verified);
+    }
+
+    #[test]
+    fn account_status_suspended_minor_still_surfaces_flag() {
+        let resp = AccountStatusResponse::from_account_row(
+            "pk".to_string(),
+            None,
+            None,
+            keycast_core::types::user::UserStatus::Suspended,
+            Some("reason".to_string()),
+            true,
+            None,
+        );
+        // Regression guard: verified_minor stays true when suspended, while
+        // account_status / suspended_reason now populate.
+        assert!(resp.verified_minor);
+        assert_eq!(resp.account_status.as_deref(), Some("suspended"));
+        assert_eq!(resp.suspended_reason.as_deref(), Some("reason"));
+        assert_eq!(resp.email, ""); // None -> default
+        assert!(!resp.email_verified);
+    }
 
     #[test]
     fn test_validate_origin_https() {

--- a/api/tests/account_status_minor_test.rs
+++ b/api/tests/account_status_minor_test.rs
@@ -1,0 +1,80 @@
+// ABOUTME: Repository-layer tests for the approved-minor flag on the account-status query
+// ABOUTME: Covers get_account_status_with_minor backing GET /user/account (keycast#263)
+
+#![cfg(feature = "integration-tests")]
+
+mod common;
+
+use keycast_core::repositories::UserRepository;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+
+const TENANT_ID: i64 = 1;
+
+async fn insert_user(pool: &PgPool, verified_minor: bool) -> String {
+    let pubkey = Keys::generate().public_key().to_hex();
+    if verified_minor {
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, verified_minor, verified_minor_at, created_at, updated_at) \
+             VALUES ($1, $2, TRUE, NOW(), NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(TENANT_ID)
+        .execute(pool)
+        .await
+        .expect("insert minor user");
+    } else {
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(TENANT_ID)
+        .execute(pool)
+        .await
+        .expect("insert regular user");
+    }
+    pubkey
+}
+
+#[tokio::test]
+async fn approved_minor_surfaces_flag_while_active() {
+    common::assert_test_database_url();
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let pubkey = insert_user(&pool, true).await;
+
+    let (_email, _email_verified, status, _suspended_reason, verified_minor, verified_minor_at) =
+        repo.get_account_status_with_minor(&pubkey, TENANT_ID)
+            .await
+            .expect("query ok")
+            .expect("user exists");
+
+    // The whole point of keycast#263: an approved minor is `active`, yet the flag must
+    // still come through so clients can detect the protected-minor state.
+    assert!(
+        status.is_active(),
+        "approved minor account should be active"
+    );
+    assert!(verified_minor, "verified_minor should be true");
+    assert!(
+        verified_minor_at.is_some(),
+        "verified_minor_at should be populated"
+    );
+}
+
+#[tokio::test]
+async fn regular_user_reports_not_a_minor() {
+    common::assert_test_database_url();
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let pubkey = insert_user(&pool, false).await;
+
+    let (.., verified_minor, verified_minor_at) = repo
+        .get_account_status_with_minor(&pubkey, TENANT_ID)
+        .await
+        .expect("query ok")
+        .expect("user exists");
+
+    assert!(!verified_minor, "regular user must not read as a minor");
+    assert!(verified_minor_at.is_none());
+}

--- a/api/tests/account_status_minor_test.rs
+++ b/api/tests/account_status_minor_test.rs
@@ -78,3 +78,18 @@ async fn regular_user_reports_not_a_minor() {
     assert!(!verified_minor, "regular user must not read as a minor");
     assert!(verified_minor_at.is_none());
 }
+
+#[tokio::test]
+async fn returns_none_for_unknown_user() {
+    common::assert_test_database_url();
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let unknown = Keys::generate().public_key().to_hex();
+
+    let row = repo
+        .get_account_status_with_minor(&unknown, TENANT_ID)
+        .await
+        .expect("query ok");
+
+    assert!(row.is_none(), "unknown pubkey must yield None");
+}

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -642,6 +642,37 @@ impl UserRepository {
         .map_err(Into::into)
     }
 
+    /// Like `get_account_status`, but also returns the approved-minor flag and timestamp.
+    /// Backs `GET /user/account` so clients can detect the protected-minor (13-15) state
+    /// directly from Keycast. Kept separate from `get_account_status` so the oauth
+    /// login/session paths that share that method are untouched.
+    /// Returns (email, email_verified, status, suspended_reason, verified_minor, verified_minor_at).
+    pub async fn get_account_status_with_minor(
+        &self,
+        pubkey: &str,
+        tenant_id: i64,
+    ) -> Result<
+        Option<(
+            Option<String>,
+            Option<bool>,
+            UserStatus,
+            Option<String>,
+            bool,
+            Option<DateTime<Utc>>,
+        )>,
+        RepositoryError,
+    > {
+        sqlx::query_as(
+            "SELECT email, email_verified, status, suspended_reason, verified_minor, verified_minor_at \
+             FROM users WHERE pubkey = $1 AND tenant_id = $2",
+        )
+        .bind(pubkey)
+        .bind(tenant_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
     /// Get user's account status fields for admin queries.
     /// Returns (status, suspended_reason, suspended_at) or None if user not found.
     pub async fn get_user_status(


### PR DESCRIPTION
## What

Exposes the durable approved-minor (13-15) flag on Keycast's account-status endpoint so clients can detect the **protected-minor** state directly from Keycast. Keystone of the protected-minor safeguards epic (raised by Liz; tracked privately in the T&S repo, divinevideo/support-trust-safety#173).

Closes #263.

## Changes

- `AccountStatusResponse` (`GET /user/account`) gains two fields:
  - `verified_minor: bool` — always present
  - `verified_minor_at` (timestamp) — present only when set, omitted otherwise
- New repo method `get_account_status_with_minor` returns the existing account-status fields **plus** the minor flag in a single query. Kept separate from `get_account_status` so the shared oauth login/session paths are untouched.
- The flag is returned **independently of `account_status`**: an approved minor is `active`, so gating it behind the existing "None when active" logic would hide it.

## Response shape

`GET /user/account` for an approved-minor account:

```json
{
  "email": "user@example.com",
  "email_verified": true,
  "public_key": "<hex>",
  "verified_minor": true,
  "verified_minor_at": "2026-06-30T12:00:00Z"
}
```

A non-minor account returns `"verified_minor": false` and omits `verified_minor_at`. `account_status` / `suspended_reason` continue to appear only for non-active accounts. Field naming matches the admin `UserStatusResponse` for consistency.

## Tests

- Repo-level integration tests (`api/tests/account_status_minor_test.rs`): an approved minor surfaces the flag **while `active`**; a regular user reports `false` with no timestamp.
- Run locally against Postgres 16 (matching CI): **both pass**, and the full `keycast_core` (113) and `keycast_api` (376 across 38 binaries) integration suites are green with this change — no regressions from the added response fields or repo method.
- A handler-level HTTP test is deferred: it requires minting a UCAN user token. The data-exposure core is covered at the repo layer, and the handler change is straightforward wiring.

## Notes

- Additive, read-only change to an existing response. No migration — the `verified_minor` / `verified_minor_at` columns already exist.
- Unblocks the client-side protected-minor work (consume the flag, lock adult content, restrict DMs).
