### PR TITLE
feat(auth): reliable email verification for in-app browsers — idempotent verify-on-load + in-app PIN fallback

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1990,11 +1990,16 @@ pub async fn finalize_pending_registration(
     // terminal guard above already refuses re-mint once a code has been redeemed.
     // `freshly_minted` records whether THIS call created the code (vs reused an existing live one).
     // It gates the delivery-failure cleanup below: a reused code is owned by a prior finalize.
-    let (new_code, freshly_minted) = if let Some(existing) = oauth_code_repo
-        .find_live_exchange_code(tenant_id, &oauth_data.user_pubkey, &oauth_data.client_id)
-        .await?
+    let (new_code, code_expires_at, freshly_minted) = if let Some((existing, expires_at)) =
+        oauth_code_repo
+            .find_live_exchange_code_with_expiry(
+                tenant_id,
+                &oauth_data.user_pubkey,
+                &oauth_data.client_id,
+            )
+            .await?
     {
-        (existing, false)
+        (existing, expires_at, false)
     } else {
         let minted: String = rand::thread_rng()
             .sample_iter(&rand::distributions::Alphanumeric)
@@ -2018,12 +2023,17 @@ pub async fn finalize_pending_registration(
             is_headless: oauth_data.is_headless, // Inherit from original registration
         };
         oauth_code_repo.store(store_params).await?;
-        (minted, true)
+        (minted, code_expires_at, true)
+    };
+    let redis_ttl_seconds = if freshly_minted {
+        600
+    } else {
+        (code_expires_at - Utc::now()).num_seconds().max(1) as u64
     };
 
     if let Some((device_code, redis)) = strict_delivery {
         let key = format!("oauth_poll:{}", device_code);
-        if let Err(e) = redis.setex(&key, 600, &new_code).await {
+        if let Err(e) = redis.setex(&key, redis_ttl_seconds, &new_code).await {
             tracing::error!(
                 event = "headless_poll_delivery_failed",
                 tenant_id = tenant_id,
@@ -2057,7 +2067,7 @@ pub async fn finalize_pending_registration(
         // is also returned synchronously in the response body (so a Redis miss is not fatal).
         if let Some(redis) = redis {
             let key = format!("oauth_poll:{}", device_code);
-            if let Err(e) = redis.setex(&key, 600, &new_code).await {
+            if let Err(e) = redis.setex(&key, redis_ttl_seconds, &new_code).await {
                 tracing::warn!("Failed to store OAuth code in Redis for polling: {}", e);
                 // Continue - redirect flow / synchronous return still works.
             } else {

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -6198,6 +6198,106 @@ mod tests {
         );
     }
 
+    /// Acceptance: the link path and the PIN path produce identical materialization, because both
+    /// funnel through finalize_pending_registration (keycast#262). The only difference is the
+    /// headless Redis-delivery strictness, which does not change the user/keys/code outcome.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_link_and_pin_paths_finalize_identically() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state_with_redis(pool.clone()).await;
+        let redis = auth_state.state.redis.clone();
+        let repo = keycast_core::repositories::OAuthCodeRepository::new(pool.clone());
+
+        let email_a = format!("identical-link-{}@example.com", Uuid::new_v4());
+        let email_b = format!("identical-pin-{}@example.com", Uuid::new_v4());
+        let (pubkey_a, token_a, _dc_a) =
+            insert_headless_pending_registration(&pool, &email_a).await;
+        let (pubkey_b, token_b, _dc_b) =
+            insert_headless_pending_registration(&pool, &email_b).await;
+
+        let data_a = repo
+            .find_by_verification_token(&token_a, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        let data_b = repo
+            .find_by_verification_token(&token_b, 1)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // A finalizes via the link path's delivery mode; B via the PIN path's.
+        let ra = super::finalize_pending_registration(
+            &pool,
+            redis.as_ref(),
+            1,
+            &data_a,
+            super::HeadlessDelivery::RedisRequired,
+        )
+        .await
+        .expect("link-path finalize succeeds");
+        let rb = super::finalize_pending_registration(
+            &pool,
+            redis.as_ref(),
+            1,
+            &data_b,
+            super::HeadlessDelivery::RedisBestEffort,
+        )
+        .await
+        .expect("pin-path finalize succeeds");
+
+        assert_eq!(ra.is_headless, rb.is_headless);
+        assert!(!ra.new_code.is_empty() && !rb.new_code.is_empty());
+
+        // Both paths materialize an identically-shaped result: verified user + 1 personal key +
+        // a fresh headless 10-minute exchange code, with the pending row preserved.
+        for (pubkey, code) in [(&pubkey_a, &ra.new_code), (&pubkey_b, &rb.new_code)] {
+            let (verified,): (bool,) = sqlx::query_as(
+                "SELECT email_verified FROM users WHERE pubkey = $1 AND tenant_id = 1",
+            )
+            .bind(pubkey)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert!(verified, "user must be materialized as verified");
+
+            let (key_count,): (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM personal_keys WHERE user_pubkey = $1 AND tenant_id = 1",
+            )
+            .bind(pubkey)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(key_count, 1, "personal_keys must be created exactly once");
+
+            let minted = repo
+                .find_valid(1, code)
+                .await
+                .unwrap()
+                .expect("a fresh exchange code must be minted");
+            assert!(minted.is_headless);
+        }
+
+        assert!(
+            repo.find_by_verification_token(&token_a, 1)
+                .await
+                .unwrap()
+                .is_some(),
+            "link-path pending row must be preserved"
+        );
+        assert!(
+            repo.find_by_verification_token(&token_b, 1)
+                .await
+                .unwrap()
+                .is_some(),
+            "pin-path pending row must be preserved"
+        );
+
+        cleanup_verify_email_test_data(&pool, &pubkey_a, &token_a).await;
+        cleanup_verify_email_test_data(&pool, &pubkey_b, &token_b).await;
+    }
+
     #[cfg(feature = "integration-tests")]
     async fn insert_pending_oauth_registration(
         pool: &PgPool,

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1811,42 +1811,35 @@ pub async fn finalize_pending_registration(
     // terminal guard above already refuses re-mint once a code has been redeemed.
     // `freshly_minted` records whether THIS call created the code (vs reused an existing live one).
     // It gates the delivery-failure cleanup below: a reused code is owned by a prior finalize.
-    let (new_code, code_expires_at, freshly_minted) = if let Some((existing, expires_at)) =
-        oauth_code_repo
-            .find_live_exchange_code_with_expiry_for_pending(tenant_id, &oauth_data)
-            .await?
-    {
-        (existing, expires_at, false)
-    } else {
-        let minted: String = rand::thread_rng()
-            .sample_iter(&rand::distributions::Alphanumeric)
-            .take(32)
-            .map(char::from)
-            .collect();
-
-        let code_expires_at = Utc::now() + Duration::minutes(10);
-        let store_params = keycast_core::repositories::StoreOAuthCodeParams {
-            tenant_id,
-            code: &minted,
-            user_pubkey: &oauth_data.user_pubkey,
-            client_id: &oauth_data.client_id,
-            redirect_uri: &oauth_data.redirect_uri,
-            scope: &oauth_data.scope,
-            code_challenge: oauth_data.code_challenge.as_deref(),
-            code_challenge_method: oauth_data.code_challenge_method.as_deref(),
-            expires_at: code_expires_at,
-            previous_auth_id: oauth_data.previous_auth_id,
-            state: oauth_data.state.as_deref(),
-            is_headless: oauth_data.is_headless, // Inherit from original registration
-        };
-        if !oauth_code_repo
-            .store_for_pending_registration(store_params, &oauth_data)
-            .await?
-        {
-            return Err(AuthError::RegistrationAlreadyCompleted);
-        }
-        (minted, code_expires_at, true)
-    };
+    let candidate: String = rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(32)
+        .map(char::from)
+        .collect();
+    let candidate_expires_at = Utc::now() + Duration::minutes(10);
+    let stored = oauth_code_repo
+        .get_or_store_exchange_code_for_pending(
+            keycast_core::repositories::StoreOAuthCodeParams {
+                tenant_id,
+                code: &candidate,
+                user_pubkey: &oauth_data.user_pubkey,
+                client_id: &oauth_data.client_id,
+                redirect_uri: &oauth_data.redirect_uri,
+                scope: &oauth_data.scope,
+                code_challenge: oauth_data.code_challenge.as_deref(),
+                code_challenge_method: oauth_data.code_challenge_method.as_deref(),
+                expires_at: candidate_expires_at,
+                previous_auth_id: oauth_data.previous_auth_id,
+                state: oauth_data.state.as_deref(),
+                is_headless: oauth_data.is_headless,
+            },
+            &oauth_data,
+        )
+        .await?
+        .ok_or(AuthError::RegistrationAlreadyCompleted)?;
+    let new_code = stored.code;
+    let code_expires_at = stored.expires_at;
+    let freshly_minted = stored.freshly_minted;
     let redis_ttl_seconds = if freshly_minted {
         600
     } else {
@@ -1864,20 +1857,8 @@ pub async fn finalize_pending_registration(
                 error = %e,
                 "Failed to store headless OAuth code in Redis for polling"
             );
-            // Only clean up a code we freshly minted on this call. A reused code is owned by a prior
-            // finalize that already handled its own Redis delivery; deleting it here would strand a
-            // code the polling app may already hold (keycast#262). Retry either way.
-            if freshly_minted {
-                if let Err(cleanup_err) = oauth_code_repo.delete(tenant_id, &new_code).await {
-                    tracing::error!(
-                        tenant_id = tenant_id,
-                        user_pubkey = %oauth_data.user_pubkey,
-                        code = %new_code,
-                        error = %cleanup_err,
-                        "Failed to clean up OAuth code after Redis polling write failed"
-                    );
-                }
-            }
+            // Keep the code for retry. Another concurrent finalizer may already have reused and
+            // delivered it, so even the call that minted it cannot safely delete it here.
             return Err(headless_retry_error());
         }
         tracing::debug!(
@@ -6170,6 +6151,53 @@ mod tests {
         cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
     }
 
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_concurrent_finalizers_return_the_same_exchange_code() {
+        let pool = create_test_db().await;
+        let email = format!("verify-concurrent-{}@example.com", Uuid::new_v4());
+        let (pubkey, token) = insert_oauth_pending_registration(&pool, &email).await;
+        let repo = keycast_core::repositories::OAuthCodeRepository::new(pool.clone());
+        let pending = repo
+            .find_by_verification_token(&token, 1)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let (first, second) = tokio::join!(
+            super::finalize_pending_registration(
+                &pool,
+                None,
+                1,
+                &pending,
+                super::HeadlessDelivery::RedisBestEffort,
+            ),
+            super::finalize_pending_registration(
+                &pool,
+                None,
+                1,
+                &pending,
+                super::HeadlessDelivery::RedisBestEffort,
+            ),
+        );
+        let first = first.unwrap();
+        let second = second.unwrap();
+        assert_eq!(first.new_code, second.new_code);
+
+        let exchange_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE tenant_id = 1 AND pending_email_verification_token = $1
+               AND pending_email IS NULL",
+        )
+        .bind(&token)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(exchange_count, 1);
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
+    }
+
     /// A prefetch (mail scanner / link preview) of the verify link must not strand the user:
     /// the pending row survives, so the user's later real click still completes.
     #[cfg(feature = "integration-tests")]
@@ -6872,11 +6900,10 @@ mod tests {
         cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
     }
 
-    /// A failed strict Redis delivery removes only the exchange code minted by this finalize,
-    /// while preserving the materialized user and pending row so the link can be retried.
+    /// A failed strict Redis delivery preserves the exchange code for a retry.
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
-    async fn test_finalize_pending_registration_fresh_code_redis_failure_cleans_orphan() {
+    async fn test_finalize_pending_registration_fresh_code_redis_failure_preserves_code() {
         let pool = create_test_db().await;
         let auth_state = create_test_auth_state_with_failing_redis(pool.clone()).await;
         let redis = auth_state.state.redis.as_ref().expect("failing Redis");
@@ -6924,8 +6951,8 @@ mod tests {
             repo.find_live_exchange_code_with_expiry_for_pending(1, &pending)
                 .await
                 .unwrap()
-                .is_none(),
-            "the freshly minted undeliverable exchange code must be deleted"
+                .is_some(),
+            "the live code must remain reusable after a retryable Redis failure"
         );
 
         cleanup_verify_email_test_data(&pool, &pubkey, &token).await;

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -751,6 +751,38 @@ impl From<bcrypt::BcryptError> for AuthError {
     }
 }
 
+/// Map a verification finalize error into the headless API's error type so the in-app PIN path
+/// (keycast#262) inherits the link path's behavior — in particular the duplicate-email 409.
+impl From<AuthError> for super::headless::HeadlessError {
+    fn from(e: AuthError) -> Self {
+        use super::headless::HeadlessError;
+        match e {
+            AuthError::EmailAlreadyExists => HeadlessError::Conflict(
+                "This email is already registered. Please log in instead.".to_string(),
+            ),
+            AuthError::Database(ref db_err)
+                if has_database_constraint(db_err, USERS_EMAIL_TENANT_CONSTRAINT) =>
+            {
+                HeadlessError::Conflict(
+                    "This email is already registered. Please log in instead.".to_string(),
+                )
+            }
+            AuthError::Conflict(msg) => HeadlessError::Conflict(msg),
+            AuthError::ServiceUnavailable {
+                message,
+                retry_after,
+            } => HeadlessError::ServiceUnavailable {
+                message,
+                retry_after,
+            },
+            other => {
+                tracing::error!("PIN verification finalize failed: {:?}", other);
+                HeadlessError::Internal("Email verification could not be completed".to_string())
+            }
+        }
+    }
+}
+
 /// Extract user public key from UCAN token in Authorization header or cookie
 /// tenant_id is required to validate the token was issued for this tenant
 pub(crate) async fn extract_user_from_token(

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -2190,43 +2190,51 @@ async fn perform_email_verification(
         .ok_or(AuthError::InvalidToken)?;
 
     let public_key = token_data.pubkey;
+    let verification_expired = token_data
+        .email_verification_expires_at
+        .as_ref()
+        .is_some_and(|expires| expires < &Utc::now());
 
-    // Already verified (e.g. user clicked the link again) - show success
+    // Keep an already-verified first-party token useful for the rest of its original verification
+    // window. A mail scanner may be the first caller that flips email_verified; the user's later
+    // click must still reach the session-cookie path instead of losing auto-login. Once the window
+    // expires, the retained token remains a harmless "already verified" acknowledgement and must
+    // no longer mint a session.
     if token_data.email_verified {
-        return Ok(VerifyOutcome::AlreadyVerified);
-    }
-
-    // Check if token is expired
-    if let Some(expires) = token_data.email_verification_expires_at {
-        if expires < Utc::now() {
+        if verification_expired {
+            return Ok(VerifyOutcome::AlreadyVerified);
+        }
+    } else {
+        // An unverified account cannot complete after the verification window expires.
+        if verification_expired {
             return Ok(VerifyOutcome::Expired);
         }
-    }
 
-    // Check async bcrypt state: password_hash IS NULL means still processing
-    if token_data.password_hash.is_none() {
-        let age = Utc::now().signed_duration_since(token_data.created_at);
-        if age.num_seconds() > 120 {
-            // Hash should complete in <1s normally. After 2min, assume instance died.
-            // User needs to re-register (cleanup job will delete this row)
-            tracing::warn!(
-                "Password hash not completed after {}s for token {}..., likely instance died",
+        // Check async bcrypt state: password_hash IS NULL means still processing
+        if token_data.password_hash.is_none() {
+            let age = Utc::now().signed_duration_since(token_data.created_at);
+            if age.num_seconds() > 120 {
+                // Hash should complete in <1s normally. After 2min, assume instance died.
+                // User needs to re-register (cleanup job will delete this row)
+                tracing::warn!(
+                    "Password hash not completed after {}s for token {}..., likely instance died",
+                    age.num_seconds(),
+                    &token[..std::cmp::min(8, token.len())]
+                );
+                return Err(AuthError::RegistrationExpired);
+            }
+            // Still processing - tell caller to retry
+            tracing::debug!(
+                "Password hash still processing (age: {}s) for token {}...",
                 age.num_seconds(),
                 &token[..std::cmp::min(8, token.len())]
             );
-            return Err(AuthError::RegistrationExpired);
+            return Ok(VerifyOutcome::Processing);
         }
-        // Still processing - tell caller to retry
-        tracing::debug!(
-            "Password hash still processing (age: {}s) for token {}...",
-            age.num_seconds(),
-            &token[..std::cmp::min(8, token.len())]
-        );
-        return Ok(VerifyOutcome::Processing);
-    }
 
-    // Mark email as verified (token kept for idempotent re-verification)
-    user_repo.verify_email(&public_key, tenant_id).await?;
+        // Mark email as verified (token kept for idempotent re-verification).
+        user_repo.verify_email(&public_key, tenant_id).await?;
+    }
 
     // Get user's email and account status for UCAN
     let email = user_repo.get_email(&public_key, tenant_id).await?;
@@ -5617,7 +5625,7 @@ mod tests {
     use crate::state::KeycastState;
     #[cfg(feature = "integration-tests")]
     use axum::{
-        extract::State,
+        extract::{Query, State},
         http::{
             header::{AUTHORIZATION, ORIGIN},
             HeaderMap, HeaderValue, StatusCode,
@@ -6133,6 +6141,9 @@ mod tests {
     async fn test_verify_email_prefetch_does_not_strand_user() {
         let pool = create_test_db().await;
         let auth_state = create_test_auth_state(pool.clone());
+
+        // OAuth registrations retain their pending row so a scanner hit cannot consume the
+        // redirect/code that the user's later visit needs.
         let email = format!("verify-prefetch-{}@example.com", Uuid::new_v4());
         let (pubkey, token) = insert_oauth_pending_registration(&pool, &email).await;
 
@@ -6177,6 +6188,97 @@ mod tests {
         );
 
         cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
+
+        // First-party registrations retain their users-table token. A scanner GET may perform
+        // the verification first, but the user's later GET must still receive a session cookie
+        // while the original verification window is live.
+        let first_party_keys = Keys::generate();
+        let first_party_pubkey = first_party_keys.public_key().to_hex();
+        let first_party_token = format!("verify_first_party_{}", Uuid::new_v4());
+        let first_party_email = format!("verify-first-party-{}@example.com", Uuid::new_v4());
+        let first_party_password_hash =
+            bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap();
+        let first_party_expires_at = Utc::now() + Duration::hours(24);
+        let first_party_secret = first_party_keys.secret_key().to_secret_bytes();
+        let user_repo = keycast_core::repositories::UserRepository::new(pool.clone());
+
+        cleanup_verify_email_test_data(&pool, &first_party_pubkey, &first_party_token).await;
+        user_repo
+            .register_with_personal_key(
+                &first_party_pubkey,
+                1,
+                &first_party_email,
+                Some(&first_party_password_hash),
+                &first_party_token,
+                first_party_expires_at,
+                &first_party_secret,
+            )
+            .await
+            .unwrap();
+
+        let scanner_get = verify_email_get(
+            create_test_tenant(),
+            State(auth_state.clone()),
+            HeaderMap::new(),
+            Query(VerifyEmailQuery {
+                token: Some(first_party_token.clone()),
+            }),
+        )
+        .await;
+        assert!(scanner_get.status().is_redirection());
+        assert!(
+            scanner_get
+                .headers()
+                .contains_key(axum::http::header::SET_COOKIE),
+            "the first GET should verify and issue a session cookie"
+        );
+
+        let user_get = verify_email_get(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            Query(VerifyEmailQuery {
+                token: Some(first_party_token.clone()),
+            }),
+        )
+        .await;
+        assert!(
+            user_get.status().is_redirection(),
+            "the user's GET after scanner prefetch should still redirect into the app"
+        );
+        assert!(
+            user_get
+                .headers()
+                .contains_key(axum::http::header::SET_COOKIE),
+            "the user's GET after scanner prefetch must re-arm the first-party session cookie"
+        );
+
+        sqlx::query(
+            "UPDATE users SET email_verification_expires_at = NOW() - INTERVAL '1 second' \
+             WHERE pubkey = $1 AND tenant_id = 1",
+        )
+        .bind(&first_party_pubkey)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let expired_reclick = verify_email_get(
+            create_test_tenant(),
+            State(create_test_auth_state(pool.clone())),
+            HeaderMap::new(),
+            Query(VerifyEmailQuery {
+                token: Some(first_party_token.clone()),
+            }),
+        )
+        .await;
+        assert_eq!(expired_reclick.status(), StatusCode::OK);
+        assert!(
+            !expired_reclick
+                .headers()
+                .contains_key(axum::http::header::SET_COOKIE),
+            "an expired retained token must acknowledge verification without minting a session"
+        );
+
+        cleanup_verify_email_test_data(&pool, &first_party_pubkey, &first_party_token).await;
     }
 
     /// Build a Redis-backed AuthState for headless GET tests (the link path requires Redis).

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1992,11 +1992,7 @@ pub async fn finalize_pending_registration(
     // It gates the delivery-failure cleanup below: a reused code is owned by a prior finalize.
     let (new_code, code_expires_at, freshly_minted) = if let Some((existing, expires_at)) =
         oauth_code_repo
-            .find_live_exchange_code_with_expiry(
-                tenant_id,
-                &oauth_data.user_pubkey,
-                &oauth_data.client_id,
-            )
+            .find_live_exchange_code_with_expiry_for_pending(tenant_id, oauth_data)
             .await?
     {
         (existing, expires_at, false)
@@ -2022,7 +2018,12 @@ pub async fn finalize_pending_registration(
             state: oauth_data.state.as_deref(),
             is_headless: oauth_data.is_headless, // Inherit from original registration
         };
-        oauth_code_repo.store(store_params).await?;
+        if !oauth_code_repo
+            .store_for_pending_registration(store_params, oauth_data)
+            .await?
+        {
+            return Err(AuthError::RegistrationAlreadyCompleted);
+        }
         (minted, code_expires_at, true)
     };
     let redis_ttl_seconds = if freshly_minted {

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -2348,7 +2348,44 @@ pub async fn verify_email(
     Json(req): Json<VerifyEmailRequest>,
 ) -> Result<impl IntoResponse, AuthError> {
     let tenant_id = tenant.0.id;
-    let outcome = perform_email_verification(&auth_state, &headers, tenant_id, &req.token).await?;
+    // Emitted with the same event_type as the GET path so both transports are comparable in the
+    // auth-event feed (keycast#262 made the GET primary).
+    let outcome =
+        match perform_email_verification(&auth_state, &headers, tenant_id, &req.token).await {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                record_verify_email_event(
+                    &auth_state.state.db,
+                    &headers,
+                    tenant_id,
+                    "POST",
+                    "failure",
+                    Some(verify_email_reason_code(&err)),
+                    verify_email_error_status(&err),
+                )
+                .await;
+                return Err(err);
+            }
+        };
+
+    let outcome_reason = match &outcome {
+        VerifyOutcome::Headless => "headless",
+        VerifyOutcome::OAuthRedirect { .. } => "oauth_redirect",
+        VerifyOutcome::AlreadyVerified => "already_verified",
+        VerifyOutcome::Processing => "processing",
+        VerifyOutcome::Expired => "expired",
+        VerifyOutcome::LoggedIn { .. } => "logged_in",
+    };
+    record_verify_email_event(
+        &auth_state.state.db,
+        &headers,
+        tenant_id,
+        "POST",
+        "success",
+        Some(outcome_reason),
+        200,
+    )
+    .await;
 
     let response = match outcome {
         VerifyOutcome::Headless => (
@@ -2443,12 +2480,22 @@ pub struct VerifyEmailQuery {
 pub async fn verify_email_get(
     tenant: crate::api::tenant::TenantExtractor,
     State(auth_state): State<super::routes::AuthState>,
-    _headers: HeaderMap,
+    headers: HeaderMap,
     Query(query): Query<VerifyEmailQuery>,
 ) -> Response {
     let tenant_id = tenant.0.id;
+    let pool = auth_state.state.db.clone();
+    let emit = |outcome: &'static str, reason: Option<&'static str>, status: i32| {
+        let pool = pool.clone();
+        let headers = headers.clone();
+        async move {
+            record_verify_email_event(&pool, &headers, tenant_id, "GET", outcome, reason, status)
+                .await;
+        }
+    };
 
     let Some(token) = query.token.filter(|t| !t.is_empty()) else {
+        emit("failure", Some("missing_token"), 400).await;
         return verify_html_page(
             StatusCode::BAD_REQUEST,
             "Invalid link",
@@ -2458,18 +2505,25 @@ pub async fn verify_email_get(
 
     match perform_pending_email_verification(&auth_state, tenant_id, &token).await {
         Ok(Some(PendingVerifyOutcome::OAuthRedirect { redirect_url })) => {
+            emit("success", Some("oauth_redirect"), 303).await;
             Redirect::to(&redirect_url).into_response()
         }
-        Ok(Some(PendingVerifyOutcome::Headless)) => verify_html_page(
-            StatusCode::OK,
-            "Email verified!",
-            "Your email is verified. You can return to the app to continue.",
-        ),
-        Ok(Some(PendingVerifyOutcome::AlreadyVerified)) => verify_html_page(
-            StatusCode::OK,
-            "Already verified",
-            "Your email is already verified. You can return to the app or log in.",
-        ),
+        Ok(Some(PendingVerifyOutcome::Headless)) => {
+            emit("success", Some("headless"), 200).await;
+            verify_html_page(
+                StatusCode::OK,
+                "Email verified!",
+                "Your email is verified. You can return to the app to continue.",
+            )
+        }
+        Ok(Some(PendingVerifyOutcome::AlreadyVerified)) => {
+            emit("success", Some("already_verified"), 200).await;
+            verify_html_page(
+                StatusCode::OK,
+                "Already verified",
+                "Your email is already verified. You can return to the app or log in.",
+            )
+        }
         Ok(None) => {
             // Not a pending registration. Only a token that still resolves to a users row belongs
             // to the first-party interactive flow, which the SPA owns (it POSTs and mints the
@@ -2477,13 +2531,21 @@ pub async fn verify_email_get(
             // a 401 "Please log in again" — the one place this GET would still need client-side
             // JavaScript, which is exactly what verifying on GET exists to avoid (keycast#268).
             let user_repo = UserRepository::new(auth_state.state.db.clone());
-            match user_repo.find_by_verification_token(&token, tenant_id).await {
+            match user_repo
+                .find_by_verification_token(&token, tenant_id)
+                .await
+            {
                 Ok(Some(_)) => {
+                    // Not an outcome yet: the interactive POST records the terminal one.
+                    emit("accepted", Some("interactive_handoff"), 303).await;
                     let interactive_url =
                         format!("/verify-email?token={}", urlencoding::encode(&token));
                     Redirect::to(&interactive_url).into_response()
                 }
-                Ok(None) => verify_link_superseded_page(),
+                Ok(None) => {
+                    emit("failure", Some("verification_link_superseded"), 200).await;
+                    verify_link_superseded_page()
+                }
                 // Can't tell a dead link from a database blip, so retry rather than declaring the
                 // link dead.
                 Err(err) => {
@@ -2492,6 +2554,7 @@ pub async fn verify_email_get(
                         error = %err,
                         "Failed to resolve verification token on GET verify"
                     );
+                    emit("failure", Some("database_error"), 503).await;
                     verify_html_retry_page(5)
                 }
             }
@@ -2499,17 +2562,21 @@ pub async fn verify_email_get(
         // Retryable: the link may still be good, so render a non-terminal page that retries
         // itself instead of a success-looking 2xx or terminal invalid-link page.
         Err(AuthError::ServiceUnavailable { retry_after, .. }) => {
+            emit("failure", Some("retryable_unavailable"), 503).await;
             verify_html_retry_page(retry_after.unwrap_or(5))
         }
         // Terminal: the email belongs to another account (mirrors the POST path's 409).
-        Err(AuthError::EmailAlreadyExists) => verify_html_page(
-            StatusCode::CONFLICT,
-            "Email already registered",
-            "This email is already registered. Please log in instead.",
-        ),
-        Err(AuthError::Database(err))
-            if has_database_constraint(&err, USERS_EMAIL_TENANT_CONSTRAINT) =>
+        Err(AuthError::EmailAlreadyExists) => {
+            emit("failure", Some("email_already_exists"), 409).await;
+            verify_html_page(
+                StatusCode::CONFLICT,
+                "Email already registered",
+                "This email is already registered. Please log in instead.",
+            )
+        }
+        Err(err @ AuthError::Database(_)) if matches!(&err, AuthError::Database(e) if has_database_constraint(e, USERS_EMAIL_TENANT_CONSTRAINT)) =>
         {
+            emit("failure", Some("email_already_exists"), 409).await;
             verify_html_page(
                 StatusCode::CONFLICT,
                 "Email already registered",
@@ -2517,33 +2584,116 @@ pub async fn verify_email_get(
             )
         }
         // Rate limited: the link is still good, so retry rather than declaring it dead.
-        Err(AuthError::TooManyRequests { retry_after, .. }) => verify_html_retry_page(retry_after),
-        Err(AuthError::Database(_))
-        | Err(AuthError::PasswordHash(_))
-        | Err(AuthError::Encryption(_))
-        | Err(AuthError::Internal(_))
-        | Err(AuthError::EmailSendFailed(_)) => verify_html_retry_page(5),
+        Err(AuthError::TooManyRequests { retry_after, .. }) => {
+            emit("failure", Some("rate_limited"), 429).await;
+            verify_html_retry_page(retry_after)
+        }
+        Err(
+            err @ (AuthError::Database(_)
+            | AuthError::PasswordHash(_)
+            | AuthError::Encryption(_)
+            | AuthError::Internal(_)
+            | AuthError::EmailSendFailed(_)),
+        ) => {
+            emit("failure", Some(verify_email_reason_code(&err)), 503).await;
+            verify_html_retry_page(5)
+        }
         // A link that no longer resolves gets the actionable dead-link page, not a generic failure.
-        Err(AuthError::VerificationLinkSuperseded) => verify_link_superseded_page(),
-        Err(AuthError::InvalidCredentials)
-        | Err(AuthError::EmailNotVerified)
-        | Err(AuthError::UserNotFound)
-        | Err(AuthError::MissingToken)
-        | Err(AuthError::InvalidToken)
-        | Err(AuthError::TokenExpired)
-        | Err(AuthError::DuplicateKey)
-        | Err(AuthError::InvalidEmail)
-        | Err(AuthError::BadRequest(_))
-        | Err(AuthError::Forbidden(_))
-        | Err(AuthError::RegistrationExpired)
-        | Err(AuthError::RegistrationAlreadyCompleted)
-        | Err(AuthError::KeyEgressDenied)
-        | Err(AuthError::OAuthProtocol { .. })
-        | Err(AuthError::Conflict(_)) => verify_html_page(
-            StatusCode::OK,
-            "Verification failed",
-            "This verification link is invalid or has expired. If you already verified, you can log in.",
-        ),
+        Err(AuthError::VerificationLinkSuperseded) => {
+            emit("failure", Some("verification_link_superseded"), 200).await;
+            verify_link_superseded_page()
+        }
+        Err(err) => {
+            emit("failure", Some(verify_email_reason_code(&err)), 200).await;
+            verify_html_page(
+                StatusCode::OK,
+                "Verification failed",
+                "This verification link is invalid or has expired. If you already verified, you can log in.",
+            )
+        }
+    }
+}
+
+/// `auth_events.endpoint` for both verify-email transports.
+pub(crate) const VERIFY_EMAIL_ENDPOINT: &str = "/api/auth/verify-email";
+
+/// Record one verify-email attempt to the shared auth-event feed.
+///
+/// Both transports emit this with the same `event_type`, differing only in `metadata_json.method`,
+/// so GET and POST outcomes are directly comparable. That matters most right after the switch to
+/// verifying on GET (keycast#262): the GET is now the primary path, and the
+/// `verification_link_superseded` rate is the signal for whether duplicate signups
+/// (keycast#268 Fix A) actually stopped in production.
+async fn record_verify_email_event(
+    pool: &PgPool,
+    headers: &HeaderMap,
+    tenant_id: i64,
+    method: &'static str,
+    outcome: &'static str,
+    reason_code: Option<&str>,
+    http_status: i32,
+) {
+    super::auth_observability::record_auth_event_and_log(
+        pool,
+        headers,
+        None,
+        super::auth_observability::AuthEvent {
+            tenant_id,
+            endpoint: VERIFY_EMAIL_ENDPOINT,
+            event_type: "email_verification",
+            outcome,
+            reason_code,
+            http_status,
+            email: None,
+            pubkey: None,
+            client_id: None,
+            redirect_origin: None,
+            metadata_json: serde_json::json!({ "method": method }),
+        },
+    )
+    .await;
+}
+
+/// HTTP status a verify-email failure will answer with, for the auth-event feed.
+///
+/// Kept in step with `AuthError`'s `IntoResponse`; only the statuses this route can actually
+/// produce are enumerated, and anything else records the 503 the catch-all answers with.
+fn verify_email_error_status(error: &AuthError) -> i32 {
+    match error {
+        AuthError::EmailAlreadyExists => 409,
+        AuthError::Database(err) if has_database_constraint(err, USERS_EMAIL_TENANT_CONSTRAINT) => {
+            409
+        }
+        AuthError::DuplicateKey
+        | AuthError::Conflict(_)
+        | AuthError::RegistrationAlreadyCompleted => 409,
+        AuthError::VerificationLinkSuperseded | AuthError::InvalidToken => 401,
+        AuthError::TooManyRequests { .. } => 429,
+        AuthError::RegistrationExpired => 410,
+        AuthError::BadRequest(_) | AuthError::InvalidEmail => 400,
+        AuthError::Forbidden(_) | AuthError::KeyEgressDenied => 403,
+        _ => 503,
+    }
+}
+
+/// Classify a verify-email failure into a stable `reason_code` for the auth-event feed.
+fn verify_email_reason_code(error: &AuthError) -> &'static str {
+    match error {
+        AuthError::ServiceUnavailable { .. } => "retryable_unavailable",
+        AuthError::TooManyRequests { .. } => "rate_limited",
+        AuthError::EmailAlreadyExists => "email_already_exists",
+        AuthError::Database(err) if has_database_constraint(err, USERS_EMAIL_TENANT_CONSTRAINT) => {
+            "email_already_exists"
+        }
+        AuthError::Database(_) => "database_error",
+        AuthError::VerificationLinkSuperseded => "verification_link_superseded",
+        AuthError::RegistrationExpired => "registration_expired",
+        AuthError::RegistrationAlreadyCompleted => "registration_already_completed",
+        AuthError::DuplicateKey => "account_email_conflict",
+        AuthError::InvalidToken | AuthError::MissingToken | AuthError::TokenExpired => {
+            "invalid_token"
+        }
+        _ => "other",
     }
 }
 
@@ -6615,6 +6765,70 @@ mod tests {
             !body.contains("log in again"),
             "dead-link page must not tell a user with no session to log in again, got: {body}"
         );
+    }
+
+    /// The GET path records auth events for its outcomes, matching the POST path's event_type so
+    /// the two transports are comparable. Post-merge the GET is the primary verification path, and
+    /// the `verification_link_superseded` rate is the signal for whether duplicate signups
+    /// actually stopped in production (keycast#268).
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_get_records_auth_event_for_dead_link() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+        let token = format!("nonexistent_{}", Uuid::new_v4());
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            crate::api::http::auth_observability::REQUEST_ID_HEADER,
+            token.parse().expect("token is a valid header value"),
+        );
+
+        let _ = verify_email_get(
+            create_test_tenant(),
+            State(auth_state),
+            headers,
+            axum::extract::Query(VerifyEmailQuery {
+                token: Some(token.clone()),
+            }),
+        )
+        .await
+        .into_response();
+
+        let event: Option<(String,)> = sqlx::query_as(
+            "SELECT concat_ws('|', endpoint, event_type, outcome, reason_code, http_status)
+             FROM auth_events WHERE request_id = $1",
+        )
+        .bind(&token)
+        .fetch_optional(&pool)
+        .await
+        .expect("query should succeed");
+
+        let event = event
+            .expect("GET verify must record an auth event, not silently drop the outcome")
+            .0;
+        assert_eq!(
+            event,
+            "/api/auth/verify-email|email_verification|failure|verification_link_superseded|200"
+        );
+
+        let method: Option<String> = sqlx::query_scalar(
+            "SELECT metadata_json->>'method' FROM auth_events WHERE request_id = $1",
+        )
+        .bind(&token)
+        .fetch_one(&pool)
+        .await
+        .expect("query should succeed");
+        assert_eq!(
+            method.as_deref(),
+            Some("GET"),
+            "the transport must be recorded so GET and POST stay comparable"
+        );
+
+        let _ = sqlx::query("DELETE FROM auth_events WHERE request_id = $1")
+            .bind(&token)
+            .execute(&pool)
+            .await;
     }
 
     /// A superseded token reaching the POST/SPA path answers with the same actionable copy and a

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -26,8 +26,8 @@ use crate::password_verifier::{
 use keycast_core::metrics::METRICS;
 use keycast_core::repositories::{
     AccountStatusWithMinorRow, AuthEventRepository, CreateOAuthAuthorizationParams,
-    OAuthAuthorizationRepository, OAuthCodeRepository, PersonalKeysRepository, PolicyRepository,
-    UserRepository, VerifiedMinorRow,
+    OAuthAuthorizationRepository, OAuthCodeData, OAuthCodeRepository, PersonalKeysRepository,
+    PolicyRepository, UserRepository, VerifiedMinorRow,
 };
 use keycast_core::traits::CustomPermission;
 use nostr_sdk::{Keys, PublicKey, ToBech32, UnsignedEvent};
@@ -1637,6 +1637,353 @@ pub async fn get_bunker_url(
     }
 }
 
+/// Outcome of completing a pending registration: the freshly minted 10-minute exchange code
+/// plus the routing context the caller needs to build its response.
+pub struct FinalizedRegistration {
+    /// Fresh 10-minute OAuth authorization code the app/browser exchanges for tokens.
+    pub new_code: String,
+    pub redirect_uri: String,
+    pub state: Option<String>,
+    pub is_headless: bool,
+}
+
+/// How a freshly minted headless exchange code reaches the waiting app.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum HeadlessDelivery {
+    /// Email-link path: the app only learns the code via Redis polling, so Redis must be available
+    /// and the push must succeed — otherwise the app would be stranded with no code to pick up.
+    RedisRequired,
+    /// In-app PIN path: the code is returned synchronously in the response body, so the Redis push
+    /// is best-effort and a Redis outage must not fail the flow.
+    RedisBestEffort,
+}
+
+/// Delete a pending registration row that can never complete (terminal conflict).
+///
+/// Pending rows are otherwise kept so re-verification re-arms a fresh exchange code; deletion is
+/// reserved for conflicts where no exchange code could ever be minted from the row.
+async fn delete_pending_registration(
+    oauth_code_repo: &OAuthCodeRepository,
+    kept_token: Option<&str>,
+    tenant_id: i64,
+) -> Result<(), AuthError> {
+    if let Some(token) = kept_token {
+        oauth_code_repo
+            .delete_by_verification_token(token, tenant_id)
+            .await?;
+    }
+    Ok(())
+}
+
+/// Shared completion path for a pending email-verification registration (keycast#262).
+///
+/// Invoked by both the email-link verification path and the in-app PIN path so they produce
+/// identical results: deferred user creation (including duplicate-email handling), a fresh
+/// 10-minute exchange code, and the headless Redis polling push.
+///
+/// The pending `oauth_codes` row is intentionally NOT deleted here. Re-verifying within the 24h
+/// window re-arms a fresh exchange code, which is what makes link prefetch/preview harmless: a
+/// mail-scanner GET can no longer materialize the user, mint a short-lived code, delete the row,
+/// and strand the user's real visit. The row expires on its own at the end of the verify window.
+pub async fn finalize_pending_registration(
+    pool: &PgPool,
+    redis: Option<&crate::redis::PrefixedRedis>,
+    tenant_id: i64,
+    oauth_data: &OAuthCodeData,
+    delivery: HeadlessDelivery,
+) -> Result<FinalizedRegistration, AuthError> {
+    let email = oauth_data
+        .pending_email
+        .as_ref()
+        .ok_or_else(|| account_incomplete("Registration is incomplete. Please register again."))?;
+    let password_hash = oauth_data
+        .pending_password_hash
+        .as_ref()
+        .ok_or_else(|| account_incomplete("Registration is incomplete. Please register again."))?;
+    // The token kept on the materialized user row is the one already stored on the pending row,
+    // so the link path can be re-clicked idempotently (it resolves the same user).
+    let kept_token = oauth_data.pending_email_verification_token.as_deref();
+
+    let oauth_code_repo = OAuthCodeRepository::new(pool.clone());
+    let user_repo = UserRepository::new(pool.clone());
+    let existing_user = user_repo
+        .oauth_registration_state(&oauth_data.user_pubkey, tenant_id)
+        .await?;
+
+    if let Some(existing) = existing_user {
+        match existing.email.as_deref() {
+            Some(existing_email) if existing_email == email => {
+                if existing.email_verified && existing.has_password_hash {
+                    // Genuine retry: a prior attempt already applied the pending
+                    // credentials. Backfill the personal key if that attempt (or
+                    // another creation path) left it missing.
+                    tracing::info!(
+                        "Retrying email verification for existing user: {}",
+                        oauth_data.user_pubkey
+                    );
+                    if let (Some(encrypted_secret), false) = (
+                        oauth_data.pending_encrypted_secret.as_deref(),
+                        existing.has_personal_key,
+                    ) {
+                        user_repo
+                            .backfill_personal_key(
+                                &oauth_data.user_pubkey,
+                                tenant_id,
+                                encrypted_secret,
+                            )
+                            .await?;
+                        tracing::info!(
+                            "Backfilled missing personal key during verification retry: {}",
+                            oauth_data.user_pubkey
+                        );
+                    }
+                } else {
+                    // A same-email row can come from standard registration before
+                    // verification or before bcrypt finishes. Complete it before
+                    // minting an OAuth code.
+                    if let Err(err) = user_repo
+                        .complete_pending_oauth_registration(
+                            &oauth_data.user_pubkey,
+                            tenant_id,
+                            email,
+                            password_hash,
+                            kept_token,
+                            oauth_data.pending_encrypted_secret.as_deref(),
+                        )
+                        .await
+                    {
+                        if matches!(err, keycast_core::repositories::RepositoryError::Duplicate) {
+                            delete_pending_registration(&oauth_code_repo, kept_token, tenant_id)
+                                .await?;
+                            return Err(AuthError::EmailAlreadyExists);
+                        }
+                        return Err(err.into());
+                    }
+                    tracing::info!(
+                        "Completed incomplete same-email registration row: {}",
+                        oauth_data.user_pubkey
+                    );
+                }
+            }
+            Some(_) => {
+                // The pubkey is already bound to a different email. Never
+                // overwrite an existing account's credentials from an
+                // unauthenticated verification.
+                tracing::warn!(
+                    "Email verification for pubkey {} conflicts with an existing account email",
+                    oauth_data.user_pubkey
+                );
+                delete_pending_registration(&oauth_code_repo, kept_token, tenant_id).await?;
+                return Err(AuthError::DuplicateKey);
+            }
+            None => {
+                // Bare row pre-created by another path (team membership,
+                // authorization pre-creation): apply the pending registration
+                // instead of silently dropping it.
+                if let Err(err) = user_repo
+                    .complete_pending_oauth_registration(
+                        &oauth_data.user_pubkey,
+                        tenant_id,
+                        email,
+                        password_hash,
+                        kept_token,
+                        oauth_data.pending_encrypted_secret.as_deref(),
+                    )
+                    .await
+                {
+                    if matches!(err, keycast_core::repositories::RepositoryError::Duplicate) {
+                        delete_pending_registration(&oauth_code_repo, kept_token, tenant_id).await?;
+                        return Err(AuthError::EmailAlreadyExists);
+                    }
+                    return Err(err.into());
+                }
+                tracing::info!(
+                    "Applied pending registration to pre-existing user row: {}",
+                    oauth_data.user_pubkey
+                );
+            }
+        }
+    } else if let Some(ref encrypted_secret) = oauth_data.pending_encrypted_secret {
+        // Auto-generated or direct nsec: create user + personal_keys atomically.
+        let now = Utc::now();
+        let mut tx = pool.begin().await?;
+
+        if let Err(err) = sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, email_verification_token, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        )
+        .bind(&oauth_data.user_pubkey)
+        .bind(tenant_id)
+        .bind(email)
+        .bind(password_hash)
+        .bind(true) // email_verified = true
+        .bind(kept_token)
+        .bind(now)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        {
+            if has_database_constraint(&err, USERS_EMAIL_TENANT_CONSTRAINT) {
+                // Duplicate email: this registration can never complete, so the pending row is
+                // terminal — delete it rather than leaving a row that only ever 409s.
+                tx.rollback().await?;
+                delete_pending_registration(&oauth_code_repo, kept_token, tenant_id).await?;
+                return Err(AuthError::EmailAlreadyExists);
+            }
+            return Err(err.into());
+        }
+
+        sqlx::query(
+            "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(&oauth_data.user_pubkey)
+        .bind(encrypted_secret)
+        .bind(tenant_id)
+        .bind(now)
+        .bind(now)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        tracing::info!(
+            "Created user and personal_keys for OAuth registration: {}",
+            oauth_data.user_pubkey
+        );
+    } else {
+        // BYOK flow: just create user, keys will come at token exchange.
+        if let Err(err) = user_repo
+            .create_with_password_verified(
+                &oauth_data.user_pubkey,
+                tenant_id,
+                email,
+                password_hash,
+                true, // email_verified = true
+                kept_token,
+            )
+            .await
+        {
+            if matches!(err, keycast_core::repositories::RepositoryError::Duplicate) {
+                delete_pending_registration(&oauth_code_repo, kept_token, tenant_id).await?;
+                return Err(AuthError::EmailAlreadyExists);
+            }
+            return Err(err.into());
+        }
+
+        tracing::info!(
+            "Created user for BYOK OAuth registration: {}",
+            oauth_data.user_pubkey
+        );
+    }
+
+    let headless_retry_error = || AuthError::ServiceUnavailable {
+        message: "Email verified, but app sign-in is still finishing. Please retry shortly."
+            .to_string(),
+        retry_after: Some(5),
+    };
+
+    // For the link path (RedisRequired), validate device_code + Redis BEFORE minting so we never
+    // mint a code the polling app could never receive.
+    let strict_delivery = if oauth_data.is_headless && delivery == HeadlessDelivery::RedisRequired {
+        let device_code = oauth_data.device_code.as_ref().ok_or_else(|| {
+            tracing::error!(
+                event = "headless_poll_delivery_failed",
+                tenant_id = tenant_id,
+                user_pubkey = %oauth_data.user_pubkey,
+                "Headless verification is missing device_code"
+            );
+            headless_retry_error()
+        })?;
+        let redis = redis.ok_or_else(|| {
+            tracing::error!(
+                event = "headless_poll_delivery_failed",
+                tenant_id = tenant_id,
+                user_pubkey = %oauth_data.user_pubkey,
+                "Headless verification requires Redis, but Redis is unavailable"
+            );
+            headless_retry_error()
+        })?;
+        Some((device_code, redis))
+    } else {
+        None
+    };
+
+    // Generate a fresh authorization code (10 minute exchange window — do not lengthen).
+    let new_code: String = rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(32)
+        .map(char::from)
+        .collect();
+
+    let code_expires_at = Utc::now() + Duration::minutes(10);
+    let store_params = keycast_core::repositories::StoreOAuthCodeParams {
+        tenant_id,
+        code: &new_code,
+        user_pubkey: &oauth_data.user_pubkey,
+        client_id: &oauth_data.client_id,
+        redirect_uri: &oauth_data.redirect_uri,
+        scope: &oauth_data.scope,
+        code_challenge: oauth_data.code_challenge.as_deref(),
+        code_challenge_method: oauth_data.code_challenge_method.as_deref(),
+        expires_at: code_expires_at,
+        previous_auth_id: oauth_data.previous_auth_id,
+        state: oauth_data.state.as_deref(),
+        is_headless: oauth_data.is_headless, // Inherit from original registration
+    };
+    oauth_code_repo.store(store_params).await?;
+
+    if let Some((device_code, redis)) = strict_delivery {
+        let key = format!("oauth_poll:{}", device_code);
+        if let Err(e) = redis.setex(&key, 600, &new_code).await {
+            tracing::error!(
+                event = "headless_poll_delivery_failed",
+                tenant_id = tenant_id,
+                user_pubkey = %oauth_data.user_pubkey,
+                device_code = %device_code,
+                error = %e,
+                "Failed to store headless OAuth code in Redis for polling"
+            );
+            if let Err(cleanup_err) = oauth_code_repo.delete(tenant_id, &new_code).await {
+                tracing::error!(
+                    tenant_id = tenant_id,
+                    user_pubkey = %oauth_data.user_pubkey,
+                    code = %new_code,
+                    error = %cleanup_err,
+                    "Failed to clean up OAuth code after Redis polling write failed"
+                );
+            }
+            return Err(headless_retry_error());
+        }
+        tracing::debug!(
+            "Stored OAuth code in Redis for headless polling: device_code={}",
+            device_code
+        );
+    } else if let Some(ref device_code) = oauth_data.device_code {
+        // Best-effort push: non-headless same-device verification, or the PIN path where the code
+        // is also returned synchronously in the response body (so a Redis miss is not fatal).
+        if let Some(redis) = redis {
+            let key = format!("oauth_poll:{}", device_code);
+            if let Err(e) = redis.setex(&key, 600, &new_code).await {
+                tracing::warn!("Failed to store OAuth code in Redis for polling: {}", e);
+                // Continue - redirect flow / synchronous return still works.
+            } else {
+                tracing::debug!(
+                    "Stored OAuth code in Redis for polling: device_code={}",
+                    device_code
+                );
+            }
+        }
+    }
+
+    Ok(FinalizedRegistration {
+        new_code,
+        redirect_uri: oauth_data.redirect_uri.clone(),
+        state: oauth_data.state.clone(),
+        is_headless: oauth_data.is_headless,
+    })
+}
+
 /// Verify email address with token
 /// Handles two flows:
 /// 1. OAuth registration: token in oauth_codes → complete OAuth flow → redirect to client
@@ -1664,301 +2011,18 @@ pub async fn verify_email(
             oauth_data.pending_email
         );
 
-        let email = oauth_data.pending_email.as_ref().ok_or_else(|| {
-            account_incomplete("Registration is incomplete. Please register again.")
-        })?;
-        let password_hash = oauth_data.pending_password_hash.as_ref().ok_or_else(|| {
-            account_incomplete("Registration is incomplete. Please register again.")
-        })?;
-
-        // Create user with email_verified=true (they just verified!)
-        let user_repo = UserRepository::new(pool.clone());
-        let existing_user = user_repo
-            .oauth_registration_state(&oauth_data.user_pubkey, tenant_id)
-            .await?;
-
-        if let Some(existing) = existing_user {
-            match existing.email.as_deref() {
-                Some(existing_email) if existing_email == email => {
-                    if existing.email_verified && existing.has_password_hash {
-                        // Genuine retry: a prior attempt already applied the pending
-                        // credentials. Backfill the personal key if that attempt (or
-                        // another creation path) left it missing.
-                        tracing::info!(
-                            "Retrying OAuth email verification for existing user: {}",
-                            oauth_data.user_pubkey
-                        );
-                        if let (Some(encrypted_secret), false) = (
-                            oauth_data.pending_encrypted_secret.as_deref(),
-                            existing.has_personal_key,
-                        ) {
-                            user_repo
-                                .backfill_personal_key(
-                                    &oauth_data.user_pubkey,
-                                    tenant_id,
-                                    encrypted_secret,
-                                )
-                                .await?;
-                            tracing::info!(
-                                "Backfilled missing personal key during OAuth verification retry: {}",
-                                oauth_data.user_pubkey
-                            );
-                        }
-                    } else {
-                        // A same-email row can come from standard registration before
-                        // verification or before bcrypt finishes. Complete it before
-                        // minting an OAuth code.
-                        if let Err(err) = user_repo
-                            .complete_pending_oauth_registration(
-                                &oauth_data.user_pubkey,
-                                tenant_id,
-                                email,
-                                password_hash,
-                                &req.token,
-                                oauth_data.pending_encrypted_secret.as_deref(),
-                            )
-                            .await
-                        {
-                            if matches!(err, keycast_core::repositories::RepositoryError::Duplicate)
-                            {
-                                oauth_code_repo
-                                    .delete_by_verification_token(&req.token, tenant_id)
-                                    .await?;
-                                return Err(AuthError::EmailAlreadyExists);
-                            }
-                            return Err(err.into());
-                        }
-                        tracing::info!(
-                            "Completed incomplete same-email OAuth registration row: {}",
-                            oauth_data.user_pubkey
-                        );
-                    }
-                }
-                Some(_) => {
-                    // The pubkey is already bound to a different email. Never
-                    // overwrite an existing account's credentials from an
-                    // unauthenticated verification link.
-                    tracing::warn!(
-                        "OAuth email verification for pubkey {} conflicts with an existing account email",
-                        oauth_data.user_pubkey
-                    );
-                    oauth_code_repo
-                        .delete_by_verification_token(&req.token, tenant_id)
-                        .await?;
-                    return Err(AuthError::DuplicateKey);
-                }
-                None => {
-                    // Bare row pre-created by another path (team membership,
-                    // authorization pre-creation): apply the pending registration
-                    // instead of silently dropping it.
-                    if let Err(err) = user_repo
-                        .complete_pending_oauth_registration(
-                            &oauth_data.user_pubkey,
-                            tenant_id,
-                            email,
-                            password_hash,
-                            &req.token,
-                            oauth_data.pending_encrypted_secret.as_deref(),
-                        )
-                        .await
-                    {
-                        if matches!(err, keycast_core::repositories::RepositoryError::Duplicate) {
-                            oauth_code_repo
-                                .delete_by_verification_token(&req.token, tenant_id)
-                                .await?;
-                            return Err(AuthError::EmailAlreadyExists);
-                        }
-                        return Err(err.into());
-                    }
-                    tracing::info!(
-                        "Applied pending OAuth registration to pre-existing user row: {}",
-                        oauth_data.user_pubkey
-                    );
-                }
-            }
-        } else if let Some(ref encrypted_secret) = oauth_data.pending_encrypted_secret {
-            // Auto-generated or direct nsec: create user + personal_keys
-            // Use a transaction to ensure atomicity
-            let now = Utc::now();
-            let mut tx = pool.begin().await?;
-
-            if let Err(err) = sqlx::query(
-                "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, email_verification_token, created_at, updated_at)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
-            )
-            .bind(&oauth_data.user_pubkey)
-            .bind(tenant_id)
-            .bind(email)
-            .bind(password_hash)
-            .bind(true) // email_verified = true
-            .bind(&req.token) // Keep token for idempotent re-verification
-            .bind(now)
-            .bind(now)
-            .execute(&mut *tx)
-            .await
-            {
-                if has_database_constraint(&err, USERS_EMAIL_TENANT_CONSTRAINT) {
-                    tx.rollback().await?;
-                    oauth_code_repo
-                        .delete_by_verification_token(&req.token, tenant_id)
-                        .await?;
-                    return Err(AuthError::EmailAlreadyExists);
-                }
-                return Err(err.into());
-            }
-
-            sqlx::query(
-                "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
-                 VALUES ($1, $2, $3, $4, $5)",
-            )
-            .bind(&oauth_data.user_pubkey)
-            .bind(encrypted_secret)
-            .bind(tenant_id)
-            .bind(now)
-            .bind(now)
-            .execute(&mut *tx)
-            .await?;
-
-            tx.commit().await?;
-
-            tracing::info!(
-                "Created user and personal_keys for OAuth registration: {}",
-                oauth_data.user_pubkey
-            );
-        } else {
-            // BYOK flow: just create user, keys will come at token exchange
-            if let Err(err) = user_repo
-                .create_with_password_verified(
-                    &oauth_data.user_pubkey,
-                    tenant_id,
-                    email,
-                    password_hash,
-                    true,             // email_verified = true
-                    Some(&req.token), // Keep token for idempotent re-verification
-                )
-                .await
-            {
-                if matches!(err, keycast_core::repositories::RepositoryError::Duplicate) {
-                    oauth_code_repo
-                        .delete_by_verification_token(&req.token, tenant_id)
-                        .await?;
-                    return Err(AuthError::EmailAlreadyExists);
-                }
-                return Err(err.into());
-            }
-
-            tracing::info!(
-                "Created user for BYOK OAuth registration: {}",
-                oauth_data.user_pubkey
-            );
-        }
-
-        let headless_retry_error = || AuthError::ServiceUnavailable {
-            message: "Email verified, but app sign-in is still finishing. Please retry shortly."
-                .to_string(),
-            retry_after: Some(5),
-        };
-
-        let required_device_code = if oauth_data.is_headless {
-            Some(oauth_data.device_code.as_ref().ok_or_else(|| {
-                tracing::error!(
-                    event = "headless_poll_delivery_failed",
-                    tenant_id = tenant_id,
-                    user_pubkey = %oauth_data.user_pubkey,
-                    "Headless verification is missing device_code"
-                );
-                headless_retry_error()
-            })?)
-        } else {
-            None
-        };
-
-        let required_redis = if oauth_data.is_headless {
-            Some(auth_state.state.redis.as_ref().ok_or_else(|| {
-                tracing::error!(
-                    event = "headless_poll_delivery_failed",
-                    tenant_id = tenant_id,
-                    user_pubkey = %oauth_data.user_pubkey,
-                    "Headless verification requires Redis, but Redis is unavailable"
-                );
-                headless_retry_error()
-            })?)
-        } else {
-            None
-        };
-
-        // Generate new authorization code for the redirect
-        let new_code: String = rand::thread_rng()
-            .sample_iter(&rand::distributions::Alphanumeric)
-            .take(32)
-            .map(char::from)
-            .collect();
-
-        // Store the new code (10 minute expiry for exchange)
-        let code_expires_at = Utc::now() + Duration::minutes(10);
-        let store_params = keycast_core::repositories::StoreOAuthCodeParams {
+        // Complete the registration via the shared finalize path. This intentionally does NOT
+        // delete the pending row: re-clicking the link within the 24h window re-arms a fresh
+        // 10-minute code, which makes link prefetch/preview harmless (keycast#262 Part A).
+        let finalized = finalize_pending_registration(
+            pool,
+            auth_state.state.redis.as_ref(),
             tenant_id,
-            code: &new_code,
-            user_pubkey: &oauth_data.user_pubkey,
-            client_id: &oauth_data.client_id,
-            redirect_uri: &oauth_data.redirect_uri,
-            scope: &oauth_data.scope,
-            code_challenge: oauth_data.code_challenge.as_deref(),
-            code_challenge_method: oauth_data.code_challenge_method.as_deref(),
-            expires_at: code_expires_at,
-            previous_auth_id: oauth_data.previous_auth_id,
-            state: oauth_data.state.as_deref(),
-            is_headless: oauth_data.is_headless, // Inherit from original registration
-        };
-        oauth_code_repo.store(store_params).await?;
-
-        if let Some(device_code) = required_device_code {
-            let redis =
-                required_redis.expect("headless flow must validate Redis before storing code");
-            let key = format!("oauth_poll:{}", device_code);
-            if let Err(e) = redis.setex(&key, 600, &new_code).await {
-                tracing::error!(
-                    event = "headless_poll_delivery_failed",
-                    tenant_id = tenant_id,
-                    user_pubkey = %oauth_data.user_pubkey,
-                    device_code = %device_code,
-                    error = %e,
-                    "Failed to store headless OAuth code in Redis for polling"
-                );
-                if let Err(cleanup_err) = oauth_code_repo.delete(tenant_id, &new_code).await {
-                    tracing::error!(
-                        tenant_id = tenant_id,
-                        user_pubkey = %oauth_data.user_pubkey,
-                        code = %new_code,
-                        error = %cleanup_err,
-                        "Failed to clean up OAuth code after Redis polling write failed"
-                    );
-                }
-                return Err(headless_retry_error());
-            }
-            tracing::debug!(
-                "Stored OAuth code in Redis for headless polling: device_code={}",
-                device_code
-            );
-        } else if let Some(ref device_code) = oauth_data.device_code {
-            if let Some(redis) = &auth_state.state.redis {
-                let key = format!("oauth_poll:{}", device_code);
-                if let Err(e) = redis.setex(&key, 600, &new_code).await {
-                    tracing::warn!("Failed to store OAuth code in Redis for polling: {}", e);
-                    // Continue - redirect flow still works for same-device verification
-                } else {
-                    tracing::debug!(
-                        "Stored OAuth code in Redis for polling: device_code={}",
-                        device_code
-                    );
-                }
-            }
-        }
-
-        // Delete the pending registration entry
-        oauth_code_repo
-            .delete_by_verification_token(&req.token, tenant_id)
-            .await?;
+            &oauth_data,
+            HeadlessDelivery::RedisRequired,
+        )
+        .await?;
+        let new_code = finalized.new_code;
 
         // For headless flows (mobile app), don't redirect — the app is polling
         // via device_code/Redis and will pick up the code automatically.
@@ -5643,6 +5707,166 @@ mod tests {
 
         cleanup_verify_email_test_data(&pool, &existing_pubkey, &verification_token).await;
         cleanup_verify_email_test_data(&pool, &pending_pubkey, &verification_token).await;
+    }
+
+    /// Extract the `code` query parameter from a verify redirect URL like `{uri}?code=XXX&state=YYY`.
+    #[cfg(feature = "integration-tests")]
+    fn extract_code_from_redirect(redirect_to: &str) -> String {
+        let after = redirect_to
+            .split("code=")
+            .nth(1)
+            .expect("redirect should carry a code");
+        after.split('&').next().unwrap().to_string()
+    }
+
+    /// Insert a non-headless OAuth pending registration (browser flow) and return (pubkey, token).
+    #[cfg(feature = "integration-tests")]
+    async fn insert_oauth_pending_registration(pool: &PgPool, email: &str) -> (String, String) {
+        let pending_keys = Keys::generate();
+        let pending_pubkey = pending_keys.public_key().to_hex();
+        let verification_token = format!("verify_{}", Uuid::new_v4());
+        let placeholder_code = format!("placeholder_{}", Uuid::new_v4());
+        let password_hash = bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap();
+        let expires_at = Utc::now() + Duration::hours(24);
+        let encrypted_secret = pending_keys.secret_key().to_secret_bytes().to_vec();
+
+        cleanup_verify_email_test_data(pool, &pending_pubkey, &verification_token).await;
+
+        sqlx::query(
+            "INSERT INTO oauth_codes (
+                tenant_id, code, user_pubkey, client_id, redirect_uri, scope,
+                expires_at, created_at, pending_email, pending_password_hash,
+                pending_email_verification_token, pending_encrypted_secret
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), $8, $9, $10, $11)",
+        )
+        .bind(1_i64)
+        .bind(&placeholder_code)
+        .bind(&pending_pubkey)
+        .bind("TestApp")
+        .bind("https://test.example.com/callback")
+        .bind("policy:social")
+        .bind(expires_at)
+        .bind(email)
+        .bind(&password_hash)
+        .bind(&verification_token)
+        .bind(&encrypted_secret)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        (pending_pubkey, verification_token)
+    }
+
+    /// Re-verifying an OAuth registration within the window must re-arm a fresh 10-min code
+    /// WITHOUT deleting the pending row (keycast#262 Part A idempotency).
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_oauth_idempotent_rearms_without_deleting_pending() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+        let email = format!("verify-idem-{}@example.com", Uuid::new_v4());
+        let (pubkey, token) = insert_oauth_pending_registration(&pool, &email).await;
+
+        let first = verify_email(
+            create_test_tenant(),
+            State(auth_state.clone()),
+            HeaderMap::new(),
+            Json(VerifyEmailRequest {
+                token: token.clone(),
+            }),
+        )
+        .await
+        .map(|r| r.into_response())
+        .unwrap_or_else(|e| e.into_response());
+        assert_eq!(first.status(), StatusCode::OK);
+        let body1 = response_json(first).await;
+        let code1 = extract_code_from_redirect(body1["redirect_to"].as_str().unwrap());
+
+        // Pending row must survive the first verify (so prefetch can't strand a later real visit).
+        let repo = keycast_core::repositories::OAuthCodeRepository::new(pool.clone());
+        assert!(
+            repo.find_by_verification_token(&token, 1)
+                .await
+                .unwrap()
+                .is_some(),
+            "pending row must survive verify (idempotent re-arm)"
+        );
+
+        let second = verify_email(
+            create_test_tenant(),
+            State(auth_state.clone()),
+            HeaderMap::new(),
+            Json(VerifyEmailRequest {
+                token: token.clone(),
+            }),
+        )
+        .await
+        .map(|r| r.into_response())
+        .unwrap_or_else(|e| e.into_response());
+        assert_eq!(
+            second.status(),
+            StatusCode::OK,
+            "re-verify must still succeed, not fail with InvalidToken"
+        );
+        let body2 = response_json(second).await;
+        let code2 = extract_code_from_redirect(body2["redirect_to"].as_str().unwrap());
+
+        assert_ne!(code1, code2, "each verify must mint a fresh exchange code");
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
+    }
+
+    /// A prefetch (mail scanner / link preview) of the verify link must not strand the user:
+    /// the pending row survives, so the user's later real click still completes.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_prefetch_does_not_strand_user() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+        let email = format!("verify-prefetch-{}@example.com", Uuid::new_v4());
+        let (pubkey, token) = insert_oauth_pending_registration(&pool, &email).await;
+
+        // Simulated prefetch hit.
+        let prefetch = verify_email(
+            create_test_tenant(),
+            State(auth_state.clone()),
+            HeaderMap::new(),
+            Json(VerifyEmailRequest {
+                token: token.clone(),
+            }),
+        )
+        .await
+        .map(|r| r.into_response())
+        .unwrap_or_else(|e| e.into_response());
+        assert_eq!(prefetch.status(), StatusCode::OK);
+
+        // The user's real click afterwards must still complete (not InvalidToken / stranded).
+        let real = verify_email(
+            create_test_tenant(),
+            State(auth_state.clone()),
+            HeaderMap::new(),
+            Json(VerifyEmailRequest {
+                token: token.clone(),
+            }),
+        )
+        .await
+        .map(|r| r.into_response())
+        .unwrap_or_else(|e| e.into_response());
+        assert_eq!(
+            real.status(),
+            StatusCode::OK,
+            "user's real click after a prefetch must still verify"
+        );
+        let body = response_json(real).await;
+        assert_eq!(body["success"], true);
+        // Must re-arm via the pending-registration path (fresh redirect + code), NOT fall through
+        // to the degenerate users-table "already verified" branch that mints no exchange code.
+        assert!(
+            body["redirect_to"].is_string(),
+            "real click after prefetch must re-arm a fresh exchange code, not silently strand"
+        );
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
     }
 
     #[cfg(feature = "integration-tests")]

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1983,35 +1983,41 @@ pub async fn finalize_pending_registration(
         None
     };
 
-    // Generate a fresh authorization code (10 minute exchange window — do not lengthen).
-    let new_code: String = rand::thread_rng()
-        .sample_iter(&rand::distributions::Alphanumeric)
-        .take(32)
-        .map(char::from)
-        .collect();
+    // Re-arm idempotently (keycast#262): if a still-live exchange code was already minted for this
+    // registration (an earlier re-click or mail prefetch), reuse it instead of minting a
+    // replacement. A re-mint would strand the code the polling app may already hold. Only mint a
+    // fresh code (10 minute exchange window — do not lengthen) when none is live. The consumed_at
+    // terminal guard above already refuses re-mint once a code has been redeemed.
+    let new_code = if let Some(existing) = oauth_code_repo
+        .find_live_exchange_code(tenant_id, &oauth_data.user_pubkey, &oauth_data.client_id)
+        .await?
+    {
+        existing
+    } else {
+        let minted: String = rand::thread_rng()
+            .sample_iter(&rand::distributions::Alphanumeric)
+            .take(32)
+            .map(char::from)
+            .collect();
 
-    let code_expires_at = Utc::now() + Duration::minutes(10);
-    let store_params = keycast_core::repositories::StoreOAuthCodeParams {
-        tenant_id,
-        code: &new_code,
-        user_pubkey: &oauth_data.user_pubkey,
-        client_id: &oauth_data.client_id,
-        redirect_uri: &oauth_data.redirect_uri,
-        scope: &oauth_data.scope,
-        code_challenge: oauth_data.code_challenge.as_deref(),
-        code_challenge_method: oauth_data.code_challenge_method.as_deref(),
-        expires_at: code_expires_at,
-        previous_auth_id: oauth_data.previous_auth_id,
-        state: oauth_data.state.as_deref(),
-        is_headless: oauth_data.is_headless, // Inherit from original registration
+        let code_expires_at = Utc::now() + Duration::minutes(10);
+        let store_params = keycast_core::repositories::StoreOAuthCodeParams {
+            tenant_id,
+            code: &minted,
+            user_pubkey: &oauth_data.user_pubkey,
+            client_id: &oauth_data.client_id,
+            redirect_uri: &oauth_data.redirect_uri,
+            scope: &oauth_data.scope,
+            code_challenge: oauth_data.code_challenge.as_deref(),
+            code_challenge_method: oauth_data.code_challenge_method.as_deref(),
+            expires_at: code_expires_at,
+            previous_auth_id: oauth_data.previous_auth_id,
+            state: oauth_data.state.as_deref(),
+            is_headless: oauth_data.is_headless, // Inherit from original registration
+        };
+        oauth_code_repo.store(store_params).await?;
+        minted
     };
-    // At most one live exchange code per registration: drop any previously minted, un-redeemed
-    // exchange code for this user+client before storing the fresh one, so a re-click cannot leave
-    // several valid codes outstanding (keycast#262).
-    oauth_code_repo
-        .delete_unredeemed_exchange_codes(tenant_id, &oauth_data.user_pubkey, &oauth_data.client_id)
-        .await?;
-    oauth_code_repo.store(store_params).await?;
 
     if let Some((device_code, redis)) = strict_delivery {
         let key = format!("oauth_poll:{}", device_code);

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -514,7 +514,7 @@ pub enum AuthError {
     Forbidden(String),   // User has no authorization for this origin
     KeyEgressDenied,     // Policy refuses raw-key egress for this account
     RegistrationExpired, // Async bcrypt timed out (instance died)
-    /// The pending registration's exchange code was already redeemed; re-mint is refused
+    /// The pending registration already completed token issuance; re-mint is refused
     /// (keycast#262 bounded lifecycle).
     RegistrationAlreadyCompleted,
     ServiceUnavailable {
@@ -1735,7 +1735,7 @@ pub async fn finalize_pending_registration(
     oauth_data: &OAuthCodeData,
     delivery: HeadlessDelivery,
 ) -> Result<FinalizedRegistration, AuthError> {
-    // Terminal: once the registration's exchange code has been redeemed, the row is consumed and
+    // Terminal: once the registration's exchange code has issued tokens, the row is consumed and
     // must not re-mint again (keycast#262). Re-clicks before redemption still re-arm a fresh code
     // (the intended harmless idempotency); re-clicks after completion are refused here.
     if oauth_data.consumed_at.is_some() {
@@ -2139,7 +2139,7 @@ async fn perform_email_verification(
         // Complete via the shared finalize path. This intentionally does NOT delete the pending
         // row: re-verifying within the 24h window re-arms a fresh 10-minute code, which makes
         // link prefetch/preview harmless (keycast#262 Part A). Once the registration has been
-        // completed (exchange code redeemed), finalize refuses to re-mint; a re-clicked link then
+        // completed token issuance, finalize refuses to re-mint; a re-clicked link then
         // shows the friendly "already verified" page rather than an error.
         let finalized = match finalize_pending_registration(
             pool,
@@ -2460,6 +2460,8 @@ pub async fn verify_email_get(
                 "This email is already registered. Please log in instead.",
             )
         }
+        // Rate limited: the link is still good, so retry rather than declaring it dead.
+        Err(AuthError::TooManyRequests { retry_after, .. }) => verify_html_retry_page(retry_after),
         Err(AuthError::Database(_))
         | Err(AuthError::PasswordHash(_))
         | Err(AuthError::Encryption(_))
@@ -2477,6 +2479,8 @@ pub async fn verify_email_get(
         | Err(AuthError::Forbidden(_))
         | Err(AuthError::RegistrationExpired)
         | Err(AuthError::RegistrationAlreadyCompleted)
+        | Err(AuthError::KeyEgressDenied)
+        | Err(AuthError::OAuthProtocol { .. })
         | Err(AuthError::Conflict(_)) => verify_html_page(
             StatusCode::OK,
             "Verification failed",

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -2094,8 +2094,7 @@ pub async fn finalize_pending_registration(
     })
 }
 
-/// Result of running the shared email-verification logic, rendered as JSON by the POST handler
-/// and as HTML/redirect by the GET handler so both transports stay behaviorally identical.
+/// Result of running the interactive POST email-verification logic.
 enum VerifyOutcome {
     /// Non-headless OAuth: send the browser to the client callback carrying a fresh code.
     OAuthRedirect { redirect_url: String },
@@ -2111,78 +2110,99 @@ enum VerifyOutcome {
     Expired,
 }
 
-/// Core email-verification logic shared by the POST (JSON) and GET (browser) handlers.
-///
-/// Verification runs entirely server-side here, so it does not depend on any client JavaScript —
-/// the key fix for sandboxed in-app browsers that never run the SPA's `onMount` fetch (keycast#262).
+/// Outcomes that a server-side GET may produce. This deliberately excludes first-party user
+/// verification and session issuance, which require the interactive POST flow.
+enum PendingVerifyOutcome {
+    OAuthRedirect { redirect_url: String },
+    Headless,
+    AlreadyVerified,
+}
+
+/// Finalize only an OAuth/headless pending registration, if the token belongs to one.
+async fn perform_pending_email_verification(
+    auth_state: &super::routes::AuthState,
+    tenant_id: i64,
+    token: &str,
+) -> Result<Option<PendingVerifyOutcome>, AuthError> {
+    let pool = &auth_state.state.db;
+    let oauth_code_repo = OAuthCodeRepository::new(pool.clone());
+    let Some(oauth_data) = oauth_code_repo
+        .find_by_verification_token(token, tenant_id)
+        .await?
+    else {
+        return Ok(None);
+    };
+
+    tracing::info!(
+        "Email verification for OAuth registration: pubkey {}, email {:?}",
+        oauth_data.user_pubkey,
+        oauth_data.pending_email
+    );
+
+    // Complete via the shared finalize path. This intentionally does NOT delete the pending row:
+    // re-verifying within the 24h window re-arms a fresh 10-minute code, which makes link
+    // prefetch/preview harmless. Once token issuance completes, finalize refuses to re-mint.
+    let finalized = match finalize_pending_registration(
+        pool,
+        auth_state.state.redis.as_ref(),
+        tenant_id,
+        &oauth_data,
+        HeadlessDelivery::RedisRequired,
+    )
+    .await
+    {
+        Ok(finalized) => finalized,
+        Err(AuthError::RegistrationAlreadyCompleted) => {
+            return Ok(Some(PendingVerifyOutcome::AlreadyVerified))
+        }
+        Err(e) => return Err(e),
+    };
+
+    if finalized.is_headless {
+        tracing::info!(
+            event = "email_verification",
+            tenant_id = tenant_id,
+            flow = "oauth_headless",
+            success = true,
+            "Email verified (headless), app will pick up code via polling"
+        );
+        return Ok(Some(PendingVerifyOutcome::Headless));
+    }
+
+    let mut redirect_url = format!("{}?code={}", finalized.redirect_uri, finalized.new_code);
+    if let Some(ref state) = finalized.state {
+        redirect_url = format!("{}&state={}", redirect_url, state);
+    }
+    tracing::info!(
+        event = "email_verification",
+        tenant_id = tenant_id,
+        flow = "oauth",
+        success = true,
+        "Email verified, redirecting to OAuth client"
+    );
+    Ok(Some(PendingVerifyOutcome::OAuthRedirect { redirect_url }))
+}
+
+/// Core POST email-verification logic. OAuth/headless pending rows finalize server-side; normal
+/// first-party registrations are verified and receive a session only through this interactive POST.
 async fn perform_email_verification(
     auth_state: &super::routes::AuthState,
     headers: &HeaderMap,
     tenant_id: i64,
     token: &str,
 ) -> Result<VerifyOutcome, AuthError> {
-    let pool = &auth_state.state.db;
-    let key_manager = auth_state.state.key_manager.as_ref();
-
-    // First: Check oauth_codes for pending OAuth registration
-    let oauth_code_repo = OAuthCodeRepository::new(pool.clone());
-    if let Some(oauth_data) = oauth_code_repo
-        .find_by_verification_token(token, tenant_id)
-        .await?
-    {
-        tracing::info!(
-            "Email verification for OAuth registration: pubkey {}, email {:?}",
-            oauth_data.user_pubkey,
-            oauth_data.pending_email
-        );
-
-        // Complete via the shared finalize path. This intentionally does NOT delete the pending
-        // row: re-verifying within the 24h window re-arms a fresh 10-minute code, which makes
-        // link prefetch/preview harmless (keycast#262 Part A). Once the registration has been
-        // completed token issuance, finalize refuses to re-mint; a re-clicked link then
-        // shows the friendly "already verified" page rather than an error.
-        let finalized = match finalize_pending_registration(
-            pool,
-            auth_state.state.redis.as_ref(),
-            tenant_id,
-            &oauth_data,
-            HeadlessDelivery::RedisRequired,
-        )
-        .await
-        {
-            Ok(finalized) => finalized,
-            Err(AuthError::RegistrationAlreadyCompleted) => {
-                return Ok(VerifyOutcome::AlreadyVerified)
+    if let Some(outcome) = perform_pending_email_verification(auth_state, tenant_id, token).await? {
+        return Ok(match outcome {
+            PendingVerifyOutcome::OAuthRedirect { redirect_url } => {
+                VerifyOutcome::OAuthRedirect { redirect_url }
             }
-            Err(e) => return Err(e),
-        };
-
-        if finalized.is_headless {
-            tracing::info!(
-                event = "email_verification",
-                tenant_id = tenant_id,
-                flow = "oauth_headless",
-                success = true,
-                "Email verified (headless), app will pick up code via polling"
-            );
-            return Ok(VerifyOutcome::Headless);
-        }
-
-        let mut redirect_url = format!("{}?code={}", finalized.redirect_uri, finalized.new_code);
-        if let Some(ref state) = finalized.state {
-            redirect_url = format!("{}&state={}", redirect_url, state);
-        }
-        tracing::info!(
-            event = "email_verification",
-            tenant_id = tenant_id,
-            flow = "oauth",
-            success = true,
-            "Email verified, redirecting to OAuth client"
-        );
-        return Ok(VerifyOutcome::OAuthRedirect { redirect_url });
+            PendingVerifyOutcome::Headless => VerifyOutcome::Headless,
+            PendingVerifyOutcome::AlreadyVerified => VerifyOutcome::AlreadyVerified,
+        });
     }
 
-    // Second: Check users table for normal registration
+    let pool = &auth_state.state.db;
+    let key_manager = auth_state.state.key_manager.as_ref();
     let user_repo = UserRepository::new(pool.clone());
     let token_data = user_repo
         .find_by_verification_token(token, tenant_id)
@@ -2195,11 +2215,10 @@ async fn perform_email_verification(
         .as_ref()
         .is_none_or(|expires| expires < &Utc::now());
 
-    // Keep an already-verified first-party token useful for the rest of its original verification
-    // window. A mail scanner may be the first caller that flips email_verified; the user's later
-    // click must still reach the session-cookie path instead of losing auto-login. Once the window
-    // expires, the retained token remains a harmless "already verified" acknowledgement and must
-    // no longer mint a session.
+    // Keep an already-verified first-party token useful for retrying the interactive POST during
+    // its original verification window (for example, if the first response was lost). Once the
+    // window expires, the retained token remains a harmless acknowledgement and must not mint a
+    // new session.
     if token_data.email_verified {
         if verification_expired {
             return Ok(VerifyOutcome::AlreadyVerified);
@@ -2393,13 +2412,13 @@ pub struct VerifyEmailQuery {
 
 /// Verify email address by GET (the link target in verification emails).
 ///
-/// Verification happens on this server-side GET, so it works even in sandboxed in-app browsers
-/// that never run the SPA's client JavaScript (keycast#262 Part A). Renders a minimal HTML page
-/// for headless / error states and 3xx-redirects for OAuth / first-party flows.
+/// OAuth/headless pending registrations finalize on this server-side GET so sandboxed in-app
+/// browsers do not need JavaScript. First-party tokens are handed to the interactive page without
+/// mutating user state or issuing a session; only that page's POST may do so.
 pub async fn verify_email_get(
     tenant: crate::api::tenant::TenantExtractor,
     State(auth_state): State<super::routes::AuthState>,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Query(query): Query<VerifyEmailQuery>,
 ) -> Response {
     let tenant_id = tenant.0.id;
@@ -2412,34 +2431,25 @@ pub async fn verify_email_get(
         );
     };
 
-    match perform_email_verification(&auth_state, &headers, tenant_id, &token).await {
-        Ok(VerifyOutcome::OAuthRedirect { redirect_url }) => {
+    match perform_pending_email_verification(&auth_state, tenant_id, &token).await {
+        Ok(Some(PendingVerifyOutcome::OAuthRedirect { redirect_url })) => {
             Redirect::to(&redirect_url).into_response()
         }
-        Ok(VerifyOutcome::LoggedIn { cookie }) => {
-            // Set the session cookie, then send the browser to the app home.
-            ([(axum::http::header::SET_COOKIE, cookie)], Redirect::to("/")).into_response()
-        }
-        Ok(VerifyOutcome::Headless) => verify_html_page(
+        Ok(Some(PendingVerifyOutcome::Headless)) => verify_html_page(
             StatusCode::OK,
             "Email verified!",
             "Your email is verified. You can return to the app to continue.",
         ),
-        Ok(VerifyOutcome::AlreadyVerified) => verify_html_page(
+        Ok(Some(PendingVerifyOutcome::AlreadyVerified)) => verify_html_page(
             StatusCode::OK,
             "Already verified",
             "Your email is already verified. You can return to the app or log in.",
         ),
-        Ok(VerifyOutcome::Processing) => verify_html_page(
-            StatusCode::OK,
-            "Almost there…",
-            "We're finishing your registration. Please refresh this page in a few seconds.",
-        ),
-        Ok(VerifyOutcome::Expired) => verify_html_page(
-            StatusCode::OK,
-            "Link expired",
-            "This verification link has expired. Please request a new one from the app.",
-        ),
+        Ok(None) => {
+            let interactive_url =
+                format!("/verify-email?token={}", urlencoding::encode(&token));
+            Redirect::to(&interactive_url).into_response()
+        }
         // Retryable: the link may still be good, so render a non-terminal page that retries
         // itself instead of a success-looking 2xx or terminal invalid-link page.
         Err(AuthError::ServiceUnavailable { retry_after, .. }) => {
@@ -6193,9 +6203,8 @@ mod tests {
 
         cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
 
-        // First-party registrations retain their users-table token. A scanner GET may perform
-        // the verification first, but the user's later GET must still receive a session cookie
-        // while the original verification window is live.
+        // First-party registration links hand off to the interactive page. A scanner GET must not
+        // verify the user or mint a first-party session; the page's POST performs that transition.
         let first_party_keys = Keys::generate();
         let first_party_pubkey = first_party_keys.public_key().to_hex();
         let first_party_token = format!("verify_first_party_{}", Uuid::new_v4());
@@ -6231,80 +6240,49 @@ mod tests {
         .await;
         assert!(scanner_get.status().is_redirection());
         assert!(
-            scanner_get
+            !scanner_get
                 .headers()
                 .contains_key(axum::http::header::SET_COOKIE),
-            "the first GET should verify and issue a session cookie"
+            "a first-party GET must never issue a session cookie"
+        );
+        let (verified_after_get,): (bool,) =
+            sqlx::query_as("SELECT email_verified FROM users WHERE pubkey = $1 AND tenant_id = 1")
+                .bind(&first_party_pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            !verified_after_get,
+            "a first-party GET must not mutate verification state"
         );
 
-        let user_get = verify_email_get(
+        let interactive_post = verify_email(
             create_test_tenant(),
             State(auth_state.clone()),
             HeaderMap::new(),
-            Query(VerifyEmailQuery {
-                token: Some(first_party_token.clone()),
+            Json(VerifyEmailRequest {
+                token: first_party_token.clone(),
             }),
         )
-        .await;
-        assert!(
-            user_get.status().is_redirection(),
-            "the user's GET after scanner prefetch should still redirect into the app"
-        );
-        assert!(
-            user_get
-                .headers()
-                .contains_key(axum::http::header::SET_COOKIE),
-            "the user's GET after scanner prefetch must re-arm the first-party session cookie"
-        );
-
-        sqlx::query(
-            "UPDATE users SET email_verification_expires_at = NULL \
-             WHERE pubkey = $1 AND tenant_id = 1",
-        )
-        .bind(&first_party_pubkey)
-        .execute(&pool)
         .await
-        .unwrap();
-        let missing_expiry_reclick = verify_email_get(
-            create_test_tenant(),
-            State(auth_state.clone()),
-            HeaderMap::new(),
-            Query(VerifyEmailQuery {
-                token: Some(first_party_token.clone()),
-            }),
-        )
-        .await;
-        assert_eq!(missing_expiry_reclick.status(), StatusCode::OK);
+        .map(|r| r.into_response())
+        .unwrap_or_else(|e| e.into_response());
+        assert_eq!(interactive_post.status(), StatusCode::OK);
         assert!(
-            !missing_expiry_reclick
+            interactive_post
                 .headers()
                 .contains_key(axum::http::header::SET_COOKIE),
-            "an already-verified row without a concrete expiry must not mint a session"
+            "the interactive POST must still issue the first-party session cookie"
         );
-
-        sqlx::query(
-            "UPDATE users SET email_verification_expires_at = NOW() - INTERVAL '1 second' \
-             WHERE pubkey = $1 AND tenant_id = 1",
-        )
-        .bind(&first_party_pubkey)
-        .execute(&pool)
-        .await
-        .unwrap();
-        let expired_reclick = verify_email_get(
-            create_test_tenant(),
-            State(auth_state),
-            HeaderMap::new(),
-            Query(VerifyEmailQuery {
-                token: Some(first_party_token.clone()),
-            }),
-        )
-        .await;
-        assert_eq!(expired_reclick.status(), StatusCode::OK);
+        let (verified_after_post,): (bool,) =
+            sqlx::query_as("SELECT email_verified FROM users WHERE pubkey = $1 AND tenant_id = 1")
+                .bind(&first_party_pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
         assert!(
-            !expired_reclick
-                .headers()
-                .contains_key(axum::http::header::SET_COOKIE),
-            "an expired retained token must acknowledge verification without minting a session"
+            verified_after_post,
+            "the interactive POST must complete first-party verification"
         );
 
         cleanup_verify_email_test_data(&pool, &first_party_pubkey, &first_party_token).await;
@@ -6467,11 +6445,11 @@ mod tests {
         cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
     }
 
-    /// GET verify with a bogus token must render an HTML error page for the browser, not a 500
-    /// or a raw JSON body.
+    /// A token not belonging to a pending OAuth/headless row is handed to the interactive page.
+    /// GET does not inspect the first-party users table, so valid and bogus tokens behave alike.
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
-    async fn test_verify_email_get_invalid_token_renders_html_not_500() {
+    async fn test_verify_email_get_non_pending_token_redirects_to_interactive_page() {
         let pool = create_test_db().await;
         let auth_state = create_test_auth_state(pool.clone());
 
@@ -6486,19 +6464,21 @@ mod tests {
         .await
         .into_response();
 
-        assert_ne!(
-            response.status(),
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "invalid token must not 500"
-        );
-        let content_type = response
-            .headers()
-            .get(axum::http::header::CONTENT_TYPE)
-            .map(|v| v.to_str().unwrap().to_string())
-            .unwrap_or_default();
+        assert!(response.status().is_redirection());
         assert!(
-            content_type.contains("text/html"),
-            "invalid-token GET verify should render HTML, got {content_type}"
+            !response
+                .headers()
+                .contains_key(axum::http::header::SET_COOKIE),
+            "GET must not issue a first-party session"
+        );
+        let location = response
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+            .unwrap();
+        assert!(
+            location.starts_with("/verify-email?token="),
+            "non-pending tokens must be handed to the interactive page, got {location}"
         );
     }
 

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -52,6 +52,16 @@ pub(crate) const INVALID_EMAIL_MESSAGE: &str = "Please enter a valid email addre
 pub(crate) const EMAIL_ALREADY_EXISTS_CODE: &str = "EMAIL_ALREADY_EXISTS";
 pub(crate) const EMAIL_ALREADY_EXISTS_MESSAGE: &str =
     "This email is already registered. Please log in instead.";
+/// A verification link that resolves to nothing: already used, or replaced by a newer
+/// verification email (keycast#268). Deliberately distinct from [`AuthError::InvalidToken`], whose
+/// "Please log in again." copy is correct for a bad *session* token but is a dead end here — the
+/// user has no session to return to, and the actionable advice is to open the newest email or
+/// resend from the app.
+pub(crate) const VERIFICATION_LINK_SUPERSEDED_CODE: &str = "VERIFICATION_LINK_SUPERSEDED";
+pub(crate) const VERIFICATION_LINK_SUPERSEDED_HEADING: &str = "Link no longer valid";
+pub(crate) const VERIFICATION_LINK_SUPERSEDED_MESSAGE: &str =
+    "This link was already used or replaced by a newer verification email. \
+     Check your most recent email, or tap Resend in the app.";
 pub(crate) const EMAIL_NOT_VERIFIED_CODE: &str = "EMAIL_NOT_VERIFIED";
 pub(crate) const EMAIL_NOT_VERIFIED_MESSAGE: &str =
     "Please verify your email address before continuing. Check your inbox for the verification link.";
@@ -501,6 +511,10 @@ pub enum AuthError {
     Internal(String),
     MissingToken,
     InvalidToken,
+    /// An email-verification link that no longer resolves: already used, or superseded by a newer
+    /// verification email (keycast#268). Distinct from [`AuthError::InvalidToken`] so the dead-link
+    /// copy can be actionable instead of telling a logged-out user to log in again.
+    VerificationLinkSuperseded,
     TokenExpired,
     EmailSendFailed(String),
     DuplicateKey, // Nostr pubkey already registered (BYOK case)
@@ -626,6 +640,15 @@ impl IntoResponse for AuthError {
                 StatusCode::UNAUTHORIZED,
                 "Invalid or expired token. Please log in again.".to_string(),
             ),
+            // Status deliberately unchanged from the InvalidToken it replaced (401): only the copy
+            // and the machine-readable code are new, so no client keying off the status breaks.
+            AuthError::VerificationLinkSuperseded => {
+                return coded_error_response(
+                    StatusCode::UNAUTHORIZED,
+                    VERIFICATION_LINK_SUPERSEDED_MESSAGE,
+                    VERIFICATION_LINK_SUPERSEDED_CODE,
+                );
+            }
             AuthError::EmailSendFailed(e) => {
                 // Log the real error but return generic message to user
                 tracing::error!("Email send error: {}", e);
@@ -2204,10 +2227,12 @@ async fn perform_email_verification(
     let pool = &auth_state.state.db;
     let key_manager = auth_state.state.key_manager.as_ref();
     let user_repo = UserRepository::new(pool.clone());
+    // Matches neither a pending registration nor a users row: the link was already used or a
+    // newer verification email replaced it (keycast#268).
     let token_data = user_repo
         .find_by_verification_token(token, tenant_id)
         .await?
-        .ok_or(AuthError::InvalidToken)?;
+        .ok_or(AuthError::VerificationLinkSuperseded)?;
 
     let public_key = token_data.pubkey;
     let verification_expired = token_data
@@ -2446,9 +2471,30 @@ pub async fn verify_email_get(
             "Your email is already verified. You can return to the app or log in.",
         ),
         Ok(None) => {
-            let interactive_url =
-                format!("/verify-email?token={}", urlencoding::encode(&token));
-            Redirect::to(&interactive_url).into_response()
+            // Not a pending registration. Only a token that still resolves to a users row belongs
+            // to the first-party interactive flow, which the SPA owns (it POSTs and mints the
+            // session). Anything else is a dead link, and bouncing it to the SPA just relays it to
+            // a 401 "Please log in again" — the one place this GET would still need client-side
+            // JavaScript, which is exactly what verifying on GET exists to avoid (keycast#268).
+            let user_repo = UserRepository::new(auth_state.state.db.clone());
+            match user_repo.find_by_verification_token(&token, tenant_id).await {
+                Ok(Some(_)) => {
+                    let interactive_url =
+                        format!("/verify-email?token={}", urlencoding::encode(&token));
+                    Redirect::to(&interactive_url).into_response()
+                }
+                Ok(None) => verify_link_superseded_page(),
+                // Can't tell a dead link from a database blip, so retry rather than declaring the
+                // link dead.
+                Err(err) => {
+                    tracing::error!(
+                        tenant_id = tenant_id,
+                        error = %err,
+                        "Failed to resolve verification token on GET verify"
+                    );
+                    verify_html_retry_page(5)
+                }
+            }
         }
         // Retryable: the link may still be good, so render a non-terminal page that retries
         // itself instead of a success-looking 2xx or terminal invalid-link page.
@@ -2477,6 +2523,8 @@ pub async fn verify_email_get(
         | Err(AuthError::Encryption(_))
         | Err(AuthError::Internal(_))
         | Err(AuthError::EmailSendFailed(_)) => verify_html_retry_page(5),
+        // A link that no longer resolves gets the actionable dead-link page, not a generic failure.
+        Err(AuthError::VerificationLinkSuperseded) => verify_link_superseded_page(),
         Err(AuthError::InvalidCredentials)
         | Err(AuthError::EmailNotVerified)
         | Err(AuthError::UserNotFound)
@@ -2497,6 +2545,19 @@ pub async fn verify_email_get(
             "This verification link is invalid or has expired. If you already verified, you can log in.",
         ),
     }
+}
+
+/// Terminal page for a verification link that no longer resolves — already used, or replaced by a
+/// newer verification email (keycast#268).
+///
+/// Served as 200 like the other terminal outcomes on this route: in-app browsers replace 4xx/5xx
+/// bodies with their own error chrome, which would hide the one instruction that resolves this.
+fn verify_link_superseded_page() -> Response {
+    verify_html_page(
+        StatusCode::OK,
+        VERIFICATION_LINK_SUPERSEDED_HEADING,
+        VERIFICATION_LINK_SUPERSEDED_MESSAGE,
+    )
 }
 
 /// Render the retryable-failure page for the GET verify flow: 503 + `Retry-After` plus an HTML
@@ -5388,6 +5449,7 @@ mod tests {
     use super::generate_server_signed_ucan;
     use super::validate_origin;
     use super::AccountStatusResponse;
+    use super::{VERIFICATION_LINK_SUPERSEDED_CODE, VERIFICATION_LINK_SUPERSEDED_HEADING};
     use axum::response::IntoResponse;
     use ucan::Ucan;
 
@@ -6445,20 +6507,44 @@ mod tests {
         cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
     }
 
-    /// A token not belonging to a pending OAuth/headless row is handed to the interactive page.
-    /// GET does not inspect the first-party users table, so valid and bogus tokens behave alike.
+    /// Insert a first-party (users-table) row carrying a live verification token.
+    #[cfg(feature = "integration-tests")]
+    async fn insert_first_party_pending_user(pool: &PgPool, email: &str) -> (String, String) {
+        let pubkey = Keys::generate().public_key().to_hex();
+        let token = format!("verify_first_party_{}", Uuid::new_v4());
+        let password_hash = bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap();
+
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, email_verification_token, email_verification_expires_at, created_at, updated_at)
+             VALUES ($1, 1, $2, $3, false, $4, NOW() + INTERVAL \'24 hours\', NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(email)
+        .bind(&password_hash)
+        .bind(&token)
+        .execute(pool)
+        .await
+        .expect("first-party user row should insert");
+
+        (pubkey, token)
+    }
+
+    /// A token that still resolves to a first-party users row is handed to the interactive page,
+    /// which owns that flow (it POSTs and mints the session).
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
-    async fn test_verify_email_get_non_pending_token_redirects_to_interactive_page() {
+    async fn test_verify_email_get_first_party_token_redirects_to_interactive_page() {
         let pool = create_test_db().await;
         let auth_state = create_test_auth_state(pool.clone());
+        let email = format!("verify-get-first-party-{}@example.com", Uuid::new_v4());
+        let (pubkey, token) = insert_first_party_pending_user(&pool, &email).await;
 
         let response = verify_email_get(
             create_test_tenant(),
             State(auth_state),
             HeaderMap::new(),
             axum::extract::Query(VerifyEmailQuery {
-                token: Some(format!("nonexistent_{}", Uuid::new_v4())),
+                token: Some(token.clone()),
             }),
         )
         .await
@@ -6478,7 +6564,98 @@ mod tests {
             .unwrap();
         assert!(
             location.starts_with("/verify-email?token="),
-            "non-pending tokens must be handed to the interactive page, got {location}"
+            "first-party tokens must be handed to the interactive page, got {location}"
+        );
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
+    }
+
+    /// A token that resolves to nothing - already used, or superseded by a newer verification
+    /// email - renders a terminal server-side page saying so (keycast#268).
+    ///
+    /// It must NOT bounce to the SPA: that path POSTs, 401s, and tells a user with no account and
+    /// no session to "log in again", and it is the one place this GET would still need client-side
+    /// JavaScript, which is what verifying on GET exists to avoid.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_get_dead_token_renders_superseded_page() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+
+        let response = verify_email_get(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            axum::extract::Query(VerifyEmailQuery {
+                token: Some(format!("nonexistent_{}", Uuid::new_v4())),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert!(
+            !response.status().is_redirection(),
+            "a dead token must not be relayed to the SPA"
+        );
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should be readable");
+        let body = String::from_utf8_lossy(&body);
+        assert!(
+            body.contains(VERIFICATION_LINK_SUPERSEDED_HEADING),
+            "dead-link page should carry the superseded heading, got: {body}"
+        );
+        assert!(
+            body.contains("replaced by a newer verification email"),
+            "dead-link page should explain the real cause, got: {body}"
+        );
+        assert!(
+            !body.contains("log in again"),
+            "dead-link page must not tell a user with no session to log in again, got: {body}"
+        );
+    }
+
+    /// A superseded token reaching the POST/SPA path answers with the same actionable copy and a
+    /// machine-readable code, instead of the generic "Please log in again." (keycast#268).
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_post_dead_token_does_not_say_log_in_again() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+
+        let response = verify_email(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            Json(VerifyEmailRequest {
+                token: format!("nonexistent_{}", Uuid::new_v4()),
+            }),
+        )
+        .await
+        .map(axum::response::IntoResponse::into_response)
+        .unwrap_or_else(axum::response::IntoResponse::into_response);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should be readable");
+        let body: serde_json::Value =
+            serde_json::from_slice(&body).expect("error body should be JSON");
+
+        assert_eq!(
+            body["code"].as_str(),
+            Some(VERIFICATION_LINK_SUPERSEDED_CODE),
+            "clients need a machine-readable code to branch on, got: {body}"
+        );
+        let message = body["error"].as_str().unwrap_or_default();
+        assert!(
+            !message.contains("log in again"),
+            "superseded verification links must not say 'log in again', got: {message}"
+        );
+        assert!(
+            message.contains("replaced by a newer verification email"),
+            "message should explain the real cause, got: {message}"
         );
     }
 

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1837,12 +1837,22 @@ pub async fn finalize_pending_registration(
         }
     } else if let Some(ref encrypted_secret) = oauth_data.pending_encrypted_secret {
         // Auto-generated or direct nsec: create user + personal_keys atomically.
+        //
+        // Idempotent under concurrency (link GET + PIN, mail prefetch, multiple instances): the
+        // users INSERT uses ON CONFLICT (pubkey) DO NOTHING RETURNING, and the personal_keys INSERT
+        // only runs when we actually created the user. `personal_keys` has no unique key on
+        // user_pubkey, so a blind insert on the losing race would duplicate key material; gating on
+        // the RETURNING row prevents that. No returned row => a concurrent finalize already
+        // materialized this user, so we fall through as "already exists" and re-mint a fresh code
+        // (keycast#262 finalize-race).
         let now = Utc::now();
         let mut tx = pool.begin().await?;
 
-        if let Err(err) = sqlx::query(
+        let inserted: Option<(String,)> = match sqlx::query_as(
             "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, email_verification_token, created_at, updated_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+             ON CONFLICT (pubkey) DO NOTHING
+             RETURNING pubkey",
         )
         .bind(&oauth_data.user_pubkey)
         .bind(tenant_id)
@@ -1852,37 +1862,48 @@ pub async fn finalize_pending_registration(
         .bind(kept_token)
         .bind(now)
         .bind(now)
-        .execute(&mut *tx)
+        .fetch_optional(&mut *tx)
         .await
         {
-            if has_database_constraint(&err, USERS_EMAIL_TENANT_CONSTRAINT) {
+            Ok(row) => row,
+            Err(err) if has_database_constraint(&err, USERS_EMAIL_TENANT_CONSTRAINT) => {
                 // Duplicate email: this registration can never complete, so the pending row is
                 // terminal — delete it rather than leaving a row that only ever 409s.
                 tx.rollback().await?;
                 delete_pending_registration(&oauth_code_repo, kept_token, tenant_id).await?;
                 return Err(AuthError::EmailAlreadyExists);
             }
-            return Err(err.into());
+            Err(err) => return Err(err.into()),
+        };
+
+        if inserted.is_some() {
+            sqlx::query(
+                "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
+                 VALUES ($1, $2, $3, $4, $5)",
+            )
+            .bind(&oauth_data.user_pubkey)
+            .bind(encrypted_secret)
+            .bind(tenant_id)
+            .bind(now)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+
+            tracing::info!(
+                "Created user and personal_keys for OAuth registration: {}",
+                oauth_data.user_pubkey
+            );
+        } else {
+            // Lost the race: another finalize already created this user (and its keys). Nothing to
+            // insert; commit the empty tx and proceed to re-mint a fresh exchange code.
+            tx.commit().await?;
+            tracing::info!(
+                "User already materialized by concurrent finalize, skipping creation: {}",
+                oauth_data.user_pubkey
+            );
         }
-
-        sqlx::query(
-            "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
-             VALUES ($1, $2, $3, $4, $5)",
-        )
-        .bind(&oauth_data.user_pubkey)
-        .bind(encrypted_secret)
-        .bind(tenant_id)
-        .bind(now)
-        .bind(now)
-        .execute(&mut *tx)
-        .await?;
-
-        tx.commit().await?;
-
-        tracing::info!(
-            "Created user and personal_keys for OAuth registration: {}",
-            oauth_data.user_pubkey
-        );
     } else {
         // BYOK flow: just create user, keys will come at token exchange.
         if let Err(err) = user_repo

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -2433,6 +2433,27 @@ pub async fn verify_email_get(
             "Link expired",
             "This verification link has expired. Please request a new one from the app.",
         ),
+        // Retryable: verification succeeded except for code delivery (e.g. Redis hiccup). The
+        // link is still good — render a non-terminal page that retries itself, never a bare 2xx
+        // that reads as success and never the terminal invalid-link page.
+        Err(AuthError::ServiceUnavailable { retry_after, .. }) => {
+            verify_html_retry_page(retry_after.unwrap_or(5))
+        }
+        // Terminal: the email belongs to another account (mirrors the POST path's 409).
+        Err(AuthError::EmailAlreadyExists) => verify_html_page(
+            StatusCode::CONFLICT,
+            "Email already registered",
+            "This email is already registered. Please log in instead.",
+        ),
+        Err(AuthError::Database(err))
+            if has_database_constraint(&err, USERS_EMAIL_TENANT_CONSTRAINT) =>
+        {
+            verify_html_page(
+                StatusCode::CONFLICT,
+                "Email already registered",
+                "This email is already registered. Please log in instead.",
+            )
+        }
         Err(_) => verify_html_page(
             StatusCode::OK,
             "Verification failed",
@@ -2441,10 +2462,39 @@ pub async fn verify_email_get(
     }
 }
 
+/// Render the retryable-failure page for the GET verify flow: 503 + `Retry-After` plus an HTML
+/// meta refresh, so both HTTP clients and webview users (who may have no address bar to reload
+/// with) retry automatically instead of reading a dead end.
+fn verify_html_retry_page(retry_after_secs: u32) -> Response {
+    let mut response = verify_html_page_with_refresh(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Almost there…",
+        "Your email is verified, but sign-in is still finishing. This page will retry automatically in a few seconds.",
+        Some(retry_after_secs),
+    );
+    if let Ok(value) = retry_after_secs.to_string().parse() {
+        response.headers_mut().insert("Retry-After", value);
+    }
+    response
+}
+
 /// Render a minimal, self-contained HTML status page for the GET verify flow.
 fn verify_html_page(status: StatusCode, heading: &str, message: &str) -> Response {
+    verify_html_page_with_refresh(status, heading, message, None)
+}
+
+/// [`verify_html_page`] with an optional `<meta http-equiv="refresh">` interval in seconds.
+fn verify_html_page_with_refresh(
+    status: StatusCode,
+    heading: &str,
+    message: &str,
+    refresh_secs: Option<u32>,
+) -> Response {
+    let refresh_tag = refresh_secs
+        .map(|secs| format!("<meta http-equiv=\"refresh\" content=\"{secs}\">"))
+        .unwrap_or_default();
     let body = format!(
-        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">{refresh_tag}\
          <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\
          <title>{heading}</title>\
          <style>body{{font-family:system-ui,-apple-system,sans-serif;background:#0d1117;color:#e6edf3;\
@@ -6289,6 +6339,110 @@ mod tests {
             content_type.contains("text/html"),
             "invalid-token GET verify should render HTML, got {content_type}"
         );
+    }
+
+    /// GET verify hitting the duplicate-email conflict must render the "log in instead" page with
+    /// a 409, not the generic invalid-link page (f4): the registration is terminally dead, and
+    /// the page must say why.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_get_duplicate_email_shows_login_page() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+        let existing_pubkey = Keys::generate().public_key().to_hex();
+        let duplicate_email = format!("verify-get-dup-{}@example.com", Uuid::new_v4());
+        let password_hash = bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap();
+
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+             VALUES ($1, 1, $2, $3, true, NOW(), NOW())",
+        )
+        .bind(&existing_pubkey)
+        .bind(&duplicate_email)
+        .bind(&password_hash)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let (pending_pubkey, token) =
+            insert_oauth_pending_registration(&pool, &duplicate_email).await;
+
+        let response = verify_email_get(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            axum::extract::Query(VerifyEmailQuery {
+                token: Some(token.clone()),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::CONFLICT,
+            "duplicate email on GET verify should surface as 409"
+        );
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body_bytes);
+        assert!(
+            body.contains("already registered"),
+            "page must tell the user the email is already registered: {body}"
+        );
+
+        cleanup_verify_email_test_data(&pool, &existing_pubkey, &token).await;
+        cleanup_verify_email_test_data(&pool, &pending_pubkey, &token).await;
+    }
+
+    /// GET verify for a headless registration when Redis is unavailable must render a
+    /// retry-friendly 503 page (finalize returns ServiceUnavailable), not a terminal
+    /// "verification failed" page: the link is still good and a refresh will succeed (f4).
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_get_headless_without_redis_returns_retry_page() {
+        let pool = create_test_db().await;
+        // No Redis on this state: the headless RedisRequired path must fail retryably.
+        let auth_state = create_test_auth_state(pool.clone());
+        let email = format!("verify-get-noredis-{}@example.com", Uuid::new_v4());
+        let (pubkey, token, _device_code) =
+            insert_headless_pending_registration(&pool, &email).await;
+
+        let response = verify_email_get(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            axum::extract::Query(VerifyEmailQuery {
+                token: Some(token.clone()),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "retryable failure must not render as a 2xx success-looking page"
+        );
+        assert!(
+            response.headers().get("Retry-After").is_some(),
+            "retryable page should carry Retry-After"
+        );
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body_bytes);
+        assert!(
+            body.contains("http-equiv=\"refresh\""),
+            "retry page should auto-refresh so webview users are not stranded: {body}"
+        );
+        assert!(
+            !body.contains("invalid"),
+            "retry page must not read as a terminal failure: {body}"
+        );
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
     }
 
     /// Acceptance: the link path and the PIN path produce identical materialization, because both

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -2,9 +2,9 @@
 // ABOUTME: Implements UCAN-based authentication and NIP-46 bunker URL generation
 
 use axum::{
-    extract::State,
+    extract::{Query, State},
     http::{HeaderMap, StatusCode},
-    response::{IntoResponse, Response},
+    response::{Html, IntoResponse, Redirect, Response},
     Json,
 };
 use bcrypt::{hash, verify, DEFAULT_COST};
@@ -1984,36 +1984,51 @@ pub async fn finalize_pending_registration(
     })
 }
 
-/// Verify email address with token
-/// Handles two flows:
-/// 1. OAuth registration: token in oauth_codes → complete OAuth flow → redirect to client
-/// 2. Normal registration: token in users → mark verified → issue UCAN → set cookie
-pub async fn verify_email(
-    tenant: crate::api::tenant::TenantExtractor,
-    State(auth_state): State<super::routes::AuthState>,
-    headers: HeaderMap,
-    Json(req): Json<VerifyEmailRequest>,
-) -> Result<impl IntoResponse, AuthError> {
+/// Result of running the shared email-verification logic, rendered as JSON by the POST handler
+/// and as HTML/redirect by the GET handler so both transports stay behaviorally identical.
+enum VerifyOutcome {
+    /// Non-headless OAuth: send the browser to the client callback carrying a fresh code.
+    OAuthRedirect { redirect_url: String },
+    /// Headless (mobile app): the app polls for the code; the page just shows success.
+    Headless,
+    /// First-party normal registration: user is logged in; carries the session cookie.
+    LoggedIn { cookie: String },
+    /// Idempotent re-click on an already-verified first-party account.
+    AlreadyVerified,
+    /// Async bcrypt hash still running; the caller should retry shortly.
+    Processing,
+    /// The verification link has expired.
+    Expired,
+}
+
+/// Core email-verification logic shared by the POST (JSON) and GET (browser) handlers.
+///
+/// Verification runs entirely server-side here, so it does not depend on any client JavaScript —
+/// the key fix for sandboxed in-app browsers that never run the SPA's `onMount` fetch (keycast#262).
+async fn perform_email_verification(
+    auth_state: &super::routes::AuthState,
+    headers: &HeaderMap,
+    tenant_id: i64,
+    token: &str,
+) -> Result<VerifyOutcome, AuthError> {
     let pool = &auth_state.state.db;
     let key_manager = auth_state.state.key_manager.as_ref();
-    let tenant_id = tenant.0.id;
 
     // First: Check oauth_codes for pending OAuth registration
     let oauth_code_repo = OAuthCodeRepository::new(pool.clone());
     if let Some(oauth_data) = oauth_code_repo
-        .find_by_verification_token(&req.token, tenant_id)
+        .find_by_verification_token(token, tenant_id)
         .await?
     {
-        // Found in oauth_codes - this is an OAuth registration flow
         tracing::info!(
             "Email verification for OAuth registration: pubkey {}, email {:?}",
             oauth_data.user_pubkey,
             oauth_data.pending_email
         );
 
-        // Complete the registration via the shared finalize path. This intentionally does NOT
-        // delete the pending row: re-clicking the link within the 24h window re-arms a fresh
-        // 10-minute code, which makes link prefetch/preview harmless (keycast#262 Part A).
+        // Complete via the shared finalize path. This intentionally does NOT delete the pending
+        // row: re-verifying within the 24h window re-arms a fresh 10-minute code, which makes
+        // link prefetch/preview harmless (keycast#262 Part A).
         let finalized = finalize_pending_registration(
             pool,
             auth_state.state.redis.as_ref(),
@@ -2022,12 +2037,8 @@ pub async fn verify_email(
             HeadlessDelivery::RedisRequired,
         )
         .await?;
-        let new_code = finalized.new_code;
 
-        // For headless flows (mobile app), don't redirect — the app is polling
-        // via device_code/Redis and will pick up the code automatically.
-        // The browser just shows a success page.
-        if oauth_data.is_headless {
+        if finalized.is_headless {
             tracing::info!(
                 event = "email_verification",
                 tenant_id = tenant_id,
@@ -2035,27 +2046,13 @@ pub async fn verify_email(
                 success = true,
                 "Email verified (headless), app will pick up code via polling"
             );
-
-            return Ok((
-                axum::http::StatusCode::OK,
-                axum::Json(VerifyEmailResponse {
-                    success: true,
-                    message: "Email verified! Open the app to continue.".to_string(),
-                    redirect_to: None,
-                    authenticated: None,
-                    status: Some("headless".to_string()),
-                    retry_after: None,
-                }),
-            )
-                .into_response());
+            return Ok(VerifyOutcome::Headless);
         }
 
-        // Non-headless: redirect to OAuth client's callback URL
-        let mut redirect_url = format!("{}?code={}", oauth_data.redirect_uri, new_code);
-        if let Some(ref state) = oauth_data.state {
+        let mut redirect_url = format!("{}?code={}", finalized.redirect_uri, finalized.new_code);
+        if let Some(ref state) = finalized.state {
             redirect_url = format!("{}&state={}", redirect_url, state);
         }
-
         tracing::info!(
             event = "email_verification",
             tenant_id = tenant_id,
@@ -2063,25 +2060,13 @@ pub async fn verify_email(
             success = true,
             "Email verified, redirecting to OAuth client"
         );
-
-        return Ok((
-            axum::http::StatusCode::OK,
-            axum::Json(VerifyEmailResponse {
-                success: true,
-                message: "Email verified! Redirecting to app...".to_string(),
-                redirect_to: Some(redirect_url),
-                authenticated: None,
-                status: None,
-                retry_after: None,
-            }),
-        )
-            .into_response());
+        return Ok(VerifyOutcome::OAuthRedirect { redirect_url });
     }
 
     // Second: Check users table for normal registration
     let user_repo = UserRepository::new(pool.clone());
     let token_data = user_repo
-        .find_by_verification_token(&req.token, tenant_id)
+        .find_by_verification_token(token, tenant_id)
         .await?
         .ok_or(AuthError::InvalidToken)?;
 
@@ -2089,35 +2074,13 @@ pub async fn verify_email(
 
     // Already verified (e.g. user clicked the link again) - show success
     if token_data.email_verified {
-        return Ok((
-            axum::http::StatusCode::OK,
-            axum::Json(VerifyEmailResponse {
-                success: true,
-                message: "Your email is already verified. You can log in.".to_string(),
-                redirect_to: None,
-                authenticated: None,
-                status: None,
-                retry_after: None,
-            }),
-        )
-            .into_response());
+        return Ok(VerifyOutcome::AlreadyVerified);
     }
 
     // Check if token is expired
     if let Some(expires) = token_data.email_verification_expires_at {
         if expires < Utc::now() {
-            return Ok((
-                axum::http::StatusCode::OK,
-                axum::Json(VerifyEmailResponse {
-                    success: false,
-                    message: "Verification link has expired. Please request a new one.".to_string(),
-                    redirect_to: None,
-                    authenticated: None,
-                    status: None,
-                    retry_after: None,
-                }),
-            )
-                .into_response());
+            return Ok(VerifyOutcome::Expired);
         }
     }
 
@@ -2130,28 +2093,17 @@ pub async fn verify_email(
             tracing::warn!(
                 "Password hash not completed after {}s for token {}..., likely instance died",
                 age.num_seconds(),
-                &req.token[..std::cmp::min(8, req.token.len())]
+                &token[..std::cmp::min(8, token.len())]
             );
             return Err(AuthError::RegistrationExpired);
         }
-        // Still processing - tell frontend to poll
+        // Still processing - tell caller to retry
         tracing::debug!(
             "Password hash still processing (age: {}s) for token {}...",
             age.num_seconds(),
-            &req.token[..std::cmp::min(8, req.token.len())]
+            &token[..std::cmp::min(8, token.len())]
         );
-        return Ok((
-            axum::http::StatusCode::OK,
-            axum::Json(VerifyEmailResponse {
-                success: false,
-                message: "Processing your registration, please wait...".to_string(),
-                redirect_to: None,
-                authenticated: None,
-                status: Some("processing".to_string()),
-                retry_after: Some(1),
-            }),
-        )
-            .into_response());
+        return Ok(VerifyOutcome::Processing);
     }
 
     // Mark email as verified (token kept for idempotent re-verification)
@@ -2184,7 +2136,7 @@ pub async fn verify_email(
     let keys = Keys::new(secret_key.into());
 
     // Extract redirect_origin from Origin header for UCAN
-    let redirect_origin = extract_origin_from_headers(&headers)
+    let redirect_origin = extract_origin_from_headers(headers)
         .or_else(|_| std::env::var("APP_URL"))
         .unwrap_or_else(|_| "http://localhost:3000".to_string());
 
@@ -2207,25 +2159,192 @@ pub async fn verify_email(
         "Email verified successfully, issuing UCAN"
     );
 
-    // Set UCAN session cookie
     let cookie = format!(
         "keycast_session={}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=86400",
         ucan_token
     );
+    Ok(VerifyOutcome::LoggedIn { cookie })
+}
 
-    Ok((
-        axum::http::StatusCode::OK,
-        [(axum::http::header::SET_COOKIE, cookie)],
-        axum::Json(VerifyEmailResponse {
-            success: true,
-            message: "Email verified successfully! You are now logged in.".to_string(),
-            redirect_to: None,
-            authenticated: Some(true),
-            status: None,
-            retry_after: None,
-        }),
-    )
-        .into_response())
+/// Verify email address with token (POST, JSON — used by the SPA verify page / clients).
+/// Handles two flows:
+/// 1. OAuth registration: token in oauth_codes → complete OAuth flow → redirect to client
+/// 2. Normal registration: token in users → mark verified → issue UCAN → set cookie
+pub async fn verify_email(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<super::routes::AuthState>,
+    headers: HeaderMap,
+    Json(req): Json<VerifyEmailRequest>,
+) -> Result<impl IntoResponse, AuthError> {
+    let tenant_id = tenant.0.id;
+    let outcome = perform_email_verification(&auth_state, &headers, tenant_id, &req.token).await?;
+
+    let response = match outcome {
+        VerifyOutcome::Headless => (
+            StatusCode::OK,
+            Json(VerifyEmailResponse {
+                success: true,
+                message: "Email verified! Open the app to continue.".to_string(),
+                redirect_to: None,
+                authenticated: None,
+                status: Some("headless".to_string()),
+                retry_after: None,
+            }),
+        )
+            .into_response(),
+        VerifyOutcome::OAuthRedirect { redirect_url } => (
+            StatusCode::OK,
+            Json(VerifyEmailResponse {
+                success: true,
+                message: "Email verified! Redirecting to app...".to_string(),
+                redirect_to: Some(redirect_url),
+                authenticated: None,
+                status: None,
+                retry_after: None,
+            }),
+        )
+            .into_response(),
+        VerifyOutcome::AlreadyVerified => (
+            StatusCode::OK,
+            Json(VerifyEmailResponse {
+                success: true,
+                message: "Your email is already verified. You can log in.".to_string(),
+                redirect_to: None,
+                authenticated: None,
+                status: None,
+                retry_after: None,
+            }),
+        )
+            .into_response(),
+        VerifyOutcome::Expired => (
+            StatusCode::OK,
+            Json(VerifyEmailResponse {
+                success: false,
+                message: "Verification link has expired. Please request a new one.".to_string(),
+                redirect_to: None,
+                authenticated: None,
+                status: None,
+                retry_after: None,
+            }),
+        )
+            .into_response(),
+        VerifyOutcome::Processing => (
+            StatusCode::OK,
+            Json(VerifyEmailResponse {
+                success: false,
+                message: "Processing your registration, please wait...".to_string(),
+                redirect_to: None,
+                authenticated: None,
+                status: Some("processing".to_string()),
+                retry_after: Some(1),
+            }),
+        )
+            .into_response(),
+        VerifyOutcome::LoggedIn { cookie } => (
+            StatusCode::OK,
+            [(axum::http::header::SET_COOKIE, cookie)],
+            Json(VerifyEmailResponse {
+                success: true,
+                message: "Email verified successfully! You are now logged in.".to_string(),
+                redirect_to: None,
+                authenticated: Some(true),
+                status: None,
+                retry_after: None,
+            }),
+        )
+            .into_response(),
+    };
+
+    Ok(response)
+}
+
+/// Query parameters for the GET verify-email link.
+#[derive(Debug, Deserialize)]
+pub struct VerifyEmailQuery {
+    pub token: Option<String>,
+}
+
+/// Verify email address by GET (the link target in verification emails).
+///
+/// Verification happens on this server-side GET, so it works even in sandboxed in-app browsers
+/// that never run the SPA's client JavaScript (keycast#262 Part A). Renders a minimal HTML page
+/// for headless / error states and 3xx-redirects for OAuth / first-party flows.
+pub async fn verify_email_get(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<super::routes::AuthState>,
+    headers: HeaderMap,
+    Query(query): Query<VerifyEmailQuery>,
+) -> Response {
+    let tenant_id = tenant.0.id;
+
+    let Some(token) = query.token.filter(|t| !t.is_empty()) else {
+        return verify_html_page(
+            StatusCode::BAD_REQUEST,
+            "Invalid link",
+            "This verification link is missing its token. Please use the link from your email.",
+        );
+    };
+
+    match perform_email_verification(&auth_state, &headers, tenant_id, &token).await {
+        Ok(VerifyOutcome::OAuthRedirect { redirect_url }) => {
+            Redirect::to(&redirect_url).into_response()
+        }
+        Ok(VerifyOutcome::LoggedIn { cookie }) => {
+            // Set the session cookie, then send the browser to the app home.
+            ([(axum::http::header::SET_COOKIE, cookie)], Redirect::to("/")).into_response()
+        }
+        Ok(VerifyOutcome::Headless) => verify_html_page(
+            StatusCode::OK,
+            "Email verified!",
+            "Your email is verified. You can return to the app to continue.",
+        ),
+        Ok(VerifyOutcome::AlreadyVerified) => verify_html_page(
+            StatusCode::OK,
+            "Already verified",
+            "Your email is already verified. You can return to the app or log in.",
+        ),
+        Ok(VerifyOutcome::Processing) => verify_html_page(
+            StatusCode::OK,
+            "Almost there…",
+            "We're finishing your registration. Please refresh this page in a few seconds.",
+        ),
+        Ok(VerifyOutcome::Expired) => verify_html_page(
+            StatusCode::OK,
+            "Link expired",
+            "This verification link has expired. Please request a new one from the app.",
+        ),
+        Err(_) => verify_html_page(
+            StatusCode::OK,
+            "Verification failed",
+            "This verification link is invalid or has expired. If you already verified, you can log in.",
+        ),
+    }
+}
+
+/// Render a minimal, self-contained HTML status page for the GET verify flow.
+fn verify_html_page(status: StatusCode, heading: &str, message: &str) -> Response {
+    let body = format!(
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\
+         <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\
+         <title>{heading}</title>\
+         <style>body{{font-family:system-ui,-apple-system,sans-serif;background:#0d1117;color:#e6edf3;\
+         display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0;padding:1rem}}\
+         .card{{max-width:420px;text-align:center;background:#161b22;border:1px solid #30363d;\
+         border-radius:1rem;padding:2rem}}h1{{font-size:1.4rem;margin:0 0 .5rem}}\
+         p{{color:#9da7b3;margin:0;font-size:.95rem}}</style></head>\
+         <body><div class=\"card\"><h1>{heading}</h1><p>{message}</p></div></body></html>",
+        heading = html_escape(heading),
+        message = html_escape(message),
+    );
+    (status, Html(body)).into_response()
+}
+
+/// Minimal HTML-escaping for the small set of static status strings rendered above.
+fn html_escape(input: &str) -> String {
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 #[derive(Debug, Deserialize)]
@@ -5298,7 +5417,8 @@ mod tests {
 
     #[cfg(feature = "integration-tests")]
     use super::{
-        generate_ucan_token, login, update_profile, verify_email, ProfileData, VerifyEmailRequest,
+        generate_ucan_token, login, update_profile, verify_email, verify_email_get, ProfileData,
+        VerifyEmailQuery, VerifyEmailRequest,
     };
     #[cfg(feature = "integration-tests")]
     use crate::api::http::routes::AuthState;
@@ -5867,6 +5987,183 @@ mod tests {
         );
 
         cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
+    }
+
+    /// Build a Redis-backed AuthState for headless GET tests (the link path requires Redis).
+    #[cfg(feature = "integration-tests")]
+    async fn create_test_auth_state_with_redis(pool: PgPool) -> AuthState {
+        let mut state = create_test_auth_state(pool);
+        let redis_url =
+            std::env::var("TEST_REDIS_URL").unwrap_or_else(|_| "redis://localhost:16379".into());
+        let client = redis::Client::open(redis_url.as_str()).unwrap();
+        let conn = redis::aio::ConnectionManager::new(client).await.unwrap();
+        let redis = crate::redis::PrefixedRedis::new(conn, Some("test_verify".to_string()));
+        let inner = Arc::get_mut(&mut state.state).expect("unique Arc");
+        inner.redis = Some(redis);
+        state
+    }
+
+    /// Insert a headless pending registration (device_code set) and return (pubkey, token, device_code).
+    #[cfg(feature = "integration-tests")]
+    async fn insert_headless_pending_registration(
+        pool: &PgPool,
+        email: &str,
+    ) -> (String, String, String) {
+        let pending_keys = Keys::generate();
+        let pending_pubkey = pending_keys.public_key().to_hex();
+        let verification_token = format!("verify_{}", Uuid::new_v4());
+        let placeholder_code = format!("placeholder_{}", Uuid::new_v4());
+        let device_code = format!("dc_{}", Uuid::new_v4());
+        let password_hash = bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap();
+        let expires_at = Utc::now() + Duration::hours(24);
+        let encrypted_secret = pending_keys.secret_key().to_secret_bytes().to_vec();
+
+        cleanup_verify_email_test_data(pool, &pending_pubkey, &verification_token).await;
+
+        sqlx::query(
+            "INSERT INTO oauth_codes (
+                tenant_id, code, user_pubkey, client_id, redirect_uri, scope,
+                expires_at, created_at, pending_email, pending_password_hash,
+                pending_email_verification_token, pending_encrypted_secret, device_code, is_headless
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), $8, $9, $10, $11, $12, true)",
+        )
+        .bind(1_i64)
+        .bind(&placeholder_code)
+        .bind(&pending_pubkey)
+        .bind("TestApp")
+        .bind("https://test.example.com/callback")
+        .bind("policy:social")
+        .bind(expires_at)
+        .bind(email)
+        .bind(&password_hash)
+        .bind(&verification_token)
+        .bind(&encrypted_secret)
+        .bind(&device_code)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        (pending_pubkey, verification_token, device_code)
+    }
+
+    /// GET /api/auth/verify-email for a non-headless OAuth registration must verify server-side
+    /// (no client JS) and 3xx-redirect the browser to the client callback carrying a fresh code.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_get_oauth_redirects_with_code() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+        let email = format!("verify-get-oauth-{}@example.com", Uuid::new_v4());
+        let (pubkey, token) = insert_oauth_pending_registration(&pool, &email).await;
+
+        let response = verify_email_get(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            axum::extract::Query(VerifyEmailQuery {
+                token: Some(token.clone()),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert!(
+            response.status().is_redirection(),
+            "GET verify for OAuth should redirect, got {}",
+            response.status()
+        );
+        let location = response
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .expect("redirect must set Location")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            location.contains("code="),
+            "redirect Location must carry an exchange code: {location}"
+        );
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
+    }
+
+    /// GET verify for a headless registration shows an HTML success page (the app polls for the
+    /// code) and re-arms a fresh code without deleting the pending row.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_get_headless_returns_success_page() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state_with_redis(pool.clone()).await;
+        let email = format!("verify-get-headless-{}@example.com", Uuid::new_v4());
+        let (pubkey, token, _device_code) =
+            insert_headless_pending_registration(&pool, &email).await;
+
+        let response = verify_email_get(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            axum::extract::Query(VerifyEmailQuery {
+                token: Some(token.clone()),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .map(|v| v.to_str().unwrap().to_string())
+            .unwrap_or_default();
+        assert!(
+            content_type.contains("text/html"),
+            "headless GET verify should render an HTML page, got {content_type}"
+        );
+
+        // Pending row survives (idempotent re-arm).
+        let repo = keycast_core::repositories::OAuthCodeRepository::new(pool.clone());
+        assert!(repo
+            .find_by_verification_token(&token, 1)
+            .await
+            .unwrap()
+            .is_some());
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
+    }
+
+    /// GET verify with a bogus token must render an HTML error page for the browser, not a 500
+    /// or a raw JSON body.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_get_invalid_token_renders_html_not_500() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+
+        let response = verify_email_get(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            axum::extract::Query(VerifyEmailQuery {
+                token: Some(format!("nonexistent_{}", Uuid::new_v4())),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_ne!(
+            response.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "invalid token must not 500"
+        );
+        let content_type = response
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .map(|v| v.to_str().unwrap().to_string())
+            .unwrap_or_default();
+        assert!(
+            content_type.contains("text/html"),
+            "invalid-token GET verify should render HTML, got {content_type}"
+        );
     }
 
     #[cfg(feature = "integration-tests")]

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -50,7 +50,7 @@ const USERS_EMAIL_TENANT_CONSTRAINT: &str = "idx_users_email_tenant";
 pub(crate) const INVALID_EMAIL_CODE: &str = "INVALID_EMAIL";
 pub(crate) const INVALID_EMAIL_MESSAGE: &str = "Please enter a valid email address.";
 pub(crate) const EMAIL_ALREADY_EXISTS_CODE: &str = "EMAIL_ALREADY_EXISTS";
-const EMAIL_ALREADY_EXISTS_MESSAGE: &str =
+pub(crate) const EMAIL_ALREADY_EXISTS_MESSAGE: &str =
     "This email is already registered. Please log in instead.";
 pub(crate) const EMAIL_NOT_VERIFIED_CODE: &str = "EMAIL_NOT_VERIFIED";
 pub(crate) const EMAIL_NOT_VERIFIED_MESSAGE: &str =
@@ -764,15 +764,14 @@ impl From<AuthError> for super::headless::HeadlessError {
     fn from(e: AuthError) -> Self {
         use super::headless::HeadlessError;
         match e {
-            AuthError::EmailAlreadyExists => HeadlessError::Conflict(
-                "This email is already registered. Please log in instead.".to_string(),
-            ),
+            // Dedicated variant so the response body carries the documented EMAIL_ALREADY_EXISTS
+            // code byte-identical to the link path (keycast#198/#236 contract), while the shared
+            // Conflict variant keeps emitting the generic CONFLICT code for its other cases.
+            AuthError::EmailAlreadyExists => HeadlessError::EmailAlreadyExists,
             AuthError::Database(ref db_err)
                 if has_database_constraint(db_err, USERS_EMAIL_TENANT_CONSTRAINT) =>
             {
-                HeadlessError::Conflict(
-                    "This email is already registered. Please log in instead.".to_string(),
-                )
+                HeadlessError::EmailAlreadyExists
             }
             AuthError::Conflict(msg) => HeadlessError::Conflict(msg),
             AuthError::RegistrationAlreadyCompleted => HeadlessError::Conflict(

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -514,6 +514,9 @@ pub enum AuthError {
     Forbidden(String),   // User has no authorization for this origin
     KeyEgressDenied,     // Policy refuses raw-key egress for this account
     RegistrationExpired, // Async bcrypt timed out (instance died)
+    /// The pending registration's exchange code was already redeemed; re-mint is refused
+    /// (keycast#262 bounded lifecycle).
+    RegistrationAlreadyCompleted,
     ServiceUnavailable {
         // Server at capacity or shutting down
         message: String,
@@ -683,6 +686,10 @@ impl IntoResponse for AuthError {
                 StatusCode::GONE,
                 "Registration expired. Please register again.".to_string(),
             ),
+            AuthError::RegistrationAlreadyCompleted => (
+                StatusCode::CONFLICT,
+                "This registration is already complete. Please sign in.".to_string(),
+            ),
             AuthError::ServiceUnavailable { message, retry_after } => {
                 // Return with Retry-After header if provided
                 let response = (
@@ -768,6 +775,9 @@ impl From<AuthError> for super::headless::HeadlessError {
                 )
             }
             AuthError::Conflict(msg) => HeadlessError::Conflict(msg),
+            AuthError::RegistrationAlreadyCompleted => HeadlessError::Conflict(
+                "This registration is already complete. Please sign in.".to_string(),
+            ),
             AuthError::ServiceUnavailable {
                 message,
                 retry_after,
@@ -1724,6 +1734,17 @@ pub async fn finalize_pending_registration(
     oauth_data: &OAuthCodeData,
     delivery: HeadlessDelivery,
 ) -> Result<FinalizedRegistration, AuthError> {
+    // Terminal: once the registration's exchange code has been redeemed, the row is consumed and
+    // must not re-mint again (keycast#262). Re-clicks before redemption still re-arm a fresh code
+    // (the intended harmless idempotency); re-clicks after completion are refused here.
+    if oauth_data.consumed_at.is_some() {
+        tracing::info!(
+            "Registration already completed (consumed), refusing to re-mint: {}",
+            oauth_data.user_pubkey
+        );
+        return Err(AuthError::RegistrationAlreadyCompleted);
+    }
+
     let email = oauth_data
         .pending_email
         .as_ref()
@@ -1984,6 +2005,12 @@ pub async fn finalize_pending_registration(
         state: oauth_data.state.as_deref(),
         is_headless: oauth_data.is_headless, // Inherit from original registration
     };
+    // At most one live exchange code per registration: drop any previously minted, un-redeemed
+    // exchange code for this user+client before storing the fresh one, so a re-click cannot leave
+    // several valid codes outstanding (keycast#262).
+    oauth_code_repo
+        .delete_unredeemed_exchange_codes(tenant_id, &oauth_data.user_pubkey, &oauth_data.client_id)
+        .await?;
     oauth_code_repo.store(store_params).await?;
 
     if let Some((device_code, redis)) = strict_delivery {
@@ -2081,15 +2108,24 @@ async fn perform_email_verification(
 
         // Complete via the shared finalize path. This intentionally does NOT delete the pending
         // row: re-verifying within the 24h window re-arms a fresh 10-minute code, which makes
-        // link prefetch/preview harmless (keycast#262 Part A).
-        let finalized = finalize_pending_registration(
+        // link prefetch/preview harmless (keycast#262 Part A). Once the registration has been
+        // completed (exchange code redeemed), finalize refuses to re-mint; a re-clicked link then
+        // shows the friendly "already verified" page rather than an error.
+        let finalized = match finalize_pending_registration(
             pool,
             auth_state.state.redis.as_ref(),
             tenant_id,
             &oauth_data,
             HeadlessDelivery::RedisRequired,
         )
-        .await?;
+        .await
+        {
+            Ok(finalized) => finalized,
+            Err(AuthError::RegistrationAlreadyCompleted) => {
+                return Ok(VerifyOutcome::AlreadyVerified)
+            }
+            Err(e) => return Err(e),
+        };
 
         if finalized.is_headless {
             tracing::info!(

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -5584,8 +5584,10 @@ mod tests {
     }
 
     fn create_lazy_auth_state() -> crate::api::http::routes::AuthState {
+        let database_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
         let pool = sqlx::postgres::PgPoolOptions::new()
-            .connect_lazy("postgres://postgres:password@localhost/keycast_test")
+            .connect_lazy(&database_url)
             .expect("lazy pool should be created");
         let bcrypt_queue = crate::bcrypt_queue::BcryptQueue::new();
         let secret_pool = keycast_core::secret_pool::SecretPool::new(1);

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -6320,6 +6320,21 @@ mod tests {
         state
     }
 
+    /// Build an AuthState whose Redis wrapper deterministically rejects SETEX operations.
+    #[cfg(feature = "integration-tests")]
+    async fn create_test_auth_state_with_failing_redis(pool: PgPool) -> AuthState {
+        let mut state = create_test_auth_state(pool);
+        let redis_url =
+            std::env::var("TEST_REDIS_URL").unwrap_or_else(|_| "redis://localhost:16379".into());
+        let client = redis::Client::open(redis_url.as_str()).unwrap();
+        let conn = redis::aio::ConnectionManager::new(client).await.unwrap();
+        let redis =
+            crate::redis::PrefixedRedis::new_failing(conn, Some("test_verify_fail".to_string()));
+        let inner = Arc::get_mut(&mut state.state).expect("unique Arc");
+        inner.redis = Some(redis);
+        state
+    }
+
     /// Insert a headless pending registration (device_code set) and return (pubkey, token, device_code).
     #[cfg(feature = "integration-tests")]
     async fn insert_headless_pending_registration(
@@ -6590,6 +6605,120 @@ mod tests {
         assert!(
             body.contains("temporary problem verifying your link"),
             "retry page should explain the temporary verification problem neutrally: {body}"
+        );
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
+    }
+
+    /// A failed strict Redis delivery removes only the exchange code minted by this finalize,
+    /// while preserving the materialized user and pending row so the link can be retried.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_finalize_pending_registration_fresh_code_redis_failure_cleans_orphan() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state_with_failing_redis(pool.clone()).await;
+        let redis = auth_state.state.redis.as_ref().expect("failing Redis");
+        let repo = keycast_core::repositories::OAuthCodeRepository::new(pool.clone());
+        let email = format!("verify-fresh-redis-fail-{}@example.com", Uuid::new_v4());
+        let (pubkey, token, _device_code) =
+            insert_headless_pending_registration(&pool, &email).await;
+        let pending = repo
+            .find_by_verification_token(&token, 1)
+            .await
+            .unwrap()
+            .expect("pending registration");
+
+        let result = super::finalize_pending_registration(
+            &pool,
+            Some(redis),
+            1,
+            &pending,
+            super::HeadlessDelivery::RedisRequired,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(super::AuthError::ServiceUnavailable { .. })
+        ));
+        assert!(
+            repo.find_by_verification_token(&token, 1)
+                .await
+                .unwrap()
+                .is_some(),
+            "Redis failure must preserve the pending registration for retry"
+        );
+        let (email_verified,): (bool,) =
+            sqlx::query_as("SELECT email_verified FROM users WHERE pubkey = $1 AND tenant_id = 1")
+                .bind(&pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            email_verified,
+            "the user must remain materialized and verified"
+        );
+        assert!(
+            repo.find_live_exchange_code_with_expiry_for_pending(1, &pending)
+                .await
+                .unwrap()
+                .is_none(),
+            "the freshly minted undeliverable exchange code must be deleted"
+        );
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
+    }
+
+    /// A failed strict Redis redelivery must not delete a still-live code owned by a prior
+    /// successful finalize, because the polling app may already hold that code.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_finalize_pending_registration_reused_code_redis_failure_preserves_code() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state_with_failing_redis(pool.clone()).await;
+        let redis = auth_state.state.redis.as_ref().expect("failing Redis");
+        let repo = keycast_core::repositories::OAuthCodeRepository::new(pool.clone());
+        let email = format!("verify-reused-redis-fail-{}@example.com", Uuid::new_v4());
+        let (pubkey, token, _device_code) =
+            insert_headless_pending_registration(&pool, &email).await;
+        let pending = repo
+            .find_by_verification_token(&token, 1)
+            .await
+            .unwrap()
+            .expect("pending registration");
+
+        let first = super::finalize_pending_registration(
+            &pool,
+            None,
+            1,
+            &pending,
+            super::HeadlessDelivery::RedisBestEffort,
+        )
+        .await
+        .expect("first finalize mints a reusable live code");
+
+        let result = super::finalize_pending_registration(
+            &pool,
+            Some(redis),
+            1,
+            &pending,
+            super::HeadlessDelivery::RedisRequired,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(super::AuthError::ServiceUnavailable { .. })
+        ));
+        let live_code = repo
+            .find_live_exchange_code_with_expiry_for_pending(1, &pending)
+            .await
+            .unwrap()
+            .map(|(code, _expires_at)| code);
+        assert_eq!(
+            live_code.as_deref(),
+            Some(first.new_code.as_str()),
+            "Redis redelivery failure must leave the reused code intact"
         );
 
         cleanup_verify_email_test_data(&pool, &pubkey, &token).await;

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -2432,9 +2432,8 @@ pub async fn verify_email_get(
             "Link expired",
             "This verification link has expired. Please request a new one from the app.",
         ),
-        // Retryable: verification succeeded except for code delivery (e.g. Redis hiccup). The
-        // link is still good — render a non-terminal page that retries itself, never a bare 2xx
-        // that reads as success and never the terminal invalid-link page.
+        // Retryable: the link may still be good, so render a non-terminal page that retries
+        // itself instead of a success-looking 2xx or terminal invalid-link page.
         Err(AuthError::ServiceUnavailable { retry_after, .. }) => {
             verify_html_retry_page(retry_after.unwrap_or(5))
         }
@@ -2453,7 +2452,24 @@ pub async fn verify_email_get(
                 "This email is already registered. Please log in instead.",
             )
         }
-        Err(_) => verify_html_page(
+        Err(AuthError::Database(_))
+        | Err(AuthError::PasswordHash(_))
+        | Err(AuthError::Encryption(_))
+        | Err(AuthError::Internal(_))
+        | Err(AuthError::EmailSendFailed(_)) => verify_html_retry_page(5),
+        Err(AuthError::InvalidCredentials)
+        | Err(AuthError::EmailNotVerified)
+        | Err(AuthError::UserNotFound)
+        | Err(AuthError::MissingToken)
+        | Err(AuthError::InvalidToken)
+        | Err(AuthError::TokenExpired)
+        | Err(AuthError::DuplicateKey)
+        | Err(AuthError::InvalidEmail)
+        | Err(AuthError::BadRequest(_))
+        | Err(AuthError::Forbidden(_))
+        | Err(AuthError::RegistrationExpired)
+        | Err(AuthError::RegistrationAlreadyCompleted)
+        | Err(AuthError::Conflict(_)) => verify_html_page(
             StatusCode::OK,
             "Verification failed",
             "This verification link is invalid or has expired. If you already verified, you can log in.",
@@ -2468,7 +2484,7 @@ fn verify_html_retry_page(retry_after_secs: u32) -> Response {
     let mut response = verify_html_page_with_refresh(
         StatusCode::SERVICE_UNAVAILABLE,
         "Almost there…",
-        "Your email is verified, but sign-in is still finishing. This page will retry automatically in a few seconds.",
+        "We hit a temporary problem verifying your link. This page will retry automatically in a few seconds.",
         Some(retry_after_secs),
     );
     if let Ok(value) = retry_after_secs.to_string().parse() {
@@ -6439,6 +6455,14 @@ mod tests {
         assert!(
             !body.contains("invalid"),
             "retry page must not read as a terminal failure: {body}"
+        );
+        assert!(
+            !body.contains("Your email is verified"),
+            "retry page must not claim verification succeeded before retryable work completes: {body}"
+        );
+        assert!(
+            body.contains("temporary problem verifying your link"),
+            "retry page should explain the temporary verification problem neutrally: {body}"
         );
 
         cleanup_verify_email_test_data(&pool, &pubkey, &token).await;

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1727,6 +1727,8 @@ async fn delete_pending_registration(
 /// window re-arms a fresh exchange code, which is what makes link prefetch/preview harmless: a
 /// mail-scanner GET can no longer materialize the user, mint a short-lived code, delete the row,
 /// and strand the user's real visit. The row expires on its own at the end of the verify window.
+/// The one exception is a duplicate email (#236): that registration can never complete, so the
+/// pending row is deleted to make the 409 terminal instead of looping on every retry.
 pub async fn finalize_pending_registration(
     pool: &PgPool,
     redis: Option<&crate::redis::PrefixedRedis>,
@@ -1845,7 +1847,8 @@ pub async fn finalize_pending_registration(
                     .await
                 {
                     if matches!(err, keycast_core::repositories::RepositoryError::Duplicate) {
-                        delete_pending_registration(&oauth_code_repo, kept_token, tenant_id).await?;
+                        delete_pending_registration(&oauth_code_repo, kept_token, tenant_id)
+                            .await?;
                         return Err(AuthError::EmailAlreadyExists);
                     }
                     return Err(err.into());
@@ -1888,8 +1891,11 @@ pub async fn finalize_pending_registration(
         {
             Ok(row) => row,
             Err(err) if has_database_constraint(&err, USERS_EMAIL_TENANT_CONSTRAINT) => {
-                // Duplicate email: this registration can never complete, so the pending row is
-                // terminal — delete it rather than leaving a row that only ever 409s.
+                // Duplicate email: this registration can never complete (the email belongs to
+                // another user), so terminate it — delete the pending row so the 409 is terminal
+                // and a retried token no longer loops through duplicate insertion (#236). This is
+                // the one exception to the keep-the-pending-row re-arm rule: no exchange code can
+                // ever be minted from this row, so deleting it strands nothing.
                 tx.rollback().await?;
                 delete_pending_registration(&oauth_code_repo, kept_token, tenant_id).await?;
                 return Err(AuthError::EmailAlreadyExists);
@@ -1939,6 +1945,7 @@ pub async fn finalize_pending_registration(
             .await
         {
             if matches!(err, keycast_core::repositories::RepositoryError::Duplicate) {
+                // Same terminal duplicate-email handling as the keyed path above (#236).
                 delete_pending_registration(&oauth_code_repo, kept_token, tenant_id).await?;
                 return Err(AuthError::EmailAlreadyExists);
             }

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1754,24 +1754,6 @@ pub async fn finalize_pending_registration(
         .as_deref()
         .ok_or_else(|| account_incomplete("Registration is incomplete. Please register again."))?;
     let oauth_code_repo = OAuthCodeRepository::new(pool.clone());
-    let oauth_data = match oauth_code_repo
-        .materialize_pending_registration(tenant_id, verification_token)
-        .await?
-    {
-        MaterializePendingRegistrationOutcome::Materialized(pending) => *pending,
-        MaterializePendingRegistrationOutcome::DuplicateKey => return Err(AuthError::DuplicateKey),
-        MaterializePendingRegistrationOutcome::EmailAlreadyExists => {
-            return Err(AuthError::EmailAlreadyExists)
-        }
-        MaterializePendingRegistrationOutcome::NotFound => {
-            return Err(AuthError::ServiceUnavailable {
-                message: "Registration changed while it was being finalized. Please retry."
-                    .to_string(),
-                retry_after: Some(1),
-            })
-        }
-    };
-
     let headless_retry_error = || AuthError::ServiceUnavailable {
         message: "Email verified, but app sign-in is still finishing. Please retry shortly."
             .to_string(),
@@ -1804,47 +1786,34 @@ pub async fn finalize_pending_registration(
         None
     };
 
-    // Re-arm idempotently (keycast#262): if a still-live exchange code was already minted for this
-    // registration (an earlier re-click or mail prefetch), reuse it instead of minting a
-    // replacement. A re-mint would strand the code the polling app may already hold. Only mint a
-    // fresh code (10 minute exchange window — do not lengthen) when none is live. The consumed_at
-    // terminal guard above already refuses re-mint once a code has been redeemed.
-    // `freshly_minted` records whether THIS call created the code (vs reused an existing live one).
-    // It gates the delivery-failure cleanup below: a reused code is owned by a prior finalize.
     let candidate: String = rand::thread_rng()
         .sample_iter(&rand::distributions::Alphanumeric)
         .take(32)
         .map(char::from)
         .collect();
-    let candidate_expires_at = Utc::now() + Duration::minutes(10);
-    let stored = oauth_code_repo
-        .get_or_store_exchange_code_for_pending(
-            keycast_core::repositories::StoreOAuthCodeParams {
-                tenant_id,
-                code: &candidate,
-                user_pubkey: &oauth_data.user_pubkey,
-                client_id: &oauth_data.client_id,
-                redirect_uri: &oauth_data.redirect_uri,
-                scope: &oauth_data.scope,
-                code_challenge: oauth_data.code_challenge.as_deref(),
-                code_challenge_method: oauth_data.code_challenge_method.as_deref(),
-                expires_at: candidate_expires_at,
-                previous_auth_id: oauth_data.previous_auth_id,
-                state: oauth_data.state.as_deref(),
-                is_headless: oauth_data.is_headless,
-            },
-            &oauth_data,
-        )
+    let finalized = match oauth_code_repo
+        .materialize_pending_registration(tenant_id, verification_token, &candidate)
         .await?
-        .ok_or(AuthError::RegistrationAlreadyCompleted)?;
-    let new_code = stored.code;
-    let code_expires_at = stored.expires_at;
-    let freshly_minted = stored.freshly_minted;
-    let redis_ttl_seconds = if freshly_minted {
-        600
-    } else {
-        (code_expires_at - Utc::now()).num_seconds().max(1) as u64
+    {
+        MaterializePendingRegistrationOutcome::Ready(finalized) => *finalized,
+        MaterializePendingRegistrationOutcome::Processing => return Err(headless_retry_error()),
+        MaterializePendingRegistrationOutcome::DuplicateKey => return Err(AuthError::DuplicateKey),
+        MaterializePendingRegistrationOutcome::EmailAlreadyExists => {
+            return Err(AuthError::EmailAlreadyExists)
+        }
+        MaterializePendingRegistrationOutcome::NotFound => {
+            return Err(AuthError::ServiceUnavailable {
+                message: "Registration changed while it was being finalized. Please retry."
+                    .to_string(),
+                retry_after: Some(1),
+            })
+        }
     };
+    let oauth_data = finalized.pending;
+    let new_code = finalized.exchange_code.code;
+    let redis_ttl_seconds = (finalized.exchange_code.expires_at - Utc::now())
+        .num_seconds()
+        .max(1) as u64;
 
     if let Some((device_code, redis)) = strict_delivery {
         let key = format!("oauth_poll:{}", device_code);
@@ -5928,8 +5897,8 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(
-            user_count.0, 1,
-            "retry should reuse the created user instead of duplicating it"
+            user_count.0, 0,
+            "strict Redis validation must run before user materialization"
         );
 
         cleanup_verify_email_test_data(&pool, &pubkey, &verification_token).await;

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1988,11 +1988,13 @@ pub async fn finalize_pending_registration(
     // replacement. A re-mint would strand the code the polling app may already hold. Only mint a
     // fresh code (10 minute exchange window — do not lengthen) when none is live. The consumed_at
     // terminal guard above already refuses re-mint once a code has been redeemed.
-    let new_code = if let Some(existing) = oauth_code_repo
+    // `freshly_minted` records whether THIS call created the code (vs reused an existing live one).
+    // It gates the delivery-failure cleanup below: a reused code is owned by a prior finalize.
+    let (new_code, freshly_minted) = if let Some(existing) = oauth_code_repo
         .find_live_exchange_code(tenant_id, &oauth_data.user_pubkey, &oauth_data.client_id)
         .await?
     {
-        existing
+        (existing, false)
     } else {
         let minted: String = rand::thread_rng()
             .sample_iter(&rand::distributions::Alphanumeric)
@@ -2016,7 +2018,7 @@ pub async fn finalize_pending_registration(
             is_headless: oauth_data.is_headless, // Inherit from original registration
         };
         oauth_code_repo.store(store_params).await?;
-        minted
+        (minted, true)
     };
 
     if let Some((device_code, redis)) = strict_delivery {
@@ -2030,14 +2032,19 @@ pub async fn finalize_pending_registration(
                 error = %e,
                 "Failed to store headless OAuth code in Redis for polling"
             );
-            if let Err(cleanup_err) = oauth_code_repo.delete(tenant_id, &new_code).await {
-                tracing::error!(
-                    tenant_id = tenant_id,
-                    user_pubkey = %oauth_data.user_pubkey,
-                    code = %new_code,
-                    error = %cleanup_err,
-                    "Failed to clean up OAuth code after Redis polling write failed"
-                );
+            // Only clean up a code we freshly minted on this call. A reused code is owned by a prior
+            // finalize that already handled its own Redis delivery; deleting it here would strand a
+            // code the polling app may already hold (keycast#262). Retry either way.
+            if freshly_minted {
+                if let Err(cleanup_err) = oauth_code_repo.delete(tenant_id, &new_code).await {
+                    tracing::error!(
+                        tenant_id = tenant_id,
+                        user_pubkey = %oauth_data.user_pubkey,
+                        code = %new_code,
+                        error = %cleanup_err,
+                        "Failed to clean up OAuth code after Redis polling write failed"
+                    );
+                }
             }
             return Err(headless_retry_error());
         }

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1075,7 +1075,7 @@ pub async fn register(
     match crate::email_service::EmailService::new() {
         Ok(email_service) => {
             if let Err(e) = email_service
-                .send_verification_email(&req.email, &verification_token)
+                .send_verification_email(&req.email, &verification_token, None)
                 .await
             {
                 tracing::error!("Failed to send verification email to {}: {}", req.email, e);
@@ -2465,7 +2465,7 @@ pub async fn resend_verification(
         match crate::email_service::EmailService::new() {
             Ok(email_service) => {
                 if let Err(e) = email_service
-                    .send_verification_email(&email_clone, &token_clone)
+                    .send_verification_email(&email_clone, &token_clone, None)
                     .await
                 {
                     tracing::error!(

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -6035,7 +6035,10 @@ mod tests {
         let body2 = response_json(second).await;
         let code2 = extract_code_from_redirect(body2["redirect_to"].as_str().unwrap());
 
-        assert_ne!(code1, code2, "each verify must mint a fresh exchange code");
+        assert_eq!(
+            code1, code2,
+            "idempotent re-arm reuses the same live exchange code"
+        );
 
         cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
     }

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -5359,6 +5359,7 @@ mod tests {
     use super::generate_server_signed_ucan;
     use super::validate_origin;
     use super::AccountStatusResponse;
+    #[cfg(feature = "integration-tests")]
     use super::{VERIFICATION_LINK_SUPERSEDED_CODE, VERIFICATION_LINK_SUPERSEDED_HEADING};
     use axum::response::IntoResponse;
     use ucan::Ucan;

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -2193,7 +2193,7 @@ async fn perform_email_verification(
     let verification_expired = token_data
         .email_verification_expires_at
         .as_ref()
-        .is_some_and(|expires| expires < &Utc::now());
+        .is_none_or(|expires| expires < &Utc::now());
 
     // Keep an already-verified first-party token useful for the rest of its original verification
     // window. A mail scanner may be the first caller that flips email_verified; the user's later
@@ -6235,7 +6235,7 @@ mod tests {
 
         let user_get = verify_email_get(
             create_test_tenant(),
-            State(auth_state),
+            State(auth_state.clone()),
             HeaderMap::new(),
             Query(VerifyEmailQuery {
                 token: Some(first_party_token.clone()),
@@ -6254,6 +6254,31 @@ mod tests {
         );
 
         sqlx::query(
+            "UPDATE users SET email_verification_expires_at = NULL \
+             WHERE pubkey = $1 AND tenant_id = 1",
+        )
+        .bind(&first_party_pubkey)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let missing_expiry_reclick = verify_email_get(
+            create_test_tenant(),
+            State(auth_state.clone()),
+            HeaderMap::new(),
+            Query(VerifyEmailQuery {
+                token: Some(first_party_token.clone()),
+            }),
+        )
+        .await;
+        assert_eq!(missing_expiry_reclick.status(), StatusCode::OK);
+        assert!(
+            !missing_expiry_reclick
+                .headers()
+                .contains_key(axum::http::header::SET_COOKIE),
+            "an already-verified row without a concrete expiry must not mint a session"
+        );
+
+        sqlx::query(
             "UPDATE users SET email_verification_expires_at = NOW() - INTERVAL '1 second' \
              WHERE pubkey = $1 AND tenant_id = 1",
         )
@@ -6263,7 +6288,7 @@ mod tests {
         .unwrap();
         let expired_reclick = verify_email_get(
             create_test_tenant(),
-            State(create_test_auth_state(pool.clone())),
+            State(auth_state),
             HeaderMap::new(),
             Query(VerifyEmailQuery {
                 token: Some(first_party_token.clone()),

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -770,6 +770,10 @@ impl From<keycast_core::repositories::RepositoryError> for AuthError {
         match e {
             RepositoryError::Duplicate => AuthError::EmailAlreadyExists,
             RepositoryError::NotFound(_) => AuthError::UserNotFound,
+            RepositoryError::Unavailable(message) => AuthError::ServiceUnavailable {
+                message,
+                retry_after: Some(1),
+            },
             _ => AuthError::Internal(e.to_string()),
         }
     }
@@ -1758,6 +1762,48 @@ pub async fn finalize_pending_registration(
     oauth_data: &OAuthCodeData,
     delivery: HeadlessDelivery,
 ) -> Result<FinalizedRegistration, AuthError> {
+    if oauth_data.consumed_at.is_some() {
+        return Err(AuthError::RegistrationAlreadyCompleted);
+    }
+    let verification_token = oauth_data
+        .pending_email_verification_token
+        .as_deref()
+        .ok_or_else(|| account_incomplete("Registration is incomplete. Please register again."))?;
+    let claim = generate_secure_token();
+    let oauth_code_repo = OAuthCodeRepository::new(pool.clone());
+    if !oauth_code_repo
+        .claim_pending_finalization(tenant_id, verification_token, &claim)
+        .await?
+    {
+        return Err(AuthError::ServiceUnavailable {
+            message: "Registration changed or is already being finalized. Please retry shortly."
+                .to_string(),
+            retry_after: Some(1),
+        });
+    }
+
+    let result =
+        finalize_claimed_pending_registration(pool, redis, tenant_id, oauth_data, delivery).await;
+    if let Err(error) = oauth_code_repo
+        .release_pending_finalization(tenant_id, verification_token, &claim)
+        .await
+    {
+        tracing::error!(
+            tenant_id,
+            error = %error,
+            "Failed to release pending-registration finalization claim"
+        );
+    }
+    result
+}
+
+async fn finalize_claimed_pending_registration(
+    pool: &PgPool,
+    redis: Option<&crate::redis::PrefixedRedis>,
+    tenant_id: i64,
+    oauth_data: &OAuthCodeData,
+    delivery: HeadlessDelivery,
+) -> Result<FinalizedRegistration, AuthError> {
     // Terminal: once the registration's exchange code has issued tokens, the row is consumed and
     // must not re-mint again (keycast#262). Re-clicks before redemption still re-arm a fresh code
     // (the intended harmless idempotency); re-clicks after completion are refused here.
@@ -2139,6 +2185,7 @@ enum PendingVerifyOutcome {
     OAuthRedirect { redirect_url: String },
     Headless,
     AlreadyVerified,
+    Expired,
 }
 
 /// Finalize only an OAuth/headless pending registration, if the token belongs to one.
@@ -2150,11 +2197,14 @@ async fn perform_pending_email_verification(
     let pool = &auth_state.state.db;
     let oauth_code_repo = OAuthCodeRepository::new(pool.clone());
     let Some(oauth_data) = oauth_code_repo
-        .find_by_verification_token(token, tenant_id)
+        .find_by_verification_token_including_expired(token, tenant_id)
         .await?
     else {
         return Ok(None);
     };
+    if oauth_data.expires_at <= Utc::now() {
+        return Ok(Some(PendingVerifyOutcome::Expired));
+    }
 
     tracing::info!(
         "Email verification for OAuth registration: pubkey {}, email {:?}",
@@ -2221,6 +2271,7 @@ async fn perform_email_verification(
             }
             PendingVerifyOutcome::Headless => VerifyOutcome::Headless,
             PendingVerifyOutcome::AlreadyVerified => VerifyOutcome::AlreadyVerified,
+            PendingVerifyOutcome::Expired => VerifyOutcome::Expired,
         });
     }
 
@@ -2376,12 +2427,17 @@ pub async fn verify_email(
         VerifyOutcome::Expired => "expired",
         VerifyOutcome::LoggedIn { .. } => "logged_in",
     };
+    let event_outcome = if matches!(&outcome, VerifyOutcome::Expired) {
+        "failure"
+    } else {
+        "success"
+    };
     record_verify_email_event(
         &auth_state.state.db,
         &headers,
         tenant_id,
         "POST",
-        "success",
+        event_outcome,
         Some(outcome_reason),
         200,
     )
@@ -2522,6 +2578,14 @@ pub async fn verify_email_get(
                 StatusCode::OK,
                 "Already verified",
                 "Your email is already verified. You can return to the app or log in.",
+            )
+        }
+        Ok(Some(PendingVerifyOutcome::Expired)) => {
+            emit("failure", Some("expired"), 410).await;
+            verify_html_page(
+                StatusCode::GONE,
+                "Verification link expired",
+                "This verification link has expired. Please sign up again.",
             )
         }
         Ok(None) => {
@@ -6765,6 +6829,83 @@ mod tests {
             !body.contains("log in again"),
             "dead-link page must not tell a user with no session to log in again, got: {body}"
         );
+    }
+
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_expired_pending_token_is_not_reported_as_superseded_or_successful() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+        let email = format!("verify-expired-{}@example.com", Uuid::new_v4());
+        let (pubkey, token) = insert_oauth_pending_registration(&pool, &email).await;
+        sqlx::query(
+            "UPDATE oauth_codes SET expires_at = NOW() - INTERVAL '1 second'
+             WHERE pending_email_verification_token = $1 AND tenant_id = 1",
+        )
+        .bind(&token)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let get_request_id = format!("get_{}", Uuid::new_v4());
+        let mut get_headers = HeaderMap::new();
+        get_headers.insert(
+            crate::api::http::auth_observability::REQUEST_ID_HEADER,
+            get_request_id.parse().unwrap(),
+        );
+        let get_response = verify_email_get(
+            create_test_tenant(),
+            State(auth_state.clone()),
+            get_headers,
+            Query(VerifyEmailQuery {
+                token: Some(token.clone()),
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(get_response.status(), StatusCode::GONE);
+
+        let post_request_id = format!("post_{}", Uuid::new_v4());
+        let mut post_headers = HeaderMap::new();
+        post_headers.insert(
+            crate::api::http::auth_observability::REQUEST_ID_HEADER,
+            post_request_id.parse().unwrap(),
+        );
+        let post_response = verify_email(
+            create_test_tenant(),
+            State(auth_state),
+            post_headers,
+            Json(VerifyEmailRequest {
+                token: token.clone(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_response();
+        assert_eq!(post_response.status(), StatusCode::OK);
+
+        for (request_id, expected) in [
+            (
+                &get_request_id,
+                "/api/auth/verify-email|email_verification|failure|expired|410",
+            ),
+            (
+                &post_request_id,
+                "/api/auth/verify-email|email_verification|failure|expired|200",
+            ),
+        ] {
+            let event: String = sqlx::query_scalar(
+                "SELECT concat_ws('|', endpoint, event_type, outcome, reason_code, http_status)
+                 FROM auth_events WHERE request_id = $1",
+            )
+            .bind(request_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(event, expected);
+        }
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &token).await;
     }
 
     /// The GET path records auth events for its outcomes, matching the POST path's event_type so

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -26,8 +26,9 @@ use crate::password_verifier::{
 use keycast_core::metrics::METRICS;
 use keycast_core::repositories::{
     AccountStatusWithMinorRow, AuthEventRepository, CreateOAuthAuthorizationParams,
-    OAuthAuthorizationRepository, OAuthCodeData, OAuthCodeRepository, PersonalKeysRepository,
-    PolicyRepository, UserRepository, VerifiedMinorRow,
+    MaterializePendingRegistrationOutcome, OAuthAuthorizationRepository, OAuthCodeData,
+    OAuthCodeRepository, PersonalKeysRepository, PolicyRepository, UserRepository,
+    VerifiedMinorRow,
 };
 use keycast_core::traits::CustomPermission;
 use nostr_sdk::{Keys, PublicKey, ToBech32, UnsignedEvent};
@@ -1726,23 +1727,6 @@ pub enum HeadlessDelivery {
     RedisBestEffort,
 }
 
-/// Delete a pending registration row that can never complete (terminal conflict).
-///
-/// Pending rows are otherwise kept so re-verification re-arms a fresh exchange code; deletion is
-/// reserved for conflicts where no exchange code could ever be minted from the row.
-async fn delete_pending_registration(
-    oauth_code_repo: &OAuthCodeRepository,
-    kept_token: Option<&str>,
-    tenant_id: i64,
-) -> Result<(), AuthError> {
-    if let Some(token) = kept_token {
-        oauth_code_repo
-            .delete_by_verification_token(token, tenant_id)
-            .await?;
-    }
-    Ok(())
-}
-
 /// Shared completion path for a pending email-verification registration (keycast#262).
 ///
 /// Invoked by both the email-link verification path and the in-app PIN path so they produce
@@ -1769,262 +1753,24 @@ pub async fn finalize_pending_registration(
         .pending_email_verification_token
         .as_deref()
         .ok_or_else(|| account_incomplete("Registration is incomplete. Please register again."))?;
-    let claim = generate_secure_token();
     let oauth_code_repo = OAuthCodeRepository::new(pool.clone());
-    if !oauth_code_repo
-        .claim_pending_finalization(tenant_id, verification_token, &claim)
+    let oauth_data = match oauth_code_repo
+        .materialize_pending_registration(tenant_id, verification_token)
         .await?
     {
-        return Err(AuthError::ServiceUnavailable {
-            message: "Registration changed or is already being finalized. Please retry shortly."
-                .to_string(),
-            retry_after: Some(1),
-        });
-    }
-
-    let result =
-        finalize_claimed_pending_registration(pool, redis, tenant_id, oauth_data, delivery).await;
-    if let Err(error) = oauth_code_repo
-        .release_pending_finalization(tenant_id, verification_token, &claim)
-        .await
-    {
-        tracing::error!(
-            tenant_id,
-            error = %error,
-            "Failed to release pending-registration finalization claim"
-        );
-    }
-    result
-}
-
-async fn finalize_claimed_pending_registration(
-    pool: &PgPool,
-    redis: Option<&crate::redis::PrefixedRedis>,
-    tenant_id: i64,
-    oauth_data: &OAuthCodeData,
-    delivery: HeadlessDelivery,
-) -> Result<FinalizedRegistration, AuthError> {
-    // Terminal: once the registration's exchange code has issued tokens, the row is consumed and
-    // must not re-mint again (keycast#262). Re-clicks before redemption still re-arm a fresh code
-    // (the intended harmless idempotency); re-clicks after completion are refused here.
-    if oauth_data.consumed_at.is_some() {
-        tracing::info!(
-            "Registration already completed (consumed), refusing to re-mint: {}",
-            oauth_data.user_pubkey
-        );
-        return Err(AuthError::RegistrationAlreadyCompleted);
-    }
-
-    let email = oauth_data
-        .pending_email
-        .as_ref()
-        .ok_or_else(|| account_incomplete("Registration is incomplete. Please register again."))?;
-    let password_hash = oauth_data
-        .pending_password_hash
-        .as_ref()
-        .ok_or_else(|| account_incomplete("Registration is incomplete. Please register again."))?;
-    // The token kept on the materialized user row is the one already stored on the pending row,
-    // so the link path can be re-clicked idempotently (it resolves the same user).
-    let kept_token = oauth_data.pending_email_verification_token.as_deref();
-
-    let oauth_code_repo = OAuthCodeRepository::new(pool.clone());
-    let user_repo = UserRepository::new(pool.clone());
-    let existing_user = user_repo
-        .oauth_registration_state(&oauth_data.user_pubkey, tenant_id)
-        .await?;
-
-    if let Some(existing) = existing_user {
-        match existing.email.as_deref() {
-            Some(existing_email) if existing_email == email => {
-                if existing.email_verified && existing.has_password_hash {
-                    // Genuine retry: a prior attempt already applied the pending
-                    // credentials. Backfill the personal key if that attempt (or
-                    // another creation path) left it missing.
-                    tracing::info!(
-                        "Retrying email verification for existing user: {}",
-                        oauth_data.user_pubkey
-                    );
-                    if let (Some(encrypted_secret), false) = (
-                        oauth_data.pending_encrypted_secret.as_deref(),
-                        existing.has_personal_key,
-                    ) {
-                        user_repo
-                            .backfill_personal_key(
-                                &oauth_data.user_pubkey,
-                                tenant_id,
-                                encrypted_secret,
-                            )
-                            .await?;
-                        tracing::info!(
-                            "Backfilled missing personal key during verification retry: {}",
-                            oauth_data.user_pubkey
-                        );
-                    }
-                } else {
-                    // A same-email row can come from standard registration before
-                    // verification or before bcrypt finishes. Complete it before
-                    // minting an OAuth code.
-                    if let Err(err) = user_repo
-                        .complete_pending_oauth_registration(
-                            &oauth_data.user_pubkey,
-                            tenant_id,
-                            email,
-                            password_hash,
-                            kept_token,
-                            oauth_data.pending_encrypted_secret.as_deref(),
-                        )
-                        .await
-                    {
-                        if matches!(err, keycast_core::repositories::RepositoryError::Duplicate) {
-                            delete_pending_registration(&oauth_code_repo, kept_token, tenant_id)
-                                .await?;
-                            return Err(AuthError::EmailAlreadyExists);
-                        }
-                        return Err(err.into());
-                    }
-                    tracing::info!(
-                        "Completed incomplete same-email registration row: {}",
-                        oauth_data.user_pubkey
-                    );
-                }
-            }
-            Some(_) => {
-                // The pubkey is already bound to a different email. Never
-                // overwrite an existing account's credentials from an
-                // unauthenticated verification.
-                tracing::warn!(
-                    "Email verification for pubkey {} conflicts with an existing account email",
-                    oauth_data.user_pubkey
-                );
-                delete_pending_registration(&oauth_code_repo, kept_token, tenant_id).await?;
-                return Err(AuthError::DuplicateKey);
-            }
-            None => {
-                // Bare row pre-created by another path (team membership,
-                // authorization pre-creation): apply the pending registration
-                // instead of silently dropping it.
-                if let Err(err) = user_repo
-                    .complete_pending_oauth_registration(
-                        &oauth_data.user_pubkey,
-                        tenant_id,
-                        email,
-                        password_hash,
-                        kept_token,
-                        oauth_data.pending_encrypted_secret.as_deref(),
-                    )
-                    .await
-                {
-                    if matches!(err, keycast_core::repositories::RepositoryError::Duplicate) {
-                        delete_pending_registration(&oauth_code_repo, kept_token, tenant_id)
-                            .await?;
-                        return Err(AuthError::EmailAlreadyExists);
-                    }
-                    return Err(err.into());
-                }
-                tracing::info!(
-                    "Applied pending registration to pre-existing user row: {}",
-                    oauth_data.user_pubkey
-                );
-            }
+        MaterializePendingRegistrationOutcome::Materialized(pending) => *pending,
+        MaterializePendingRegistrationOutcome::DuplicateKey => return Err(AuthError::DuplicateKey),
+        MaterializePendingRegistrationOutcome::EmailAlreadyExists => {
+            return Err(AuthError::EmailAlreadyExists)
         }
-    } else if let Some(ref encrypted_secret) = oauth_data.pending_encrypted_secret {
-        // Auto-generated or direct nsec: create user + personal_keys atomically.
-        //
-        // Idempotent under concurrency (link GET + PIN, mail prefetch, multiple instances): the
-        // users INSERT uses ON CONFLICT (pubkey) DO NOTHING RETURNING, and the personal_keys INSERT
-        // only runs when we actually created the user. `personal_keys` has no unique key on
-        // user_pubkey, so a blind insert on the losing race would duplicate key material; gating on
-        // the RETURNING row prevents that. No returned row => a concurrent finalize already
-        // materialized this user, so we fall through as "already exists" and re-mint a fresh code
-        // (keycast#262 finalize-race).
-        let now = Utc::now();
-        let mut tx = pool.begin().await?;
-
-        let inserted: Option<(String,)> = match sqlx::query_as(
-            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, email_verification_token, created_at, updated_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-             ON CONFLICT (pubkey) DO NOTHING
-             RETURNING pubkey",
-        )
-        .bind(&oauth_data.user_pubkey)
-        .bind(tenant_id)
-        .bind(email)
-        .bind(password_hash)
-        .bind(true) // email_verified = true
-        .bind(kept_token)
-        .bind(now)
-        .bind(now)
-        .fetch_optional(&mut *tx)
-        .await
-        {
-            Ok(row) => row,
-            Err(err) if has_database_constraint(&err, USERS_EMAIL_TENANT_CONSTRAINT) => {
-                // Duplicate email: this registration can never complete (the email belongs to
-                // another user), so terminate it — delete the pending row so the 409 is terminal
-                // and a retried token no longer loops through duplicate insertion (#236). This is
-                // the one exception to the keep-the-pending-row re-arm rule: no exchange code can
-                // ever be minted from this row, so deleting it strands nothing.
-                tx.rollback().await?;
-                delete_pending_registration(&oauth_code_repo, kept_token, tenant_id).await?;
-                return Err(AuthError::EmailAlreadyExists);
-            }
-            Err(err) => return Err(err.into()),
-        };
-
-        if inserted.is_some() {
-            sqlx::query(
-                "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
-                 VALUES ($1, $2, $3, $4, $5)",
-            )
-            .bind(&oauth_data.user_pubkey)
-            .bind(encrypted_secret)
-            .bind(tenant_id)
-            .bind(now)
-            .bind(now)
-            .execute(&mut *tx)
-            .await?;
-
-            tx.commit().await?;
-
-            tracing::info!(
-                "Created user and personal_keys for OAuth registration: {}",
-                oauth_data.user_pubkey
-            );
-        } else {
-            // Lost the race: another finalize already created this user (and its keys). Nothing to
-            // insert; commit the empty tx and proceed to re-mint a fresh exchange code.
-            tx.commit().await?;
-            tracing::info!(
-                "User already materialized by concurrent finalize, skipping creation: {}",
-                oauth_data.user_pubkey
-            );
+        MaterializePendingRegistrationOutcome::NotFound => {
+            return Err(AuthError::ServiceUnavailable {
+                message: "Registration changed while it was being finalized. Please retry."
+                    .to_string(),
+                retry_after: Some(1),
+            })
         }
-    } else {
-        // BYOK flow: just create user, keys will come at token exchange.
-        if let Err(err) = user_repo
-            .create_with_password_verified(
-                &oauth_data.user_pubkey,
-                tenant_id,
-                email,
-                password_hash,
-                true, // email_verified = true
-                kept_token,
-            )
-            .await
-        {
-            if matches!(err, keycast_core::repositories::RepositoryError::Duplicate) {
-                // Same terminal duplicate-email handling as the keyed path above (#236).
-                delete_pending_registration(&oauth_code_repo, kept_token, tenant_id).await?;
-                return Err(AuthError::EmailAlreadyExists);
-            }
-            return Err(err.into());
-        }
-
-        tracing::info!(
-            "Created user for BYOK OAuth registration: {}",
-            oauth_data.user_pubkey
-        );
-    }
+    };
 
     let headless_retry_error = || AuthError::ServiceUnavailable {
         message: "Email verified, but app sign-in is still finishing. Please retry shortly."
@@ -2067,7 +1813,7 @@ async fn finalize_claimed_pending_registration(
     // It gates the delivery-failure cleanup below: a reused code is owned by a prior finalize.
     let (new_code, code_expires_at, freshly_minted) = if let Some((existing, expires_at)) =
         oauth_code_repo
-            .find_live_exchange_code_with_expiry_for_pending(tenant_id, oauth_data)
+            .find_live_exchange_code_with_expiry_for_pending(tenant_id, &oauth_data)
             .await?
     {
         (existing, expires_at, false)
@@ -2094,7 +1840,7 @@ async fn finalize_claimed_pending_registration(
             is_headless: oauth_data.is_headless, // Inherit from original registration
         };
         if !oauth_code_repo
-            .store_for_pending_registration(store_params, oauth_data)
+            .store_for_pending_registration(store_params, &oauth_data)
             .await?
         {
             return Err(AuthError::RegistrationAlreadyCompleted);

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -847,6 +847,21 @@ pub async fn headless_verify_pin(
     )
     .await?;
 
+    // Correct PIN: clear the failed-attempt counter that `reserve_pin_attempt` incremented before
+    // the bcrypt compare. Only failed attempts should count toward the lockout cap (keycast#262), so
+    // a successful verify (and any idempotent re-verify of the same correct PIN) must not lock out.
+    // Best-effort: the registration already finalized, so a stray counter is not worth failing on.
+    if let Err(e) = oauth_code_repo
+        .reset_pin_attempts(&req.device_code, tenant_id)
+        .await
+    {
+        tracing::warn!(
+            "Failed to reset pin_attempts after successful PIN verify for {}: {}",
+            pending.user_pubkey,
+            e
+        );
+    }
+
     tracing::info!(
         event = "email_pin_verify",
         tenant_id = tenant_id,

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -727,13 +727,19 @@ const MAX_PIN_ATTEMPTS: i32 = 5;
 /// bounds the registration's whole life instead, and exhausting it disables PIN entry while
 /// leaving the emailed link working.
 ///
-/// 50 rather than a round guess, for three reasons. NIST SP 800-63B-4 §3.2.2 sets 100 as the
-/// normative ceiling for consecutive failed attempts against a specific authenticator before it
-/// must be disabled, so 50 sits inside a standard rather than being invented, at half that
-/// ceiling. A legitimate user's realistic worst case is around 15 — the 5-attempt cap across the
-/// two or three resends a real person makes — so 50 leaves more than three times that headroom.
-/// And against a 10^6 PIN space it holds lifetime exposure near 0.005%, against roughly 0.14% with
-/// no lifetime cap at all.
+/// The value is bounded from both sides rather than derived, and 50 is a choice inside that band:
+///
+/// - Ceiling: NIST SP 800-63B-4 §3.2.2 requires a verifier to limit consecutive failed attempts
+///   against a specific authenticator to no more than 100 before disabling it. That rules out
+///   anything above 100; it is not a reason to pick any particular value below it.
+/// - Floor: a legitimate user must not hit this. The realistic worst case is the per-PIN cap spent
+///   against the original PIN plus each of two or three resends, so 20 rather than 15.
+/// - Exposure: against a 10^6 PIN space the cap is very nearly the whole story, so N attempts is
+///   about N in a million. 50 gives roughly 0.005%, against roughly 0.14% with no lifetime cap.
+///
+/// Anything in roughly 25..100 satisfies all three. 50 is picked for headroom over the floor
+/// without crowding the ceiling, and the honest description is that the band is justified and the
+/// exact number inside it is not.
 const MAX_PIN_ATTEMPTS_LIFETIME: i32 = 50;
 
 #[derive(Debug, Deserialize)]
@@ -955,6 +961,22 @@ pub async fn headless_verify_pin(
             .await;
             return Err(HeadlessError::PinUnavailable);
         }
+        // The window closed between the snapshot check above and this reservation. Same answer as
+        // that check, so the boundary reports expiry rather than falling through to a comparison
+        // against a dead registration.
+        PinAttemptReservation::Expired => {
+            record_pin_verify_failure(
+                pool,
+                &headers,
+                tenant_id,
+                Some(&pending.user_pubkey),
+                pending.pending_email.as_deref(),
+                "registration_expired",
+                StatusCode::GONE.as_u16().into(),
+            )
+            .await;
+            return Err(HeadlessError::PinExpired);
+        }
     };
 
     // Constant-time PIN comparison (bcrypt's own compare; work factor dominates). Both this real
@@ -1003,6 +1025,26 @@ pub async fn headless_verify_pin(
         return Err(error);
     }
 
+    // The PIN was correct, so release the slot this request reserved BEFORE running finalize.
+    // `reserve_pin_attempt` charges every attempt up front, including this one, and finalize is
+    // fallible for reasons that have nothing to do with the user's PIN — a database blip, a Redis
+    // outage, a key-manager error. Releasing afterwards would leave a correct PIN permanently
+    // counted as a failed guess on every finalize error, so repeated server-side failures could
+    // burn a legitimate user's lifetime budget with the right code in their hand.
+    //
+    // Best-effort: this is a counter, not the gate. If it fails the user has at worst one fewer
+    // attempt, and the caps are still exact.
+    if let Err(e) = oauth_code_repo
+        .reset_pin_attempts(&req.device_code, tenant_id)
+        .await
+    {
+        tracing::warn!(
+            "Failed to release the PIN attempt slot after a correct PIN for {}: {}",
+            pending.user_pubkey,
+            e
+        );
+    }
+
     // Correct PIN: run the SAME finalize path as the link (idempotent; does not delete the row).
     // RedisBestEffort because the code is returned synchronously below, so a Redis outage is fine.
     let finalized = match super::auth::finalize_pending_registration(
@@ -1022,21 +1064,6 @@ pub async fn headless_verify_pin(
         }
         Err(e) => return Err(e.into()),
     };
-
-    // Correct PIN: clear the failed-attempt counter that `reserve_pin_attempt` incremented before
-    // the bcrypt compare. Only failed attempts should count toward the lockout cap (keycast#262), so
-    // a successful verify (and any idempotent re-verify of the same correct PIN) must not lock out.
-    // Best-effort: the registration already finalized, so a stray counter is not worth failing on.
-    if let Err(e) = oauth_code_repo
-        .reset_pin_attempts(&req.device_code, tenant_id)
-        .await
-    {
-        tracing::warn!(
-            "Failed to reset pin_attempts after successful PIN verify for {}: {}",
-            pending.user_pubkey,
-            e
-        );
-    }
 
     tracing::info!(
         event = "email_pin_verify",
@@ -1116,9 +1143,20 @@ pub async fn headless_resend_pin(
     // `find_by_device_code` no longer filters expired rows, so this path has to. A resend
     // deliberately does not extend `expires_at` (keycast#262 bounded lifecycle), so re-arming a
     // registration whose window has closed would mail the user a PIN and a link that both fail.
+    //
+    // Report this one honestly instead of through the uniform success. Verify-pin answers an
+    // expired registration with PIN_EXPIRED, and the caller's recovery for that is to resend — so
+    // claiming a resend succeeded here would send the user into a cooldown waiting for mail that
+    // is never coming, which is the same false-success trap this change set removed from the
+    // cooldown path. A failed resend leaves the affordance retryable and lets the user conclude
+    // they need to register again. Reaching this requires holding the registration's device_code,
+    // so it discloses nothing the caller did not already have.
     if pending.expires_at <= Utc::now() {
-        tracing::debug!("resend-pin: registration expired, skipping (not revealed to client)");
-        return Ok(success());
+        tracing::debug!("resend-pin: registration expired, nothing can be re-armed");
+        return Ok(Json(HeadlessResendPinResponse {
+            success: false,
+            message: "This registration has expired. Please sign up again.".to_string(),
+        }));
     }
 
     // Cheap pre-check so an obvious cooldown hit does not pay for bcrypt. This is an optimization,
@@ -2088,6 +2126,114 @@ mod tests {
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// Verify-pin answers an expired registration with PIN_EXPIRED, whose recovery affordance is
+    /// resend. A resend cannot revive an expired registration, so it must say so rather than
+    /// report the uniform success — otherwise the user is sent into a cooldown waiting for mail
+    /// that will never arrive, which is the same false success this change set removed elsewhere.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    #[serial]
+    async fn test_resend_pin_on_an_expired_registration_reports_failure() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("resend-pin-expired-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        let (old_hash,): (Option<String>,) =
+            sqlx::query_as("SELECT pin_hash FROM oauth_codes WHERE device_code = $1")
+                .bind(&device_code)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        sqlx::query("UPDATE oauth_codes SET expires_at = $2 WHERE device_code = $1")
+            .bind(&device_code)
+            .bind(Utc::now() - Duration::minutes(1))
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let response = call_resend_pin(auth_state, &device_code).await;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(
+            response_json(response).await["success"],
+            false,
+            "a resend that cannot possibly work must not claim it succeeded"
+        );
+
+        let (new_hash,): (Option<String>,) =
+            sqlx::query_as("SELECT pin_hash FROM oauth_codes WHERE device_code = $1")
+                .bind(&device_code)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            new_hash, old_hash,
+            "an expired registration must not be re-armed"
+        );
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// A correct PIN must give its reserved slot back. `reserve_pin_attempt` charges every attempt
+    /// up front, so without the release a correct PIN stays counted as a failed guess against the
+    /// registration's lifetime budget.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_correct_pin_releases_its_reserved_attempt_slot() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("verify-pin-release-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        // Two prior failures, so the release is visible as a decrement rather than as a reset.
+        sqlx::query(
+            "UPDATE oauth_codes SET pin_attempts = 2, pin_failed_total = 2 WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let response = call_verify_pin(auth_state, &device_code, "123456").await;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let (attempts, failed_total): (i32, i32) = sqlx::query_as(
+            "SELECT pin_attempts, pin_failed_total FROM oauth_codes \
+             WHERE device_code = $1 AND pending_email IS NOT NULL",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(attempts, 0, "a correct PIN clears the per-PIN counter");
+        assert_eq!(
+            failed_total, 2,
+            "a correct PIN must give back exactly the slot it reserved, leaving the two real \
+             failures counted"
+        );
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM personal_keys WHERE user_pubkey = $1")
+            .bind(&pubkey)
             .execute(&pool)
             .await;
         let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -11,7 +11,8 @@ use bcrypt::verify;
 use chrono::{Duration, Utc};
 use keycast_core::metrics::METRICS;
 use keycast_core::repositories::{
-    OAuthCodeRepository, PolicyRepository, StoreOAuthCodeWithRegistrationParams, UserRepository,
+    OAuthCodeRepository, PinAttemptReservation, PolicyRepository,
+    StoreOAuthCodeWithRegistrationParams, UserRepository,
 };
 use nostr_sdk::Keys;
 use rand::Rng;
@@ -714,20 +715,26 @@ async fn extract_first_party_or_user_signed_user(
 // Headless Verify PIN (in-app fallback for the email verification link)
 // ============================================================================
 
-/// Failed PIN attempts allowed before the PIN is locked until resend (keycast#262).
+/// Failed attempts allowed against the *current* PIN before it locks (keycast#262). A resend
+/// clears this, which is what makes a resend the way out of a lockout.
 const MAX_PIN_ATTEMPTS: i32 = 5;
 
-/// How long an issued 6-digit PIN stays usable, measured from `pin_sent_at`.
+/// Failed attempts allowed across every PIN a single registration issues. Nothing clears this.
 ///
-/// Deliberately far shorter than the pending registration's own 24h window: a 6-digit secret has
-/// only a million values, so its useful lifetime should be bounded by how long a person plausibly
-/// takes to read the mail, not by how long the registration stays open. The email's verification
-/// link is unaffected and remains valid for the full registration window, and a resend re-arms a
-/// fresh PIN, so an aged-out PIN is a recoverable state rather than a dead end.
+/// [`MAX_PIN_ATTEMPTS`] alone is escapable: it resets on resend, so an attacker who resends each
+/// time it is spent gets a fresh PIN and a fresh cap indefinitely, leaving the resend cooldown as
+/// the only real limit — roughly 1,440 guesses over the registration's 24-hour window. This cap
+/// bounds the registration's whole life instead, and exhausting it disables PIN entry while
+/// leaving the emailed link working.
 ///
-/// Comfortably longer than [`PIN_RESEND_COOLDOWN_MINUTES`] so a user whose PIN ages out can always
-/// obtain a new one immediately instead of landing between an unusable PIN and a live cooldown.
-const PIN_VALIDITY_MINUTES: i64 = 60;
+/// 50 rather than a round guess, for three reasons. NIST SP 800-63B-4 §3.2.2 sets 100 as the
+/// normative ceiling for consecutive failed attempts against a specific authenticator before it
+/// must be disabled, so 50 sits inside a standard rather than being invented, at half that
+/// ceiling. A legitimate user's realistic worst case is around 15 — the 5-attempt cap across the
+/// two or three resends a real person makes — so 50 leaves more than three times that headroom.
+/// And against a 10^6 PIN space it holds lifetime exposure near 0.005%, against roughly 0.14% with
+/// no lifetime cap at all.
+const MAX_PIN_ATTEMPTS_LIFETIME: i32 = 50;
 
 #[derive(Debug, Deserialize)]
 pub struct HeadlessVerifyPinRequest {
@@ -854,6 +861,25 @@ pub async fn headless_verify_pin(
         return Err(HeadlessError::RegistrationAlreadyCompleted);
     }
 
+    // The registration's verification window has closed. `find_by_device_code` deliberately does
+    // not filter this out, so that an expired registration reads differently from an unknown
+    // device_code: telling the user their code did not match would be false and would invite them
+    // to retype it forever. The PIN carries no window of its own — it is one of two presentations
+    // of the same confirmation code as the emailed link, so it expires exactly when the link does.
+    if pending.expires_at <= Utc::now() {
+        record_pin_verify_failure(
+            pool,
+            &headers,
+            tenant_id,
+            Some(&pending.user_pubkey),
+            pending.pending_email.as_deref(),
+            "registration_expired",
+            StatusCode::GONE.as_u16().into(),
+        )
+        .await;
+        return Err(HeadlessError::PinExpired);
+    }
+
     let Some(pin_hash) = pending.pin_hash.clone() else {
         // No PIN was ever issued for this registration (for example a browser OAuth registration).
         // Say so, so the caller steers the user to the email link or a resend instead of insisting
@@ -873,7 +899,7 @@ pub async fn headless_verify_pin(
 
     // A PIN exists but was never confirmed delivered, so the user cannot be holding it. Treat it
     // as unavailable rather than wrong: a resend both delivers and re-arms.
-    let Some(pin_sent_at) = pending.pin_sent_at else {
+    if pending.pin_sent_at.is_none() {
         record_pin_verify_failure(
             pool,
             &headers,
@@ -885,42 +911,50 @@ pub async fn headless_verify_pin(
         )
         .await;
         return Err(HeadlessError::PinUnavailable);
-    };
-
-    // The PIN aged out of its own validity window while the registration is still open. Distinct
-    // from a wrong PIN and from a lockout, and recoverable by a resend.
-    if Utc::now() - pin_sent_at >= Duration::minutes(PIN_VALIDITY_MINUTES) {
-        record_pin_verify_failure(
-            pool,
-            &headers,
-            tenant_id,
-            Some(&pending.user_pubkey),
-            pending.pending_email.as_deref(),
-            "pin_expired",
-            StatusCode::GONE.as_u16().into(),
-        )
-        .await;
-        return Err(HeadlessError::PinExpired);
     }
 
     // Atomically reserve an attempt slot BEFORE the expensive bcrypt compare. The conditional
-    // UPDATE increments only while under the cap, so at most MAX_PIN_ATTEMPTS comparisons can run
-    // for this device_code even across concurrent requests. `None` means the row is at the cap.
-    let Some(attempt) = oauth_code_repo
-        .reserve_pin_attempt(&req.device_code, tenant_id, MAX_PIN_ATTEMPTS)
-        .await?
-    else {
-        record_pin_verify_failure(
-            pool,
-            &headers,
+    // UPDATE increments only while under both caps, so no more comparisons can run for this
+    // device_code than the caps allow, even across concurrent requests.
+    let attempt = match oauth_code_repo
+        .reserve_pin_attempt(
+            &req.device_code,
             tenant_id,
-            Some(&pending.user_pubkey),
-            pending.pending_email.as_deref(),
-            "pin_locked",
-            StatusCode::LOCKED.as_u16().into(),
+            MAX_PIN_ATTEMPTS,
+            MAX_PIN_ATTEMPTS_LIFETIME,
         )
-        .await;
-        return Err(HeadlessError::PinLocked);
+        .await?
+    {
+        PinAttemptReservation::Reserved { attempt } => attempt,
+        PinAttemptReservation::CurrentPinLocked => {
+            record_pin_verify_failure(
+                pool,
+                &headers,
+                tenant_id,
+                Some(&pending.user_pubkey),
+                pending.pending_email.as_deref(),
+                "pin_locked",
+                StatusCode::LOCKED.as_u16().into(),
+            )
+            .await;
+            return Err(HeadlessError::PinLocked);
+        }
+        // Lifetime cap spent: a resend cannot recover this, so do not say "request a new code".
+        // PIN entry is done for this registration; the emailed link still works, which is what
+        // the unavailable response steers the user to.
+        PinAttemptReservation::LifetimeExhausted => {
+            record_pin_verify_failure(
+                pool,
+                &headers,
+                tenant_id,
+                Some(&pending.user_pubkey),
+                pending.pending_email.as_deref(),
+                "pin_lifetime_exhausted",
+                StatusCode::FORBIDDEN.as_u16().into(),
+            )
+            .await;
+            return Err(HeadlessError::PinUnavailable);
+        }
     };
 
     // Constant-time PIN comparison (bcrypt's own compare; work factor dominates). Both this real
@@ -1076,6 +1110,14 @@ pub async fn headless_resend_pin(
     };
 
     if pending.consumed_at.is_some() {
+        return Ok(success());
+    }
+
+    // `find_by_device_code` no longer filters expired rows, so this path has to. A resend
+    // deliberately does not extend `expires_at` (keycast#262 bounded lifecycle), so re-arming a
+    // registration whose window has closed would mail the user a PIN and a link that both fail.
+    if pending.expires_at <= Utc::now() {
+        tracing::debug!("resend-pin: registration expired, skipping (not revealed to client)");
         return Ok(success());
     }
 
@@ -1339,7 +1381,7 @@ impl From<crate::bcrypt_queue::BcryptQueueError> for HeadlessError {
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "integration-tests")]
-    use super::{MAX_PIN_ATTEMPTS, PIN_VALIDITY_MINUTES};
+    use super::{MAX_PIN_ATTEMPTS, MAX_PIN_ATTEMPTS_LIFETIME};
     #[cfg(feature = "integration-tests")]
     use chrono::{Duration, Utc};
     use nostr_sdk::Keys;
@@ -1935,37 +1977,114 @@ mod tests {
             .await;
     }
 
-    /// A PIN past its validity window is reported as expired, not as a wrong PIN, so the caller
-    /// tells the user to request a new code. The registration itself is still open.
+    /// Once the registration's own window closes, the PIN goes with it — the PIN and the emailed
+    /// link are two presentations of the same confirmation code, so they expire together. That is
+    /// reported as expired rather than as a wrong PIN, which would be false and would invite the
+    /// user to retype a code that can never work again.
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
-    async fn test_verify_pin_aged_out_pin_reports_expired() {
+    async fn test_verify_pin_expired_registration_reports_expired() {
         let auth_state = create_lazy_auth_state();
         let pool = auth_state.state.db.clone();
         let email = format!("verify-pin-expired-{}@example.com", uuid::Uuid::new_v4());
         let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
 
-        let aged_out = Utc::now() - Duration::minutes(PIN_VALIDITY_MINUTES + 1);
-        sqlx::query("UPDATE oauth_codes SET pin_sent_at = $2 WHERE device_code = $1")
+        sqlx::query("UPDATE oauth_codes SET expires_at = $2 WHERE device_code = $1")
             .bind(&device_code)
-            .bind(aged_out)
+            .bind(Utc::now() - Duration::minutes(1))
             .execute(&pool)
             .await
             .unwrap();
 
-        // Even the correct PIN is refused once it has aged out.
+        // Even the correct PIN is refused once the registration has expired.
         let response = call_verify_pin(auth_state, &device_code, "123456").await;
         assert_eq!(response.status(), axum::http::StatusCode::GONE);
         assert_eq!(response_json(response).await["code"], "PIN_EXPIRED");
 
-        // An expired PIN must not consume a lockout slot: the recovery action is a resend.
-        let (attempts,): (i32,) =
-            sqlx::query_as("SELECT pin_attempts FROM oauth_codes WHERE device_code = $1")
-                .bind(&device_code)
-                .fetch_one(&pool)
-                .await
-                .unwrap();
+        // Expiry must not consume an attempt slot: there is nothing to brute-force here.
+        let (attempts, failed_total): (i32, i32) = sqlx::query_as(
+            "SELECT pin_attempts, pin_failed_total FROM oauth_codes WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
         assert_eq!(attempts, 0);
+        assert_eq!(failed_total, 0);
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// The per-PIN cap resets on resend, which is what makes a resend the way out of a lockout.
+    /// That alone would be escapable forever, so a lifetime cap bounds the whole registration.
+    /// Exhausting it disables PIN entry permanently — a resend does not recover it — so the reply
+    /// must steer the user to the emailed link rather than telling them to request a new code.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    #[serial]
+    async fn test_verify_pin_lifetime_cap_is_not_cleared_by_a_resend() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("verify-pin-lifetime-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        // Park the registration one failure short of its lifetime cap, with the current PIN
+        // already locked and the resend cooldown clear — exactly the state an attacker who has
+        // been cycling resend-then-guess arrives in.
+        sqlx::query(
+            "UPDATE oauth_codes SET pin_attempts = $2, pin_failed_total = $3, \
+             pin_resend_at = NOW() - INTERVAL '10 minutes' WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .bind(MAX_PIN_ATTEMPTS)
+        .bind(MAX_PIN_ATTEMPTS_LIFETIME - 1)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // A resend clears the per-PIN lockout, as it must for legitimate recovery...
+        let resend = call_resend_pin(auth_state.clone(), &device_code).await;
+        assert_eq!(resend.status(), axum::http::StatusCode::OK);
+        let (attempts, failed_total): (i32, i32) = sqlx::query_as(
+            "SELECT pin_attempts, pin_failed_total FROM oauth_codes WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(attempts, 0, "resend clears the per-PIN cap");
+        assert_eq!(
+            failed_total,
+            MAX_PIN_ATTEMPTS_LIFETIME - 1,
+            "resend must NOT clear the lifetime counter"
+        );
+
+        // ...and the very next failure spends the lifetime cap.
+        let last = call_verify_pin(auth_state.clone(), &device_code, "000000").await;
+        assert_eq!(last.status(), axum::http::StatusCode::UNAUTHORIZED);
+
+        // From here PIN entry is closed for this registration, and a resend does not reopen it.
+        let exhausted = call_verify_pin(auth_state.clone(), &device_code, "000000").await;
+        assert_eq!(exhausted.status(), axum::http::StatusCode::FORBIDDEN);
+        assert_eq!(response_json(exhausted).await["code"], "PIN_UNAVAILABLE");
+
+        sqlx::query("UPDATE oauth_codes SET pin_resend_at = NOW() - INTERVAL '10 minutes' WHERE device_code = $1")
+            .bind(&device_code).execute(&pool).await.unwrap();
+        let resend_again = call_resend_pin(auth_state.clone(), &device_code).await;
+        assert_eq!(resend_again.status(), axum::http::StatusCode::OK);
+        let still_closed = call_verify_pin(auth_state, &device_code, "000000").await;
+        assert_eq!(
+            still_closed.status(),
+            axum::http::StatusCode::FORBIDDEN,
+            "a resend must not reopen PIN entry once the lifetime cap is spent"
+        );
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
@@ -2045,15 +2164,20 @@ mod tests {
             axum::http::StatusCode::SERVICE_UNAVAILABLE
         );
 
-        let (attempts,): (i32,) =
-            sqlx::query_as("SELECT pin_attempts FROM oauth_codes WHERE device_code = $1")
-                .bind(&device_code)
-                .fetch_one(&pool)
-                .await
-                .unwrap();
+        let (attempts, failed_total): (i32, i32) = sqlx::query_as(
+            "SELECT pin_attempts, pin_failed_total FROM oauth_codes WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
         assert_eq!(
             attempts, 0,
             "bcrypt backpressure must not advance the lockout counter"
+        );
+        assert_eq!(
+            failed_total, 0,
+            "bcrypt backpressure must not advance the lifetime counter either"
         );
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -241,7 +241,9 @@ pub async fn headless_register(
         })
         .await?;
 
-    // Send verification email
+    // Send verification email. Only start the resend cooldown after confirmed delivery; otherwise
+    // the user must be able to request an immediate replacement.
+    let mut email_delivered = false;
     match crate::email_service::EmailService::new() {
         Ok(email_service) => {
             if let Err(e) = email_service
@@ -251,6 +253,7 @@ pub async fn headless_register(
                 tracing::error!("Failed to send verification email to {}: {}", req.email, e);
                 // Continue - user can request resend later
             } else {
+                email_delivered = true;
                 tracing::info!("Sent verification email to {}", req.email);
             }
         }
@@ -260,6 +263,11 @@ pub async fn headless_register(
                 e
             );
         }
+    }
+    if email_delivered {
+        oauth_code_repo
+            .mark_pin_sent(&device_code, tenant_id)
+            .await?;
     }
 
     // Track successful registration
@@ -794,6 +802,15 @@ pub async fn headless_verify_pin(
         return Err(HeadlessError::PinVerificationFailed);
     };
 
+    if pending.consumed_at.is_some() {
+        return Ok(Json(HeadlessVerifyPinResponse {
+            success: true,
+            code: String::new(),
+            pubkey: pending.user_pubkey,
+            state: pending.state,
+        }));
+    }
+
     let Some(pin_hash) = pending.pin_hash.clone() else {
         // No PIN was issued for this registration. Burn comparable bcrypt work so this is
         // indistinguishable by latency from a wrong-PIN attempt before rejecting uniformly.
@@ -860,14 +877,26 @@ pub async fn headless_verify_pin(
 
     // Correct PIN: run the SAME finalize path as the link (idempotent; does not delete the row).
     // RedisBestEffort because the code is returned synchronously below, so a Redis outage is fine.
-    let finalized = super::auth::finalize_pending_registration(
+    let finalized = match super::auth::finalize_pending_registration(
         pool,
         auth_state.state.redis.as_ref(),
         tenant_id,
         &pending,
         super::auth::HeadlessDelivery::RedisBestEffort,
     )
-    .await?;
+    .await
+    {
+        Ok(finalized) => finalized,
+        Err(super::auth::AuthError::RegistrationAlreadyCompleted) => {
+            return Ok(Json(HeadlessVerifyPinResponse {
+                success: true,
+                code: String::new(),
+                pubkey: pending.user_pubkey,
+                state: pending.state,
+            }))
+        }
+        Err(e) => return Err(e.into()),
+    };
 
     // Correct PIN: clear the failed-attempt counter that `reserve_pin_attempt` incremented before
     // the bcrypt compare. Only failed attempts should count toward the lockout cap (keycast#262), so
@@ -951,6 +980,10 @@ pub async fn headless_resend_pin(
         return Ok(success());
     };
 
+    if pending.consumed_at.is_some() {
+        return Ok(success());
+    }
+
     // Cooldown: silently skip if a PIN was sent within the window.
     if let Some(sent_at) = pending.pin_sent_at {
         if (Utc::now() - sent_at).num_minutes() < PIN_RESEND_COOLDOWN_MINUTES {
@@ -974,26 +1007,45 @@ pub async fn headless_resend_pin(
             .map_err(|e| HeadlessError::Internal(format!("Task join error: {}", e)))?
             .map_err(|e| HeadlessError::Internal(format!("PIN hash error: {}", e)))?;
 
+    let old_token = pending.pending_email_verification_token.clone();
+    let old_pin_hash = pending.pin_hash.clone();
+    let old_pin_attempts = pending.pin_attempts;
+    let old_pin_sent_at = pending.pin_sent_at;
+
     oauth_code_repo
         .reset_pin_for_resend(&req.device_code, tenant_id, &new_token, &new_pin_hash)
         .await?;
 
-    // Re-send the link + PIN (best-effort; the user can request another resend after the cooldown).
-    match crate::email_service::EmailService::new() {
+    // Re-send the link + PIN. If delivery fails, roll back the mutation so the previous credential
+    // remains valid and the resend cooldown is not armed by an undelivered replacement.
+    let send_result = match crate::email_service::EmailService::new() {
         Ok(email_service) => {
-            if let Err(e) = email_service
+            email_service
                 .send_verification_email(&email, &new_token, Some(&new_pin))
                 .await
-            {
-                tracing::error!("Failed to resend verification email to {}: {}", email, e);
-            }
         }
         Err(e) => {
             tracing::warn!(
                 "Email service unavailable, skipping PIN resend email: {}",
                 e
             );
+            Err(e)
         }
+    };
+
+    if let Err(e) = send_result {
+        tracing::error!("Failed to resend verification email to {}: {}", email, e);
+        oauth_code_repo
+            .restore_pin_after_failed_resend(
+                &req.device_code,
+                tenant_id,
+                old_token.as_deref(),
+                old_pin_hash.as_deref(),
+                old_pin_attempts,
+                old_pin_sent_at,
+            )
+            .await?;
+        return Ok(success());
     }
 
     tracing::info!(
@@ -1115,6 +1167,7 @@ impl From<keycast_core::repositories::RepositoryError> for HeadlessError {
 #[cfg(test)]
 mod tests {
     use nostr_sdk::Keys;
+    use serial_test::serial;
 
     struct LazyTestKeyManager;
 
@@ -1181,6 +1234,44 @@ mod tests {
             .await
             .expect("response body should be readable");
         serde_json::from_slice(&body).expect("response body should be JSON")
+    }
+
+    struct EmailEnvGuard {
+        rust_env: Option<String>,
+        node_env: Option<String>,
+        sendgrid_api_key: Option<String>,
+        disable_emails: Option<String>,
+    }
+
+    impl Drop for EmailEnvGuard {
+        fn drop(&mut self) {
+            restore_env_var("RUST_ENV", self.rust_env.as_deref());
+            restore_env_var("NODE_ENV", self.node_env.as_deref());
+            restore_env_var("SENDGRID_API_KEY", self.sendgrid_api_key.as_deref());
+            restore_env_var("DISABLE_EMAILS", self.disable_emails.as_deref());
+        }
+    }
+
+    fn restore_env_var(key: &str, value: Option<&str>) {
+        if let Some(value) = value {
+            std::env::set_var(key, value);
+        } else {
+            std::env::remove_var(key);
+        }
+    }
+
+    fn force_email_service_failure() -> EmailEnvGuard {
+        let guard = EmailEnvGuard {
+            rust_env: std::env::var("RUST_ENV").ok(),
+            node_env: std::env::var("NODE_ENV").ok(),
+            sendgrid_api_key: std::env::var("SENDGRID_API_KEY").ok(),
+            disable_emails: std::env::var("DISABLE_EMAILS").ok(),
+        };
+        std::env::set_var("RUST_ENV", "production");
+        std::env::remove_var("NODE_ENV");
+        std::env::remove_var("SENDGRID_API_KEY");
+        std::env::remove_var("DISABLE_EMAILS");
+        guard
     }
 
     #[tokio::test]
@@ -1255,6 +1346,7 @@ mod tests {
     /// headless_register stores a hashed 6-digit PIN on the pending row (keycast#262).
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
+    #[serial]
     async fn test_headless_register_stores_hashed_pin() {
         let auth_state = create_lazy_auth_state();
         let pool = auth_state.state.db.clone();
@@ -1299,6 +1391,64 @@ mod tests {
             "pin_hash must be a bcrypt hash, got {pin_hash}"
         );
         assert_eq!(pin_attempts, 0, "attempt counter starts at zero");
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE email = $1")
+            .bind(&email)
+            .execute(&pool)
+            .await;
+    }
+
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    #[serial]
+    async fn test_headless_register_email_failure_does_not_start_resend_cooldown() {
+        let _email_env = force_email_service_failure();
+
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("headless-email-fail-{}@example.com", uuid::Uuid::new_v4());
+
+        let response = super::headless_register(
+            create_unit_test_tenant(),
+            axum::extract::State(auth_state),
+            axum::Json(super::HeadlessRegisterRequest {
+                email: email.clone(),
+                password: "testpassword123".to_string(),
+                client_id: "TestClient".to_string(),
+                redirect_uri: "https://client.example/callback".to_string(),
+                nsec: None,
+                scope: None,
+                code_challenge: None,
+                code_challenge_method: None,
+                state: None,
+            }),
+        )
+        .await
+        .map(axum::response::IntoResponse::into_response)
+        .expect("headless_register should still create the pending registration");
+
+        let body = response_json(response).await;
+        let device_code = body["device_code"]
+            .as_str()
+            .expect("response carries device_code")
+            .to_string();
+
+        let (pin_sent_at,): (Option<chrono::DateTime<chrono::Utc>>,) = sqlx::query_as(
+            "SELECT pin_sent_at FROM oauth_codes WHERE device_code = $1 AND tenant_id = 1",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .expect("pending row should exist");
+
+        assert!(
+            pin_sent_at.is_none(),
+            "failed initial email delivery must allow immediate resend"
+        );
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
@@ -1531,6 +1681,43 @@ mod tests {
     }
 
     #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_pin_completed_registration_returns_idempotent_success() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("verify-pin-complete-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        sqlx::query("UPDATE oauth_codes SET consumed_at = NOW() WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let response = call_verify_pin(auth_state, &device_code, "123456").await;
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::OK,
+            "completed registrations should match the link path's friendly success semantics"
+        );
+        let body = response_json(response).await;
+        assert_eq!(body["success"], true);
+        assert!(
+            body["code"].as_str().is_none_or(str::is_empty),
+            "already-completed idempotent success must not mint a new exchange code"
+        );
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    #[cfg(feature = "integration-tests")]
     async fn call_resend_pin(
         auth_state: crate::api::http::routes::AuthState,
         device_code: &str,
@@ -1553,6 +1740,7 @@ mod tests {
     /// and resets the attempt counter to zero.
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
+    #[serial]
     async fn test_resend_pin_rearms_after_lockout() {
         let auth_state = create_lazy_auth_state();
         let pool = auth_state.state.db.clone();
@@ -1642,6 +1830,140 @@ mod tests {
 
         assert_eq!(new_hash, old_hash, "cooldown must not re-mint the PIN");
         assert_eq!(new_token, old_token, "cooldown must not re-mint the token");
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    #[serial]
+    async fn test_resend_pin_email_failure_preserves_existing_pin_and_cooldown() {
+        let _email_env = force_email_service_failure();
+
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("resend-pin-email-fail-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        let old_sent_at = chrono::Utc::now() - chrono::Duration::minutes(10);
+        sqlx::query(
+            "UPDATE oauth_codes SET pin_attempts = 5, pin_sent_at = $2 WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .bind(old_sent_at)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let (old_hash, old_token, old_attempts, old_pin_sent_at): (
+            Option<String>,
+            Option<String>,
+            i32,
+            Option<chrono::DateTime<chrono::Utc>>,
+        ) = sqlx::query_as(
+            "SELECT pin_hash, pending_email_verification_token, pin_attempts, pin_sent_at FROM oauth_codes WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let response = call_resend_pin(auth_state, &device_code).await;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let (new_hash, new_token, new_attempts, new_pin_sent_at): (
+            Option<String>,
+            Option<String>,
+            i32,
+            Option<chrono::DateTime<chrono::Utc>>,
+        ) = sqlx::query_as(
+            "SELECT pin_hash, pending_email_verification_token, pin_attempts, pin_sent_at FROM oauth_codes WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(new_hash, old_hash, "failed resend must preserve old PIN");
+        assert_eq!(
+            new_token, old_token,
+            "failed resend must preserve old verification link"
+        );
+        assert_eq!(
+            new_attempts, old_attempts,
+            "failed resend must preserve lockout state until replacement is deliverable"
+        );
+        assert_eq!(
+            new_pin_sent_at, old_pin_sent_at,
+            "failed resend must not arm a new cooldown"
+        );
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    #[serial]
+    async fn test_resend_pin_completed_registration_is_noop() {
+        let _email_env = force_email_service_failure();
+
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("resend-pin-complete-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        sqlx::query(
+            "UPDATE oauth_codes SET consumed_at = NOW(), pin_sent_at = NOW() - INTERVAL '10 minutes' WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let (old_hash, old_token, old_attempts): (Option<String>, Option<String>, i32) =
+            sqlx::query_as(
+                "SELECT pin_hash, pending_email_verification_token, pin_attempts FROM oauth_codes WHERE device_code = $1",
+            )
+            .bind(&device_code)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let response = call_resend_pin(auth_state, &device_code).await;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let (new_hash, new_token, new_attempts): (Option<String>, Option<String>, i32) =
+            sqlx::query_as(
+                "SELECT pin_hash, pending_email_verification_token, pin_attempts FROM oauth_codes WHERE device_code = $1",
+            )
+            .bind(&device_code)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(new_hash, old_hash, "completed resend must not rotate PIN");
+        assert_eq!(
+            new_token, old_token,
+            "completed resend must not rotate link"
+        );
+        assert_eq!(
+            new_attempts, old_attempts,
+            "completed resend must not reset attempts"
+        );
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -1439,7 +1439,7 @@ mod tests {
     #[cfg(feature = "integration-tests")]
     use super::{MAX_PIN_ATTEMPTS, MAX_PIN_ATTEMPTS_LIFETIME};
     #[cfg(feature = "integration-tests")]
-    use chrono::{Duration, Utc};
+    use chrono::{DateTime, Duration, Utc};
     use nostr_sdk::Keys;
     #[cfg(feature = "integration-tests")]
     use serial_test::serial;
@@ -1665,6 +1665,25 @@ mod tests {
         };
 
         let first = register("firstpassword123", "challenge-one").await;
+
+        // Registration itself is an uncooldowned recovery path: model a current PIN that has hit
+        // its five-attempt lockout and whose resend cooldown is armed. Supersession may restore
+        // usability, but it must not restore the lifetime guessing budget.
+        let first_expiry = Utc::now() + chrono::Duration::hours(1);
+        let first_sent_at = Utc::now() - chrono::Duration::minutes(1);
+        sqlx::query(
+            "UPDATE oauth_codes
+             SET pin_attempts = 5, pin_failed_total = 5,
+                 pin_sent_at = $2, pin_resend_at = $2, expires_at = $3
+             WHERE pending_email = $1 AND tenant_id = 1 AND consumed_at IS NULL",
+        )
+        .bind(&email)
+        .bind(first_sent_at)
+        .bind(first_expiry)
+        .execute(&pool)
+        .await
+        .expect("locked registration setup should succeed");
+
         let second = register("secondpassword456", "challenge-two").await;
 
         let first_device_code = first["device_code"]
@@ -1683,8 +1702,18 @@ mod tests {
         );
 
         // Exactly one pending row, one live verification token: only one email is actionable.
-        let rows: Vec<(String, Option<String>, Option<String>, i32)> = sqlx::query_as(
-            "SELECT pending_password_hash, code_challenge, pending_email_verification_token, pin_attempts
+        let rows: Vec<(
+            String,
+            Option<String>,
+            Option<String>,
+            i32,
+            i32,
+            Option<DateTime<Utc>>,
+            Option<DateTime<Utc>>,
+            DateTime<Utc>,
+        )> = sqlx::query_as(
+            "SELECT pending_password_hash, code_challenge, pending_email_verification_token,
+                    pin_attempts, pin_failed_total, pin_sent_at, pin_resend_at, expires_at
              FROM oauth_codes
              WHERE pending_email = $1 AND tenant_id = 1 AND consumed_at IS NULL",
         )
@@ -1698,7 +1727,16 @@ mod tests {
             1,
             "a duplicate register must not create a second pending registration"
         );
-        let (password_hash, code_challenge, token, pin_attempts) = rows.into_iter().next().unwrap();
+        let (
+            password_hash,
+            code_challenge,
+            token,
+            pin_attempts,
+            pin_failed_total,
+            pin_sent_at,
+            pin_resend_at,
+            expires_at,
+        ) = rows.into_iter().next().unwrap();
 
         // The newest attempt wins: a user who retyped their password must be able to log in with
         // the password they last submitted, and the stored PKCE challenge must match the verifier
@@ -1719,6 +1757,22 @@ mod tests {
             "the second attempt's PKCE challenge must win"
         );
         assert_eq!(pin_attempts, 0, "superseding re-arms the attempt counter");
+        assert_eq!(
+            pin_failed_total, 5,
+            "superseding must not grant a fresh lifetime guessing budget"
+        );
+        assert!(
+            pin_resend_at.is_none(),
+            "superseding must not inherit the old PIN's resend cooldown"
+        );
+        assert!(
+            pin_sent_at.is_some_and(|sent_at| sent_at > first_sent_at),
+            "the replacement PIN should be stamped only after its delivery succeeds"
+        );
+        assert!(
+            expires_at > first_expiry,
+            "an explicit re-registration should start a fresh verification window"
+        );
 
         // The first email's token is dead — that link now renders the terminal
         // superseded page rather than stranding the user on a 401.

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -63,6 +63,26 @@ pub struct HeadlessRegisterResponse {
 
 /// POST /api/headless/register
 ///
+/// Map a policy-lookup error at registration. A genuinely missing policy is a client error
+/// reported as "Unknown policy '<slug>'", but any other repository error (e.g. a DB connection
+/// failure such as 28P01) must surface as `Internal` rather than being masked as a missing
+/// policy — masking a connection error as "Unknown policy" hid a real fault and caused a review
+/// mis-triage (keycast#262).
+fn map_policy_lookup_error(
+    policy_slug: &str,
+    err: keycast_core::repositories::RepositoryError,
+) -> HeadlessError {
+    use keycast_core::repositories::RepositoryError;
+    match err {
+        RepositoryError::NotFound(_) => {
+            HeadlessError::InvalidRequest(format!("Unknown policy '{}'", policy_slug))
+        }
+        other => {
+            HeadlessError::Internal(format!("Failed to look up policy '{policy_slug}': {other}"))
+        }
+    }
+}
+
 /// Register a new user without web UI. Returns device_code for email verification polling.
 ///
 /// Flow:
@@ -100,11 +120,13 @@ pub async fn headless_register(
         let policy_slug = parse_policy_scope(scope)
             .map_err(|e| HeadlessError::InvalidRequest(format!("{:?}", e)))?;
 
-        // Verify policy exists
+        // Verify policy exists. A missing policy is a client error, but a DB failure here must
+        // surface as-is rather than being masked as "Unknown policy" (keycast#262).
         let policy_repo = PolicyRepository::new(pool.clone());
-        policy_repo.find_by_slug(&policy_slug).await.map_err(|_| {
-            HeadlessError::InvalidRequest(format!("Unknown policy '{}'", policy_slug))
-        })?;
+        policy_repo
+            .find_by_slug(&policy_slug)
+            .await
+            .map_err(|e| map_policy_lookup_error(&policy_slug, e))?;
     }
 
     // Use provided nsec or generate new Nostr keypair
@@ -1188,6 +1210,46 @@ mod tests {
         let body = response_json(response).await;
         assert_eq!(body["code"], crate::api::http::auth::INVALID_EMAIL_CODE);
         assert_eq!(body["error"], "Please enter a valid email address.");
+    }
+
+    /// A genuinely missing policy is a client error surfaced as "Unknown policy '<slug>'".
+    #[test]
+    fn test_map_policy_lookup_error_not_found_reports_unknown_policy() {
+        use keycast_core::repositories::RepositoryError;
+        let err = super::map_policy_lookup_error(
+            "full",
+            RepositoryError::NotFound("record not found".to_string()),
+        );
+        match err {
+            super::HeadlessError::InvalidRequest(msg) => {
+                assert_eq!(msg, "Unknown policy 'full'");
+            }
+            other => panic!("expected InvalidRequest for a missing policy, got {other:?}"),
+        }
+    }
+
+    /// A real DB failure (e.g. 28P01 auth error) must NOT be masked as a missing policy —
+    /// masking a connection error as "Unknown policy" caused a review mis-triage (keycast#262).
+    #[test]
+    fn test_map_policy_lookup_error_db_error_is_not_masked() {
+        use keycast_core::repositories::RepositoryError;
+        let err = super::map_policy_lookup_error(
+            "full",
+            RepositoryError::Database("password authentication failed".to_string()),
+        );
+        match err {
+            super::HeadlessError::Internal(msg) => {
+                assert!(
+                    !msg.contains("Unknown policy"),
+                    "a DB error must not be reported as a missing policy, got: {msg}"
+                );
+                assert!(
+                    msg.contains("password authentication failed"),
+                    "the real DB error should surface, got: {msg}"
+                );
+            }
+            other => panic!("expected Internal for a DB failure, got {other:?}"),
+        }
     }
 
     /// headless_register stores a hashed 6-digit PIN on the pending row (keycast#262).

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -2167,6 +2167,72 @@ mod tests {
             .await;
     }
 
+    /// The PIN path runs the same finalize as the email link, so it must inherit the link path's
+    /// recovery for a users row that already exists without the pending credentials — created, for
+    /// example, by team membership or authorization pre-creation. Treating "a row exists" as
+    /// "nothing left to do" would leave that row permanently without an email, a password, or a
+    /// personal key while still handing the caller a usable exchange code.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_pin_completes_a_bare_pre_existing_user_row() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("verify-pin-bare-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        // A bare row for the same pubkey, carrying none of the pending registration.
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at) \
+             VALUES ($1, 1, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let response = call_verify_pin(auth_state, &device_code, "123456").await;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert!(
+            response_json(response).await["code"]
+                .as_str()
+                .is_some_and(|c| !c.is_empty()),
+            "verify-pin still returns an exchange code"
+        );
+
+        let (row_email, verified, has_password, has_key): (Option<String>, bool, bool, bool) =
+            sqlx::query_as(
+                "SELECT u.email, u.email_verified, u.password_hash IS NOT NULL, \
+                 EXISTS(SELECT 1 FROM personal_keys pk WHERE pk.user_pubkey = u.pubkey) \
+                 FROM users u WHERE u.pubkey = $1 AND u.tenant_id = 1",
+            )
+            .bind(&pubkey)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            row_email.as_deref(),
+            Some(email.as_str()),
+            "the pending email must be applied to the pre-existing row"
+        );
+        assert!(verified, "the row must end up verified");
+        assert!(has_password, "the pending password must be applied");
+        assert!(has_key, "the pending personal key must be applied");
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM personal_keys WHERE user_pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
     #[cfg(feature = "integration-tests")]
     async fn call_resend_pin(
         auth_state: crate::api::http::routes::AuthState,

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -205,6 +205,8 @@ pub async fn headless_register(
             state: req.state.as_deref(),
             device_code: Some(&device_code),
             is_headless: true,
+            // PIN fallback is added in a later step; no PIN issued yet.
+            pin_hash: None,
         })
         .await?;
 

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -1079,8 +1079,10 @@ pub async fn headless_resend_pin(
         return Ok(success());
     }
 
-    // Cooldown: silently skip if a resend already ran within the window. Anchored on
-    // `pin_resend_at`, which registration leaves NULL, so the first resend always proceeds.
+    // Cheap pre-check so an obvious cooldown hit does not pay for bcrypt. This is an optimization,
+    // not the gate: `reset_pin_for_resend` re-evaluates the cooldown atomically as part of the
+    // rotation, which is what actually prevents two concurrent resends from both rotating.
+    // Anchored on `pin_resend_at`, which registration leaves NULL, so the first resend proceeds.
     if let Some(resent_at) = pending.pin_resend_at {
         if Utc::now() - resent_at < Duration::minutes(PIN_RESEND_COOLDOWN_MINUTES) {
             tracing::debug!("resend-pin: within cooldown, skipping (not revealed to client)");
@@ -1109,9 +1111,23 @@ pub async fn headless_resend_pin(
     let old_pin_sent_at = pending.pin_sent_at;
     let old_pin_resend_at = pending.pin_resend_at;
 
-    oauth_code_repo
-        .reset_pin_for_resend(&req.device_code, tenant_id, &new_token, &new_pin_hash)
-        .await?;
+    // Atomically claim the resend. A loser exits through the same uniform response, so a
+    // double-submit costs the user nothing and never leaves them holding a PIN that was overwritten
+    // by a concurrent rotation.
+    let cooldown_cutoff = Utc::now() - Duration::minutes(PIN_RESEND_COOLDOWN_MINUTES);
+    if !oauth_code_repo
+        .reset_pin_for_resend(
+            &req.device_code,
+            tenant_id,
+            &new_token,
+            &new_pin_hash,
+            cooldown_cutoff,
+        )
+        .await?
+    {
+        tracing::debug!("resend-pin: lost the resend claim, skipping (not revealed to client)");
+        return Ok(success());
+    }
 
     // Re-send the link + PIN. If delivery fails, roll back the mutation so the previous credential
     // remains valid and the resend cooldown is not armed by an undelivered replacement.
@@ -1132,7 +1148,9 @@ pub async fn headless_resend_pin(
 
     if let Err(e) = send_result {
         tracing::error!("Failed to resend verification email to {}: {}", email, e);
-        oauth_code_repo
+        // Guarded on the hash this call wrote, so a later resend that did reach the user is never
+        // rolled back out from under them.
+        let restored = oauth_code_repo
             .restore_pin_after_failed_resend(
                 &req.device_code,
                 tenant_id,
@@ -1143,8 +1161,14 @@ pub async fn headless_resend_pin(
                     pin_sent_at: old_pin_sent_at,
                     pin_resend_at: old_pin_resend_at,
                 },
+                &new_pin_hash,
             )
             .await?;
+        if !restored {
+            tracing::info!(
+                "resend-pin: skipped rollback because a later resend already replaced the PIN"
+            );
+        }
         return Ok(success());
     }
 
@@ -2497,6 +2521,84 @@ mod tests {
         assert_eq!(
             new_pin_resend_at, old_pin_resend_at,
             "failed resend must not arm a new cooldown"
+        );
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// A resend whose email could not be delivered rolls its own mutation back. That rollback must
+    /// be guarded: if another resend already succeeded in the meantime, restoring the older
+    /// snapshot would invalidate the PIN that is sitting in the user's inbox right now, so the code
+    /// they were just sent would not work.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    #[serial]
+    async fn test_failed_resend_does_not_clobber_a_later_successful_one() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("repro-clobber-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        sqlx::query("UPDATE oauth_codes SET pin_resend_at = NOW() - INTERVAL '10 minutes' WHERE device_code = $1")
+            .bind(&device_code).execute(&pool).await.unwrap();
+
+        type Snap = (
+            Option<String>,
+            Option<String>,
+            i32,
+            Option<chrono::DateTime<Utc>>,
+            Option<chrono::DateTime<Utc>>,
+        );
+        let (b_hash, b_token, b_attempts, b_sent, b_resend): Snap =
+            sqlx::query_as("SELECT pin_hash, pending_email_verification_token, pin_attempts, pin_sent_at, pin_resend_at FROM oauth_codes WHERE device_code = $1")
+                .bind(&device_code).fetch_one(&pool).await.unwrap();
+
+        let r = call_resend_pin(auth_state, &device_code).await;
+        assert_eq!(r.status(), axum::http::StatusCode::OK);
+        let (a_hash,): (Option<String>,) =
+            sqlx::query_as("SELECT pin_hash FROM oauth_codes WHERE device_code = $1")
+                .bind(&device_code)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_ne!(
+            a_hash, b_hash,
+            "precondition: the successful resend rotated the PIN"
+        );
+
+        keycast_core::repositories::OAuthCodeRepository::new(pool.clone())
+            .restore_pin_after_failed_resend(
+                &device_code,
+                1,
+                keycast_core::repositories::PinResendSnapshot {
+                    verification_token: b_token.as_deref(),
+                    pin_hash: b_hash.as_deref(),
+                    pin_attempts: b_attempts,
+                    pin_sent_at: b_sent,
+                    pin_resend_at: b_resend,
+                },
+                b_hash.as_deref().expect("snapshot carries a PIN hash"),
+            )
+            .await
+            .unwrap();
+
+        let (final_hash,): (Option<String>,) =
+            sqlx::query_as("SELECT pin_hash FROM oauth_codes WHERE device_code = $1")
+                .bind(&device_code)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            final_hash, a_hash,
+            "a failed resend must not restore over a PIN a later resend already delivered"
         );
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -847,6 +847,118 @@ pub async fn headless_verify_pin(
 }
 
 // ============================================================================
+// Headless Resend PIN (lockout recovery + new code)
+// ============================================================================
+
+/// Minutes between PIN resends (mirrors the users-table `email_verification_sent_at` cooldown).
+const PIN_RESEND_COOLDOWN_MINUTES: i64 = 5;
+
+#[derive(Debug, Deserialize)]
+pub struct HeadlessResendPinRequest {
+    /// RFC 8628 device_code from registration (the app-held secret).
+    pub device_code: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HeadlessResendPinResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+/// POST /api/headless/resend-pin
+///
+/// Lockout recovery + PIN resend (keycast#262). Keyed by device_code, it re-mints a fresh
+/// verification token + 6-digit PIN, resets the attempt counter, refreshes the verify window, and
+/// re-sends the email — subject to a 5-minute cooldown. Always returns a uniform success response
+/// so it leaks neither registration existence nor lockout state.
+///
+/// Pending headless registrations have no `users` row yet, so the users-table resend path does not
+/// apply; this is the device_code-keyed equivalent on the `oauth_codes` row.
+pub async fn headless_resend_pin(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<super::routes::AuthState>,
+    Json(req): Json<HeadlessResendPinRequest>,
+) -> Result<impl IntoResponse, HeadlessError> {
+    let pool = &auth_state.state.db;
+    let tenant_id = tenant.0.id;
+
+    // Uniform response regardless of outcome (anti-enumeration / no lockout signal).
+    let success = || {
+        Json(HeadlessResendPinResponse {
+            success: true,
+            message: "If your registration is pending, a new code has been sent.".to_string(),
+        })
+    };
+
+    let oauth_code_repo = OAuthCodeRepository::new(pool.clone());
+    let Some(pending) = oauth_code_repo
+        .find_by_device_code(&req.device_code, tenant_id)
+        .await?
+    else {
+        return Ok(success());
+    };
+
+    // Cooldown: silently skip if a PIN was sent within the window.
+    if let Some(sent_at) = pending.pin_sent_at {
+        if (Utc::now() - sent_at).num_minutes() < PIN_RESEND_COOLDOWN_MINUTES {
+            tracing::debug!("resend-pin: within cooldown, skipping (not revealed to client)");
+            return Ok(success());
+        }
+    }
+
+    let Some(email) = pending.pending_email.clone() else {
+        return Ok(success());
+    };
+
+    // Mint a fresh token + PIN, reset the attempt counter, refresh the 24h verify window.
+    let new_token = generate_secure_token();
+    let new_pin: String = format!("{:06}", rand::thread_rng().gen_range(0..1_000_000));
+    let pin_for_hash = new_pin.clone();
+    let new_pin_hash =
+        tokio::task::spawn_blocking(move || bcrypt::hash(&pin_for_hash, bcrypt::DEFAULT_COST))
+            .await
+            .map_err(|e| HeadlessError::Internal(format!("Task join error: {}", e)))?
+            .map_err(|e| HeadlessError::Internal(format!("PIN hash error: {}", e)))?;
+
+    let new_expires_at = Utc::now() + Duration::hours(EMAIL_VERIFICATION_EXPIRY_HOURS);
+    oauth_code_repo
+        .reset_pin_for_resend(
+            &req.device_code,
+            tenant_id,
+            &new_token,
+            &new_pin_hash,
+            new_expires_at,
+        )
+        .await?;
+
+    // Re-send the link + PIN (best-effort; the user can request another resend after the cooldown).
+    match crate::email_service::EmailService::new() {
+        Ok(email_service) => {
+            if let Err(e) = email_service
+                .send_verification_email(&email, &new_token, Some(&new_pin))
+                .await
+            {
+                tracing::error!("Failed to resend verification email to {}: {}", email, e);
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Email service unavailable, skipping PIN resend email: {}",
+                e
+            );
+        }
+    }
+
+    tracing::info!(
+        event = "email_pin_resend",
+        tenant_id = tenant_id,
+        "Re-armed PIN and resent verification email"
+    );
+
+    Ok(success())
+}
+
+// ============================================================================
 // Error Type
 // ============================================================================
 
@@ -1325,6 +1437,129 @@ mod tests {
             .await;
         let _ = sqlx::query("DELETE FROM users WHERE pubkey = ANY($1)")
             .bind(vec![existing_pubkey, pending_pubkey])
+            .execute(&pool)
+            .await;
+    }
+
+    #[cfg(feature = "integration-tests")]
+    async fn call_resend_pin(
+        auth_state: crate::api::http::routes::AuthState,
+        device_code: &str,
+    ) -> axum::response::Response {
+        match super::headless_resend_pin(
+            create_unit_test_tenant(),
+            axum::extract::State(auth_state),
+            axum::Json(super::HeadlessResendPinRequest {
+                device_code: device_code.to_string(),
+            }),
+        )
+        .await
+        {
+            Ok(r) => axum::response::IntoResponse::into_response(r),
+            Err(e) => axum::response::IntoResponse::into_response(e),
+        }
+    }
+
+    /// After the attempt cap locks the PIN, a resend (past the cooldown) re-arms a fresh PIN/token
+    /// and resets the attempt counter to zero.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_resend_pin_rearms_after_lockout() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("resend-pin-ok-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        // Simulate a locked PIN whose last send is past the cooldown.
+        sqlx::query(
+            "UPDATE oauth_codes SET pin_attempts = 5, pin_sent_at = NOW() - INTERVAL '10 minutes' WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let (old_hash, old_token): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT pin_hash, pending_email_verification_token FROM oauth_codes WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let response = call_resend_pin(auth_state, &device_code).await;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let (attempts, new_hash, new_token): (i32, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT pin_attempts, pin_hash, pending_email_verification_token FROM oauth_codes WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(attempts, 0, "resend resets the attempt counter");
+        assert_ne!(new_hash, old_hash, "resend mints a fresh PIN");
+        assert_ne!(
+            new_token, old_token,
+            "resend mints a fresh verification token"
+        );
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// Within the 5-minute cooldown, resend is a silent no-op (PIN/token unchanged).
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_resend_pin_respects_cooldown() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("resend-pin-cooldown-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        // Last send just now → inside the cooldown window.
+        sqlx::query("UPDATE oauth_codes SET pin_sent_at = NOW() WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let (old_hash, old_token): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT pin_hash, pending_email_verification_token FROM oauth_codes WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let response = call_resend_pin(auth_state, &device_code).await;
+        // Uniform success response (no lockout/cooldown signal leaked to the client).
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let (new_hash, new_token): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT pin_hash, pending_email_verification_token FROM oauth_codes WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(new_hash, old_hash, "cooldown must not re-mint the PIN");
+        assert_eq!(new_token, old_token, "cooldown must not re-mint the token");
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
             .execute(&pool)
             .await;
     }

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -220,7 +220,7 @@ pub async fn headless_register(
     // Store pending registration in oauth_codes (deferred user creation)
     let expires_at = Utc::now() + Duration::hours(EMAIL_VERIFICATION_EXPIRY_HOURS);
     let oauth_code_repo = OAuthCodeRepository::new(pool.clone());
-    oauth_code_repo
+    let stored = oauth_code_repo
         .store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
             tenant_id,
             code: &placeholder_code,
@@ -241,6 +241,19 @@ pub async fn headless_register(
             pin_hash: Some(&pin_hash),
         })
         .await?;
+
+    // A duplicate register supersedes the earlier pending registration in place and keeps its
+    // device_code (keycast#268). Poll on the row's device_code, not the one we just generated, so
+    // the app polls the registration that actually exists.
+    let device_code = stored.device_code.unwrap_or(device_code);
+    if stored.superseded {
+        tracing::info!(
+            event = "headless_registration_superseded",
+            tenant_id = tenant_id,
+            client_id = %req.client_id,
+            "Duplicate registration re-armed the existing pending registration"
+        );
+    }
 
     // Send verification email. Only start the resend cooldown after confirmed delivery; otherwise
     // the user must be able to request an immediate replacement.
@@ -1375,6 +1388,129 @@ mod tests {
             }
             other => panic!("expected Internal for a DB failure, got {other:?}"),
         }
+    }
+
+    /// A duplicate register for the same email supersedes the first pending registration instead
+    /// of minting a second row, token and email (keycast#268).
+    ///
+    /// Production symptom this covers: divine-mobile called `POST /api/headless/register` twice
+    /// 2.9s apart for one signup. Two pending rows meant two verification emails; opening the
+    /// older link 409'd (deleting the stale row) and opening it again 401'd with "Invalid or
+    /// expired token. Please log in again."
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    #[serial]
+    async fn test_duplicate_headless_register_supersedes_pending_registration() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("headless-dup-{}@example.com", uuid::Uuid::new_v4());
+
+        let register = |password: &'static str, challenge: &'static str| {
+            let auth_state = auth_state.clone();
+            let email = email.clone();
+            async move {
+                let response = super::headless_register(
+                    create_unit_test_tenant(),
+                    axum::extract::State(auth_state),
+                    axum::Json(super::HeadlessRegisterRequest {
+                        email,
+                        password: password.to_string(),
+                        client_id: "TestClient".to_string(),
+                        redirect_uri: "https://client.example/callback".to_string(),
+                        nsec: None,
+                        scope: None,
+                        code_challenge: Some(challenge.to_string()),
+                        code_challenge_method: Some("S256".to_string()),
+                        state: None,
+                    }),
+                )
+                .await
+                .map(axum::response::IntoResponse::into_response)
+                .expect("headless_register should succeed");
+                response_json(response).await
+            }
+        };
+
+        let first = register("firstpassword123", "challenge-one").await;
+        let second = register("secondpassword456", "challenge-two").await;
+
+        let first_device_code = first["device_code"]
+            .as_str()
+            .expect("first response carries device_code")
+            .to_string();
+        let second_device_code = second["device_code"]
+            .as_str()
+            .expect("second response carries device_code")
+            .to_string();
+
+        // The app keeps polling the registration it already knows about.
+        assert_eq!(
+            second_device_code, first_device_code,
+            "a duplicate register must return the existing registration's device_code"
+        );
+
+        // Exactly one pending row, one live verification token: only one email is actionable.
+        let rows: Vec<(String, Option<String>, Option<String>, i32)> = sqlx::query_as(
+            "SELECT pending_password_hash, code_challenge, pending_email_verification_token, pin_attempts
+             FROM oauth_codes
+             WHERE pending_email = $1 AND tenant_id = 1 AND consumed_at IS NULL",
+        )
+        .bind(&email)
+        .fetch_all(&pool)
+        .await
+        .expect("query should succeed");
+
+        assert_eq!(
+            rows.len(),
+            1,
+            "a duplicate register must not create a second pending registration"
+        );
+        let (password_hash, code_challenge, token, pin_attempts) = rows.into_iter().next().unwrap();
+
+        // The newest attempt wins: a user who retyped their password must be able to log in with
+        // the password they last submitted, and the stored PKCE challenge must match the verifier
+        // the app is now holding or token exchange would fail PKCE.
+        assert!(
+            bcrypt::verify("secondpassword456", &password_hash)
+                .expect("stored hash should be verifiable"),
+            "the second attempt's password must win"
+        );
+        assert!(
+            !bcrypt::verify("firstpassword123", &password_hash)
+                .expect("stored hash should be verifiable"),
+            "the superseded attempt's password must not survive"
+        );
+        assert_eq!(
+            code_challenge.as_deref(),
+            Some("challenge-two"),
+            "the second attempt's PKCE challenge must win"
+        );
+        assert_eq!(pin_attempts, 0, "superseding re-arms the attempt counter");
+
+        // The first email's token is dead — that link now renders the terminal
+        // superseded page rather than stranding the user on a 401.
+        let token = token.expect("pending row keeps a verification token");
+        let stale_token_rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE pending_email_verification_token = $1 AND tenant_id = 1",
+        )
+        .bind(&token)
+        .fetch_one(&pool)
+        .await
+        .expect("query should succeed");
+        assert_eq!(
+            stale_token_rows, 1,
+            "only the surviving registration's token resolves"
+        );
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE pending_email = $1")
+            .bind(&email)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE email = $1")
+            .bind(&email)
+            .execute(&pool)
+            .await;
     }
 
     /// headless_register stores a hashed 6-digit PIN on the pending row (keycast#262).

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -926,7 +926,8 @@ pub async fn headless_resend_pin(
         return Ok(success());
     };
 
-    // Mint a fresh token + PIN, reset the attempt counter, refresh the 24h verify window.
+    // Mint a fresh token + PIN and reset the attempt counter. The original 24h verify window is
+    // preserved (resend does not extend expires_at) so the pending row stays bounded (keycast#262).
     let new_token = generate_secure_token();
     let new_pin: String = format!("{:06}", rand::thread_rng().gen_range(0..1_000_000));
     let pin_for_hash = new_pin.clone();
@@ -936,15 +937,8 @@ pub async fn headless_resend_pin(
             .map_err(|e| HeadlessError::Internal(format!("Task join error: {}", e)))?
             .map_err(|e| HeadlessError::Internal(format!("PIN hash error: {}", e)))?;
 
-    let new_expires_at = Utc::now() + Duration::hours(EMAIL_VERIFICATION_EXPIRY_HOURS);
     oauth_code_repo
-        .reset_pin_for_resend(
-            &req.device_code,
-            tenant_id,
-            &new_token,
-            &new_pin_hash,
-            new_expires_at,
-        )
+        .reset_pin_for_resend(&req.device_code, tenant_id, &new_token, &new_pin_hash)
         .await?;
 
     // Re-send the link + PIN (best-effort; the user can request another resend after the cooldown).

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -724,6 +724,18 @@ async fn record_pin_verify_failure(
     .await;
 }
 
+/// Spend bcrypt work equivalent to a real PIN comparison.
+///
+/// Verify-pin rejects several states before ever reaching the bcrypt compare (unknown
+/// `device_code`, no PIN issued, already locked). Burning a dummy hash on those paths keeps their
+/// latency comparable to a wrong-PIN attempt so the rejected state is not distinguishable by timing.
+async fn burn_dummy_bcrypt() {
+    let _ = tokio::task::spawn_blocking(|| {
+        let _ = bcrypt::hash("dummy", bcrypt::DEFAULT_COST);
+    })
+    .await;
+}
+
 /// POST /api/headless/verify-pin
 ///
 /// In-app fallback for the email verification link (keycast#262): for webviews that never run the
@@ -747,10 +759,7 @@ pub async fn headless_verify_pin(
 
     let Some(pending) = pending else {
         // Burn comparable time so an unknown/expired device_code isn't distinguishable by latency.
-        let _ = tokio::task::spawn_blocking(|| {
-            let _ = bcrypt::hash("dummy", bcrypt::DEFAULT_COST);
-        })
-        .await;
+        burn_dummy_bcrypt().await;
         record_pin_verify_failure(
             pool,
             &headers,
@@ -764,6 +773,9 @@ pub async fn headless_verify_pin(
     };
 
     let Some(pin_hash) = pending.pin_hash.clone() else {
+        // No PIN was issued for this registration. Burn comparable bcrypt work so this is
+        // indistinguishable by latency from a wrong-PIN attempt before rejecting uniformly.
+        burn_dummy_bcrypt().await;
         record_pin_verify_failure(
             pool,
             &headers,
@@ -776,8 +788,15 @@ pub async fn headless_verify_pin(
         return Err(HeadlessError::PinVerificationFailed);
     };
 
-    // Already locked: reject without checking the PIN (uniform error, no lockout signal).
-    if pending.pin_attempts >= MAX_PIN_ATTEMPTS {
+    // Atomically reserve an attempt slot BEFORE the expensive bcrypt compare. The conditional
+    // UPDATE increments only while under the cap, so at most MAX_PIN_ATTEMPTS comparisons can run
+    // for this device_code even across concurrent requests. `None` means the row is at the cap
+    // (locked) — reject uniformly, burning comparable time so lockout is not a timing signal.
+    let Some(attempt) = oauth_code_repo
+        .reserve_pin_attempt(&req.device_code, tenant_id, MAX_PIN_ATTEMPTS)
+        .await?
+    else {
+        burn_dummy_bcrypt().await;
         record_pin_verify_failure(
             pool,
             &headers,
@@ -788,7 +807,7 @@ pub async fn headless_verify_pin(
         )
         .await;
         return Err(HeadlessError::PinVerificationFailed);
-    }
+    };
 
     // Constant-time PIN comparison (bcrypt's own compare; work factor dominates).
     let candidate = req.pin.clone();
@@ -799,11 +818,8 @@ pub async fn headless_verify_pin(
         .unwrap_or(false);
 
     if !valid {
-        let new_count = oauth_code_repo
-            .increment_pin_attempts(&req.device_code, tenant_id)
-            .await?
-            .unwrap_or(0);
-        let reason = if new_count >= MAX_PIN_ATTEMPTS {
+        // The slot was already consumed by the atomic reserve above; just classify and record.
+        let reason = if attempt >= MAX_PIN_ATTEMPTS {
             "pin_locked"
         } else {
             "wrong_pin"

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -1191,6 +1191,9 @@ pub async fn headless_resend_pin(
     let Some(email) = pending.pending_email.clone() else {
         return Ok(success());
     };
+    let Some(old_token) = pending.pending_email_verification_token.clone() else {
+        return Ok(success());
+    };
 
     // Mint a fresh token + PIN and reset the attempt counter. The original 24h verify window is
     // preserved (resend does not extend expires_at) so the pending row stays bounded (keycast#262).
@@ -1203,7 +1206,6 @@ pub async fn headless_resend_pin(
             .map_err(|e| HeadlessError::Internal(format!("Task join error: {}", e)))?
             .map_err(|e| HeadlessError::Internal(format!("PIN hash error: {}", e)))?;
 
-    let old_token = pending.pending_email_verification_token.clone();
     let old_pin_hash = pending.pin_hash.clone();
     let old_pin_attempts = pending.pin_attempts;
     let old_pin_sent_at = pending.pin_sent_at;
@@ -1217,6 +1219,7 @@ pub async fn headless_resend_pin(
         .reset_pin_for_resend(
             &req.device_code,
             tenant_id,
+            &old_token,
             &new_token,
             &new_pin_hash,
             cooldown_cutoff,
@@ -1253,7 +1256,7 @@ pub async fn headless_resend_pin(
                 &req.device_code,
                 tenant_id,
                 keycast_core::repositories::PinResendSnapshot {
-                    verification_token: old_token.as_deref(),
+                    verification_token: Some(&old_token),
                     pin_hash: old_pin_hash.as_deref(),
                     pin_attempts: old_pin_attempts,
                     pin_sent_at: old_pin_sent_at,

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -760,11 +760,10 @@ async fn record_pin_verify_failure(
 /// Verify-pin rejects several states before ever reaching the bcrypt compare (unknown
 /// `device_code`, no PIN issued, already locked). Burning a dummy hash on those paths keeps their
 /// latency comparable to a wrong-PIN attempt so the rejected state is not distinguishable by timing.
-async fn burn_dummy_bcrypt() {
-    let _ = tokio::task::spawn_blocking(|| {
-        let _ = bcrypt::hash("dummy", bcrypt::DEFAULT_COST);
-    })
-    .await;
+async fn burn_dummy_bcrypt(
+    bcrypt_sender: &crate::bcrypt_queue::BcryptSender,
+) -> Result<(), HeadlessError> {
+    bcrypt_sender.burn_dummy().await.map_err(Into::into)
 }
 
 /// POST /api/headless/verify-pin
@@ -790,7 +789,7 @@ pub async fn headless_verify_pin(
 
     let Some(pending) = pending else {
         // Burn comparable time so an unknown/expired device_code isn't distinguishable by latency.
-        burn_dummy_bcrypt().await;
+        burn_dummy_bcrypt(&auth_state.state.bcrypt_sender).await?;
         record_pin_verify_failure(
             pool,
             &headers,
@@ -815,7 +814,7 @@ pub async fn headless_verify_pin(
     let Some(pin_hash) = pending.pin_hash.clone() else {
         // No PIN was issued for this registration. Burn comparable bcrypt work so this is
         // indistinguishable by latency from a wrong-PIN attempt before rejecting uniformly.
-        burn_dummy_bcrypt().await;
+        burn_dummy_bcrypt(&auth_state.state.bcrypt_sender).await?;
         record_pin_verify_failure(
             pool,
             &headers,
@@ -836,7 +835,7 @@ pub async fn headless_verify_pin(
         .reserve_pin_attempt(&req.device_code, tenant_id, MAX_PIN_ATTEMPTS)
         .await?
     else {
-        burn_dummy_bcrypt().await;
+        burn_dummy_bcrypt(&auth_state.state.bcrypt_sender).await?;
         record_pin_verify_failure(
             pool,
             &headers,
@@ -849,13 +848,13 @@ pub async fn headless_verify_pin(
         return Err(HeadlessError::PinVerificationFailed);
     };
 
-    // Constant-time PIN comparison (bcrypt's own compare; work factor dominates).
-    let candidate = req.pin.clone();
-    let stored = pin_hash;
-    let valid = tokio::task::spawn_blocking(move || verify(&candidate, &stored))
-        .await
-        .map_err(|e| HeadlessError::Internal(format!("Task join error: {}", e)))?
-        .unwrap_or(false);
+    // Constant-time PIN comparison (bcrypt's own compare; work factor dominates). Both this real
+    // comparison and the dummy rejection paths share the same bounded worker pool.
+    let valid = auth_state
+        .state
+        .bcrypt_sender
+        .verify(secrecy::SecretString::from(req.pin.clone()), pin_hash)
+        .await?;
 
     if !valid {
         // The slot was already consumed by the atomic reserve above; just classify and record.
@@ -1173,6 +1172,15 @@ impl From<keycast_core::repositories::RepositoryError> for HeadlessError {
     }
 }
 
+impl From<crate::bcrypt_queue::BcryptQueueError> for HeadlessError {
+    fn from(_error: crate::bcrypt_queue::BcryptQueueError) -> Self {
+        HeadlessError::ServiceUnavailable {
+            message: "Verification service is busy. Please try again shortly.".to_string(),
+            retry_after: Some(1),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use nostr_sdk::Keys;
@@ -1206,6 +1214,7 @@ mod tests {
             .connect_lazy(&database_url)
             .expect("lazy pool should be created");
         let bcrypt_queue = crate::bcrypt_queue::BcryptQueue::new();
+        let _bcrypt_workers = bcrypt_queue.spawn_workers(pool.clone());
         let secret_pool = keycast_core::secret_pool::SecretPool::new(1);
         let tenant_cache = moka::future::Cache::builder().max_capacity(10).build();
         let key_manager: std::sync::Arc<Box<dyn keycast_core::encryption::KeyManager>> =

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -918,6 +918,9 @@ pub async fn headless_verify_pin(
         .await;
         return Err(HeadlessError::PinUnavailable);
     }
+    let Some(expected_generation_token) = pending.pending_email_verification_token.clone() else {
+        return Err(HeadlessError::PinUnavailable);
+    };
 
     // Atomically reserve an attempt slot BEFORE the expensive bcrypt compare. The conditional
     // UPDATE increments only while under both caps, so no more comparisons can run for this
@@ -926,6 +929,7 @@ pub async fn headless_verify_pin(
         .reserve_pin_attempt(
             &req.device_code,
             tenant_id,
+            &expected_generation_token,
             MAX_PIN_ATTEMPTS,
             MAX_PIN_ATTEMPTS_LIFETIME,
         )
@@ -992,7 +996,7 @@ pub async fn headless_verify_pin(
             // The queue rejected or abandoned the job before bcrypt produced a comparison result,
             // so this request must not consume the attempt slot reserved above.
             oauth_code_repo
-                .refund_pin_attempt(&req.device_code, tenant_id)
+                .refund_pin_attempt(&req.device_code, tenant_id, &expected_generation_token)
                 .await?;
             return Err(error.into());
         }
@@ -1053,7 +1057,7 @@ pub async fn headless_verify_pin(
     // Best-effort: this is a counter, not the gate. If it fails the user has at worst one fewer
     // attempt, and the caps are still exact.
     if let Err(e) = oauth_code_repo
-        .reset_pin_attempts(&req.device_code, tenant_id)
+        .reset_pin_attempts(&req.device_code, tenant_id, &expected_generation_token)
         .await
     {
         tracing::warn!(

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -171,9 +171,7 @@ pub async fn headless_register(
         .await?
         .is_some()
     {
-        return Err(HeadlessError::Conflict(
-            "This email is already registered. Please log in instead.".to_string(),
-        ));
+        return Err(HeadlessError::EmailAlreadyExists);
     }
 
     // Encrypt the secret key
@@ -241,7 +239,13 @@ pub async fn headless_register(
             is_headless: true,
             pin_hash: Some(&pin_hash),
         })
-        .await?;
+        .await
+        .map_err(|error| match error {
+            keycast_core::repositories::RepositoryError::Duplicate => {
+                HeadlessError::EmailAlreadyExists
+            }
+            other => other.into(),
+        })?;
 
     // A duplicate register supersedes the earlier pending registration in place and keeps its
     // device_code (keycast#268). Poll on the row's device_code, not the one we just generated, so
@@ -1828,6 +1832,58 @@ mod tests {
             .bind(&email)
             .execute(&pool)
             .await;
+    }
+
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    #[serial]
+    async fn test_headless_register_existing_email_uses_documented_error_code() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("headless-existing-{}@example.com", uuid::Uuid::new_v4());
+        let pubkey = Keys::generate().public_key().to_hex();
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, email_verified, created_at, updated_at)
+             VALUES ($1, 1, $2, true, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(&email)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let result = super::headless_register(
+            create_unit_test_tenant(),
+            axum::extract::State(auth_state),
+            axum::Json(super::HeadlessRegisterRequest {
+                email: email.clone(),
+                password: "testpassword123".to_string(),
+                client_id: "TestClient".to_string(),
+                redirect_uri: "https://client.example/callback".to_string(),
+                nsec: None,
+                scope: None,
+                code_challenge: Some("challenge".to_string()),
+                code_challenge_method: Some("S256".to_string()),
+                state: None,
+            }),
+        )
+        .await;
+        let error = match result {
+            Ok(_) => panic!("an already-materialized email must be rejected"),
+            Err(error) => error,
+        };
+        let response = axum::response::IntoResponse::into_response(error);
+        assert_eq!(response.status(), axum::http::StatusCode::CONFLICT);
+        assert_eq!(
+            response_json(response).await["code"],
+            super::super::auth::EMAIL_ALREADY_EXISTS_CODE
+        );
+
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
     }
 
     /// headless_register stores a hashed 6-digit PIN on the pending row (keycast#262).

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -11,7 +11,7 @@ use bcrypt::verify;
 use chrono::{Duration, Utc};
 use keycast_core::metrics::METRICS;
 use keycast_core::repositories::{
-    OAuthCodeRepository, PinAttemptReservation, PolicyRepository,
+    OAuthCodeRepository, PinAttemptRelease, PinAttemptReservation, PolicyRepository,
     StoreOAuthCodeWithRegistrationParams, UserRepository,
 };
 use nostr_sdk::Keys;
@@ -1054,17 +1054,11 @@ pub async fn headless_verify_pin(
     // counted as a failed guess on every finalize error, so repeated server-side failures could
     // burn a legitimate user's lifetime budget with the right code in their hand.
     //
-    // Best-effort: this is a counter, not the gate. If it fails the user has at worst one fewer
-    // attempt, and the caps are still exact.
-    if let Err(e) = oauth_code_repo
+    let released = oauth_code_repo
         .reset_pin_attempts(&req.device_code, tenant_id, &expected_generation_token)
-        .await
-    {
-        tracing::warn!(
-            "Failed to release the PIN attempt slot after a correct PIN for {}: {}",
-            pending.user_pubkey,
-            e
-        );
+        .await?;
+    if released != PinAttemptRelease::CurrentGeneration {
+        return Err(HeadlessError::PinInvalid);
     }
 
     // Correct PIN: run the SAME finalize path as the link (idempotent; does not delete the row).

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -1167,6 +1167,7 @@ impl From<keycast_core::repositories::RepositoryError> for HeadlessError {
 #[cfg(test)]
 mod tests {
     use nostr_sdk::Keys;
+    #[cfg(feature = "integration-tests")]
     use serial_test::serial;
 
     struct LazyTestKeyManager;
@@ -1236,6 +1237,7 @@ mod tests {
         serde_json::from_slice(&body).expect("response body should be JSON")
     }
 
+    #[cfg(feature = "integration-tests")]
     struct EmailEnvGuard {
         rust_env: Option<String>,
         node_env: Option<String>,
@@ -1243,6 +1245,7 @@ mod tests {
         disable_emails: Option<String>,
     }
 
+    #[cfg(feature = "integration-tests")]
     impl Drop for EmailEnvGuard {
         fn drop(&mut self) {
             restore_env_var("RUST_ENV", self.rust_env.as_deref());
@@ -1252,6 +1255,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "integration-tests")]
     fn restore_env_var(key: &str, value: Option<&str>) {
         if let Some(value) = value {
             std::env::set_var(key, value);
@@ -1260,6 +1264,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "integration-tests")]
     fn force_email_service_failure() -> EmailEnvGuard {
         let guard = EmailEnvGuard {
             rust_env: std::env::var("RUST_ENV").ok(),

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -998,6 +998,24 @@ pub async fn headless_verify_pin(
         }
     };
 
+    // bcrypt is deliberately slow, so the registration's window can close while it runs. Classify
+    // that as expiry rather than letting a wrong PIN read as "did not match" or a correct one fall
+    // through to a finalize that cannot succeed. Uses the window already loaded above, so this
+    // costs no query.
+    if pending.expires_at <= Utc::now() {
+        record_pin_verify_failure(
+            pool,
+            &headers,
+            tenant_id,
+            Some(&pending.user_pubkey),
+            pending.pending_email.as_deref(),
+            "registration_expired",
+            StatusCode::GONE.as_u16().into(),
+        )
+        .await;
+        return Err(HeadlessError::PinExpired);
+    }
+
     if !valid {
         // The slot was already consumed by the atomic reserve above; just classify and record.
         // Spending the last slot is reported as locked rather than merely wrong, so the user is
@@ -2190,28 +2208,42 @@ mod tests {
             .await;
     }
 
-    /// A correct PIN must give its reserved slot back. `reserve_pin_attempt` charges every attempt
-    /// up front, so without the release a correct PIN stays counted as a failed guess against the
-    /// registration's lifetime budget.
+    /// A correct PIN must give its reserved slot back even when what follows fails.
+    ///
+    /// `reserve_pin_attempt` charges every attempt up front, and finalize is fallible for reasons
+    /// that have nothing to do with the user's PIN. If the slot were released only after a
+    /// successful finalize, a correct PIN would stay counted as a failed guess on every such
+    /// failure, so repeated server-side errors could burn a legitimate user's lifetime budget while
+    /// they hold the right code.
+    ///
+    /// Clearing `pending_password_hash` is the deterministic finalize failure used here: unlike the
+    /// duplicate-email conflict, it leaves the pending row in place to be inspected.
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
-    async fn test_correct_pin_releases_its_reserved_attempt_slot() {
+    async fn test_correct_pin_releases_its_slot_even_when_finalize_fails() {
         let auth_state = create_lazy_auth_state();
         let pool = auth_state.state.db.clone();
         let email = format!("verify-pin-release-{}@example.com", uuid::Uuid::new_v4());
         let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
 
-        // Two prior failures, so the release is visible as a decrement rather than as a reset.
+        // Two prior failures, so the release reads as a decrement rather than as a reset.
         sqlx::query(
-            "UPDATE oauth_codes SET pin_attempts = 2, pin_failed_total = 2 WHERE device_code = $1",
+            "UPDATE oauth_codes \
+             SET pin_attempts = 2, pin_failed_total = 2, pending_password_hash = NULL \
+             WHERE device_code = $1",
         )
         .bind(&device_code)
         .execute(&pool)
         .await
         .unwrap();
 
+        // Correct PIN, but finalize fails.
         let response = call_verify_pin(auth_state, &device_code, "123456").await;
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert!(
+            !response.status().is_success(),
+            "finalize must fail for this test to mean anything, got {}",
+            response.status()
+        );
 
         let (attempts, failed_total): (i32, i32) = sqlx::query_as(
             "SELECT pin_attempts, pin_failed_total FROM oauth_codes \
@@ -2220,20 +2252,56 @@ mod tests {
         .bind(&device_code)
         .fetch_one(&pool)
         .await
-        .unwrap();
+        .expect("the pending row must survive an incomplete-registration failure");
         assert_eq!(attempts, 0, "a correct PIN clears the per-PIN counter");
         assert_eq!(
             failed_total, 2,
-            "a correct PIN must give back exactly the slot it reserved, leaving the two real \
-             failures counted"
+            "a correct PIN must give back the slot it reserved even though finalize failed, \
+             leaving only the two real failures counted"
         );
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
             .execute(&pool)
             .await;
-        let _ = sqlx::query("DELETE FROM personal_keys WHERE user_pubkey = $1")
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
             .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// bcrypt is deliberately slow, so the registration's window can close while a comparison is
+    /// running. That must still read as expiry rather than as a wrong PIN. Simulated by expiring
+    /// the row mid-flight, which is what the elapsed bcrypt time would otherwise do.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_pin_expiring_during_the_comparison_reports_expired() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("verify-pin-race-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        // Alive at the snapshot check and at the reservation, so the request gets past both and
+        // runs a real comparison; the window then closes before the result is classified.
+        let expire_at = Utc::now() + Duration::milliseconds(120);
+        sqlx::query("UPDATE oauth_codes SET expires_at = $2 WHERE device_code = $1")
+            .bind(&device_code)
+            .bind(expire_at)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // A wrong PIN would otherwise be reported as simply not matching.
+        let response = call_verify_pin(auth_state, &device_code, "000000").await;
+        assert!(
+            Utc::now() > expire_at,
+            "the comparison must actually outlast the window for this test to mean anything"
+        );
+        assert_eq!(response.status(), axum::http::StatusCode::GONE);
+        assert_eq!(response_json(response).await["code"], "PIN_EXPIRED");
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
             .execute(&pool)
             .await;
         let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -1247,8 +1247,8 @@ pub async fn headless_resend_pin(
 
     if let Err(e) = send_result {
         tracing::error!("Failed to resend verification email to {}: {}", email, e);
-        // Guarded on the hash this call wrote, so a later resend that did reach the user is never
-        // rolled back out from under them.
+        // Guarded on the token and hash this call wrote, and serialized with redemption, so neither
+        // a later resend nor an in-progress token exchange is rolled back out from under the user.
         let restored = oauth_code_repo
             .restore_pin_after_failed_resend(
                 &req.device_code,
@@ -1260,12 +1260,13 @@ pub async fn headless_resend_pin(
                     pin_sent_at: old_pin_sent_at,
                     pin_resend_at: old_pin_resend_at,
                 },
+                &new_token,
                 &new_pin_hash,
             )
             .await?;
         if !restored {
             tracing::info!(
-                "resend-pin: skipped rollback because a later resend already replaced the PIN"
+                "resend-pin: skipped rollback because the replacement generation is no longer safe to restore"
             );
         }
         return Ok(success());
@@ -3024,6 +3025,7 @@ mod tests {
                     pin_sent_at: b_sent,
                     pin_resend_at: b_resend,
                 },
+                b_token.as_deref().expect("snapshot carries a token"),
                 b_hash.as_deref().expect("snapshot carries a PIN hash"),
             )
             .await

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -667,6 +667,186 @@ async fn extract_first_party_or_user_signed_user(
 }
 
 // ============================================================================
+// Headless Verify PIN (in-app fallback for the email verification link)
+// ============================================================================
+
+/// Failed PIN attempts allowed before the PIN is locked until resend (keycast#262).
+const MAX_PIN_ATTEMPTS: i32 = 5;
+
+#[derive(Debug, Deserialize)]
+pub struct HeadlessVerifyPinRequest {
+    /// RFC 8628 device_code from registration — the 64-char app-held secret and real gate.
+    pub device_code: String,
+    /// 6-digit PIN emailed to the user (defense-in-depth on top of device_code).
+    pub pin: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HeadlessVerifyPinResponse {
+    pub success: bool,
+    /// Authorization code to exchange for bunker_url — returned synchronously (Redis-independent).
+    pub code: String,
+    /// Nostr public key (hex)
+    pub pubkey: String,
+    /// OAuth state (echoed back)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+}
+
+/// Record a verify-pin failure to the shared brute-force feed (#258). The `reason` is internal
+/// only — the client always sees the same uniform error (anti-enumeration).
+async fn record_pin_verify_failure(
+    pool: &sqlx::PgPool,
+    headers: &HeaderMap,
+    tenant_id: i64,
+    pubkey: Option<&str>,
+    email: Option<&str>,
+    reason: &str,
+) {
+    super::auth_observability::record_auth_event_and_log(
+        pool,
+        headers,
+        None,
+        super::auth_observability::AuthEvent {
+            tenant_id,
+            endpoint: "/api/headless/verify-pin",
+            event_type: "email_pin_verify",
+            outcome: "failure",
+            reason_code: Some(reason),
+            http_status: 401,
+            email,
+            pubkey,
+            client_id: None,
+            redirect_origin: None,
+            metadata_json: serde_json::json!({}),
+        },
+    )
+    .await;
+}
+
+/// POST /api/headless/verify-pin
+///
+/// In-app fallback for the email verification link (keycast#262): for webviews that never run the
+/// link page, a different device, or a mangled link, the user types the 6-digit PIN. The pending
+/// row is located by `device_code` (the real authenticator); the PIN is defense-in-depth, bounded
+/// by [`MAX_PIN_ATTEMPTS`]. On success the same finalize path as the link runs and the OAuth
+/// authorization code is returned synchronously in the body (no Redis dependency).
+pub async fn headless_verify_pin(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<super::routes::AuthState>,
+    headers: HeaderMap,
+    Json(req): Json<HeadlessVerifyPinRequest>,
+) -> Result<impl IntoResponse, HeadlessError> {
+    let pool = &auth_state.state.db;
+    let tenant_id = tenant.0.id;
+
+    let oauth_code_repo = OAuthCodeRepository::new(pool.clone());
+    let pending = oauth_code_repo
+        .find_by_device_code(&req.device_code, tenant_id)
+        .await?;
+
+    let Some(pending) = pending else {
+        // Burn comparable time so an unknown/expired device_code isn't distinguishable by latency.
+        let _ = tokio::task::spawn_blocking(|| {
+            let _ = bcrypt::hash("dummy", bcrypt::DEFAULT_COST);
+        })
+        .await;
+        record_pin_verify_failure(
+            pool,
+            &headers,
+            tenant_id,
+            None,
+            None,
+            "device_code_not_found",
+        )
+        .await;
+        return Err(HeadlessError::PinVerificationFailed);
+    };
+
+    let Some(pin_hash) = pending.pin_hash.clone() else {
+        record_pin_verify_failure(
+            pool,
+            &headers,
+            tenant_id,
+            Some(&pending.user_pubkey),
+            pending.pending_email.as_deref(),
+            "no_pin_issued",
+        )
+        .await;
+        return Err(HeadlessError::PinVerificationFailed);
+    };
+
+    // Already locked: reject without checking the PIN (uniform error, no lockout signal).
+    if pending.pin_attempts >= MAX_PIN_ATTEMPTS {
+        record_pin_verify_failure(
+            pool,
+            &headers,
+            tenant_id,
+            Some(&pending.user_pubkey),
+            pending.pending_email.as_deref(),
+            "pin_locked",
+        )
+        .await;
+        return Err(HeadlessError::PinVerificationFailed);
+    }
+
+    // Constant-time PIN comparison (bcrypt's own compare; work factor dominates).
+    let candidate = req.pin.clone();
+    let stored = pin_hash;
+    let valid = tokio::task::spawn_blocking(move || verify(&candidate, &stored))
+        .await
+        .map_err(|e| HeadlessError::Internal(format!("Task join error: {}", e)))?
+        .unwrap_or(false);
+
+    if !valid {
+        let new_count = oauth_code_repo
+            .increment_pin_attempts(&req.device_code, tenant_id)
+            .await?
+            .unwrap_or(0);
+        let reason = if new_count >= MAX_PIN_ATTEMPTS {
+            "pin_locked"
+        } else {
+            "wrong_pin"
+        };
+        record_pin_verify_failure(
+            pool,
+            &headers,
+            tenant_id,
+            Some(&pending.user_pubkey),
+            pending.pending_email.as_deref(),
+            reason,
+        )
+        .await;
+        return Err(HeadlessError::PinVerificationFailed);
+    }
+
+    // Correct PIN: run the SAME finalize path as the link (idempotent; does not delete the row).
+    // RedisBestEffort because the code is returned synchronously below, so a Redis outage is fine.
+    let finalized = super::auth::finalize_pending_registration(
+        pool,
+        auth_state.state.redis.as_ref(),
+        tenant_id,
+        &pending,
+        super::auth::HeadlessDelivery::RedisBestEffort,
+    )
+    .await?;
+
+    tracing::info!(
+        event = "email_pin_verify",
+        tenant_id = tenant_id,
+        outcome = "success",
+        "PIN verified, registration finalized"
+    );
+
+    Ok(Json(HeadlessVerifyPinResponse {
+        success: true,
+        code: finalized.new_code,
+        pubkey: pending.user_pubkey,
+        state: finalized.state,
+    }))
+}
+
+// ============================================================================
 // Error Type
 // ============================================================================
 
@@ -678,6 +858,9 @@ pub enum HeadlessError {
     InvalidRequest(String),
     Conflict(String),
     Internal(String),
+    /// Uniform rejection for every verify-pin failure mode (unknown device_code, wrong/locked/
+    /// expired PIN) — never reveals which, nor lockout state (anti-enumeration).
+    PinVerificationFailed,
     ServiceUnavailable {
         message: String,
         retry_after: Option<u32>,
@@ -704,6 +887,12 @@ impl IntoResponse for HeadlessError {
             ),
             HeadlessError::InvalidRequest(msg) => (StatusCode::BAD_REQUEST, msg, "INVALID_REQUEST"),
             HeadlessError::Conflict(msg) => (StatusCode::CONFLICT, msg, "CONFLICT"),
+            HeadlessError::PinVerificationFailed => (
+                StatusCode::UNAUTHORIZED,
+                "Invalid or expired verification code. Please try again or request a new one."
+                    .to_string(),
+                "PIN_VERIFICATION_FAILED",
+            ),
             HeadlessError::Internal(msg) => {
                 tracing::error!("Headless internal error: {}", msg);
                 (
@@ -916,6 +1105,226 @@ mod tests {
             .await;
         let _ = sqlx::query("DELETE FROM users WHERE email = $1")
             .bind(&email)
+            .execute(&pool)
+            .await;
+    }
+
+    /// Insert a pending headless registration with a known PIN. Returns (pubkey, device_code).
+    #[cfg(feature = "integration-tests")]
+    async fn insert_pending_with_pin(
+        pool: &sqlx::PgPool,
+        email: &str,
+        pin_plain: &str,
+    ) -> (String, String) {
+        let keys = Keys::generate();
+        let pubkey = keys.public_key().to_hex();
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let token = format!("verify_{}", uuid::Uuid::new_v4());
+        let placeholder = format!("placeholder_{}", uuid::Uuid::new_v4());
+        let password_hash = bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap();
+        let pin_hash = bcrypt::hash(pin_plain, bcrypt::DEFAULT_COST).unwrap();
+        let encrypted_secret = keys.secret_key().to_secret_bytes().to_vec();
+        let expires_at = chrono::Utc::now() + chrono::Duration::hours(24);
+
+        sqlx::query(
+            "INSERT INTO oauth_codes (
+                tenant_id, code, user_pubkey, client_id, redirect_uri, scope,
+                expires_at, created_at, pending_email, pending_password_hash,
+                pending_email_verification_token, pending_encrypted_secret,
+                device_code, is_headless, pin_hash, pin_attempts
+            ) VALUES (1, $1, $2, $3, $4, $5, $6, NOW(), $7, $8, $9, $10, $11, true, $12, 0)",
+        )
+        .bind(&placeholder)
+        .bind(&pubkey)
+        .bind("TestApp")
+        .bind("https://test.example.com/callback")
+        .bind("policy:social")
+        .bind(expires_at)
+        .bind(email)
+        .bind(&password_hash)
+        .bind(&token)
+        .bind(&encrypted_secret)
+        .bind(&device_code)
+        .bind(&pin_hash)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        (pubkey, device_code)
+    }
+
+    #[cfg(feature = "integration-tests")]
+    async fn call_verify_pin(
+        auth_state: crate::api::http::routes::AuthState,
+        device_code: &str,
+        pin: &str,
+    ) -> axum::response::Response {
+        match super::headless_verify_pin(
+            create_unit_test_tenant(),
+            axum::extract::State(auth_state),
+            axum::http::HeaderMap::new(),
+            axum::Json(super::HeadlessVerifyPinRequest {
+                device_code: device_code.to_string(),
+                pin: pin.to_string(),
+            }),
+        )
+        .await
+        {
+            Ok(r) => axum::response::IntoResponse::into_response(r),
+            Err(e) => axum::response::IntoResponse::into_response(e),
+        }
+    }
+
+    /// Happy path: correct PIN finalizes and returns the OAuth code synchronously in the body.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_pin_happy_path_returns_code_synchronously() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("verify-pin-ok-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        let response = call_verify_pin(auth_state, &device_code, "123456").await;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["success"], true);
+        assert!(
+            body["code"].as_str().is_some_and(|c| !c.is_empty()),
+            "verify-pin must return an exchange code synchronously"
+        );
+        assert_eq!(body["pubkey"], pubkey);
+
+        // User materialized as verified.
+        let verified: (bool,) =
+            sqlx::query_as("SELECT email_verified FROM users WHERE pubkey = $1 AND tenant_id = 1")
+                .bind(&pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(verified.0);
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM personal_keys WHERE user_pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// After 5 failed attempts the PIN is locked; even the correct PIN then fails uniformly.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_pin_attempt_cap_locks_at_5() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("verify-pin-lock-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        let mut statuses = Vec::new();
+        for _ in 0..5 {
+            let r = call_verify_pin(auth_state.clone(), &device_code, "000000").await;
+            statuses.push(r.status());
+        }
+        assert!(
+            statuses.iter().all(|s| !s.is_success()),
+            "wrong PIN attempts must all fail"
+        );
+
+        // Correct PIN after the cap must still fail (locked), not succeed.
+        let locked = call_verify_pin(auth_state, &device_code, "123456").await;
+        assert!(
+            !locked.status().is_success(),
+            "correct PIN after lockout must not finalize"
+        );
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// Anti-enumeration: an unknown device_code and a wrong PIN are indistinguishable to the client.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_pin_anti_enumeration_uniform_errors() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("verify-pin-enum-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        let wrong_pin = call_verify_pin(auth_state.clone(), &device_code, "000000").await;
+        let wrong_device = call_verify_pin(
+            auth_state,
+            &format!("dc_{}", uuid::Uuid::new_v4()),
+            "000000",
+        )
+        .await;
+
+        assert_eq!(
+            wrong_pin.status(),
+            wrong_device.status(),
+            "wrong PIN and wrong device_code must return the same status"
+        );
+        let wrong_pin_body = response_json(wrong_pin).await;
+        let wrong_device_body = response_json(wrong_device).await;
+        assert_eq!(
+            wrong_pin_body, wrong_device_body,
+            "failure bodies must be identical (no enumeration / lockout signal)"
+        );
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// Duplicate email: the PIN path funnels through the shared finalize, so it inherits the
+    /// 409 conflict behavior of the link path.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_pin_duplicate_email_conflict() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("verify-pin-dup-{}@example.com", uuid::Uuid::new_v4());
+
+        // Pre-existing user owns the email.
+        let existing_pubkey = Keys::generate().public_key().to_hex();
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+             VALUES ($1, 1, $2, $3, true, NOW(), NOW())",
+        )
+        .bind(&existing_pubkey)
+        .bind(&email)
+        .bind(bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let (pending_pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        let response = call_verify_pin(auth_state, &device_code, "123456").await;
+        assert_eq!(response.status(), axum::http::StatusCode::CONFLICT);
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = ANY($1)")
+            .bind(vec![existing_pubkey, pending_pubkey])
             .execute(&pool)
             .await;
     }

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -1702,16 +1702,19 @@ mod tests {
         );
 
         // Exactly one pending row, one live verification token: only one email is actionable.
-        let rows: Vec<(
-            String,
-            Option<String>,
-            Option<String>,
-            i32,
-            i32,
-            Option<DateTime<Utc>>,
-            Option<DateTime<Utc>>,
-            DateTime<Utc>,
-        )> = sqlx::query_as(
+        #[derive(sqlx::FromRow)]
+        struct PendingRegistrationState {
+            pending_password_hash: String,
+            code_challenge: Option<String>,
+            pending_email_verification_token: Option<String>,
+            pin_attempts: i32,
+            pin_failed_total: i32,
+            pin_sent_at: Option<DateTime<Utc>>,
+            pin_resend_at: Option<DateTime<Utc>>,
+            expires_at: DateTime<Utc>,
+        }
+
+        let rows: Vec<PendingRegistrationState> = sqlx::query_as(
             "SELECT pending_password_hash, code_challenge, pending_email_verification_token,
                     pin_attempts, pin_failed_total, pin_sent_at, pin_resend_at, expires_at
              FROM oauth_codes
@@ -1727,56 +1730,53 @@ mod tests {
             1,
             "a duplicate register must not create a second pending registration"
         );
-        let (
-            password_hash,
-            code_challenge,
-            token,
-            pin_attempts,
-            pin_failed_total,
-            pin_sent_at,
-            pin_resend_at,
-            expires_at,
-        ) = rows.into_iter().next().unwrap();
+        let row = rows.into_iter().next().unwrap();
 
         // The newest attempt wins: a user who retyped their password must be able to log in with
         // the password they last submitted, and the stored PKCE challenge must match the verifier
         // the app is now holding or token exchange would fail PKCE.
         assert!(
-            bcrypt::verify("secondpassword456", &password_hash)
+            bcrypt::verify("secondpassword456", &row.pending_password_hash)
                 .expect("stored hash should be verifiable"),
             "the second attempt's password must win"
         );
         assert!(
-            !bcrypt::verify("firstpassword123", &password_hash)
+            !bcrypt::verify("firstpassword123", &row.pending_password_hash)
                 .expect("stored hash should be verifiable"),
             "the superseded attempt's password must not survive"
         );
         assert_eq!(
-            code_challenge.as_deref(),
+            row.code_challenge.as_deref(),
             Some("challenge-two"),
             "the second attempt's PKCE challenge must win"
         );
-        assert_eq!(pin_attempts, 0, "superseding re-arms the attempt counter");
         assert_eq!(
-            pin_failed_total, 5,
+            row.pin_attempts, 0,
+            "superseding re-arms the attempt counter"
+        );
+        assert_eq!(
+            row.pin_failed_total, 5,
             "superseding must not grant a fresh lifetime guessing budget"
         );
         assert!(
-            pin_resend_at.is_none(),
+            row.pin_resend_at.is_none(),
             "superseding must not inherit the old PIN's resend cooldown"
         );
         assert!(
-            pin_sent_at.is_some_and(|sent_at| sent_at > first_sent_at),
+            row.pin_sent_at
+                .is_some_and(|sent_at| sent_at > first_sent_at),
             "the replacement PIN should be stamped only after its delivery succeeds"
         );
         assert!(
-            expires_at > first_expiry,
+            row.expires_at > first_expiry,
             "an explicit re-registration should start a fresh verification window"
         );
 
         // The first email's token is dead — that link now renders the terminal
         // superseded page rather than stranding the user on a 401.
-        let token = token.expect("pending row keeps a verification token");
+        let token = row
+            .pending_email_verification_token
+            .expect("pending row keeps a verification token");
         let stale_token_rows: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM oauth_codes
              WHERE pending_email_verification_token = $1 AND tenant_id = 1",

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -177,6 +177,16 @@ pub async fn headless_register(
             .map_err(|e| HeadlessError::Internal(format!("Task join error: {}", e)))?
             .map_err(|e| HeadlessError::Internal(format!("Password hash error: {}", e)))?;
 
+    // Generate a 6-digit in-app verification PIN (keycast#262), emailed alongside the link as a
+    // second transport for the same proof. Stored hashed; the device_code is the real gate.
+    let pin: String = format!("{:06}", rand::thread_rng().gen_range(0..1_000_000));
+    let pin_for_hash = pin.clone();
+    let pin_hash =
+        tokio::task::spawn_blocking(move || bcrypt::hash(&pin_for_hash, bcrypt::DEFAULT_COST))
+            .await
+            .map_err(|e| HeadlessError::Internal(format!("Task join error: {}", e)))?
+            .map_err(|e| HeadlessError::Internal(format!("PIN hash error: {}", e)))?;
+
     // Generate placeholder authorization code (will be replaced after email verification)
     let placeholder_code: String = rand::thread_rng()
         .sample_iter(&rand::distributions::Alphanumeric)
@@ -205,8 +215,7 @@ pub async fn headless_register(
             state: req.state.as_deref(),
             device_code: Some(&device_code),
             is_headless: true,
-            // PIN fallback is added in a later step; no PIN issued yet.
-            pin_hash: None,
+            pin_hash: Some(&pin_hash),
         })
         .await?;
 
@@ -214,7 +223,7 @@ pub async fn headless_register(
     match crate::email_service::EmailService::new() {
         Ok(email_service) => {
             if let Err(e) = email_service
-                .send_verification_email(&req.email, &verification_token)
+                .send_verification_email(&req.email, &verification_token, Some(&pin))
                 .await
             {
                 tracing::error!("Failed to send verification email to {}: {}", req.email, e);
@@ -851,5 +860,63 @@ mod tests {
         let body = response_json(response).await;
         assert_eq!(body["code"], crate::api::http::auth::INVALID_EMAIL_CODE);
         assert_eq!(body["error"], "Please enter a valid email address.");
+    }
+
+    /// headless_register stores a hashed 6-digit PIN on the pending row (keycast#262).
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_headless_register_stores_hashed_pin() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("headless-pin-{}@example.com", uuid::Uuid::new_v4());
+
+        let response = super::headless_register(
+            create_unit_test_tenant(),
+            axum::extract::State(auth_state),
+            axum::Json(super::HeadlessRegisterRequest {
+                email: email.clone(),
+                password: "testpassword123".to_string(),
+                client_id: "TestClient".to_string(),
+                redirect_uri: "https://client.example/callback".to_string(),
+                nsec: None,
+                scope: None,
+                code_challenge: None,
+                code_challenge_method: None,
+                state: None,
+            }),
+        )
+        .await
+        .map(axum::response::IntoResponse::into_response)
+        .expect("headless_register should succeed");
+
+        let body = response_json(response).await;
+        let device_code = body["device_code"]
+            .as_str()
+            .expect("response carries device_code")
+            .to_string();
+
+        let (pin_hash, pin_attempts): (Option<String>, i32) = sqlx::query_as(
+            "SELECT pin_hash, pin_attempts FROM oauth_codes WHERE device_code = $1 AND tenant_id = 1",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .expect("pending row should exist");
+
+        let pin_hash = pin_hash.expect("a PIN must be hashed and stored at registration");
+        assert!(
+            pin_hash.starts_with("$2"),
+            "pin_hash must be a bcrypt hash, got {pin_hash}"
+        );
+        assert_eq!(pin_attempts, 0, "attempt counter starts at zero");
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE email = $1")
+            .bind(&email)
+            .execute(&pool)
+            .await;
     }
 }

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -850,11 +850,22 @@ pub async fn headless_verify_pin(
 
     // Constant-time PIN comparison (bcrypt's own compare; work factor dominates). Both this real
     // comparison and the dummy rejection paths share the same bounded worker pool.
-    let valid = auth_state
+    let valid = match auth_state
         .state
         .bcrypt_sender
         .verify(secrecy::SecretString::from(req.pin.clone()), pin_hash)
-        .await?;
+        .await
+    {
+        Ok(valid) => valid,
+        Err(error) => {
+            // The queue rejected or abandoned the job before bcrypt produced a comparison result,
+            // so this request must not consume the attempt slot reserved above.
+            oauth_code_repo
+                .refund_pin_attempt(&req.device_code, tenant_id)
+                .await?;
+            return Err(error.into());
+        }
+    };
 
     if !valid {
         // The slot was already consumed by the atomic reserve above; just classify and record.
@@ -1615,6 +1626,49 @@ mod tests {
         assert!(
             !locked.status().is_success(),
             "correct PIN after lockout must not finalize"
+        );
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// A rejected bcrypt job returns 503 without consuming a PIN-attempt slot.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_pin_bcrypt_503_refunds_reserved_attempt() {
+        let mut auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("verify-pin-busy-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        let disconnected_queue = crate::bcrypt_queue::BcryptQueue::new();
+        let disconnected_sender = disconnected_queue.sender();
+        drop(disconnected_queue);
+        std::sync::Arc::get_mut(&mut auth_state.state)
+            .expect("test auth state should have one owner")
+            .bcrypt_sender = disconnected_sender;
+
+        let response = call_verify_pin(auth_state, &device_code, "000000").await;
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+
+        let (attempts,): (i32,) =
+            sqlx::query_as("SELECT pin_attempts FROM oauth_codes WHERE device_code = $1")
+                .bind(&device_code)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            attempts, 0,
+            "bcrypt backpressure must not advance the lockout counter"
         );
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -281,7 +281,7 @@ pub async fn headless_register(
     }
     if email_delivered {
         oauth_code_repo
-            .mark_pin_sent(&device_code, tenant_id)
+            .mark_pin_sent(&device_code, tenant_id, &verification_token)
             .await?;
     }
 
@@ -1270,6 +1270,12 @@ pub async fn headless_resend_pin(
         return Ok(success());
     }
 
+    // A later registration or resend may have replaced this generation while delivery was in
+    // flight. Stamp only the token that was actually handed to the provider.
+    oauth_code_repo
+        .mark_pin_sent(&req.device_code, tenant_id, &new_token)
+        .await?;
+
     tracing::info!(
         event = "email_pin_resend",
         tenant_id = tenant_id,
@@ -1420,6 +1426,11 @@ impl From<keycast_core::repositories::RepositoryError> for HeadlessError {
                 HeadlessError::Conflict("Resource already exists".to_string())
             }
             RepositoryError::NotFound(msg) => HeadlessError::InvalidRequest(msg),
+            RepositoryError::Unavailable(_) => HeadlessError::ServiceUnavailable {
+                message: "Registration is currently being finalized. Please retry shortly."
+                    .to_string(),
+                retry_after: Some(1),
+            },
             _ => HeadlessError::Internal(e.to_string()),
         }
     }
@@ -1665,6 +1676,14 @@ mod tests {
         };
 
         let first = register("firstpassword123", "challenge-one").await;
+        let first_token: String = sqlx::query_scalar(
+            "SELECT pending_email_verification_token FROM oauth_codes
+             WHERE pending_email = $1 AND tenant_id = 1 AND consumed_at IS NULL",
+        )
+        .bind(&email)
+        .fetch_one(&pool)
+        .await
+        .expect("first registration should retain its verification token");
 
         // Registration itself is an uncooldowned recovery path: model a current PIN that has hit
         // its five-attempt lockout and whose resend cooldown is armed. Supersession may restore
@@ -1774,21 +1793,30 @@ mod tests {
 
         // The first email's token is dead — that link now renders the terminal
         // superseded page rather than stranding the user on a 401.
-        let token = row
+        let current_token = row
             .pending_email_verification_token
             .expect("pending row keeps a verification token");
         let stale_token_rows: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM oauth_codes
              WHERE pending_email_verification_token = $1 AND tenant_id = 1",
         )
-        .bind(&token)
+        .bind(&first_token)
         .fetch_one(&pool)
         .await
         .expect("query should succeed");
         assert_eq!(
-            stale_token_rows, 1,
-            "only the surviving registration's token resolves"
+            stale_token_rows, 0,
+            "the superseded registration's token must no longer resolve"
         );
+        let current_token_rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE pending_email_verification_token = $1 AND tenant_id = 1",
+        )
+        .bind(&current_token)
+        .fetch_one(&pool)
+        .await
+        .expect("query should succeed");
+        assert_eq!(current_token_rows, 1, "only the newest token resolves");
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE pending_email = $1")
             .bind(&email)

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -2300,6 +2300,25 @@ mod tests {
         assert_eq!(response.status(), axum::http::StatusCode::GONE);
         assert_eq!(response_json(response).await["code"], "PIN_EXPIRED");
 
+        // Prove the 410 came from the post-comparison check rather than from the reservation
+        // refusing an already-expired row. Reaching bcrypt requires the reservation to have
+        // succeeded while the window was still open, and a reservation charges both counters
+        // exactly once. Without this the test would pass vacuously whenever scheduling ate the
+        // window before the reservation ran.
+        let (attempts, failed_total): (i32, i32) = sqlx::query_as(
+            "SELECT pin_attempts, pin_failed_total FROM oauth_codes \
+             WHERE device_code = $1 AND pending_email IS NOT NULL",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            (attempts, failed_total),
+            (1, 1),
+            "the reservation must have succeeded before expiry, so the comparison actually ran"
+        );
+
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
             .execute(&pool)

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -18,8 +18,9 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use super::auth::{
-    generate_secure_token, normalize_registration_email, EMAIL_VERIFICATION_EXPIRY_HOURS,
-    INVALID_EMAIL_CODE, INVALID_EMAIL_MESSAGE,
+    generate_secure_token, normalize_registration_email, EMAIL_ALREADY_EXISTS_CODE,
+    EMAIL_ALREADY_EXISTS_MESSAGE, EMAIL_VERIFICATION_EXPIRY_HOURS, INVALID_EMAIL_CODE,
+    INVALID_EMAIL_MESSAGE,
 };
 use super::oauth::{extract_origin, parse_policy_scope};
 
@@ -1068,6 +1069,9 @@ pub enum HeadlessError {
     InvalidEmail,
     InvalidRequest(String),
     Conflict(String),
+    /// Duplicate email during registration finalize. Dedicated variant (not `Conflict`) so the
+    /// body carries the documented `EMAIL_ALREADY_EXISTS` code byte-identical to the link path.
+    EmailAlreadyExists,
     Internal(String),
     /// Uniform rejection for every verify-pin failure mode (unknown device_code, wrong/locked/
     /// expired PIN) — never reveals which, nor lockout state (anti-enumeration).
@@ -1098,6 +1102,11 @@ impl IntoResponse for HeadlessError {
             ),
             HeadlessError::InvalidRequest(msg) => (StatusCode::BAD_REQUEST, msg, "INVALID_REQUEST"),
             HeadlessError::Conflict(msg) => (StatusCode::CONFLICT, msg, "CONFLICT"),
+            HeadlessError::EmailAlreadyExists => (
+                StatusCode::CONFLICT,
+                EMAIL_ALREADY_EXISTS_MESSAGE.to_string(),
+                EMAIL_ALREADY_EXISTS_CODE,
+            ),
             HeadlessError::PinVerificationFailed => (
                 StatusCode::UNAUTHORIZED,
                 "Invalid or expired verification code. Please try again or request a new one."
@@ -1674,6 +1683,12 @@ mod tests {
 
         let response = call_verify_pin(auth_state, &device_code, "123456").await;
         assert_eq!(response.status(), axum::http::StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(
+            body["code"],
+            super::super::auth::EMAIL_ALREADY_EXISTS_CODE,
+            "PIN path must emit the same documented duplicate-email code as the link path"
+        );
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -1115,8 +1115,10 @@ mod tests {
     }
 
     fn create_lazy_auth_state() -> crate::api::http::routes::AuthState {
+        let database_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
         let pool = sqlx::postgres::PgPoolOptions::new()
-            .connect_lazy("postgres://postgres:password@localhost/keycast_test")
+            .connect_lazy(&database_url)
             .expect("lazy pool should be created");
         let bcrypt_queue = crate::bcrypt_queue::BcryptQueue::new();
         let secret_pool = keycast_core::secret_pool::SecretPool::new(1);

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -717,6 +717,18 @@ async fn extract_first_party_or_user_signed_user(
 /// Failed PIN attempts allowed before the PIN is locked until resend (keycast#262).
 const MAX_PIN_ATTEMPTS: i32 = 5;
 
+/// How long an issued 6-digit PIN stays usable, measured from `pin_sent_at`.
+///
+/// Deliberately far shorter than the pending registration's own 24h window: a 6-digit secret has
+/// only a million values, so its useful lifetime should be bounded by how long a person plausibly
+/// takes to read the mail, not by how long the registration stays open. The email's verification
+/// link is unaffected and remains valid for the full registration window, and a resend re-arms a
+/// fresh PIN, so an aged-out PIN is a recoverable state rather than a dead end.
+///
+/// Comfortably longer than [`PIN_RESEND_COOLDOWN_MINUTES`] so a user whose PIN ages out can always
+/// obtain a new one immediately instead of landing between an unusable PIN and a live cooldown.
+const PIN_VALIDITY_MINUTES: i64 = 60;
+
 #[derive(Debug, Deserialize)]
 pub struct HeadlessVerifyPinRequest {
     /// RFC 8628 device_code from registration — the 64-char app-held secret and real gate.
@@ -737,8 +749,10 @@ pub struct HeadlessVerifyPinResponse {
     pub state: Option<String>,
 }
 
-/// Record a verify-pin failure to the shared brute-force feed (#258). The `reason` is internal
-/// only — the client always sees the same uniform error (anti-enumeration).
+/// Record a verify-pin failure to the shared brute-force feed (#258).
+///
+/// `reason` is the internal classification and `http_status` the status actually returned, so the
+/// feed stays aligned with what the caller observed.
 async fn record_pin_verify_failure(
     pool: &sqlx::PgPool,
     headers: &HeaderMap,
@@ -746,6 +760,7 @@ async fn record_pin_verify_failure(
     pubkey: Option<&str>,
     email: Option<&str>,
     reason: &str,
+    http_status: i32,
 ) {
     super::auth_observability::record_auth_event_and_log(
         pool,
@@ -757,7 +772,7 @@ async fn record_pin_verify_failure(
             event_type: "email_pin_verify",
             outcome: "failure",
             reason_code: Some(reason),
-            http_status: 401,
+            http_status,
             email,
             pubkey,
             client_id: None,
@@ -770,9 +785,9 @@ async fn record_pin_verify_failure(
 
 /// Spend bcrypt work equivalent to a real PIN comparison.
 ///
-/// Verify-pin rejects several states before ever reaching the bcrypt compare (unknown
-/// `device_code`, no PIN issued, already locked). Burning a dummy hash on those paths keeps their
-/// latency comparable to a wrong-PIN attempt so the rejected state is not distinguishable by timing.
+/// Used on the one verify-pin rejection that must stay indistinguishable from a wrong PIN: an
+/// unknown `device_code`. Every other rejection reports its own status and code, so burning work
+/// on those would buy no secrecy while consuming the bounded bcrypt worker pool.
 async fn burn_dummy_bcrypt(
     bcrypt_sender: &crate::bcrypt_queue::BcryptSender,
 ) -> Result<(), HeadlessError> {
@@ -786,6 +801,20 @@ async fn burn_dummy_bcrypt(
 /// row is located by `device_code` (the real authenticator); the PIN is defense-in-depth, bounded
 /// by [`MAX_PIN_ATTEMPTS`]. On success the same finalize path as the link runs and the OAuth
 /// authorization code is returned synchronously in the body (no Redis dependency).
+///
+/// # Rejection detail
+///
+/// Rejections are specific rather than uniform, so the caller can tell the user what to do:
+/// [`HeadlessError::PinLocked`], [`HeadlessError::PinExpired`], and
+/// [`HeadlessError::PinUnavailable`] each direct the user to request a new code, while
+/// [`HeadlessError::PinInvalid`] means "check the digits and retry".
+///
+/// The single state kept deliberately uniform is an unknown `device_code`, which is reported as
+/// [`HeadlessError::PinInvalid`] with matching bcrypt work burned so it is indistinguishable from
+/// a wrong PIN. Every state that *is* reported specifically is reachable only by a caller already
+/// holding the 64-char server-issued `device_code` for that registration, so naming it discloses
+/// nothing to anyone else. What bounds PIN guessing is the [`MAX_PIN_ATTEMPTS`] cap enforced in
+/// [`OAuthCodeRepository::reserve_pin_attempt`], not the opacity of the reply.
 pub async fn headless_verify_pin(
     tenant: crate::api::tenant::TenantExtractor,
     State(auth_state): State<super::routes::AuthState>,
@@ -801,7 +830,8 @@ pub async fn headless_verify_pin(
         .await?;
 
     let Some(pending) = pending else {
-        // Burn comparable time so an unknown/expired device_code isn't distinguishable by latency.
+        // The only rejection kept uniform: an unknown or expired device_code must be
+        // indistinguishable from a wrong PIN, in latency as well as in status and code.
         burn_dummy_bcrypt(&auth_state.state.bcrypt_sender).await?;
         record_pin_verify_failure(
             pool,
@@ -810,24 +840,24 @@ pub async fn headless_verify_pin(
             None,
             None,
             "device_code_not_found",
+            StatusCode::UNAUTHORIZED.as_u16().into(),
         )
         .await;
-        return Err(HeadlessError::PinVerificationFailed);
+        return Err(HeadlessError::PinInvalid);
     };
 
+    // The registration already finished issuing tokens. Report it as a terminal conflict rather
+    // than a success carrying no code: the caller's poll can never complete against a consumed
+    // row, so a success-shaped reply would leave it waiting out its own timeout instead of
+    // telling the user the account exists and they should sign in.
     if pending.consumed_at.is_some() {
-        return Ok(Json(HeadlessVerifyPinResponse {
-            success: true,
-            code: String::new(),
-            pubkey: pending.user_pubkey,
-            state: pending.state,
-        }));
+        return Err(HeadlessError::RegistrationAlreadyCompleted);
     }
 
     let Some(pin_hash) = pending.pin_hash.clone() else {
-        // No PIN was issued for this registration. Burn comparable bcrypt work so this is
-        // indistinguishable by latency from a wrong-PIN attempt before rejecting uniformly.
-        burn_dummy_bcrypt(&auth_state.state.bcrypt_sender).await?;
+        // No PIN was ever issued for this registration (for example a browser OAuth registration).
+        // Say so, so the caller steers the user to the email link or a resend instead of insisting
+        // the digits were wrong.
         record_pin_verify_failure(
             pool,
             &headers,
@@ -835,20 +865,51 @@ pub async fn headless_verify_pin(
             Some(&pending.user_pubkey),
             pending.pending_email.as_deref(),
             "no_pin_issued",
+            StatusCode::FORBIDDEN.as_u16().into(),
         )
         .await;
-        return Err(HeadlessError::PinVerificationFailed);
+        return Err(HeadlessError::PinUnavailable);
     };
+
+    // A PIN exists but was never confirmed delivered, so the user cannot be holding it. Treat it
+    // as unavailable rather than wrong: a resend both delivers and re-arms.
+    let Some(pin_sent_at) = pending.pin_sent_at else {
+        record_pin_verify_failure(
+            pool,
+            &headers,
+            tenant_id,
+            Some(&pending.user_pubkey),
+            pending.pending_email.as_deref(),
+            "pin_never_delivered",
+            StatusCode::FORBIDDEN.as_u16().into(),
+        )
+        .await;
+        return Err(HeadlessError::PinUnavailable);
+    };
+
+    // The PIN aged out of its own validity window while the registration is still open. Distinct
+    // from a wrong PIN and from a lockout, and recoverable by a resend.
+    if Utc::now() - pin_sent_at >= Duration::minutes(PIN_VALIDITY_MINUTES) {
+        record_pin_verify_failure(
+            pool,
+            &headers,
+            tenant_id,
+            Some(&pending.user_pubkey),
+            pending.pending_email.as_deref(),
+            "pin_expired",
+            StatusCode::GONE.as_u16().into(),
+        )
+        .await;
+        return Err(HeadlessError::PinExpired);
+    }
 
     // Atomically reserve an attempt slot BEFORE the expensive bcrypt compare. The conditional
     // UPDATE increments only while under the cap, so at most MAX_PIN_ATTEMPTS comparisons can run
-    // for this device_code even across concurrent requests. `None` means the row is at the cap
-    // (locked) — reject uniformly, burning comparable time so lockout is not a timing signal.
+    // for this device_code even across concurrent requests. `None` means the row is at the cap.
     let Some(attempt) = oauth_code_repo
         .reserve_pin_attempt(&req.device_code, tenant_id, MAX_PIN_ATTEMPTS)
         .await?
     else {
-        burn_dummy_bcrypt(&auth_state.state.bcrypt_sender).await?;
         record_pin_verify_failure(
             pool,
             &headers,
@@ -856,9 +917,10 @@ pub async fn headless_verify_pin(
             Some(&pending.user_pubkey),
             pending.pending_email.as_deref(),
             "pin_locked",
+            StatusCode::LOCKED.as_u16().into(),
         )
         .await;
-        return Err(HeadlessError::PinVerificationFailed);
+        return Err(HeadlessError::PinLocked);
     };
 
     // Constant-time PIN comparison (bcrypt's own compare; work factor dominates). Both this real
@@ -882,10 +944,17 @@ pub async fn headless_verify_pin(
 
     if !valid {
         // The slot was already consumed by the atomic reserve above; just classify and record.
-        let reason = if attempt >= MAX_PIN_ATTEMPTS {
-            "pin_locked"
+        // Spending the last slot is reported as locked rather than merely wrong, so the user is
+        // told to request a new code on the attempt that exhausts the cap instead of on the next
+        // one.
+        let (error, reason, status) = if attempt >= MAX_PIN_ATTEMPTS {
+            (HeadlessError::PinLocked, "pin_locked", StatusCode::LOCKED)
         } else {
-            "wrong_pin"
+            (
+                HeadlessError::PinInvalid,
+                "wrong_pin",
+                StatusCode::UNAUTHORIZED,
+            )
         };
         record_pin_verify_failure(
             pool,
@@ -894,9 +963,10 @@ pub async fn headless_verify_pin(
             Some(&pending.user_pubkey),
             pending.pending_email.as_deref(),
             reason,
+            status.as_u16().into(),
         )
         .await;
-        return Err(HeadlessError::PinVerificationFailed);
+        return Err(error);
     }
 
     // Correct PIN: run the SAME finalize path as the link (idempotent; does not delete the row).
@@ -911,13 +981,10 @@ pub async fn headless_verify_pin(
     .await
     {
         Ok(finalized) => finalized,
+        // Same terminal case as the `consumed_at` check above, reached when the registration
+        // completed between that read and this call.
         Err(super::auth::AuthError::RegistrationAlreadyCompleted) => {
-            return Ok(Json(HeadlessVerifyPinResponse {
-                success: true,
-                code: String::new(),
-                pubkey: pending.user_pubkey,
-                state: pending.state,
-            }))
+            return Err(HeadlessError::RegistrationAlreadyCompleted)
         }
         Err(e) => return Err(e.into()),
     };
@@ -956,7 +1023,11 @@ pub async fn headless_verify_pin(
 // Headless Resend PIN (lockout recovery + new code)
 // ============================================================================
 
-/// Minutes between PIN resends (mirrors the users-table `email_verification_sent_at` cooldown).
+/// Minutes between successive PIN resends.
+///
+/// Measured from `pin_resend_at`, which is stamped only by an actual resend. Registration stamps
+/// `pin_sent_at` instead, so the first resend a user asks for is never swallowed by a cooldown
+/// they never started — which matters because a resend is the only way out of a PIN lockout.
 const PIN_RESEND_COOLDOWN_MINUTES: i64 = 5;
 
 #[derive(Debug, Deserialize)]
@@ -1008,9 +1079,10 @@ pub async fn headless_resend_pin(
         return Ok(success());
     }
 
-    // Cooldown: silently skip if a PIN was sent within the window.
-    if let Some(sent_at) = pending.pin_sent_at {
-        if (Utc::now() - sent_at).num_minutes() < PIN_RESEND_COOLDOWN_MINUTES {
+    // Cooldown: silently skip if a resend already ran within the window. Anchored on
+    // `pin_resend_at`, which registration leaves NULL, so the first resend always proceeds.
+    if let Some(resent_at) = pending.pin_resend_at {
+        if Utc::now() - resent_at < Duration::minutes(PIN_RESEND_COOLDOWN_MINUTES) {
             tracing::debug!("resend-pin: within cooldown, skipping (not revealed to client)");
             return Ok(success());
         }
@@ -1035,6 +1107,7 @@ pub async fn headless_resend_pin(
     let old_pin_hash = pending.pin_hash.clone();
     let old_pin_attempts = pending.pin_attempts;
     let old_pin_sent_at = pending.pin_sent_at;
+    let old_pin_resend_at = pending.pin_resend_at;
 
     oauth_code_repo
         .reset_pin_for_resend(&req.device_code, tenant_id, &new_token, &new_pin_hash)
@@ -1063,10 +1136,13 @@ pub async fn headless_resend_pin(
             .restore_pin_after_failed_resend(
                 &req.device_code,
                 tenant_id,
-                old_token.as_deref(),
-                old_pin_hash.as_deref(),
-                old_pin_attempts,
-                old_pin_sent_at,
+                keycast_core::repositories::PinResendSnapshot {
+                    verification_token: old_token.as_deref(),
+                    pin_hash: old_pin_hash.as_deref(),
+                    pin_attempts: old_pin_attempts,
+                    pin_sent_at: old_pin_sent_at,
+                    pin_resend_at: old_pin_resend_at,
+                },
             )
             .await?;
         return Ok(success());
@@ -1096,9 +1172,19 @@ pub enum HeadlessError {
     /// body carries the documented `EMAIL_ALREADY_EXISTS` code byte-identical to the link path.
     EmailAlreadyExists,
     Internal(String),
-    /// Uniform rejection for every verify-pin failure mode (unknown device_code, wrong/locked/
-    /// expired PIN) — never reveals which, nor lockout state (anti-enumeration).
-    PinVerificationFailed,
+    /// The registration this PIN belongs to already completed token issuance. Terminal: the
+    /// account exists, so the caller should stop waiting and sign in.
+    RegistrationAlreadyCompleted,
+    /// The submitted PIN did not match. Also covers an unknown `device_code`, deliberately, so
+    /// that case stays indistinguishable from a wrong PIN.
+    PinInvalid,
+    /// The attempt cap is spent. Recoverable only by requesting a new code.
+    PinLocked,
+    /// The PIN aged out of its validity window while the registration is still open. Recoverable
+    /// by requesting a new code.
+    PinExpired,
+    /// No usable PIN exists for this registration — none was issued, or none was delivered.
+    PinUnavailable,
     ServiceUnavailable {
         message: String,
         retry_after: Option<u32>,
@@ -1130,11 +1216,32 @@ impl IntoResponse for HeadlessError {
                 EMAIL_ALREADY_EXISTS_MESSAGE.to_string(),
                 EMAIL_ALREADY_EXISTS_CODE,
             ),
-            HeadlessError::PinVerificationFailed => (
+            HeadlessError::RegistrationAlreadyCompleted => (
+                StatusCode::CONFLICT,
+                "This registration has already been completed. Please sign in.".to_string(),
+                EMAIL_ALREADY_EXISTS_CODE,
+            ),
+            HeadlessError::PinInvalid => (
                 StatusCode::UNAUTHORIZED,
-                "Invalid or expired verification code. Please try again or request a new one."
+                "That code did not match. Please check it and try again.".to_string(),
+                "PIN_INVALID",
+            ),
+            HeadlessError::PinLocked => (
+                StatusCode::LOCKED,
+                "Too many incorrect attempts. Please request a new code.".to_string(),
+                "PIN_LOCKED",
+            ),
+            HeadlessError::PinExpired => (
+                StatusCode::GONE,
+                "That code has expired. Please request a new one.".to_string(),
+                "PIN_EXPIRED",
+            ),
+            HeadlessError::PinUnavailable => (
+                StatusCode::FORBIDDEN,
+                "Code entry is not available for this registration. Please use the link in your \
+                 email or request a new code."
                     .to_string(),
-                "PIN_VERIFICATION_FAILED",
+                "PIN_UNAVAILABLE",
             ),
             HeadlessError::Internal(msg) => {
                 tracing::error!("Headless internal error: {}", msg);
@@ -1207,6 +1314,10 @@ impl From<crate::bcrypt_queue::BcryptQueueError> for HeadlessError {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "integration-tests")]
+    use super::{MAX_PIN_ATTEMPTS, PIN_VALIDITY_MINUTES};
+    #[cfg(feature = "integration-tests")]
+    use chrono::{Duration, Utc};
     use nostr_sdk::Keys;
     #[cfg(feature = "integration-tests")]
     use serial_test::serial;
@@ -1575,7 +1686,7 @@ mod tests {
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
     #[serial]
-    async fn test_headless_register_email_failure_does_not_start_resend_cooldown() {
+    async fn test_headless_register_leaves_the_resend_cooldown_unarmed() {
         let _email_env = force_email_service_failure();
 
         let auth_state = create_lazy_auth_state();
@@ -1607,8 +1718,11 @@ mod tests {
             .expect("response carries device_code")
             .to_string();
 
-        let (pin_sent_at,): (Option<chrono::DateTime<chrono::Utc>>,) = sqlx::query_as(
-            "SELECT pin_sent_at FROM oauth_codes WHERE device_code = $1 AND tenant_id = 1",
+        let (pin_sent_at, pin_resend_at): (
+            Option<chrono::DateTime<Utc>>,
+            Option<chrono::DateTime<Utc>>,
+        ) = sqlx::query_as(
+            "SELECT pin_sent_at, pin_resend_at FROM oauth_codes WHERE device_code = $1 AND tenant_id = 1",
         )
         .bind(&device_code)
         .fetch_one(&pool)
@@ -1617,7 +1731,11 @@ mod tests {
 
         assert!(
             pin_sent_at.is_none(),
-            "failed initial email delivery must allow immediate resend"
+            "an undelivered PIN must not be stamped as sent"
+        );
+        assert!(
+            pin_resend_at.is_none(),
+            "registration must never arm the resend cooldown, delivered or not"
         );
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
@@ -1630,7 +1748,12 @@ mod tests {
             .await;
     }
 
-    /// Insert a pending headless registration with a known PIN. Returns (pubkey, device_code).
+    /// Insert a pending headless registration with a known, freshly delivered PIN.
+    ///
+    /// Mirrors the state `headless_register` leaves behind on a successful send: `pin_sent_at`
+    /// stamped, `pin_resend_at` still NULL because no resend has happened yet.
+    ///
+    /// Returns (pubkey, device_code).
     #[cfg(feature = "integration-tests")]
     async fn insert_pending_with_pin(
         pool: &sqlx::PgPool,
@@ -1652,8 +1775,8 @@ mod tests {
                 tenant_id, code, user_pubkey, client_id, redirect_uri, scope,
                 expires_at, created_at, pending_email, pending_password_hash,
                 pending_email_verification_token, pending_encrypted_secret,
-                device_code, is_headless, pin_hash, pin_attempts
-            ) VALUES (1, $1, $2, $3, $4, $5, $6, NOW(), $7, $8, $9, $10, $11, true, $12, 0)",
+                device_code, is_headless, pin_hash, pin_attempts, pin_sent_at
+            ) VALUES (1, $1, $2, $3, $4, $5, $6, NOW(), $7, $8, $9, $10, $11, true, $12, 0, NOW())",
         )
         .bind(&placeholder)
         .bind(&pubkey)
@@ -1738,31 +1861,45 @@ mod tests {
             .await;
     }
 
-    /// After 5 failed attempts the PIN is locked; even the correct PIN then fails uniformly.
+    /// After 5 failed attempts the PIN is locked, and lockout is reported distinguishably from a
+    /// merely wrong PIN so the caller can tell the user to request a new code instead of repeating
+    /// "that code didn't match" forever.
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
-    async fn test_verify_pin_attempt_cap_locks_at_5() {
+    async fn test_verify_pin_attempt_cap_reports_lockout_distinguishably() {
         let auth_state = create_lazy_auth_state();
         let pool = auth_state.state.db.clone();
         let email = format!("verify-pin-lock-{}@example.com", uuid::Uuid::new_v4());
         let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
 
-        let mut statuses = Vec::new();
-        for _ in 0..5 {
+        // Attempts 1..=4 are ordinary wrong-PIN rejections.
+        for attempt in 1..MAX_PIN_ATTEMPTS {
             let r = call_verify_pin(auth_state.clone(), &device_code, "000000").await;
-            statuses.push(r.status());
+            assert_eq!(
+                r.status(),
+                axum::http::StatusCode::UNAUTHORIZED,
+                "attempt {attempt} is below the cap and must read as a wrong PIN"
+            );
+            assert_eq!(response_json(r).await["code"], "PIN_INVALID");
         }
-        assert!(
-            statuses.iter().all(|s| !s.is_success()),
-            "wrong PIN attempts must all fail"
-        );
 
-        // Correct PIN after the cap must still fail (locked), not succeed.
-        let locked = call_verify_pin(auth_state, &device_code, "123456").await;
-        assert!(
-            !locked.status().is_success(),
-            "correct PIN after lockout must not finalize"
+        // The attempt that spends the last slot already reports lockout.
+        let capped = call_verify_pin(auth_state.clone(), &device_code, "000000").await;
+        assert_eq!(
+            capped.status(),
+            axum::http::StatusCode::LOCKED,
+            "the attempt exhausting the cap must report lockout, not a wrong PIN"
         );
+        assert_eq!(response_json(capped).await["code"], "PIN_LOCKED");
+
+        // Correct PIN after the cap must still fail, and say why.
+        let locked = call_verify_pin(auth_state, &device_code, "123456").await;
+        assert_eq!(
+            locked.status(),
+            axum::http::StatusCode::LOCKED,
+            "correct PIN after lockout must not finalize, and must report lockout"
+        );
+        assert_eq!(response_json(locked).await["code"], "PIN_LOCKED");
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
@@ -1770,6 +1907,94 @@ mod tests {
             .await;
         let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
             .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// A PIN past its validity window is reported as expired, not as a wrong PIN, so the caller
+    /// tells the user to request a new code. The registration itself is still open.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_pin_aged_out_pin_reports_expired() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("verify-pin-expired-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        let aged_out = Utc::now() - Duration::minutes(PIN_VALIDITY_MINUTES + 1);
+        sqlx::query("UPDATE oauth_codes SET pin_sent_at = $2 WHERE device_code = $1")
+            .bind(&device_code)
+            .bind(aged_out)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Even the correct PIN is refused once it has aged out.
+        let response = call_verify_pin(auth_state, &device_code, "123456").await;
+        assert_eq!(response.status(), axum::http::StatusCode::GONE);
+        assert_eq!(response_json(response).await["code"], "PIN_EXPIRED");
+
+        // An expired PIN must not consume a lockout slot: the recovery action is a resend.
+        let (attempts,): (i32,) =
+            sqlx::query_as("SELECT pin_attempts FROM oauth_codes WHERE device_code = $1")
+                .bind(&device_code)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(attempts, 0);
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// A registration carrying no usable PIN reports that, rather than insisting the digits were
+    /// wrong, so the caller steers the user to the email link or a resend.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_pin_without_usable_pin_reports_unavailable() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+
+        // No PIN was ever issued for this registration.
+        let no_pin_email = format!("verify-pin-nopin-{}@example.com", uuid::Uuid::new_v4());
+        let (no_pin_pubkey, no_pin_device) =
+            insert_pending_with_pin(&pool, &no_pin_email, "123456").await;
+        sqlx::query("UPDATE oauth_codes SET pin_hash = NULL WHERE device_code = $1")
+            .bind(&no_pin_device)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let response = call_verify_pin(auth_state.clone(), &no_pin_device, "123456").await;
+        assert_eq!(response.status(), axum::http::StatusCode::FORBIDDEN);
+        assert_eq!(response_json(response).await["code"], "PIN_UNAVAILABLE");
+
+        // A PIN exists but was never confirmed delivered, so the user cannot be holding it.
+        let undelivered_email = format!("verify-pin-undeliv-{}@example.com", uuid::Uuid::new_v4());
+        let (undelivered_pubkey, undelivered_device) =
+            insert_pending_with_pin(&pool, &undelivered_email, "123456").await;
+        sqlx::query("UPDATE oauth_codes SET pin_sent_at = NULL WHERE device_code = $1")
+            .bind(&undelivered_device)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let response = call_verify_pin(auth_state, &undelivered_device, "123456").await;
+        assert_eq!(response.status(), axum::http::StatusCode::FORBIDDEN);
+        assert_eq!(response_json(response).await["code"], "PIN_UNAVAILABLE");
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = ANY($1)")
+            .bind(vec![no_pin_device, undelivered_device])
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = ANY($1)")
+            .bind(vec![no_pin_pubkey, undelivered_pubkey])
             .execute(&pool)
             .await;
     }
@@ -1817,10 +2042,12 @@ mod tests {
             .await;
     }
 
-    /// Anti-enumeration: an unknown device_code and a wrong PIN are indistinguishable to the client.
+    /// The one rejection that must stay uniform: an unknown device_code is indistinguishable from
+    /// a wrong PIN. Every other rejection is reported specifically, but this one is reachable
+    /// without holding a device_code, so it must reveal nothing.
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
-    async fn test_verify_pin_anti_enumeration_uniform_errors() {
+    async fn test_verify_pin_unknown_device_code_is_indistinguishable_from_wrong_pin() {
         let auth_state = create_lazy_auth_state();
         let pool = auth_state.state.db.clone();
         let email = format!("verify-pin-enum-{}@example.com", uuid::Uuid::new_v4());
@@ -1899,9 +2126,13 @@ mod tests {
             .await;
     }
 
+    /// A registration that already issued tokens is terminal. It must not answer with a
+    /// success-shaped body carrying no code: a caller that keeps polling against a consumed row
+    /// can never complete, so it would sit until its own timeout instead of telling the user the
+    /// account exists and they should sign in.
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
-    async fn test_verify_pin_completed_registration_returns_idempotent_success() {
+    async fn test_verify_pin_completed_registration_is_terminal_conflict() {
         let auth_state = create_lazy_auth_state();
         let pool = auth_state.state.db.clone();
         let email = format!("verify-pin-complete-{}@example.com", uuid::Uuid::new_v4());
@@ -1916,14 +2147,14 @@ mod tests {
         let response = call_verify_pin(auth_state, &device_code, "123456").await;
         assert_eq!(
             response.status(),
-            axum::http::StatusCode::OK,
-            "completed registrations should match the link path's friendly success semantics"
+            axum::http::StatusCode::CONFLICT,
+            "a completed registration must be reported as terminal, not as a codeless success"
         );
         let body = response_json(response).await;
-        assert_eq!(body["success"], true);
-        assert!(
-            body["code"].as_str().is_none_or(str::is_empty),
-            "already-completed idempotent success must not mint a new exchange code"
+        assert_eq!(
+            body["code"],
+            super::super::auth::EMAIL_ALREADY_EXISTS_CODE,
+            "the account exists, so reuse the documented already-registered code"
         );
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
@@ -1966,9 +2197,10 @@ mod tests {
         let email = format!("resend-pin-ok-{}@example.com", uuid::Uuid::new_v4());
         let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
 
-        // Simulate a locked PIN whose last send is past the cooldown.
+        // Simulate a locked PIN whose last resend is past the cooldown.
         sqlx::query(
-            "UPDATE oauth_codes SET pin_attempts = 5, pin_sent_at = NOW() - INTERVAL '10 minutes' WHERE device_code = $1",
+            "UPDATE oauth_codes SET pin_attempts = 5, pin_sent_at = NOW() - INTERVAL '10 minutes', \
+             pin_resend_at = NOW() - INTERVAL '10 minutes' WHERE device_code = $1",
         )
         .bind(&device_code)
         .execute(&pool)
@@ -2011,7 +2243,78 @@ mod tests {
             .await;
     }
 
-    /// Within the 5-minute cooldown, resend is a silent no-op (PIN/token unchanged).
+    /// The resend a user asks for right after registering must actually send. Registration stamps
+    /// `pin_sent_at`, so anchoring the cooldown there would swallow that first request while still
+    /// reporting success — and since a resend is the only way out of a PIN lockout, a user who
+    /// burns the attempt cap in the first few minutes would have no working recovery at all.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    #[serial]
+    async fn test_resend_pin_after_registration_is_not_swallowed_by_a_cooldown() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("resend-pin-first-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        // Exactly the state registration leaves behind, plus a lockout the user must escape:
+        // the PIN was delivered moments ago and no resend has happened yet.
+        sqlx::query(
+            "UPDATE oauth_codes SET pin_attempts = 5, pin_sent_at = NOW() WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let (old_hash, old_resend_at): (Option<String>, Option<chrono::DateTime<Utc>>) =
+            sqlx::query_as(
+                "SELECT pin_hash, pin_resend_at FROM oauth_codes WHERE device_code = $1",
+            )
+            .bind(&device_code)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(
+            old_resend_at.is_none(),
+            "registration must not pre-arm the resend cooldown"
+        );
+
+        let response = call_resend_pin(auth_state, &device_code).await;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let (attempts, new_hash, new_resend_at): (
+            i32,
+            Option<String>,
+            Option<chrono::DateTime<Utc>>,
+        ) = sqlx::query_as(
+            "SELECT pin_attempts, pin_hash, pin_resend_at FROM oauth_codes WHERE device_code = $1",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_ne!(
+            new_hash, old_hash,
+            "the first resend after registration must mint a fresh PIN, not silently do nothing"
+        );
+        assert_eq!(attempts, 0, "the first resend must clear the lockout");
+        assert!(
+            new_resend_at.is_some(),
+            "a real resend arms the cooldown for the ones after it"
+        );
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// Within the 5-minute cooldown, a *subsequent* resend is a silent no-op (PIN/token unchanged).
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
     async fn test_resend_pin_respects_cooldown() {
@@ -2020,8 +2323,10 @@ mod tests {
         let email = format!("resend-pin-cooldown-{}@example.com", uuid::Uuid::new_v4());
         let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
 
-        // Last send just now → inside the cooldown window.
-        sqlx::query("UPDATE oauth_codes SET pin_sent_at = NOW() WHERE device_code = $1")
+        // A resend already ran just now → inside the cooldown window.
+        sqlx::query(
+            "UPDATE oauth_codes SET pin_sent_at = NOW(), pin_resend_at = NOW() WHERE device_code = $1",
+        )
             .bind(&device_code)
             .execute(&pool)
             .await
@@ -2071,9 +2376,10 @@ mod tests {
         let email = format!("resend-pin-email-fail-{}@example.com", uuid::Uuid::new_v4());
         let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
 
-        let old_sent_at = chrono::Utc::now() - chrono::Duration::minutes(10);
+        let old_sent_at = Utc::now() - Duration::minutes(10);
         sqlx::query(
-            "UPDATE oauth_codes SET pin_attempts = 5, pin_sent_at = $2 WHERE device_code = $1",
+            "UPDATE oauth_codes SET pin_attempts = 5, pin_sent_at = $2, pin_resend_at = $2 \
+             WHERE device_code = $1",
         )
         .bind(&device_code)
         .bind(old_sent_at)
@@ -2081,34 +2387,33 @@ mod tests {
         .await
         .unwrap();
 
-        let (old_hash, old_token, old_attempts, old_pin_sent_at): (
+        type ResendFields = (
             Option<String>,
             Option<String>,
             i32,
-            Option<chrono::DateTime<chrono::Utc>>,
-        ) = sqlx::query_as(
-            "SELECT pin_hash, pending_email_verification_token, pin_attempts, pin_sent_at FROM oauth_codes WHERE device_code = $1",
-        )
-        .bind(&device_code)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+            Option<chrono::DateTime<Utc>>,
+            Option<chrono::DateTime<Utc>>,
+        );
+        const RESEND_FIELDS_SQL: &str = "SELECT pin_hash, pending_email_verification_token, \
+                                         pin_attempts, pin_sent_at, pin_resend_at \
+                                         FROM oauth_codes WHERE device_code = $1";
+
+        let (old_hash, old_token, old_attempts, old_pin_sent_at, old_pin_resend_at): ResendFields =
+            sqlx::query_as(RESEND_FIELDS_SQL)
+                .bind(&device_code)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
 
         let response = call_resend_pin(auth_state, &device_code).await;
         assert_eq!(response.status(), axum::http::StatusCode::OK);
 
-        let (new_hash, new_token, new_attempts, new_pin_sent_at): (
-            Option<String>,
-            Option<String>,
-            i32,
-            Option<chrono::DateTime<chrono::Utc>>,
-        ) = sqlx::query_as(
-            "SELECT pin_hash, pending_email_verification_token, pin_attempts, pin_sent_at FROM oauth_codes WHERE device_code = $1",
-        )
-        .bind(&device_code)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let (new_hash, new_token, new_attempts, new_pin_sent_at, new_pin_resend_at): ResendFields =
+            sqlx::query_as(RESEND_FIELDS_SQL)
+                .bind(&device_code)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
 
         assert_eq!(new_hash, old_hash, "failed resend must preserve old PIN");
         assert_eq!(
@@ -2121,6 +2426,10 @@ mod tests {
         );
         assert_eq!(
             new_pin_sent_at, old_pin_sent_at,
+            "failed resend must not restamp the PIN validity window"
+        );
+        assert_eq!(
+            new_pin_resend_at, old_pin_resend_at,
             "failed resend must not arm a new cooldown"
         );
 

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -13,10 +13,10 @@ use bcrypt::verify;
 use chrono::{Duration, Utc};
 use keycast_core::metrics::METRICS;
 use keycast_core::repositories::{
-    CreateOAuthAuthorizationParams, OAuthAuthorizationRepository, OAuthCodeRepository,
-    PersonalKeysRepository, PolicyRepository, RefreshTokenRepository, RepositoryError,
-    StoreOAuthCodeParams, StoreOAuthCodeWithRegistrationParams, StoredPendingRegistration,
-    UserRepository,
+    CreateOAuthAuthorizationParams, OAuthAuthorizationRepository, OAuthCodeData,
+    OAuthCodeRepository, PersonalKeysRepository, PolicyRepository, RefreshTokenRepository,
+    RepositoryError, StoreOAuthCodeParams, StoreOAuthCodeWithRegistrationParams,
+    StoredPendingRegistration, UserRepository,
 };
 use keycast_core::types::refresh_token::{generate_refresh_token, hash_refresh_token};
 use nostr_sdk::{Keys, ToBech32};
@@ -3104,19 +3104,20 @@ async fn handle_authorization_code_grant(
 
         pending_email_val.clone()
     } else {
-        // Normal token exchange (existing user, not registration). Redeem the exchange code now,
-        // but leave the pending registration active until every issuance step succeeds. If a
-        // downstream dependency fails, the verification link/PIN can mint a replacement code.
+        // Resolve the email before claiming the code so a lookup failure leaves it immediately
+        // redeemable.
+        let user_repo = UserRepository::new(pool.clone());
+        let email = user_repo.get_email(&user_pubkey, tenant_id).await?;
+
+        // Claim, but do not delete, the exchange code. Downstream failures release this claim so
+        // the same code can retry.
         if !oauth_code_repo
             .redeem_code(tenant_id, code, &auth_code_for_redeem)
             .await?
         {
             return Err(OAuthError::Unauthorized);
         }
-
-        // Get user's email for UCAN
-        let user_repo = UserRepository::new(pool.clone());
-        user_repo.get_email(&user_pubkey, tenant_id).await?
+        email
     };
 
     tracing::info!(
@@ -3127,7 +3128,7 @@ async fn handle_authorization_code_grant(
     );
 
     // Create OAuth authorization and generate token response
-    let response = create_oauth_authorization_and_token(
+    let issuance = create_oauth_authorization_and_token(
         CreateAuthorizationParams {
             tenant_id,
             user_pubkey: &user_pubkey,
@@ -3138,17 +3139,44 @@ async fn handle_authorization_code_grant(
             nsec_from_verifier,
             previous_auth_id,
             is_headless,
+            exchange_code: pending_email.is_none().then_some(code.as_str()),
+            exchange_code_data: pending_email.is_none().then_some(&auth_code_for_redeem),
         },
         auth_state,
     )
-    .await?;
+    .await;
+    let response = match issuance {
+        Ok(response) => response,
+        Err(error) => {
+            if pending_email.is_none() {
+                match oauth_code_repo
+                    .release_redeemed_code(tenant_id, code, &auth_code_for_redeem)
+                    .await
+                {
+                    Ok(true) => {}
+                    Ok(false) => tracing::warn!(
+                        tenant_id,
+                        code = %code,
+                        "Token issuance failed after the exchange claim expired or changed"
+                    ),
+                    Err(release_error) => tracing::error!(
+                        tenant_id,
+                        code = %code,
+                        error = %release_error,
+                        "Failed to release OAuth exchange-code claim after issuance error"
+                    ),
+                }
+            }
+            return Err(error);
+        }
+    };
 
     // `consumed_at` is the terminal registration marker. Set it only after the authorization,
     // refresh token, and response have all been created successfully; otherwise recovery remains
     // possible through the still-active pending row.
     if pending_email.is_none()
         && !oauth_code_repo
-            .mark_pending_consumed(tenant_id, &auth_code_for_redeem)
+            .mark_pending_consumed(tenant_id, code, &auth_code_for_redeem)
             .await?
     {
         tracing::error!(
@@ -3178,6 +3206,8 @@ struct CreateAuthorizationParams<'a> {
     previous_auth_id: Option<i32>,
     /// Whether this code was issued via headless flow (for first_party UCAN fact)
     is_headless: bool,
+    exchange_code: Option<&'a str>,
+    exchange_code_data: Option<&'a OAuthCodeData>,
 }
 
 /// Common function to create OAuth authorization and generate TokenResponse
@@ -3197,6 +3227,8 @@ async fn create_oauth_authorization_and_token(
         nsec_from_verifier,
         previous_auth_id,
         is_headless,
+        exchange_code,
+        exchange_code_data,
     } = params;
     let pool = &auth_state.state.db;
     let key_manager = auth_state.state.key_manager.as_ref();
@@ -3340,22 +3372,36 @@ async fn create_oauth_authorization_and_token(
     // Each authorization is a separate "ticket" for one client/device
     // Old authorizations remain valid until explicitly revoked
     let oauth_auth_repo = OAuthAuthorizationRepository::new(pool.clone());
-    let auth_id = oauth_auth_repo
-        .create(CreateOAuthAuthorizationParams {
-            tenant_id,
-            user_pubkey: user_pubkey.to_string(),
-            redirect_origin: redirect_origin.clone(),
-            client_id: client_id.to_string(),
-            bunker_public_key: bunker_public_key.to_hex(),
-            secret_hash,
-            relays: relays_json.clone(),
-            policy_id: Some(policy_id),
-            is_first_party: is_headless,
-            client_pubkey: None,
-            authorization_handle: Some(authorization_handle.clone()),
-            handle_expires_at,
-        })
-        .await?;
+    let authorization_params = CreateOAuthAuthorizationParams {
+        tenant_id,
+        user_pubkey: user_pubkey.to_string(),
+        redirect_origin: redirect_origin.clone(),
+        client_id: client_id.to_string(),
+        bunker_public_key: bunker_public_key.to_hex(),
+        secret_hash,
+        relays: relays_json.clone(),
+        policy_id: Some(policy_id),
+        is_first_party: is_headless,
+        client_pubkey: None,
+        authorization_handle: Some(authorization_handle.clone()),
+        handle_expires_at,
+    };
+    let auth_id = match (exchange_code, exchange_code_data) {
+        (Some(code), Some(auth_code)) => oauth_auth_repo
+            .create_from_redeemed_code(authorization_params, code, auth_code)
+            .await?
+            .ok_or_else(|| {
+                OAuthError::ServerError(
+                    "Authorization code processing claim expired; retry the exchange".to_string(),
+                )
+            })?,
+        (None, None) => oauth_auth_repo.create(authorization_params).await?,
+        _ => {
+            return Err(OAuthError::ServerError(
+                "Incomplete authorization code processing claim".to_string(),
+            ))
+        }
+    };
 
     tracing::info!(
         "Created OAuth authorization {} for user {} app {}",

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -4730,9 +4730,9 @@ mod tests {
     }
 
     fn create_lazy_auth_state() -> crate::api::http::routes::AuthState {
-        create_lazy_auth_state_with_database_url(
-            "postgres://postgres:password@localhost/keycast_test",
-        )
+        let database_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+        create_lazy_auth_state_with_database_url(&database_url)
     }
 
     fn create_unit_test_tenant() -> crate::api::tenant::TenantExtractor {

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -4700,7 +4700,8 @@ mod tests {
             .connect_lazy(database_url)
             .expect("lazy pool should be created");
         let bcrypt_queue = crate::bcrypt_queue::BcryptQueue::new();
-        let secret_pool = keycast_core::secret_pool::SecretPool::new(1);
+        let secret_pool = Box::leak(Box::new(keycast_core::secret_pool::SecretPool::new(1)));
+        let _secret_pool_producer = secret_pool.spawn_producer();
         let tenant_cache = moka::future::Cache::builder().max_capacity(10).build();
         let key_manager: std::sync::Arc<Box<dyn keycast_core::encryption::KeyManager>> =
             std::sync::Arc::new(Box::new(LazyTestKeyManager));
@@ -5128,6 +5129,100 @@ mod tests {
             assert_eq!(response.status(), expected_status);
             assert_eq!(response_json(response).await, expected_body);
         }
+    }
+
+    #[tokio::test]
+    async fn test_oauth_token_exchanges_plain_existing_user_code() {
+        std::env::set_var("BUNKER_RELAYS", "wss://relay.example.test");
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let keys = Keys::generate();
+        let user_pubkey = keys.public_key().to_hex();
+        let nsec = keys.secret_key().to_bech32().unwrap();
+        let email = format!("oauth-token-existing-{}@example.com", uuid::Uuid::new_v4());
+        let code = format!("oauth_token_existing_{}", uuid::Uuid::new_v4());
+        let client_id = format!("client_{}", uuid::Uuid::new_v4());
+        let redirect_uri = "http://localhost:3000/callback";
+
+        sqlx::query("INSERT INTO users (pubkey, tenant_id, email, created_at, updated_at) VALUES ($1, 1, $2, NOW(), NOW())")
+            .bind(&user_pubkey)
+            .bind(&email)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        store_oauth_code(
+            &pool,
+            1,
+            &code,
+            &user_pubkey,
+            &client_id,
+            redirect_uri,
+            "policy:social",
+            None,
+            None,
+            Utc::now() + Duration::minutes(10),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let response = match token(
+            create_unit_test_tenant(),
+            axum::extract::State(auth_state),
+            axum::Json(TokenRequest {
+                grant_type: Some("authorization_code".to_string()),
+                code: Some(code.clone()),
+                client_id,
+                redirect_uri: Some(redirect_uri.to_string()),
+                code_verifier: Some(format!("verifier.{}", nsec)),
+                refresh_token: None,
+            }),
+        )
+        .await
+        {
+            Ok(response) => response,
+            Err(error) => error.into_response(),
+        };
+        let status = response.status();
+        let body = response_json(response).await;
+
+        sqlx::query(
+            "DELETE FROM oauth_refresh_tokens
+             WHERE authorization_id IN (
+                 SELECT id FROM oauth_authorizations WHERE user_pubkey = $1 AND tenant_id = 1
+             )",
+        )
+        .bind(&user_pubkey)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("DELETE FROM oauth_authorizations WHERE user_pubkey = $1 AND tenant_id = 1")
+            .bind(&user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM personal_keys WHERE user_pubkey = $1 AND tenant_id = 1")
+            .bind(&user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM oauth_codes WHERE code = $1 OR user_pubkey = $2")
+            .bind(&code)
+            .bind(&user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1 AND tenant_id = 1")
+            .bind(&user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(status, StatusCode::OK, "unexpected token response: {body}");
+        assert!(body["access_token"].is_string(), "token response: {body}");
+        assert!(body["bunker_url"].is_string(), "token response: {body}");
     }
 
     #[tokio::test]

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -2926,7 +2926,11 @@ async fn handle_authorization_code_grant(
     let auth_code = oauth_code_repo
         .find_valid(tenant_id, code)
         .await?
-        .ok_or(OAuthError::Unauthorized)?;
+        .ok_or_else(|| {
+            OAuthError::InvalidGrant(
+                "Authorization code is invalid, expired, or already used.".to_string(),
+            )
+        })?;
     let auth_code_for_redeem = auth_code.clone();
 
     let user_pubkey = auth_code.user_pubkey;
@@ -3115,7 +3119,9 @@ async fn handle_authorization_code_grant(
             .redeem_code(tenant_id, code, &auth_code_for_redeem)
             .await?
         {
-            return Err(OAuthError::Unauthorized);
+            return Err(OAuthError::InvalidGrant(
+                "Authorization code is invalid, expired, or already used.".to_string(),
+            ));
         }
         email
     };

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -3074,7 +3074,7 @@ async fn handle_authorization_code_grant(
         match crate::email_service::EmailService::new() {
             Ok(email_service) => {
                 if let Err(e) = email_service
-                    .send_verification_email(pending_email_val, &verification_token)
+                    .send_verification_email(pending_email_val, &verification_token, None)
                     .await
                 {
                     tracing::error!(
@@ -3857,7 +3857,7 @@ pub async fn oauth_register(
     match crate::email_service::EmailService::new() {
         Ok(email_service) => {
             if let Err(e) = email_service
-                .send_verification_email(&req.email, &verification_token)
+                .send_verification_email(&req.email, &verification_token, None)
                 .await
             {
                 tracing::error!("Failed to send verification email to {}: {}", req.email, e);

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -228,6 +228,8 @@ async fn store_oauth_code_with_pending_registration(
         state,
         device_code,
         is_headless: false,
+        // Browser OAuth registration verifies via the email link in a real browser; no PIN fallback.
+        pin_hash: None,
     })
     .await?;
     Ok(())

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -3097,10 +3097,11 @@ async fn handle_authorization_code_grant(
 
         pending_email_val.clone()
     } else {
-        // Normal token exchange (existing user, not registration)
-        // One-time exchange and pending-row completion must be one authoritative DB transition.
+        // Normal token exchange (existing user, not registration). Redeem the exchange code now,
+        // but leave the pending registration active until every issuance step succeeds. If a
+        // downstream dependency fails, the verification link/PIN can mint a replacement code.
         if !oauth_code_repo
-            .redeem_code_and_mark_pending_consumed(tenant_id, code, &auth_code_for_redeem)
+            .redeem_code(tenant_id, code, &auth_code_for_redeem)
             .await?
         {
             return Err(OAuthError::Unauthorized);
@@ -3119,7 +3120,7 @@ async fn handle_authorization_code_grant(
     );
 
     // Create OAuth authorization and generate token response
-    create_oauth_authorization_and_token(
+    let response = create_oauth_authorization_and_token(
         CreateAuthorizationParams {
             tenant_id,
             user_pubkey: &user_pubkey,
@@ -3133,7 +3134,27 @@ async fn handle_authorization_code_grant(
         },
         auth_state,
     )
-    .await
+    .await?;
+
+    // `consumed_at` is the terminal registration marker. Set it only after the authorization,
+    // refresh token, and response have all been created successfully; otherwise recovery remains
+    // possible through the still-active pending row.
+    if pending_email.is_none()
+        && !oauth_code_repo
+            .mark_pending_consumed(tenant_id, &auth_code_for_redeem)
+            .await?
+    {
+        tracing::error!(
+            tenant_id,
+            user_pubkey,
+            "OAuth token issuance succeeded but pending registration completion failed"
+        );
+        return Err(OAuthError::ServerError(
+            "Failed to complete pending registration".to_string(),
+        ));
+    }
+
+    Ok(response)
 }
 
 // handle_password_grant() removed - ROPC grant type deprecated and removed

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -15,7 +15,8 @@ use keycast_core::metrics::METRICS;
 use keycast_core::repositories::{
     CreateOAuthAuthorizationParams, OAuthAuthorizationRepository, OAuthCodeRepository,
     PersonalKeysRepository, PolicyRepository, RefreshTokenRepository, RepositoryError,
-    StoreOAuthCodeParams, StoreOAuthCodeWithRegistrationParams, UserRepository,
+    StoreOAuthCodeParams, StoreOAuthCodeWithRegistrationParams, StoredPendingRegistration,
+    UserRepository,
 };
 use keycast_core::types::refresh_token::{generate_refresh_token, hash_refresh_token};
 use nostr_sdk::{Keys, ToBech32};
@@ -209,7 +210,7 @@ async fn store_oauth_code_with_pending_registration(
     pending_encrypted_secret: Option<&[u8]>,
     state: Option<&str>,
     device_code: Option<&str>,
-) -> Result<(), OAuthError> {
+) -> Result<StoredPendingRegistration, OAuthError> {
     let repo = OAuthCodeRepository::new(pool.clone());
     repo.store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
         tenant_id,
@@ -231,8 +232,8 @@ async fn store_oauth_code_with_pending_registration(
         // Browser OAuth registration verifies via the email link in a real browser; no PIN fallback.
         pin_hash: None,
     })
-    .await?;
-    Ok(())
+    .await
+    .map_err(Into::into)
 }
 
 #[derive(Debug, Deserialize)]
@@ -483,7 +484,13 @@ impl From<sqlx::Error> for OAuthError {
 
 impl From<keycast_core::repositories::RepositoryError> for OAuthError {
     fn from(e: keycast_core::repositories::RepositoryError) -> Self {
-        OAuthError::InvalidRequest(e.to_string())
+        match e {
+            keycast_core::repositories::RepositoryError::Unavailable(message)
+            | keycast_core::repositories::RepositoryError::Database(message) => {
+                OAuthError::Database(message)
+            }
+            other => OAuthError::InvalidRequest(other.to_string()),
+        }
     }
 }
 
@@ -3854,7 +3861,7 @@ pub async fn oauth_register(
     // Store authorization code with pending registration data (including state for redirect after verification)
     // User + personal_keys will be created atomically when email is verified
     let scope = req.scope.as_deref().unwrap_or("sign_event");
-    store_oauth_code_with_pending_registration(
+    let stored = store_oauth_code_with_pending_registration(
         pool,
         tenant_id,
         &code,
@@ -3873,6 +3880,7 @@ pub async fn oauth_register(
         Some(&device_code),
     )
     .await?;
+    let device_code = stored.device_code.unwrap_or(device_code);
 
     tracing::info!(
         "OAuth registration pending email verification: user {}, email {}",

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -3100,6 +3100,19 @@ async fn handle_authorization_code_grant(
         // Delete the authorization code (one-time use)
         oauth_code_repo.delete(tenant_id, code).await?;
 
+        // Mark the originating pending registration row terminal (keycast#262): once its exchange
+        // code is redeemed, finalize must refuse to re-mint. No-op when there is no pending row.
+        if let Err(e) = oauth_code_repo
+            .mark_pending_consumed(tenant_id, &user_pubkey, &client_id)
+            .await
+        {
+            tracing::warn!(
+                "Failed to mark pending registration consumed for {}: {}",
+                user_pubkey,
+                e
+            );
+        }
+
         // Get user's email for UCAN
         let user_repo = UserRepository::new(pool.clone());
         user_repo.get_email(&user_pubkey, tenant_id).await?

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -4700,8 +4700,7 @@ mod tests {
             .connect_lazy(database_url)
             .expect("lazy pool should be created");
         let bcrypt_queue = crate::bcrypt_queue::BcryptQueue::new();
-        let secret_pool = Box::leak(Box::new(keycast_core::secret_pool::SecretPool::new(1)));
-        let _secret_pool_producer = secret_pool.spawn_producer();
+        let secret_pool = keycast_core::secret_pool::SecretPool::new(1);
         let tenant_cache = moka::future::Cache::builder().max_capacity(10).build();
         let key_manager: std::sync::Arc<Box<dyn keycast_core::encryption::KeyManager>> =
             std::sync::Arc::new(Box::new(LazyTestKeyManager));
@@ -5129,100 +5128,6 @@ mod tests {
             assert_eq!(response.status(), expected_status);
             assert_eq!(response_json(response).await, expected_body);
         }
-    }
-
-    #[tokio::test]
-    async fn test_oauth_token_exchanges_plain_existing_user_code() {
-        std::env::set_var("BUNKER_RELAYS", "wss://relay.example.test");
-        let auth_state = create_lazy_auth_state();
-        let pool = auth_state.state.db.clone();
-        let keys = Keys::generate();
-        let user_pubkey = keys.public_key().to_hex();
-        let nsec = keys.secret_key().to_bech32().unwrap();
-        let email = format!("oauth-token-existing-{}@example.com", uuid::Uuid::new_v4());
-        let code = format!("oauth_token_existing_{}", uuid::Uuid::new_v4());
-        let client_id = format!("client_{}", uuid::Uuid::new_v4());
-        let redirect_uri = "http://localhost:3000/callback";
-
-        sqlx::query("INSERT INTO users (pubkey, tenant_id, email, created_at, updated_at) VALUES ($1, 1, $2, NOW(), NOW())")
-            .bind(&user_pubkey)
-            .bind(&email)
-            .execute(&pool)
-            .await
-            .unwrap();
-
-        store_oauth_code(
-            &pool,
-            1,
-            &code,
-            &user_pubkey,
-            &client_id,
-            redirect_uri,
-            "policy:social",
-            None,
-            None,
-            Utc::now() + Duration::minutes(10),
-            None,
-            None,
-        )
-        .await
-        .unwrap();
-
-        let response = match token(
-            create_unit_test_tenant(),
-            axum::extract::State(auth_state),
-            axum::Json(TokenRequest {
-                grant_type: Some("authorization_code".to_string()),
-                code: Some(code.clone()),
-                client_id,
-                redirect_uri: Some(redirect_uri.to_string()),
-                code_verifier: Some(format!("verifier.{}", nsec)),
-                refresh_token: None,
-            }),
-        )
-        .await
-        {
-            Ok(response) => response,
-            Err(error) => error.into_response(),
-        };
-        let status = response.status();
-        let body = response_json(response).await;
-
-        sqlx::query(
-            "DELETE FROM oauth_refresh_tokens
-             WHERE authorization_id IN (
-                 SELECT id FROM oauth_authorizations WHERE user_pubkey = $1 AND tenant_id = 1
-             )",
-        )
-        .bind(&user_pubkey)
-        .execute(&pool)
-        .await
-        .unwrap();
-        sqlx::query("DELETE FROM oauth_authorizations WHERE user_pubkey = $1 AND tenant_id = 1")
-            .bind(&user_pubkey)
-            .execute(&pool)
-            .await
-            .unwrap();
-        sqlx::query("DELETE FROM personal_keys WHERE user_pubkey = $1 AND tenant_id = 1")
-            .bind(&user_pubkey)
-            .execute(&pool)
-            .await
-            .unwrap();
-        sqlx::query("DELETE FROM oauth_codes WHERE code = $1 OR user_pubkey = $2")
-            .bind(&code)
-            .bind(&user_pubkey)
-            .execute(&pool)
-            .await
-            .unwrap();
-        sqlx::query("DELETE FROM users WHERE pubkey = $1 AND tenant_id = 1")
-            .bind(&user_pubkey)
-            .execute(&pool)
-            .await
-            .unwrap();
-
-        assert_eq!(status, StatusCode::OK, "unexpected token response: {body}");
-        assert!(body["access_token"].is_string(), "token response: {body}");
-        assert!(body["bunker_url"].is_string(), "token response: {body}");
     }
 
     #[tokio::test]

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -2920,6 +2920,7 @@ async fn handle_authorization_code_grant(
         .find_valid(tenant_id, code)
         .await?
         .ok_or(OAuthError::Unauthorized)?;
+    let auth_code_for_redeem = auth_code.clone();
 
     let user_pubkey = auth_code.user_pubkey;
     let client_id = auth_code.client_id;
@@ -3097,20 +3098,12 @@ async fn handle_authorization_code_grant(
         pending_email_val.clone()
     } else {
         // Normal token exchange (existing user, not registration)
-        // Delete the authorization code (one-time use)
-        oauth_code_repo.delete(tenant_id, code).await?;
-
-        // Mark the originating pending registration row terminal (keycast#262): once its exchange
-        // code is redeemed, finalize must refuse to re-mint. No-op when there is no pending row.
-        if let Err(e) = oauth_code_repo
-            .mark_pending_consumed(tenant_id, &user_pubkey, &client_id)
-            .await
+        // One-time exchange and pending-row completion must be one authoritative DB transition.
+        if !oauth_code_repo
+            .redeem_code_and_mark_pending_consumed(tenant_id, code, &auth_code_for_redeem)
+            .await?
         {
-            tracing::warn!(
-                "Failed to mark pending registration consumed for {}: {}",
-                user_pubkey,
-                e
-            );
+            return Err(OAuthError::Unauthorized);
         }
 
         // Get user's email for UCAN

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -224,6 +224,7 @@ pub fn api_routes(
         .route("/headless/login", post(headless::headless_login))
         .route("/headless/authorize", post(headless::headless_authorize))
         .route("/headless/verify-pin", post(headless::headless_verify_pin))
+        .route("/headless/resend-pin", post(headless::headless_resend_pin))
         .with_state(auth_state.clone());
 
     // Admin routes (for preloaded accounts and claim tokens)

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -72,7 +72,12 @@ pub fn api_routes(
 
     // verify_email needs auth_state for key_manager (to decrypt keys and issue UCAN)
     let verify_email_route = Router::new()
-        .route("/auth/verify-email", post(auth::verify_email))
+        // GET is the link target in verification emails: it verifies server-side (no client JS),
+        // which is what fixes sandboxed in-app browsers (keycast#262). POST stays for the SPA page.
+        .route(
+            "/auth/verify-email",
+            post(auth::verify_email).get(auth::verify_email_get),
+        )
         .with_state(auth_state.clone());
 
     let email_routes = Router::new()

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -223,6 +223,7 @@ pub fn api_routes(
         .route("/headless/register", post(headless::headless_register))
         .route("/headless/login", post(headless::headless_login))
         .route("/headless/authorize", post(headless::headless_authorize))
+        .route("/headless/verify-pin", post(headless::headless_verify_pin))
         .with_state(auth_state.clone());
 
     // Admin routes (for preloaded accounts and claim tokens)

--- a/api/src/bcrypt_queue.rs
+++ b/api/src/bcrypt_queue.rs
@@ -1,10 +1,11 @@
 // ABOUTME: Async bcrypt queue for high-scale signup handling
 // ABOUTME: Defers password hashing to background workers, using email verification latency as natural buffer
 
-use bcrypt::{hash, DEFAULT_COST};
+use bcrypt::{hash, verify, DEFAULT_COST};
 use crossbeam_channel::{bounded, Receiver, Sender, TrySendError};
 use secrecy::{ExposeSecret, SecretString};
 use sqlx::PgPool;
+use tokio::sync::oneshot;
 
 /// Queue capacity for surge buffering
 /// At cost 12 (~300ms/hash), 4 cores can process ~13 hashes/sec
@@ -19,10 +20,22 @@ pub struct BcryptJob {
     pub password: SecretString,
 }
 
+enum BcryptWork {
+    HashPassword(BcryptJob),
+    Verify {
+        candidate: SecretString,
+        stored_hash: String,
+        result_tx: oneshot::Sender<bool>,
+    },
+    Dummy {
+        result_tx: oneshot::Sender<()>,
+    },
+}
+
 /// Async bcrypt queue for deferring password hashing to background workers
 pub struct BcryptQueue {
-    tx: Sender<BcryptJob>,
-    rx: Receiver<BcryptJob>,
+    tx: Sender<BcryptWork>,
+    rx: Receiver<BcryptWork>,
 }
 
 impl BcryptQueue {
@@ -73,14 +86,40 @@ impl Default for BcryptQueue {
 /// Sender handle for the bcrypt queue
 #[derive(Clone)]
 pub struct BcryptSender {
-    tx: Sender<BcryptJob>,
+    tx: Sender<BcryptWork>,
 }
 
 impl BcryptSender {
     /// Try to queue a bcrypt job
     /// Returns error if queue is full (backpressure) or disconnected
     pub fn try_send(&self, job: BcryptJob) -> Result<(), BcryptQueueError> {
-        self.tx.try_send(job).map_err(|e| match e {
+        self.try_send_work(BcryptWork::HashPassword(job))
+    }
+
+    /// Run a bcrypt comparison through the bounded worker pool.
+    pub async fn verify(
+        &self,
+        candidate: SecretString,
+        stored_hash: String,
+    ) -> Result<bool, BcryptQueueError> {
+        let (result_tx, result_rx) = oneshot::channel();
+        self.try_send_work(BcryptWork::Verify {
+            candidate,
+            stored_hash,
+            result_tx,
+        })?;
+        result_rx.await.map_err(|_| BcryptQueueError::ShuttingDown)
+    }
+
+    /// Spend bcrypt work equivalent to a verification through the bounded worker pool.
+    pub async fn burn_dummy(&self) -> Result<(), BcryptQueueError> {
+        let (result_tx, result_rx) = oneshot::channel();
+        self.try_send_work(BcryptWork::Dummy { result_tx })?;
+        result_rx.await.map_err(|_| BcryptQueueError::ShuttingDown)
+    }
+
+    fn try_send_work(&self, work: BcryptWork) -> Result<(), BcryptQueueError> {
+        self.tx.try_send(work).map_err(|e| match e {
             TrySendError::Full(_) => BcryptQueueError::AtCapacity,
             TrySendError::Disconnected(_) => BcryptQueueError::ShuttingDown,
         })
@@ -107,7 +146,7 @@ pub enum BcryptQueueError {
 }
 
 /// Worker loop that processes bcrypt jobs from the queue
-async fn bcrypt_worker_loop(worker_id: usize, rx: Receiver<BcryptJob>, pool: PgPool) {
+async fn bcrypt_worker_loop(worker_id: usize, rx: Receiver<BcryptWork>, pool: PgPool) {
     tracing::debug!("Bcrypt worker {} started", worker_id);
 
     loop {
@@ -128,81 +167,122 @@ async fn bcrypt_worker_loop(worker_id: usize, rx: Receiver<BcryptJob>, pool: PgP
             }
         };
 
-        let token = job.token.clone();
-
-        // Hash password (CPU-bound operation)
-        // SecretString auto-zeroizes when dropped after closure completes
-        let hash_result = tokio::task::spawn_blocking({
-            let password = job.password;
-            move || {
-                let result = hash(password.expose_secret(), DEFAULT_COST);
-                // password (SecretString) dropped here, auto-zeroized
-                result
+        match job {
+            BcryptWork::HashPassword(job) => {
+                process_password_hash(worker_id, job, &pool).await;
             }
-        })
-        .await;
-
-        let password_hash = match hash_result {
-            Ok(Ok(h)) => h,
-            Ok(Err(e)) => {
-                tracing::error!(
-                    "Bcrypt worker {}: hash error for token {}: {}",
-                    worker_id,
-                    &token[..8],
-                    e
-                );
-                continue;
+            BcryptWork::Verify {
+                candidate,
+                stored_hash,
+                result_tx,
+            } => {
+                let result = tokio::task::spawn_blocking(move || {
+                    verify(candidate.expose_secret(), &stored_hash).unwrap_or(false)
+                })
+                .await;
+                let verified = match result {
+                    Ok(verified) => verified,
+                    Err(error) => {
+                        tracing::error!(
+                            "Bcrypt worker {}: verify task panicked: {}",
+                            worker_id,
+                            error
+                        );
+                        false
+                    }
+                };
+                let _ = result_tx.send(verified);
             }
-            Err(e) => {
-                tracing::error!(
-                    "Bcrypt worker {}: spawn_blocking panicked for token {}: {}",
-                    worker_id,
-                    &token[..8],
-                    e
-                );
-                continue;
-            }
-        };
-
-        // Update user row with the hash
-        let update_result = sqlx::query(
-            "UPDATE users SET password_hash = $1, updated_at = NOW()
-             WHERE email_verification_token = $2",
-        )
-        .bind(&password_hash)
-        .bind(&token)
-        .execute(&pool)
-        .await;
-
-        match update_result {
-            Ok(result) => {
-                if result.rows_affected() == 0 {
-                    // Row was deleted (TTL cleanup) before we could update it
-                    tracing::warn!(
-                        "Bcrypt worker {}: no row found for token {} (likely expired)",
+            BcryptWork::Dummy { result_tx } => {
+                let result = tokio::task::spawn_blocking(|| hash("dummy", DEFAULT_COST)).await;
+                if let Err(error) = result {
+                    tracing::error!(
+                        "Bcrypt worker {}: dummy task panicked: {}",
                         worker_id,
-                        &token[..8]
-                    );
-                } else {
-                    tracing::debug!(
-                        "Bcrypt worker {}: updated password hash for token {}",
-                        worker_id,
-                        &token[..8]
+                        error
                     );
                 }
-            }
-            Err(e) => {
-                tracing::error!(
-                    "Bcrypt worker {}: DB update failed for token {}: {}",
-                    worker_id,
-                    &token[..8],
-                    e
-                );
+                let _ = result_tx.send(());
             }
         }
     }
 
     tracing::debug!("Bcrypt worker {} exited", worker_id);
+}
+
+async fn process_password_hash(worker_id: usize, job: BcryptJob, pool: &PgPool) {
+    let token = job.token.clone();
+
+    // Hash password (CPU-bound operation)
+    // SecretString auto-zeroizes when dropped after closure completes
+    let hash_result = tokio::task::spawn_blocking({
+        let password = job.password;
+        move || {
+            let result = hash(password.expose_secret(), DEFAULT_COST);
+            // password (SecretString) dropped here, auto-zeroized
+            result
+        }
+    })
+    .await;
+
+    let password_hash = match hash_result {
+        Ok(Ok(h)) => h,
+        Ok(Err(e)) => {
+            tracing::error!(
+                "Bcrypt worker {}: hash error for token {}: {}",
+                worker_id,
+                &token[..8],
+                e
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::error!(
+                "Bcrypt worker {}: spawn_blocking panicked for token {}: {}",
+                worker_id,
+                &token[..8],
+                e
+            );
+            return;
+        }
+    };
+
+    // Update user row with the hash
+    let update_result = sqlx::query(
+        "UPDATE users SET password_hash = $1, updated_at = NOW()
+             WHERE email_verification_token = $2",
+    )
+    .bind(&password_hash)
+    .bind(&token)
+    .execute(pool)
+    .await;
+
+    match update_result {
+        Ok(result) => {
+            if result.rows_affected() == 0 {
+                // Row was deleted (TTL cleanup) before we could update it
+                tracing::warn!(
+                    "Bcrypt worker {}: no row found for token {} (likely expired)",
+                    worker_id,
+                    &token[..8]
+                );
+            } else {
+                tracing::debug!(
+                    "Bcrypt worker {}: updated password hash for token {}",
+                    worker_id,
+                    &token[..8]
+                );
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                "Bcrypt worker {}: DB update failed for token {}: {}",
+                worker_id,
+                &token[..8],
+                e
+            );
+        }
+    }
 }
 
 /// Spawn a cleanup task that periodically removes stale email signup rows
@@ -240,7 +320,7 @@ pub fn spawn_cleanup_task(pool: PgPool) -> tokio::task::JoinHandle<()> {
             }
 
             // Bound the oauth_codes pending/exchange rows: drop anything expired plus consumed
-            // pending registrations (terminal once their exchange code was redeemed) (keycast#262).
+            // pending registrations (terminal once token issuance succeeds) (keycast#262).
             let oauth_code_repo =
                 keycast_core::repositories::OAuthCodeRepository::new(pool.clone());
             match oauth_code_repo.delete_expired_and_consumed().await {
@@ -284,7 +364,7 @@ mod tests {
 
     #[test]
     fn test_queue_backpressure() {
-        let (tx, _rx) = bounded::<BcryptJob>(2);
+        let (tx, _rx) = bounded::<BcryptWork>(2);
         let sender = BcryptSender { tx };
 
         // Fill the queue
@@ -307,5 +387,29 @@ mod tests {
             password: SecretString::from("pass3".to_string()),
         });
         assert!(matches!(result, Err(BcryptQueueError::AtCapacity)));
+    }
+
+    #[tokio::test]
+    async fn test_verify_bcrypt_obeys_queue_backpressure() {
+        let (tx, _rx) = bounded::<BcryptWork>(1);
+        let sender = BcryptSender { tx };
+        sender
+            .try_send(BcryptJob {
+                token: "signup-token".to_string(),
+                password: SecretString::from("signup-password".to_string()),
+            })
+            .unwrap();
+
+        let result = sender
+            .verify(
+                SecretString::from("123456".to_string()),
+                bcrypt::hash("123456", bcrypt::DEFAULT_COST).unwrap(),
+            )
+            .await;
+
+        assert!(matches!(result, Err(BcryptQueueError::AtCapacity)));
+
+        let dummy_result = sender.burn_dummy().await;
+        assert!(matches!(dummy_result, Err(BcryptQueueError::AtCapacity)));
     }
 }

--- a/api/src/bcrypt_queue.rs
+++ b/api/src/bcrypt_queue.rs
@@ -238,6 +238,23 @@ pub fn spawn_cleanup_task(pool: PgPool) -> tokio::task::JoinHandle<()> {
                     tracing::error!("Cleanup task: failed to delete stale rows: {}", e);
                 }
             }
+
+            // Bound the oauth_codes pending/exchange rows: drop anything expired plus consumed
+            // pending registrations (terminal once their exchange code was redeemed) (keycast#262).
+            let oauth_code_repo =
+                keycast_core::repositories::OAuthCodeRepository::new(pool.clone());
+            match oauth_code_repo.delete_expired_and_consumed().await {
+                Ok(deleted) if deleted > 0 => {
+                    tracing::info!(
+                        "Cleanup task: deleted {} expired/consumed oauth_codes rows",
+                        deleted
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::error!("Cleanup task: failed to delete oauth_codes rows: {}", e);
+                }
+            }
         }
     })
 }

--- a/api/src/email_service.rs
+++ b/api/src/email_service.rs
@@ -27,15 +27,79 @@ pub struct CapturedEmail {
     pub subject: String,
     pub verification_url: Option<String>,
     pub reset_url: Option<String>,
+    /// 6-digit in-app verification PIN, when one was issued alongside the link (keycast#262).
+    pub pin: Option<String>,
+}
+
+/// Build the HTML body of a verification email.
+///
+/// When `pin` is present (headless registrations, keycast#262), the body shows a 6-digit code the
+/// user can type in the app — a second transport for the same proof, for contexts where the link
+/// can't open the app (sandboxed in-app browsers, a different device, a mangled link).
+fn verification_email_html(verification_url: &str, pin: Option<&str>) -> String {
+    let pin_block = match pin {
+        Some(pin) => format!(
+            r#"<p style="color: #666; font-size: 14px; margin-top: 30px;">
+                    Or enter this verification code in the app:
+                </p>
+                <p style="font-size: 28px; font-weight: bold; letter-spacing: 4px; color: #00B488; margin: 8px 0;">{pin}</p>"#,
+            pin = html_escape(pin)
+        ),
+        None => String::new(),
+    };
+    format!(
+        r#"
+            <html>
+            <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+                <h1 style="color: #00B488;">Verify your {brand} email</h1>
+                <p>Thanks for signing up! Please verify your email address by clicking the button below:</p>
+                <div style="margin: 30px 0;">
+                    <a href="{url}"
+                       style="background: #00B488; color: #fff; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block; font-weight: bold;">
+                        Verify Email Address
+                    </a>
+                </div>
+                <p style="color: #666; font-size: 14px;">
+                    Or copy and paste this link into your browser:<br>
+                    <a href="{url}" style="color: #00B488;">{url}</a>
+                </p>
+                {pin_block}
+                <p style="color: #666; font-size: 14px; margin-top: 30px;">
+                    If you didn't sign up for {brand}, you can safely ignore this email.
+                </p>
+            </body>
+            </html>
+            "#,
+        url = verification_url,
+        brand = BRAND_NAME,
+        pin_block = pin_block,
+    )
+}
+
+/// Build the plain-text body of a verification email (see [`verification_email_html`]).
+fn verification_email_text(verification_url: &str, pin: Option<&str>) -> String {
+    let pin_block = match pin {
+        Some(pin) => format!("\n\nOr enter this verification code in the app: {pin}"),
+        None => String::new(),
+    };
+    format!(
+        "Thanks for signing up! Please verify your email address by clicking this link:\n\n{url}{pin_block}\n\nIf you didn't sign up for {brand}, you can safely ignore this email.",
+        url = verification_url,
+        pin_block = pin_block,
+        brand = BRAND_NAME
+    )
 }
 
 /// Trait for email sending - allows swapping implementations for testing
 #[async_trait]
 pub trait EmailSender: Send + Sync {
+    /// Send the verification email. `pin`, when present, is the 6-digit in-app code emailed
+    /// alongside the link (keycast#262).
     async fn send_verification_email(
         &self,
         to_email: &str,
         verification_token: &str,
+        pin: Option<&str>,
     ) -> Result<(), String>;
     async fn send_password_reset_email(
         &self,
@@ -118,6 +182,7 @@ impl EmailSender for DevEmailSender {
         &self,
         to_email: &str,
         verification_token: &str,
+        pin: Option<&str>,
     ) -> Result<(), String> {
         // Point at the server-side GET endpoint so verification works without client JS
         // (sandboxed in-app browsers never run the SPA page's fetch — keycast#262).
@@ -135,6 +200,9 @@ impl EmailSender for DevEmailSender {
         tracing::info!("");
         tracing::info!("  Click to verify:");
         tracing::info!("  {}", verification_url);
+        if let Some(pin) = pin {
+            tracing::info!("  Or enter code in app: {}", pin);
+        }
         tracing::info!("==================================================");
         tracing::info!("");
 
@@ -151,6 +219,7 @@ impl EmailSender for DevEmailSender {
                 subject: format!("Verify your {} email address", BRAND_NAME),
                 verification_url: Some(verification_url),
                 reset_url: None,
+                pin: pin.map(str::to_string),
             });
         }
 
@@ -194,6 +263,7 @@ impl EmailSender for DevEmailSender {
                 subject: format!("Reset your {} password", BRAND_NAME),
                 verification_url: None,
                 reset_url: Some(reset_url),
+                pin: None,
             });
         }
 
@@ -227,6 +297,7 @@ impl EmailSender for DevEmailSender {
                 subject: format!("Your Vine account on {} is ready to claim", BRAND_NAME),
                 verification_url: Some(claim_url.to_string()),
                 reset_url: None,
+                pin: None,
             });
         }
 
@@ -253,6 +324,7 @@ impl EmailSender for DevEmailSender {
                 subject: format!("Confirm your new {} email address", BRAND_NAME),
                 verification_url: Some(confirm_url),
                 reset_url: None,
+                pin: None,
             });
         }
 
@@ -286,6 +358,7 @@ impl EmailSender for DevEmailSender {
                 // Store the confirm link for test inspection; cancel link goes in reset_url.
                 verification_url: Some(confirm_url),
                 reset_url: Some(cancel_url),
+                pin: None,
             });
         }
 
@@ -455,6 +528,7 @@ impl EmailSender for SendGridEmailSender {
         &self,
         to_email: &str,
         verification_token: &str,
+        pin: Option<&str>,
     ) -> Result<(), String> {
         // Point at the server-side GET endpoint so verification works without client JS
         // (sandboxed in-app browsers never run the SPA page's fetch — keycast#262).
@@ -464,36 +538,8 @@ impl EmailSender for SendGridEmailSender {
         );
 
         let subject = format!("Verify your {} email address", BRAND_NAME);
-        let html_content = format!(
-            r#"
-            <html>
-            <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-                <h1 style="color: #00B488;">Verify your {brand} email</h1>
-                <p>Thanks for signing up! Please verify your email address by clicking the button below:</p>
-                <div style="margin: 30px 0;">
-                    <a href="{url}"
-                       style="background: #00B488; color: #fff; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block; font-weight: bold;">
-                        Verify Email Address
-                    </a>
-                </div>
-                <p style="color: #666; font-size: 14px;">
-                    Or copy and paste this link into your browser:<br>
-                    <a href="{url}" style="color: #00B488;">{url}</a>
-                </p>
-                <p style="color: #666; font-size: 14px; margin-top: 30px;">
-                    If you didn't sign up for {brand}, you can safely ignore this email.
-                </p>
-            </body>
-            </html>
-            "#,
-            url = verification_url,
-            brand = BRAND_NAME
-        );
-
-        let text_content = format!(
-            "Thanks for signing up! Please verify your email address by clicking this link:\n\n{url}\n\nIf you didn't sign up for {brand}, you can safely ignore this email.",
-            url = verification_url, brand = BRAND_NAME
-        );
+        let html_content = verification_email_html(&verification_url, pin);
+        let text_content = verification_email_text(&verification_url, pin);
 
         self.send_email(to_email, &subject, &html_content, &text_content)
             .await
@@ -737,9 +783,10 @@ impl EmailService {
         &self,
         to_email: &str,
         verification_token: &str,
+        pin: Option<&str>,
     ) -> Result<(), String> {
         self.inner
-            .send_verification_email(to_email, verification_token)
+            .send_verification_email(to_email, verification_token, pin)
             .await
     }
 
@@ -784,6 +831,41 @@ impl EmailService {
 mod tests {
     use super::*;
     use std::sync::Mutex;
+
+    #[test]
+    fn verification_email_bodies_include_pin_when_present() {
+        let url = "https://login.example/api/auth/verify-email?token=abc";
+        let html = verification_email_html(url, Some("482913"));
+        let text = verification_email_text(url, Some("482913"));
+        assert!(html.contains("482913"), "HTML body must show the PIN");
+        assert!(text.contains("482913"), "text body must show the PIN");
+        // Link is still present alongside the PIN (two transports for the same proof).
+        assert!(html.contains(url));
+        assert!(text.contains(url));
+    }
+
+    #[test]
+    fn verification_email_bodies_omit_pin_when_absent() {
+        let url = "https://login.example/api/auth/verify-email?token=abc";
+        let html = verification_email_html(url, None);
+        let text = verification_email_text(url, None);
+        // No 6-digit code block when no PIN was issued (browser/OAuth flows).
+        assert!(!html.to_lowercase().contains("verification code"));
+        assert!(!text.to_lowercase().contains("verification code"));
+        assert!(html.contains(url));
+    }
+
+    #[tokio::test]
+    async fn dev_sender_captures_pin() {
+        let sender = DevEmailSender::new();
+        sender
+            .send_verification_email("user@example.com", "tok123", Some("482913"))
+            .await
+            .unwrap();
+        let captured = sender.get_captured_emails();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].pin.as_deref(), Some("482913"));
+    }
 
     // Serial test lock to prevent env var races between tests
     static ENV_LOCK: Mutex<()> = Mutex::new(());

--- a/api/src/email_service.rs
+++ b/api/src/email_service.rs
@@ -119,8 +119,10 @@ impl EmailSender for DevEmailSender {
         to_email: &str,
         verification_token: &str,
     ) -> Result<(), String> {
+        // Point at the server-side GET endpoint so verification works without client JS
+        // (sandboxed in-app browsers never run the SPA page's fetch — keycast#262).
         let verification_url = format!(
-            "{}/verify-email?token={}",
+            "{}/api/auth/verify-email?token={}",
             self.base_url, verification_token
         );
 
@@ -454,8 +456,10 @@ impl EmailSender for SendGridEmailSender {
         to_email: &str,
         verification_token: &str,
     ) -> Result<(), String> {
+        // Point at the server-side GET endpoint so verification works without client JS
+        // (sandboxed in-app browsers never run the SPA page's fetch — keycast#262).
         let verification_url = format!(
-            "{}/verify-email?token={}",
+            "{}/api/auth/verify-email?token={}",
             self.base_url, verification_token
         );
 

--- a/api/src/redis.rs
+++ b/api/src/redis.rs
@@ -18,6 +18,8 @@ pub struct PrefixedRedis {
     conn: Arc<RwLock<ConnectionManager>>,
     factory: Option<Arc<ValkeyConnectionFactory>>,
     prefix: Option<String>,
+    #[cfg(any(test, feature = "integration-tests"))]
+    fail_setex: bool,
 }
 
 impl std::fmt::Debug for PrefixedRedis {
@@ -42,7 +44,18 @@ impl PrefixedRedis {
             conn: Arc::new(RwLock::new(conn)),
             factory: None,
             prefix,
+            #[cfg(any(test, feature = "integration-tests"))]
+            fail_setex: false,
         }
+    }
+
+    /// Create a test Redis wrapper that rejects every SETEX operation.
+    #[cfg(any(test, feature = "integration-tests"))]
+    #[must_use]
+    pub fn new_failing(conn: ConnectionManager, prefix: Option<String>) -> Self {
+        let mut redis = Self::new(conn, prefix);
+        redis.fail_setex = true;
+        redis
     }
 
     /// Create a new PrefixedRedis wrapper with a factory for connection refresh.
@@ -61,6 +74,8 @@ impl PrefixedRedis {
             conn: Arc::new(RwLock::new(conn)),
             factory: Some(factory),
             prefix,
+            #[cfg(any(test, feature = "integration-tests"))]
+            fail_setex: false,
         }
     }
 
@@ -208,6 +223,14 @@ impl PrefixedRedis {
     ///
     /// Returns error if Redis operation fails or connection refresh fails.
     pub async fn setex(&self, key: &str, seconds: u64, value: &str) -> RedisResult<()> {
+        #[cfg(any(test, feature = "integration-tests"))]
+        if self.fail_setex {
+            return Err(redis::RedisError::from((
+                redis::ErrorKind::IoError,
+                "injected SETEX failure",
+            )));
+        }
+
         let prefixed = self.prefixed_key(key).into_owned();
         let value = value.to_string();
         self.with_refresh(|mut conn| {

--- a/api/tests/oauth_deferred_registration_test.rs
+++ b/api/tests/oauth_deferred_registration_test.rs
@@ -6,6 +6,7 @@
 mod common;
 
 use chrono::{Duration, Utc};
+use keycast_core::repositories::{OAuthCodeRepository, StoreOAuthCodeWithRegistrationParams};
 use nostr_sdk::Keys;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -269,35 +270,62 @@ async fn test_incomplete_oauth_allows_reregistration() {
 
     assert!(!user_exists, "User should not exist yet");
 
-    // Second OAuth register with SAME email (user can retry after abandoning first flow)
+    // Second OAuth register with SAME email (user can retry after abandoning first flow).
+    // This still succeeds - the email check passes because no user row exists - but it now
+    // supersedes the first pending row in place instead of racing a second one into existence
+    // (keycast#268).
     let user_keys_2 = Keys::generate();
     let user_pubkey_2 = user_keys_2.public_key().to_hex();
     let code_2 = format!("code-{}", Uuid::new_v4());
 
-    // This should succeed - email check passes because no user row exists
-    sqlx::query(
-        "INSERT INTO oauth_codes (code, user_pubkey, client_id, redirect_uri, scope, expires_at, tenant_id, created_at,
-         pending_email, pending_password_hash, pending_email_verification_token)
-         VALUES ($1, $2, 'Test App', $3, 'sign', $4, 1, NOW(), $5, 'hash2', 'token2')"
+    OAuthCodeRepository::new(pool.clone())
+        .store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
+            tenant_id: 1,
+            code: &code_2,
+            user_pubkey: &user_pubkey_2,
+            client_id: "Test App",
+            redirect_uri: &format!("{}/callback", redirect_origin),
+            scope: "sign",
+            code_challenge: None,
+            code_challenge_method: None,
+            expires_at: Utc::now() + Duration::minutes(10),
+            pending_email: &email,
+            pending_password_hash: "hash2",
+            pending_email_verification_token: "token2",
+            pending_encrypted_secret: None,
+            state: None,
+            device_code: None,
+            is_headless: false,
+            pin_hash: None,
+        })
+        .await
+        .expect("Second registration should succeed (no user exists yet)");
+
+    // Exactly one live pending registration survives, and it carries the second attempt.
+    let rows: Vec<(String, String, String)> = sqlx::query_as(
+        "SELECT user_pubkey, pending_password_hash, pending_email_verification_token
+         FROM oauth_codes
+         WHERE pending_email = $1 AND tenant_id = 1 AND consumed_at IS NULL",
     )
-    .bind(&code_2)
-    .bind(&user_pubkey_2)
-    .bind(format!("{}/callback", redirect_origin))
-    .bind(Utc::now() + Duration::minutes(10))
     .bind(&email)
-    .execute(&pool)
+    .fetch_all(&pool)
     .await
-    .expect("Second registration should succeed (no user exists yet)");
+    .expect("Query should succeed");
 
-    // Both oauth_codes should exist (old one will expire)
-    let code_count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM oauth_codes WHERE pending_email = $1")
-            .bind(&email)
-            .fetch_one(&pool)
-            .await
-            .expect("Query should succeed");
-
-    assert_eq!(code_count, 2, "Both oauth_codes should exist (pending)");
+    assert_eq!(
+        rows.len(),
+        1,
+        "re-registering must supersede the pending row, not add a second one"
+    );
+    assert_eq!(
+        rows[0],
+        (
+            user_pubkey_2.clone(),
+            "hash2".to_string(),
+            "token2".to_string()
+        ),
+        "the newest registration attempt must win every pending field"
+    );
 }
 
 // ============================================================================
@@ -634,8 +662,9 @@ async fn test_email_race_condition_at_token_exchange() {
     let email = format!("test-{}@example.com", Uuid::new_v4());
     let redirect_origin = format!("https://test-{}.example.com", Uuid::new_v4());
 
-    // Two users start OAuth registration with same email (race condition)
-    // Both pass early check because no user exists yet
+    // Two registrations start with the same email. Since keycast#268 they can no longer coexist
+    // as two pending rows: the second supersedes the first in place. The race this test covers
+    // therefore moves entirely to token exchange, where email uniqueness is re-checked.
 
     let user_keys_a = Keys::generate();
     let user_pubkey_a = user_keys_a.public_key().to_hex();
@@ -645,36 +674,74 @@ async fn test_email_race_condition_at_token_exchange() {
     let user_pubkey_b = user_keys_b.public_key().to_hex();
     let code_b = format!("code-b-{}", Uuid::new_v4());
 
-    // Step 1: Both OAuth registrations succeed (early check passes for both)
-    sqlx::query(
-        "INSERT INTO oauth_codes (code, user_pubkey, client_id, redirect_uri, scope, expires_at, tenant_id, created_at,
-         pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret)
-         VALUES ($1, $2, 'App', $3, 'sign', $4, 1, NOW(), $5, 'hash_a', 'token_a', $6)"
+    let repo = OAuthCodeRepository::new(pool.clone());
+    let register = |code: String,
+                    pubkey: String,
+                    hash: &'static str,
+                    token: &'static str,
+                    secret: &'static [u8]| {
+        let repo = repo.clone();
+        let email = email.clone();
+        let redirect_uri = format!("{}/callback", redirect_origin);
+        async move {
+            repo.store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
+                tenant_id: 1,
+                code: &code,
+                user_pubkey: &pubkey,
+                client_id: "App",
+                redirect_uri: &redirect_uri,
+                scope: "sign",
+                code_challenge: None,
+                code_challenge_method: None,
+                expires_at: Utc::now() + Duration::minutes(10),
+                pending_email: &email,
+                pending_password_hash: hash,
+                pending_email_verification_token: token,
+                pending_encrypted_secret: Some(secret),
+                state: None,
+                device_code: None,
+                is_headless: false,
+                pin_hash: None,
+            })
+            .await
+        }
+    };
+
+    // Step 1: Both registrations succeed (early check passes for both).
+    register(
+        code_a.clone(),
+        user_pubkey_a.clone(),
+        "hash_a",
+        "token_a",
+        &[1u8, 2, 3, 4],
     )
-    .bind(&code_a)
-    .bind(&user_pubkey_a)
-    .bind(format!("{}/callback", redirect_origin))
-    .bind(Utc::now() + Duration::minutes(10))
-    .bind(&email)
-    .bind(&[1u8, 2, 3, 4][..])
-    .execute(&pool)
     .await
     .expect("oauth_code A should succeed");
-
-    sqlx::query(
-        "INSERT INTO oauth_codes (code, user_pubkey, client_id, redirect_uri, scope, expires_at, tenant_id, created_at,
-         pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret)
-         VALUES ($1, $2, 'App', $3, 'sign', $4, 1, NOW(), $5, 'hash_b', 'token_b', $6)"
+    register(
+        code_b.clone(),
+        user_pubkey_b.clone(),
+        "hash_b",
+        "token_b",
+        &[5u8, 6, 7, 8],
     )
-    .bind(&code_b)
-    .bind(&user_pubkey_b)
-    .bind(format!("{}/callback", redirect_origin))
-    .bind(Utc::now() + Duration::minutes(10))
-    .bind(&email)
-    .bind(&[5u8, 6, 7, 8][..])
-    .execute(&pool)
     .await
     .expect("oauth_code B should succeed");
+
+    // Only registration B survives as pending: A was superseded, so it can never be redeemed.
+    let pending_pubkeys: Vec<(String,)> = sqlx::query_as(
+        "SELECT user_pubkey FROM oauth_codes
+         WHERE pending_email = $1 AND tenant_id = 1 AND consumed_at IS NULL",
+    )
+    .bind(&email)
+    .fetch_all(&pool)
+    .await
+    .expect("Query should succeed");
+
+    assert_eq!(
+        pending_pubkeys,
+        vec![(user_pubkey_b.clone(),)],
+        "the second registration must supersede the first, leaving one live pending row"
+    );
 
     // Step 2: Token exchange for oauth_code A succeeds (first to complete wins)
     // Check email uniqueness again at token exchange time
@@ -690,7 +757,8 @@ async fn test_email_race_condition_at_token_exchange() {
         "Email should not be taken before first token exchange"
     );
 
-    // Create user A
+    // Step 2: another path (first-party registration, or A's own exchange before it was
+    // superseded) materializes the email first.
     sqlx::query(
         "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
          VALUES ($1, 1, $2, 'hash_a', false, NOW(), NOW())"
@@ -711,7 +779,7 @@ async fn test_email_race_condition_at_token_exchange() {
     .await
     .expect("Should create personal_keys A");
 
-    // Step 3: Token exchange for oauth_code B fails (email now taken)
+    // Step 3: token exchange for the surviving pending registration B fails (email now taken)
     let email_taken_now: bool =
         sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM users WHERE email = $1 AND tenant_id = 1)")
             .bind(&email)
@@ -724,6 +792,6 @@ async fn test_email_race_condition_at_token_exchange() {
         "Email should be taken after first token exchange completes"
     );
 
-    // User B's token exchange would return: "This email is already registered. Please sign in instead."
-    // (The oauth_code B just expires unused)
+    // B's token exchange returns "This email is already registered. Please sign in instead."
+    // and the pending row just expires unused.
 }

--- a/api/tests/oauth_token_existing_user_test.rs
+++ b/api/tests/oauth_token_existing_user_test.rs
@@ -179,6 +179,26 @@ async fn oauth_token_exchanges_plain_existing_user_code() {
 
     let response = match token(
         create_test_tenant(),
+        State(auth_state.clone()),
+        TokenRequestBody(TokenRequest {
+            grant_type: Some("authorization_code".to_string()),
+            code: Some(code.clone()),
+            client_id: client_id.clone(),
+            redirect_uri: Some(redirect_uri.to_string()),
+            code_verifier: Some(format!("verifier.{}", nsec)),
+            refresh_token: None,
+        }),
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    };
+    let status = response.status();
+    let body = response_json(response).await;
+
+    let replay = match token(
+        create_test_tenant(),
         State(auth_state),
         TokenRequestBody(TokenRequest {
             grant_type: Some("authorization_code".to_string()),
@@ -194,14 +214,16 @@ async fn oauth_token_exchanges_plain_existing_user_code() {
         Ok(response) => response,
         Err(error) => error.into_response(),
     };
-    let status = response.status();
-    let body = response_json(response).await;
+    let replay_status = replay.status();
+    let replay_body = response_json(replay).await;
 
     cleanup_user(&pool, &user_pubkey, &code).await;
 
     assert_eq!(status, StatusCode::OK, "unexpected token response: {body}");
     assert!(body["access_token"].is_string(), "token response: {body}");
     assert!(body["bunker_url"].is_string(), "token response: {body}");
+    assert_eq!(replay_status, StatusCode::BAD_REQUEST);
+    assert_eq!(replay_body["error"], "invalid_grant");
 }
 
 #[tokio::test]

--- a/api/tests/oauth_token_existing_user_test.rs
+++ b/api/tests/oauth_token_existing_user_test.rs
@@ -2,12 +2,12 @@
 
 // ABOUTME: Integration coverage for exchanging standard OAuth codes for existing users.
 
-use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use axum::{extract::State, http::StatusCode, response::IntoResponse};
 use chrono::{Duration, Utc};
 use keycast_api::{
     api::{
         http::{
-            oauth::{token, TokenRequest},
+            oauth::{token, TokenRequest, TokenRequestBody},
             routes::AuthState,
         },
         tenant::{Tenant, TenantExtractor},
@@ -73,6 +73,7 @@ fn create_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }
@@ -170,7 +171,7 @@ async fn oauth_token_exchanges_plain_existing_user_code() {
     let response = match token(
         create_test_tenant(),
         State(auth_state),
-        Json(TokenRequest {
+        TokenRequestBody(TokenRequest {
             grant_type: Some("authorization_code".to_string()),
             code: Some(code.clone()),
             client_id,

--- a/api/tests/oauth_token_existing_user_test.rs
+++ b/api/tests/oauth_token_existing_user_test.rs
@@ -18,10 +18,7 @@ use keycast_api::{
 };
 use keycast_core::{
     encryption::{KeyManager, KeyManagerError},
-    repositories::{
-        OAuthCodeRepository, PersonalKeysRepository, StoreOAuthCodeParams,
-        StoreOAuthCodeWithRegistrationParams,
-    },
+    repositories::{OAuthCodeRepository, PersonalKeysRepository, StoreOAuthCodeParams},
     secret_pool::{SecretPool, SecretPoolReceiver},
 };
 use moka::future::Cache;
@@ -216,7 +213,6 @@ async fn oauth_token_issuance_failure_leaves_pending_registration_rearmable() {
     let email = format!("oauth-token-recovery-{}@example.com", Uuid::new_v4());
     let pending_code = format!("oauth_pending_{}", Uuid::new_v4());
     let exchange_code = format!("oauth_exchange_{}", Uuid::new_v4());
-    let replacement_code = format!("oauth_replacement_{}", Uuid::new_v4());
     let device_code = format!("device_{}", Uuid::new_v4());
     let verification_token = format!("verification_{}", Uuid::new_v4());
     let client_id = format!("client_{}", Uuid::new_v4());
@@ -237,25 +233,24 @@ async fn oauth_token_issuance_failure_leaves_pending_registration_rearmable() {
         .await
         .unwrap();
 
-    repo.store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
-        tenant_id: 1,
-        code: &pending_code,
-        user_pubkey: &user_pubkey,
-        client_id: &client_id,
-        redirect_uri,
-        scope: "policy:social",
-        code_challenge: None,
-        code_challenge_method: None,
-        expires_at: Utc::now() + Duration::hours(24),
-        pending_email: &email,
-        pending_password_hash: "already-finalized",
-        pending_email_verification_token: &verification_token,
-        pending_encrypted_secret: Some(&keys.secret_key().to_secret_bytes()),
-        state: None,
-        device_code: Some(&device_code),
-        is_headless: true,
-        pin_hash: Some("pin-hash"),
-    })
+    sqlx::query(
+        "INSERT INTO oauth_codes
+             (tenant_id, code, user_pubkey, client_id, redirect_uri, scope, expires_at, created_at,
+              pending_email, pending_password_hash, pending_email_verification_token,
+              pending_encrypted_secret, device_code, is_headless, pin_hash, pin_sent_at)
+         VALUES (1, $1, $2, $3, $4, 'policy:social', $5, NOW(), $6,
+                 'already-finalized', $7, $8, $9, true, 'pin-hash', NOW())",
+    )
+    .bind(&pending_code)
+    .bind(&user_pubkey)
+    .bind(&client_id)
+    .bind(redirect_uri)
+    .bind(Utc::now() + Duration::hours(24))
+    .bind(&email)
+    .bind(&verification_token)
+    .bind(keys.secret_key().to_secret_bytes())
+    .bind(&device_code)
+    .execute(&pool)
     .await
     .unwrap();
     let pending = repo
@@ -303,7 +298,12 @@ async fn oauth_token_issuance_failure_leaves_pending_registration_rearmable() {
     };
 
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
-    assert!(repo.find_valid(1, &exchange_code).await.unwrap().is_none());
+    let released_code = repo
+        .find_valid(1, &exchange_code)
+        .await
+        .unwrap()
+        .expect("failed issuance must preserve the same exchange code");
+    assert!(released_code.consumed_at.is_none());
     let pending_after_failure = repo
         .find_by_device_code(&device_code, 1)
         .await
@@ -313,28 +313,14 @@ async fn oauth_token_issuance_failure_leaves_pending_registration_rearmable() {
         pending_after_failure.consumed_at.is_none(),
         "failed issuance must not make the pending registration terminal"
     );
-    assert!(
-        repo.store_for_pending_registration(
-            StoreOAuthCodeParams {
-                tenant_id: 1,
-                code: &replacement_code,
-                user_pubkey: &user_pubkey,
-                client_id: &client_id,
-                redirect_uri,
-                scope: "policy:social",
-                code_challenge: None,
-                code_challenge_method: None,
-                expires_at: Utc::now() + Duration::minutes(10),
-                previous_auth_id: None,
-                state: None,
-                is_headless: true,
-            },
-            &pending_after_failure,
-        )
+    assert!(repo
+        .redeem_code(1, &exchange_code, &released_code)
         .await
-        .unwrap(),
-        "the verification flow must be able to mint a replacement exchange code"
-    );
+        .unwrap());
+    assert!(repo
+        .release_redeemed_code(1, &exchange_code, &released_code)
+        .await
+        .unwrap());
 
-    cleanup_user(&pool, &user_pubkey, &replacement_code).await;
+    cleanup_user(&pool, &user_pubkey, &exchange_code).await;
 }

--- a/api/tests/oauth_token_existing_user_test.rs
+++ b/api/tests/oauth_token_existing_user_test.rs
@@ -18,8 +18,11 @@ use keycast_api::{
 };
 use keycast_core::{
     encryption::{KeyManager, KeyManagerError},
-    repositories::{OAuthCodeRepository, StoreOAuthCodeParams},
-    secret_pool::SecretPool,
+    repositories::{
+        OAuthCodeRepository, PersonalKeysRepository, StoreOAuthCodeParams,
+        StoreOAuthCodeWithRegistrationParams,
+    },
+    secret_pool::{SecretPool, SecretPoolReceiver},
 };
 use moka::future::Cache;
 use nostr_sdk::{Keys, ToBech32};
@@ -56,9 +59,18 @@ async fn setup_pool() -> PgPool {
 }
 
 fn create_auth_state(pool: PgPool) -> AuthState {
-    let bcrypt_queue = BcryptQueue::new();
     let secret_pool = Box::leak(Box::new(SecretPool::new(1)));
     let _secret_pool_producer = secret_pool.spawn_producer();
+    build_auth_state(pool, secret_pool.receiver())
+}
+
+fn create_exhausted_auth_state(pool: PgPool) -> AuthState {
+    let receiver = SecretPool::new(1).receiver();
+    build_auth_state(pool, receiver)
+}
+
+fn build_auth_state(pool: PgPool, secret_pool: SecretPoolReceiver) -> AuthState {
+    let bcrypt_queue = BcryptQueue::new();
     let tenant_cache = Cache::builder().max_capacity(10).build();
     let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
 
@@ -72,7 +84,7 @@ fn create_auth_state(pool: PgPool) -> AuthState {
             tenant_cache,
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
-            secret_pool: secret_pool.receiver(),
+            secret_pool,
             activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
@@ -193,4 +205,136 @@ async fn oauth_token_exchanges_plain_existing_user_code() {
     assert_eq!(status, StatusCode::OK, "unexpected token response: {body}");
     assert!(body["access_token"].is_string(), "token response: {body}");
     assert!(body["bunker_url"].is_string(), "token response: {body}");
+}
+
+#[tokio::test]
+async fn oauth_token_issuance_failure_leaves_pending_registration_rearmable() {
+    let pool = setup_pool().await;
+    let auth_state = create_exhausted_auth_state(pool.clone());
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let email = format!("oauth-token-recovery-{}@example.com", Uuid::new_v4());
+    let pending_code = format!("oauth_pending_{}", Uuid::new_v4());
+    let exchange_code = format!("oauth_exchange_{}", Uuid::new_v4());
+    let replacement_code = format!("oauth_replacement_{}", Uuid::new_v4());
+    let device_code = format!("device_{}", Uuid::new_v4());
+    let verification_token = format!("verification_{}", Uuid::new_v4());
+    let client_id = format!("client_{}", Uuid::new_v4());
+    let redirect_uri = "http://localhost:3000/callback";
+    let repo = OAuthCodeRepository::new(pool.clone());
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, email_verified, created_at, updated_at)
+         VALUES ($1, 1, $2, TRUE, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(&email)
+    .execute(&pool)
+    .await
+    .unwrap();
+    PersonalKeysRepository::new(pool.clone())
+        .create(&user_pubkey, &keys.secret_key().to_secret_bytes(), 1)
+        .await
+        .unwrap();
+
+    repo.store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
+        tenant_id: 1,
+        code: &pending_code,
+        user_pubkey: &user_pubkey,
+        client_id: &client_id,
+        redirect_uri,
+        scope: "policy:social",
+        code_challenge: None,
+        code_challenge_method: None,
+        expires_at: Utc::now() + Duration::hours(24),
+        pending_email: &email,
+        pending_password_hash: "already-finalized",
+        pending_email_verification_token: &verification_token,
+        pending_encrypted_secret: Some(&keys.secret_key().to_secret_bytes()),
+        state: None,
+        device_code: Some(&device_code),
+        is_headless: true,
+        pin_hash: Some("pin-hash"),
+    })
+    .await
+    .unwrap();
+    let pending = repo
+        .find_by_device_code(&device_code, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(repo
+        .store_for_pending_registration(
+            StoreOAuthCodeParams {
+                tenant_id: 1,
+                code: &exchange_code,
+                user_pubkey: &user_pubkey,
+                client_id: &client_id,
+                redirect_uri,
+                scope: "policy:social",
+                code_challenge: None,
+                code_challenge_method: None,
+                expires_at: Utc::now() + Duration::minutes(10),
+                previous_auth_id: None,
+                state: None,
+                is_headless: true,
+            },
+            &pending,
+        )
+        .await
+        .unwrap());
+
+    let response = match token(
+        create_test_tenant(),
+        State(auth_state),
+        TokenRequestBody(TokenRequest {
+            grant_type: Some("authorization_code".to_string()),
+            code: Some(exchange_code.clone()),
+            client_id: client_id.clone(),
+            redirect_uri: Some(redirect_uri.to_string()),
+            code_verifier: None,
+            refresh_token: None,
+        }),
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    };
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(repo.find_valid(1, &exchange_code).await.unwrap().is_none());
+    let pending_after_failure = repo
+        .find_by_device_code(&device_code, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        pending_after_failure.consumed_at.is_none(),
+        "failed issuance must not make the pending registration terminal"
+    );
+    assert!(
+        repo.store_for_pending_registration(
+            StoreOAuthCodeParams {
+                tenant_id: 1,
+                code: &replacement_code,
+                user_pubkey: &user_pubkey,
+                client_id: &client_id,
+                redirect_uri,
+                scope: "policy:social",
+                code_challenge: None,
+                code_challenge_method: None,
+                expires_at: Utc::now() + Duration::minutes(10),
+                previous_auth_id: None,
+                state: None,
+                is_headless: true,
+            },
+            &pending_after_failure,
+        )
+        .await
+        .unwrap(),
+        "the verification flow must be able to mint a replacement exchange code"
+    );
+
+    cleanup_user(&pool, &user_pubkey, &replacement_code).await;
 }

--- a/api/tests/oauth_token_existing_user_test.rs
+++ b/api/tests/oauth_token_existing_user_test.rs
@@ -1,0 +1,195 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration coverage for exchanging standard OAuth codes for existing users.
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use chrono::{Duration, Utc};
+use keycast_api::{
+    api::{
+        http::{
+            oauth::{token, TokenRequest},
+            routes::AuthState,
+        },
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    repositories::{OAuthCodeRepository, StoreOAuthCodeParams},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::{Keys, ToBech32};
+use sqlx::PgPool;
+use std::sync::Arc;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+mod common;
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database")
+}
+
+fn create_auth_state(pool: PgPool) -> AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = Box::leak(Box::new(SecretPool::new(1)));
+    let _secret_pool_producer = secret_pool.spawn_producer();
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+fn create_test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: 1,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+async fn response_json(response: axum::response::Response) -> serde_json::Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body should be readable");
+    serde_json::from_slice(&body).expect("response body should be JSON")
+}
+
+async fn cleanup_user(pool: &PgPool, user_pubkey: &str, code: &str) {
+    let _ = sqlx::query(
+        "DELETE FROM oauth_refresh_tokens
+         WHERE authorization_id IN (
+             SELECT id FROM oauth_authorizations WHERE user_pubkey = $1 AND tenant_id = 1
+         )",
+    )
+    .bind(user_pubkey)
+    .execute(pool)
+    .await;
+    let _ =
+        sqlx::query("DELETE FROM oauth_authorizations WHERE user_pubkey = $1 AND tenant_id = 1")
+            .bind(user_pubkey)
+            .execute(pool)
+            .await;
+    let _ = sqlx::query("DELETE FROM personal_keys WHERE user_pubkey = $1 AND tenant_id = 1")
+        .bind(user_pubkey)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM oauth_codes WHERE code = $1 OR user_pubkey = $2")
+        .bind(code)
+        .bind(user_pubkey)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1 AND tenant_id = 1")
+        .bind(user_pubkey)
+        .execute(pool)
+        .await;
+}
+
+#[tokio::test]
+async fn oauth_token_exchanges_plain_existing_user_code() {
+    std::env::set_var("BUNKER_RELAYS", "wss://relay.example.test");
+    let pool = setup_pool().await;
+    let auth_state = create_auth_state(pool.clone());
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let nsec = keys.secret_key().to_bech32().unwrap();
+    let email = format!("oauth-token-existing-{}@example.com", Uuid::new_v4());
+    let code = format!("oauth_token_existing_{}", Uuid::new_v4());
+    let client_id = format!("client_{}", Uuid::new_v4());
+    let redirect_uri = "http://localhost:3000/callback";
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, created_at, updated_at)
+         VALUES ($1, 1, $2, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(&email)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    OAuthCodeRepository::new(pool.clone())
+        .store(StoreOAuthCodeParams {
+            tenant_id: 1,
+            code: &code,
+            user_pubkey: &user_pubkey,
+            client_id: &client_id,
+            redirect_uri,
+            scope: "policy:social",
+            code_challenge: None,
+            code_challenge_method: None,
+            expires_at: Utc::now() + Duration::minutes(10),
+            previous_auth_id: None,
+            state: None,
+            is_headless: false,
+        })
+        .await
+        .unwrap();
+
+    let response = match token(
+        create_test_tenant(),
+        State(auth_state),
+        Json(TokenRequest {
+            grant_type: Some("authorization_code".to_string()),
+            code: Some(code.clone()),
+            client_id,
+            redirect_uri: Some(redirect_uri.to_string()),
+            code_verifier: Some(format!("verifier.{}", nsec)),
+            refresh_token: None,
+        }),
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    };
+    let status = response.status();
+    let body = response_json(response).await;
+
+    cleanup_user(&pool, &user_pubkey, &code).await;
+
+    assert_eq!(status, StatusCode::OK, "unexpected token response: {body}");
+    assert!(body["access_token"].is_string(), "token response: {body}");
+    assert!(body["bunker_url"].is_string(), "token response: {body}");
+}

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -32,7 +32,7 @@ pub use oauth_authorization::{CreateOAuthAuthorizationParams, OAuthAuthorization
 pub use oauth_code::{
     MaterializePendingRegistrationOutcome, OAuthCodeData, OAuthCodeRepository,
     PinAttemptReservation, PinResendSnapshot, StoreOAuthCodeParams,
-    StoreOAuthCodeWithRegistrationParams, StoredPendingRegistration,
+    StoreOAuthCodeWithRegistrationParams, StoredExchangeCode, StoredPendingRegistration,
 };
 pub use personal_keys::PersonalKeysRepository;
 pub use policy::PolicyRepository;

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -30,8 +30,8 @@ pub use claim_token::ClaimTokenRepository;
 pub use error::RepositoryError;
 pub use oauth_authorization::{CreateOAuthAuthorizationParams, OAuthAuthorizationRepository};
 pub use oauth_code::{
-    OAuthCodeData, OAuthCodeRepository, StoreOAuthCodeParams, StoreOAuthCodeWithRegistrationParams,
-    PinResendSnapshot, StoredPendingRegistration,
+    OAuthCodeData, OAuthCodeRepository, PinAttemptReservation, PinResendSnapshot,
+    StoreOAuthCodeParams, StoreOAuthCodeWithRegistrationParams, StoredPendingRegistration,
 };
 pub use personal_keys::PersonalKeysRepository;
 pub use policy::PolicyRepository;

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -30,8 +30,9 @@ pub use claim_token::ClaimTokenRepository;
 pub use error::RepositoryError;
 pub use oauth_authorization::{CreateOAuthAuthorizationParams, OAuthAuthorizationRepository};
 pub use oauth_code::{
-    OAuthCodeData, OAuthCodeRepository, PinAttemptReservation, PinResendSnapshot,
-    StoreOAuthCodeParams, StoreOAuthCodeWithRegistrationParams, StoredPendingRegistration,
+    MaterializePendingRegistrationOutcome, OAuthCodeData, OAuthCodeRepository,
+    PinAttemptReservation, PinResendSnapshot, StoreOAuthCodeParams,
+    StoreOAuthCodeWithRegistrationParams, StoredPendingRegistration,
 };
 pub use personal_keys::PersonalKeysRepository;
 pub use policy::PolicyRepository;

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -31,6 +31,7 @@ pub use error::RepositoryError;
 pub use oauth_authorization::{CreateOAuthAuthorizationParams, OAuthAuthorizationRepository};
 pub use oauth_code::{
     OAuthCodeData, OAuthCodeRepository, StoreOAuthCodeParams, StoreOAuthCodeWithRegistrationParams,
+    StoredPendingRegistration,
 };
 pub use personal_keys::PersonalKeysRepository;
 pub use policy::PolicyRepository;

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -30,9 +30,10 @@ pub use claim_token::ClaimTokenRepository;
 pub use error::RepositoryError;
 pub use oauth_authorization::{CreateOAuthAuthorizationParams, OAuthAuthorizationRepository};
 pub use oauth_code::{
-    MaterializePendingRegistrationOutcome, OAuthCodeData, OAuthCodeRepository,
-    PinAttemptReservation, PinResendSnapshot, StoreOAuthCodeParams,
-    StoreOAuthCodeWithRegistrationParams, StoredExchangeCode, StoredPendingRegistration,
+    FinalizedPendingRegistration, MaterializePendingRegistrationOutcome, OAuthCodeData,
+    OAuthCodeRepository, PinAttemptRelease, PinAttemptReservation, PinResendSnapshot,
+    StoreOAuthCodeParams, StoreOAuthCodeWithRegistrationParams, StoredExchangeCode,
+    StoredPendingRegistration,
 };
 pub use personal_keys::PersonalKeysRepository;
 pub use policy::PolicyRepository;

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -31,7 +31,7 @@ pub use error::RepositoryError;
 pub use oauth_authorization::{CreateOAuthAuthorizationParams, OAuthAuthorizationRepository};
 pub use oauth_code::{
     OAuthCodeData, OAuthCodeRepository, StoreOAuthCodeParams, StoreOAuthCodeWithRegistrationParams,
-    StoredPendingRegistration,
+    PinResendSnapshot, StoredPendingRegistration,
 };
 pub use personal_keys::PersonalKeysRepository;
 pub use policy::PolicyRepository;

--- a/core/src/repositories/oauth_authorization.rs
+++ b/core/src/repositories/oauth_authorization.rs
@@ -702,7 +702,27 @@ mod tests {
                 .release_redeemed_code(1, &release_code, &release_data)
                 .await
         });
-        sleep(TokioDuration::from_millis(50)).await;
+        let deadline = tokio::time::Instant::now() + TokioDuration::from_secs(5);
+        loop {
+            let release_is_waiting: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM pg_stat_activity activity
+                    WHERE cardinality(pg_blocking_pids(activity.pid)) > 0
+                      AND activity.query LIKE '%UPDATE oauth_codes SET consumed_at = NULL%'
+                )",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            if release_is_waiting {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "release did not reach the exchange-row lock"
+            );
+            sleep(TokioDuration::from_millis(10)).await;
+        }
 
         let authorization_repo = OAuthAuthorizationRepository::new(pool.clone());
         let create_code = code.clone();
@@ -712,7 +732,6 @@ mod tests {
                 .create_from_redeemed_code(params, &create_code, &create_data)
                 .await
         });
-        sleep(TokioDuration::from_millis(50)).await;
         blocker.commit().await.unwrap();
 
         assert!(release.await.unwrap().unwrap());

--- a/core/src/repositories/oauth_authorization.rs
+++ b/core/src/repositories/oauth_authorization.rs
@@ -1,7 +1,7 @@
 // ABOUTME: Repository for OAuth authorization database operations
 // ABOUTME: Handles OAuth-based remote signing authorizations
 
-use crate::repositories::RepositoryError;
+use crate::repositories::{oauth_code::OAuthCodeData, RepositoryError};
 use crate::types::oauth_authorization::OAuthAuthorization;
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
@@ -155,6 +155,79 @@ impl OAuthAuthorizationRepository {
         .fetch_one(&self.pool)
         .await
         .map_err(Into::into)
+    }
+
+    /// Create an authorization only while its exact redeemed exchange-code claim is live.
+    ///
+    /// This locks only the exchange row and never the pending registration row. Callers that also
+    /// operate on pending registrations must preserve the pending-then-exchange lock order.
+    pub async fn create_from_redeemed_code(
+        &self,
+        params: CreateOAuthAuthorizationParams,
+        code: &str,
+        auth_code: &OAuthCodeData,
+    ) -> Result<Option<i32>, RepositoryError> {
+        let mut tx = self.pool.begin().await?;
+        let now = Utc::now();
+        let id = sqlx::query_scalar::<_, i32>(
+            "WITH locked_claim AS MATERIALIZED (
+                 SELECT exchange.code, exchange.user_pubkey, exchange.client_id,
+                        exchange.expires_at
+                 FROM oauth_codes exchange
+                 WHERE exchange.tenant_id = $1 AND exchange.code = $2
+                   AND exchange.user_pubkey = $3 AND exchange.client_id = $4
+                   AND exchange.redirect_uri = $5 AND exchange.scope = $6
+                   AND exchange.code_challenge IS NOT DISTINCT FROM $7
+                   AND exchange.code_challenge_method IS NOT DISTINCT FROM $8
+                   AND exchange.state IS NOT DISTINCT FROM $9
+                   AND exchange.is_headless = $10
+                   AND exchange.pending_email_verification_token IS NOT DISTINCT FROM $11
+                   AND exchange.device_code IS NOT DISTINCT FROM $12
+                   AND exchange.pending_email IS NULL
+                   AND exchange.consumed_at IS NOT NULL
+                 FOR UPDATE
+             ),
+             live_claim AS MATERIALIZED (
+                 SELECT code FROM locked_claim
+                 WHERE expires_at > clock_timestamp()
+                   AND user_pubkey = $13 AND client_id = $15
+             )
+             INSERT INTO oauth_authorizations
+                 (tenant_id, user_pubkey, redirect_origin, client_id, bunker_public_key,
+                  secret_hash, relays, policy_id, is_first_party, client_pubkey,
+                  authorization_handle, handle_expires_at, created_at, updated_at)
+             SELECT $1, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $24
+             FROM live_claim
+             RETURNING id",
+        )
+        .bind(params.tenant_id)
+        .bind(code)
+        .bind(&auth_code.user_pubkey)
+        .bind(&auth_code.client_id)
+        .bind(&auth_code.redirect_uri)
+        .bind(&auth_code.scope)
+        .bind(auth_code.code_challenge.as_deref())
+        .bind(auth_code.code_challenge_method.as_deref())
+        .bind(auth_code.state.as_deref())
+        .bind(auth_code.is_headless)
+        .bind(auth_code.pending_email_verification_token.as_deref())
+        .bind(auth_code.device_code.as_deref())
+        .bind(&params.user_pubkey)
+        .bind(&params.redirect_origin)
+        .bind(&params.client_id)
+        .bind(&params.bunker_public_key)
+        .bind(&params.secret_hash)
+        .bind(&params.relays)
+        .bind(params.policy_id)
+        .bind(params.is_first_party)
+        .bind(&params.client_pubkey)
+        .bind(&params.authorization_handle)
+        .bind(params.handle_expires_at)
+        .bind(now)
+        .fetch_optional(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(id)
     }
 
     /// Revoke an authorization by setting revoked_at to now.
@@ -523,6 +596,9 @@ impl OAuthAuthorizationRepository {
 #[cfg(all(test, feature = "integration-tests"))]
 mod tests {
     use super::*;
+    use crate::repositories::{OAuthCodeRepository, StoreOAuthCodeParams};
+    use sqlx::postgres::PgPoolOptions;
+    use tokio::time::{sleep, Duration as TokioDuration};
 
     fn assert_localhost_db() {
         let url = std::env::var("DATABASE_URL").unwrap_or_default();
@@ -539,6 +615,160 @@ mod tests {
         PgPool::connect(&database_url)
             .await
             .expect("Failed to connect to database")
+    }
+
+    async fn insert_redeemed_code(
+        pool: &PgPool,
+        expires_at: DateTime<Utc>,
+    ) -> (String, OAuthCodeData, CreateOAuthAuthorizationParams) {
+        use nostr_sdk::Keys;
+        use uuid::Uuid;
+
+        let user_pubkey = Keys::generate().public_key().to_hex();
+        let bunker_public_key = Keys::generate().public_key().to_hex();
+        let code = format!("exchange-{}", Uuid::new_v4());
+        let client_id = format!("client-{}", Uuid::new_v4());
+        let redirect_uri = format!("https://example.com/{}/callback", Uuid::new_v4());
+
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+             VALUES ($1, 1, NOW(), NOW())",
+        )
+        .bind(&user_pubkey)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let code_repo = OAuthCodeRepository::new(pool.clone());
+        code_repo
+            .store(StoreOAuthCodeParams {
+                tenant_id: 1,
+                code: &code,
+                user_pubkey: &user_pubkey,
+                client_id: &client_id,
+                redirect_uri: &redirect_uri,
+                scope: "policy:social",
+                code_challenge: Some("challenge"),
+                code_challenge_method: Some("S256"),
+                expires_at,
+                previous_auth_id: None,
+                state: Some("state"),
+                is_headless: true,
+            })
+            .await
+            .unwrap();
+        let auth_code = code_repo.find_valid(1, &code).await.unwrap().unwrap();
+        sqlx::query("UPDATE oauth_codes SET consumed_at = clock_timestamp() WHERE code = $1")
+            .bind(&code)
+            .execute(pool)
+            .await
+            .unwrap();
+
+        let params = CreateOAuthAuthorizationParams {
+            tenant_id: 1,
+            user_pubkey,
+            redirect_origin: "https://example.com".to_string(),
+            client_id,
+            bunker_public_key,
+            secret_hash: "$2b$10$test_hash".to_string(),
+            relays: "[]".to_string(),
+            policy_id: None,
+            is_first_party: true,
+            client_pubkey: None,
+            authorization_handle: None,
+            handle_expires_at: Utc::now() + chrono::Duration::days(30),
+        };
+        (code, auth_code, params)
+    }
+
+    #[tokio::test]
+    async fn test_create_from_redeemed_code_serializes_release_before_insert() {
+        let pool = setup_pool().await;
+        let (code, auth_code, params) =
+            insert_redeemed_code(&pool, Utc::now() + chrono::Duration::minutes(10)).await;
+
+        let mut blocker = pool.begin().await.unwrap();
+        sqlx::query("SELECT code FROM oauth_codes WHERE code = $1 FOR UPDATE")
+            .bind(&code)
+            .fetch_one(&mut *blocker)
+            .await
+            .unwrap();
+
+        let release_repo = OAuthCodeRepository::new(pool.clone());
+        let release_code = code.clone();
+        let release_data = auth_code.clone();
+        let release = tokio::spawn(async move {
+            release_repo
+                .release_redeemed_code(1, &release_code, &release_data)
+                .await
+        });
+        sleep(TokioDuration::from_millis(50)).await;
+
+        let authorization_repo = OAuthAuthorizationRepository::new(pool.clone());
+        let create_code = code.clone();
+        let create_data = auth_code.clone();
+        let create = tokio::spawn(async move {
+            authorization_repo
+                .create_from_redeemed_code(params, &create_code, &create_data)
+                .await
+        });
+        sleep(TokioDuration::from_millis(50)).await;
+        blocker.commit().await.unwrap();
+
+        assert!(release.await.unwrap().unwrap());
+        assert!(
+            create.await.unwrap().unwrap().is_none(),
+            "a release queued before claim locking must prevent authorization insertion"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_from_redeemed_code_rechecks_expiry_after_lock_wait() {
+        let pool = setup_pool().await;
+        let (code, auth_code, params) =
+            insert_redeemed_code(&pool, Utc::now() + chrono::Duration::milliseconds(200)).await;
+
+        let mut blocker = pool.begin().await.unwrap();
+        sqlx::query("SELECT code FROM oauth_codes WHERE code = $1 FOR UPDATE")
+            .bind(&code)
+            .fetch_one(&mut *blocker)
+            .await
+            .unwrap();
+
+        let repo = OAuthAuthorizationRepository::new(pool.clone());
+        let create_code = code.clone();
+        let create = tokio::spawn(async move {
+            repo.create_from_redeemed_code(params, &create_code, &auth_code)
+                .await
+        });
+        sleep(TokioDuration::from_millis(300)).await;
+        blocker.commit().await.unwrap();
+
+        assert!(
+            create.await.unwrap().unwrap().is_none(),
+            "a claim that expires while awaiting its lock must not authorize"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_from_redeemed_code_uses_one_pool_connection() {
+        assert_localhost_db();
+        let database_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&database_url)
+            .await
+            .unwrap();
+        let (code, auth_code, params) =
+            insert_redeemed_code(&pool, Utc::now() + chrono::Duration::minutes(10)).await;
+
+        let id = OAuthAuthorizationRepository::new(pool)
+            .create_from_redeemed_code(params, &code, &auth_code)
+            .await
+            .unwrap();
+
+        assert!(id.is_some());
     }
 
     #[tokio::test]

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -81,6 +81,16 @@ pub struct StoreOAuthCodeWithRegistrationParams<'a> {
     pub pin_hash: Option<&'a str>,
 }
 
+/// Outcome of storing a pending registration.
+#[derive(Debug, Clone)]
+pub struct StoredPendingRegistration {
+    /// The `device_code` now on the row — the caller's own on a fresh registration, or the
+    /// superseded row's existing one. This is what the client must poll.
+    pub device_code: Option<String>,
+    /// Whether this call re-armed an existing live pending registration instead of creating one.
+    pub superseded: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct OAuthCodeRepository {
     pool: PgPool,
@@ -164,15 +174,62 @@ impl OAuthCodeRepository {
     }
 
     /// Store OAuth code with pending registration data (deferred user creation).
-    /// Used by oauth_register to defer user creation until token exchange.
+    /// Used by oauth_register and headless_register to defer user creation until token exchange.
+    ///
+    /// Registering an email that already has a live pending registration **supersedes** that row
+    /// in place rather than creating a second one. The mobile client can fire
+    /// `POST /api/headless/register` twice for one signup; two rows meant two verification emails
+    /// and two device_codes, and opening the older link produced a 409 that deleted the stale row
+    /// and then a 401 "Invalid or expired token" (keycast#268).
+    ///
+    /// **The newest attempt wins every registration field**: password hash, keypair, PKCE
+    /// challenge, client_id/redirect_uri/scope/state, verification token, PIN, and the expiry
+    /// window. Re-arming must not silently keep the first attempt's password (the user may have
+    /// corrected it), and it must not keep the first attempt's `code_challenge` — the client mints
+    /// a fresh PKCE verifier per register call, so the stored challenge has to be the one matching
+    /// the verifier the app is now holding or token exchange would fail PKCE.
+    ///
+    /// **`device_code` is deliberately preserved**, and the effective one is returned. It is the
+    /// only field where the *first* attempt wins: keeping it makes the outcome independent of the
+    /// order the two responses arrive in, so an app that stored the first response's device_code
+    /// is still polling the right registration.
+    ///
+    /// `expires_at` is refreshed, unlike [`Self::reset_pin_for_resend`], which deliberately never
+    /// extends the window. A resend is free; a re-register is a whole new registration (new
+    /// bcrypt, new keypair), so it earns a fresh window — and without this an expired-but-unconsumed
+    /// row would block its own email from ever registering again, since the unique index has no
+    /// expiry predicate.
+    ///
+    /// Race-proofed by `idx_oauth_codes_live_pending_email`; the insert-or-supersede decision is a
+    /// single statement, so concurrent duplicate registers cannot both create a row.
     pub async fn store_with_pending_registration(
         &self,
         params: StoreOAuthCodeWithRegistrationParams<'_>,
-    ) -> Result<(), RepositoryError> {
-        sqlx::query(
+    ) -> Result<StoredPendingRegistration, RepositoryError> {
+        let row: (Option<String>,) = sqlx::query_as(
             "INSERT INTO oauth_codes (tenant_id, code, user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method, expires_at, created_at,
              pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret, state, device_code, is_headless, pin_hash, pin_sent_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)",
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+             ON CONFLICT (tenant_id, lower(pending_email))
+                 WHERE pending_email IS NOT NULL AND consumed_at IS NULL
+             DO UPDATE SET
+                 user_pubkey = EXCLUDED.user_pubkey,
+                 client_id = EXCLUDED.client_id,
+                 redirect_uri = EXCLUDED.redirect_uri,
+                 scope = EXCLUDED.scope,
+                 code_challenge = EXCLUDED.code_challenge,
+                 code_challenge_method = EXCLUDED.code_challenge_method,
+                 expires_at = EXCLUDED.expires_at,
+                 pending_email = EXCLUDED.pending_email,
+                 pending_password_hash = EXCLUDED.pending_password_hash,
+                 pending_email_verification_token = EXCLUDED.pending_email_verification_token,
+                 pending_encrypted_secret = EXCLUDED.pending_encrypted_secret,
+                 state = EXCLUDED.state,
+                 is_headless = EXCLUDED.is_headless,
+                 pin_hash = EXCLUDED.pin_hash,
+                 pin_attempts = 0,
+                 pin_sent_at = NULL
+             RETURNING device_code",
         )
         .bind(params.tenant_id)
         .bind(params.code)
@@ -194,9 +251,18 @@ impl OAuthCodeRepository {
         .bind(params.pin_hash)
         // pin_sent_at tracks confirmed delivery; callers set it after the email send succeeds.
         .bind(None::<DateTime<Utc>>)
-        .execute(&self.pool)
+        .fetch_one(&self.pool)
         .await?;
-        Ok(())
+
+        let device_code = row.0;
+        // The UPDATE branch leaves device_code untouched, so a returned value different from the
+        // one we offered means we superseded an existing pending registration.
+        let superseded = device_code.as_deref() != params.device_code;
+
+        Ok(StoredPendingRegistration {
+            device_code,
+            superseded,
+        })
     }
 
     /// Columns selected for every `OAuthCodeData` lookup (matches the struct's `FromRow` fields).

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -307,6 +307,31 @@ impl OAuthCodeRepository {
         Ok(row.map(|r| r.0))
     }
 
+    /// Refund a reserved PIN attempt when no bcrypt comparison ran.
+    ///
+    /// The decrement is atomic so a concurrent failed comparison remains counted. The lower bound
+    /// protects the counter if a successful verification reset it before this refund completed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RepositoryError`] when the database update fails.
+    pub async fn refund_pin_attempt(
+        &self,
+        device_code: &str,
+        tenant_id: i64,
+    ) -> Result<(), RepositoryError> {
+        sqlx::query(
+            "UPDATE oauth_codes SET pin_attempts = GREATEST(pin_attempts - 1, 0) \
+             WHERE device_code = $1 AND tenant_id = $2 \
+               AND pending_email IS NOT NULL AND consumed_at IS NULL",
+        )
+        .bind(device_code)
+        .bind(tenant_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Re-arm a pending registration for PIN resend: install a fresh verification token + PIN hash,
     /// reset the attempt counter to zero, and refresh `pin_sent_at`.
     ///

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -122,11 +122,11 @@ impl OAuthCodeRepository {
         pending: &OAuthCodeData,
     ) -> Result<bool, RepositoryError> {
         let result = sqlx::query(
-            "INSERT INTO oauth_codes (tenant_id, code, user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method, expires_at, previous_auth_id, state, is_headless, created_at)
-             SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
-             WHERE EXISTS (
-                 SELECT 1 FROM oauth_codes pending
-                 WHERE pending.tenant_id = $1
+            "INSERT INTO oauth_codes (tenant_id, code, user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method, expires_at, previous_auth_id, state, is_headless, created_at, pending_email_verification_token, device_code)
+             SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+              WHERE EXISTS (
+                  SELECT 1 FROM oauth_codes pending
+                  WHERE pending.tenant_id = $1
                    AND pending.user_pubkey = $3
                    AND pending.client_id = $4
                    AND pending.redirect_uri = $5
@@ -233,7 +233,7 @@ impl OAuthCodeRepository {
         tenant_id: i64,
     ) -> Result<Option<OAuthCodeData>, RepositoryError> {
         let query = format!(
-            "SELECT {} FROM oauth_codes WHERE pending_email_verification_token = $1 AND tenant_id = $2 AND expires_at > $3",
+            "SELECT {} FROM oauth_codes WHERE pending_email_verification_token = $1 AND tenant_id = $2 AND pending_email IS NOT NULL AND expires_at > $3",
             Self::SELECT_COLUMNS
         );
         let result = sqlx::query_as::<_, OAuthCodeData>(&query)
@@ -259,7 +259,7 @@ impl OAuthCodeRepository {
         tenant_id: i64,
     ) -> Result<Option<OAuthCodeData>, RepositoryError> {
         let query = format!(
-            "SELECT {} FROM oauth_codes WHERE device_code = $1 AND tenant_id = $2 AND expires_at > $3",
+            "SELECT {} FROM oauth_codes WHERE device_code = $1 AND tenant_id = $2 AND pending_email IS NOT NULL AND expires_at > $3",
             Self::SELECT_COLUMNS
         );
         let result = sqlx::query_as::<_, OAuthCodeData>(&query)
@@ -419,7 +419,8 @@ impl OAuthCodeRepository {
                AND exchange.code_challenge_method IS NOT DISTINCT FROM $7
                AND exchange.state IS NOT DISTINCT FROM $8
                AND exchange.is_headless = $9
-               AND exchange.device_code IS NULL
+               AND exchange.pending_email_verification_token IS NOT DISTINCT FROM $11
+               AND exchange.device_code IS NOT DISTINCT FROM $12
                AND exchange.pending_email IS NULL
                AND exchange.consumed_at IS NULL
                AND exchange.expires_at > $10
@@ -479,7 +480,7 @@ impl OAuthCodeRepository {
             return Ok(false);
         }
 
-        sqlx::query(
+        let updated = sqlx::query(
             "UPDATE oauth_codes SET consumed_at = $1
              WHERE tenant_id = $2
                AND user_pubkey = $3
@@ -491,6 +492,8 @@ impl OAuthCodeRepository {
                AND state IS NOT DISTINCT FROM $9
                AND is_headless = $10
                AND pending_email IS NOT NULL
+               AND pending_email_verification_token IS NOT DISTINCT FROM $11
+               AND device_code IS NOT DISTINCT FROM $12
                AND consumed_at IS NULL",
         )
         .bind(Utc::now())
@@ -503,8 +506,15 @@ impl OAuthCodeRepository {
         .bind(auth_code.code_challenge_method.as_deref())
         .bind(auth_code.state.as_deref())
         .bind(auth_code.is_headless)
+        .bind(auth_code.pending_email_verification_token.as_deref())
+        .bind(auth_code.device_code.as_deref())
         .execute(&mut *tx)
         .await?;
+
+        if updated.rows_affected() != 1 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
 
         tx.commit().await?;
         Ok(true)
@@ -887,24 +897,28 @@ mod tests {
             "pending registration row must NOT be returned as an exchange code"
         );
 
-        // A previously minted exchange code for the same user+client (no device_code/pending_email).
+        // A previously minted exchange code for the same pending registration.
         let exchange_code = format!("exch_{}", uuid::Uuid::new_v4());
-        repo.store(StoreOAuthCodeParams {
-            tenant_id: 1,
-            code: &exchange_code,
-            user_pubkey: &user_pubkey,
-            client_id: &client_id,
-            redirect_uri: "http://localhost:3000/callback",
-            scope: "policy:social",
-            code_challenge: None,
-            code_challenge_method: None,
-            expires_at: Utc::now() + chrono::Duration::minutes(10),
-            previous_auth_id: None,
-            state: None,
-            is_headless: true,
-        })
-        .await
-        .unwrap();
+        assert!(repo
+            .store_for_pending_registration(
+                StoreOAuthCodeParams {
+                    tenant_id: 1,
+                    code: &exchange_code,
+                    user_pubkey: &user_pubkey,
+                    client_id: &client_id,
+                    redirect_uri: "http://localhost:3000/callback",
+                    scope: "policy:social",
+                    code_challenge: None,
+                    code_challenge_method: None,
+                    expires_at: Utc::now() + chrono::Duration::minutes(10),
+                    previous_auth_id: None,
+                    state: None,
+                    is_headless: true,
+                },
+                &pending,
+            )
+            .await
+            .unwrap());
 
         // The live exchange code is now found and reused; the pending row is still untouched.
         assert_eq!(
@@ -995,22 +1009,26 @@ mod tests {
         let exchange_code = format!("exch_{}", uuid::Uuid::new_v4());
         let expires_at = Utc::now() + chrono::Duration::seconds(90);
 
-        repo.store(StoreOAuthCodeParams {
-            tenant_id: 1,
-            code: &exchange_code,
-            user_pubkey: &pending.user_pubkey,
-            client_id: &pending.client_id,
-            redirect_uri: "http://localhost:3000/callback",
-            scope: "policy:social",
-            code_challenge: None,
-            code_challenge_method: None,
-            expires_at,
-            previous_auth_id: None,
-            state: None,
-            is_headless: true,
-        })
-        .await
-        .unwrap();
+        assert!(repo
+            .store_for_pending_registration(
+                StoreOAuthCodeParams {
+                    tenant_id: 1,
+                    code: &exchange_code,
+                    user_pubkey: &pending.user_pubkey,
+                    client_id: &pending.client_id,
+                    redirect_uri: "http://localhost:3000/callback",
+                    scope: "policy:social",
+                    code_challenge: None,
+                    code_challenge_method: None,
+                    expires_at,
+                    previous_auth_id: None,
+                    state: None,
+                    is_headless: true,
+                },
+                &pending,
+            )
+            .await
+            .unwrap());
 
         let found = repo
             .find_live_exchange_code_with_expiry_for_pending(1, &pending)
@@ -1092,22 +1110,31 @@ mod tests {
         .unwrap();
 
         let exchange_a = format!("exch_a_{}", uuid::Uuid::new_v4());
-        repo.store(StoreOAuthCodeParams {
-            tenant_id: 1,
-            code: &exchange_a,
-            user_pubkey: &user_pubkey,
-            client_id: &client_id,
-            redirect_uri: "http://localhost:3000/callback",
-            scope: "policy:social",
-            code_challenge: Some("challenge-a"),
-            code_challenge_method: Some("S256"),
-            expires_at: Utc::now() + chrono::Duration::minutes(10),
-            previous_auth_id: None,
-            state: Some("state-a"),
-            is_headless: true,
-        })
-        .await
-        .unwrap();
+        let pending_a = repo
+            .find_by_device_code(&device_a, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(repo
+            .store_for_pending_registration(
+                StoreOAuthCodeParams {
+                    tenant_id: 1,
+                    code: &exchange_a,
+                    user_pubkey: &user_pubkey,
+                    client_id: &client_id,
+                    redirect_uri: "http://localhost:3000/callback",
+                    scope: "policy:social",
+                    code_challenge: Some("challenge-a"),
+                    code_challenge_method: Some("S256"),
+                    expires_at: Utc::now() + chrono::Duration::minutes(10),
+                    previous_auth_id: None,
+                    state: Some("state-a"),
+                    is_headless: true,
+                },
+                &pending_a,
+            )
+            .await
+            .unwrap());
 
         let pending_b = repo
             .find_by_device_code(&device_b, 1)
@@ -1146,22 +1173,26 @@ mod tests {
         assert!(pending.consumed_at.is_none(), "starts un-consumed");
 
         let exchange_code = format!("exch_{}", uuid::Uuid::new_v4());
-        repo.store(StoreOAuthCodeParams {
-            tenant_id: 1,
-            code: &exchange_code,
-            user_pubkey: &pending.user_pubkey,
-            client_id: &pending.client_id,
-            redirect_uri: &pending.redirect_uri,
-            scope: &pending.scope,
-            code_challenge: pending.code_challenge.as_deref(),
-            code_challenge_method: pending.code_challenge_method.as_deref(),
-            expires_at: Utc::now() + chrono::Duration::minutes(10),
-            previous_auth_id: pending.previous_auth_id,
-            state: pending.state.as_deref(),
-            is_headless: pending.is_headless,
-        })
-        .await
-        .unwrap();
+        assert!(repo
+            .store_for_pending_registration(
+                StoreOAuthCodeParams {
+                    tenant_id: 1,
+                    code: &exchange_code,
+                    user_pubkey: &pending.user_pubkey,
+                    client_id: &pending.client_id,
+                    redirect_uri: &pending.redirect_uri,
+                    scope: &pending.scope,
+                    code_challenge: pending.code_challenge.as_deref(),
+                    code_challenge_method: pending.code_challenge_method.as_deref(),
+                    expires_at: Utc::now() + chrono::Duration::minutes(10),
+                    previous_auth_id: pending.previous_auth_id,
+                    state: pending.state.as_deref(),
+                    is_headless: pending.is_headless,
+                },
+                &pending,
+            )
+            .await
+            .unwrap());
         let auth_code = repo.find_valid(1, &exchange_code).await.unwrap().unwrap();
 
         repo.redeem_code_and_mark_pending_consumed(1, &exchange_code, &auth_code)
@@ -1180,6 +1211,85 @@ mod tests {
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_exchange_code_redeem_is_one_shot_for_pending_registration() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(24);
+        insert_pending_registration(&repo, &device_code, Some("pinhash"), expires_at).await;
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        let exchange_a = format!("exch_a_{}", uuid::Uuid::new_v4());
+        let exchange_b = format!("exch_b_{}", uuid::Uuid::new_v4());
+
+        for exchange_code in [&exchange_a, &exchange_b] {
+            assert!(repo
+                .store_for_pending_registration(
+                    StoreOAuthCodeParams {
+                        tenant_id: 1,
+                        code: exchange_code,
+                        user_pubkey: &pending.user_pubkey,
+                        client_id: &pending.client_id,
+                        redirect_uri: &pending.redirect_uri,
+                        scope: &pending.scope,
+                        code_challenge: pending.code_challenge.as_deref(),
+                        code_challenge_method: pending.code_challenge_method.as_deref(),
+                        expires_at: Utc::now() + chrono::Duration::minutes(10),
+                        previous_auth_id: pending.previous_auth_id,
+                        state: pending.state.as_deref(),
+                        is_headless: pending.is_headless,
+                    },
+                    &pending,
+                )
+                .await
+                .unwrap());
+        }
+
+        let auth_code_a = repo.find_valid(1, &exchange_a).await.unwrap().unwrap();
+        assert!(
+            repo.redeem_code_and_mark_pending_consumed(1, &exchange_a, &auth_code_a)
+                .await
+                .unwrap(),
+            "first exchange code should redeem the pending registration"
+        );
+
+        let after_first = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            after_first.consumed_at.is_some(),
+            "first redemption should consume the pending row"
+        );
+
+        let auth_code_b = repo.find_valid(1, &exchange_b).await.unwrap().unwrap();
+        assert!(
+            !repo
+                .redeem_code_and_mark_pending_consumed(1, &exchange_b, &auth_code_b)
+                .await
+                .unwrap(),
+            "second sibling exchange code must not redeem after pending row is consumed"
+        );
+        assert!(
+            repo.find_valid(1, &exchange_b).await.unwrap().is_some(),
+            "failed redemption should roll back the exchange-code delete"
+        );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1 OR code IN ($2, $3)")
+            .bind(&device_code)
+            .bind(&exchange_a)
+            .bind(&exchange_b)
             .execute(&pool)
             .await
             .unwrap();
@@ -1246,22 +1356,31 @@ mod tests {
         .unwrap();
 
         let exchange_a = format!("exch_a_{}", uuid::Uuid::new_v4());
-        repo.store(StoreOAuthCodeParams {
-            tenant_id: 1,
-            code: &exchange_a,
-            user_pubkey: &user_pubkey,
-            client_id: &client_id,
-            redirect_uri: "http://localhost:3000/callback",
-            scope: "policy:social",
-            code_challenge: Some("challenge-a"),
-            code_challenge_method: Some("S256"),
-            expires_at: Utc::now() + chrono::Duration::minutes(10),
-            previous_auth_id: None,
-            state: Some("state-a"),
-            is_headless: true,
-        })
-        .await
-        .unwrap();
+        let pending_a_for_exchange = repo
+            .find_by_device_code(&device_a, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(repo
+            .store_for_pending_registration(
+                StoreOAuthCodeParams {
+                    tenant_id: 1,
+                    code: &exchange_a,
+                    user_pubkey: &user_pubkey,
+                    client_id: &client_id,
+                    redirect_uri: "http://localhost:3000/callback",
+                    scope: "policy:social",
+                    code_challenge: Some("challenge-a"),
+                    code_challenge_method: Some("S256"),
+                    expires_at: Utc::now() + chrono::Duration::minutes(10),
+                    previous_auth_id: None,
+                    state: Some("state-a"),
+                    is_headless: true,
+                },
+                &pending_a_for_exchange,
+            )
+            .await
+            .unwrap());
         let auth_code = repo.find_valid(1, &exchange_a).await.unwrap().unwrap();
 
         repo.redeem_code_and_mark_pending_consumed(1, &exchange_a, &auth_code)

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -33,6 +33,9 @@ pub struct OAuthCodeData {
     pub pin_attempts: i32,
     /// Timestamp of the last PIN issuance; backs the PIN-resend cooldown
     pub pin_sent_at: Option<DateTime<Utc>>,
+    /// Terminal marker (keycast#262): set when the registration's exchange code is redeemed. Once
+    /// non-NULL, finalize refuses to re-mint and the row is eligible for cleanup.
+    pub consumed_at: Option<DateTime<Utc>>,
 }
 
 /// Parameters for storing a basic OAuth code
@@ -152,7 +155,7 @@ impl OAuthCodeRepository {
     const SELECT_COLUMNS: &'static str =
         "user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method, \
          pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret, \
-         previous_auth_id, state, device_code, is_headless, pin_hash, pin_attempts, pin_sent_at";
+         previous_auth_id, state, device_code, is_headless, pin_hash, pin_attempts, pin_sent_at, consumed_at";
 
     /// Find a valid (non-expired) OAuth code.
     pub async fn find_valid(
@@ -251,33 +254,98 @@ impl OAuthCodeRepository {
     }
 
     /// Re-arm a pending registration for PIN resend: install a fresh verification token + PIN hash,
-    /// reset the attempt counter to zero, refresh `pin_sent_at`, and extend the verify window.
+    /// reset the attempt counter to zero, and refresh `pin_sent_at`.
     ///
     /// Used by the lockout-recovery path: after the attempt cap is hit, the user must request a resend
     /// (subject to the cooldown) which mints a new PIN and clears the lockout.
+    ///
+    /// Deliberately does NOT touch `expires_at`: the pending row keeps its original 24h registration
+    /// window. Otherwise repeated resends could extend a pending row indefinitely, defeating the
+    /// row's finite lifecycle (keycast#262).
     pub async fn reset_pin_for_resend(
         &self,
         device_code: &str,
         tenant_id: i64,
         new_verification_token: &str,
         new_pin_hash: &str,
-        new_expires_at: DateTime<Utc>,
     ) -> Result<(), RepositoryError> {
         sqlx::query(
             "UPDATE oauth_codes \
              SET pending_email_verification_token = $1, pin_hash = $2, pin_attempts = 0, \
-                 pin_sent_at = $3, expires_at = $4 \
-             WHERE device_code = $5 AND tenant_id = $6",
+                 pin_sent_at = $3 \
+             WHERE device_code = $4 AND tenant_id = $5",
         )
         .bind(new_verification_token)
         .bind(new_pin_hash)
         .bind(Utc::now())
-        .bind(new_expires_at)
         .bind(device_code)
         .bind(tenant_id)
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// Delete previously minted, un-redeemed exchange codes for a finalized registration so at most
+    /// one exchange code is ever live for it (keycast#262).
+    ///
+    /// Re-verifying within the window (link re-click, link + PIN) mints a fresh exchange code; this
+    /// removes the prior one. Exchange codes are produced by [`Self::store`] and carry neither a
+    /// `device_code` nor a `pending_email`, which is what distinguishes them from the pending
+    /// registration row — so this never deletes the pending row itself.
+    pub async fn delete_unredeemed_exchange_codes(
+        &self,
+        tenant_id: i64,
+        user_pubkey: &str,
+        client_id: &str,
+    ) -> Result<(), RepositoryError> {
+        sqlx::query(
+            "DELETE FROM oauth_codes \
+             WHERE tenant_id = $1 AND user_pubkey = $2 AND client_id = $3 \
+               AND device_code IS NULL AND pending_email IS NULL",
+        )
+        .bind(tenant_id)
+        .bind(user_pubkey)
+        .bind(client_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Mark a pending registration row terminal once its exchange code has been redeemed.
+    ///
+    /// Targets only the pending row (`device_code IS NOT NULL`) for this user + client, and only if
+    /// not already consumed. After this, finalize refuses to re-mint (keycast#262). A no-op for
+    /// normal token exchanges that have no pending row.
+    pub async fn mark_pending_consumed(
+        &self,
+        tenant_id: i64,
+        user_pubkey: &str,
+        client_id: &str,
+    ) -> Result<(), RepositoryError> {
+        sqlx::query(
+            "UPDATE oauth_codes SET consumed_at = $1 \
+             WHERE tenant_id = $2 AND user_pubkey = $3 AND client_id = $4 \
+               AND device_code IS NOT NULL AND consumed_at IS NULL",
+        )
+        .bind(Utc::now())
+        .bind(tenant_id)
+        .bind(user_pubkey)
+        .bind(client_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Delete dead rows: anything past its expiry, plus consumed pending registrations (terminal
+    /// once their exchange code was redeemed). Bounds table growth and enforces the pending row's
+    /// finite lifecycle (keycast#262). Returns the number of rows removed.
+    pub async fn delete_expired_and_consumed(&self) -> Result<u64, RepositoryError> {
+        let result =
+            sqlx::query("DELETE FROM oauth_codes WHERE expires_at < $1 OR consumed_at IS NOT NULL")
+                .bind(Utc::now())
+                .execute(&self.pool)
+                .await?;
+        Ok(result.rows_affected())
     }
 
     /// Delete pending OAuth registration by verification token.
@@ -528,16 +596,22 @@ mod tests {
         let repo = OAuthCodeRepository::new(pool.clone());
 
         let device_code = format!("dc_{}", uuid::Uuid::new_v4());
-        let expires_at = Utc::now() + chrono::Duration::hours(24);
+        // Original registration window: an exact, known expiry we can assert stays put.
+        let expires_at = Utc::now() + chrono::Duration::hours(12);
         insert_pending_registration(&repo, &device_code, Some("oldpin"), expires_at).await;
+        let original_expiry: DateTime<Utc> =
+            sqlx::query_scalar("SELECT expires_at FROM oauth_codes WHERE device_code = $1")
+                .bind(&device_code)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
 
         // Burn two attempts.
         repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
         repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
 
         let new_token = format!("verif_{}", uuid::Uuid::new_v4());
-        let new_expires = Utc::now() + chrono::Duration::hours(24);
-        repo.reset_pin_for_resend(&device_code, 1, &new_token, "newpin", new_expires)
+        repo.reset_pin_for_resend(&device_code, 1, &new_token, "newpin")
             .await
             .unwrap();
 
@@ -549,6 +623,18 @@ mod tests {
         assert_eq!(data.pin_hash.as_deref(), Some("newpin"));
         assert_eq!(data.pin_attempts, 0, "attempts reset on resend");
 
+        // Resend must NOT extend the original 24h window (keycast#262 bounded lifecycle).
+        let after_expiry: DateTime<Utc> =
+            sqlx::query_scalar("SELECT expires_at FROM oauth_codes WHERE device_code = $1")
+                .bind(&device_code)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            after_expiry, original_expiry,
+            "resend must not extend expires_at past the original registration window"
+        );
+
         // New token is now the live verification token.
         let by_token = repo
             .find_by_verification_token(&new_token, 1)
@@ -558,6 +644,178 @@ mod tests {
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_delete_unredeemed_exchange_codes_spares_pending_row() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        // A pending registration row (device_code + pending_email set).
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(24);
+        insert_pending_registration(&repo, &device_code, Some("pinhash"), expires_at).await;
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        let user_pubkey = pending.user_pubkey.clone();
+        let client_id = pending.client_id.clone();
+
+        // A previously minted exchange code for the same user+client (no device_code/pending_email).
+        let exchange_code = format!("exch_{}", uuid::Uuid::new_v4());
+        repo.store(StoreOAuthCodeParams {
+            tenant_id: 1,
+            code: &exchange_code,
+            user_pubkey: &user_pubkey,
+            client_id: &client_id,
+            redirect_uri: "http://localhost:3000/callback",
+            scope: "policy:social",
+            code_challenge: None,
+            code_challenge_method: None,
+            expires_at: Utc::now() + chrono::Duration::minutes(10),
+            previous_auth_id: None,
+            state: None,
+            is_headless: true,
+        })
+        .await
+        .unwrap();
+
+        repo.delete_unredeemed_exchange_codes(1, &user_pubkey, &client_id)
+            .await
+            .unwrap();
+
+        // Exchange code is gone; pending registration row survives.
+        assert!(
+            repo.find_valid(1, &exchange_code).await.unwrap().is_none(),
+            "prior exchange code must be deleted"
+        );
+        assert!(
+            repo.find_by_device_code(&device_code, 1)
+                .await
+                .unwrap()
+                .is_some(),
+            "pending registration row must NOT be deleted"
+        );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE user_pubkey = $1")
+            .bind(&user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_mark_pending_consumed_sets_marker_on_pending_row_only() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(24);
+        insert_pending_registration(&repo, &device_code, Some("pinhash"), expires_at).await;
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(pending.consumed_at.is_none(), "starts un-consumed");
+
+        repo.mark_pending_consumed(1, &pending.user_pubkey, &pending.client_id)
+            .await
+            .unwrap();
+
+        let after = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            after.consumed_at.is_some(),
+            "pending row should be marked consumed"
+        );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_and_consumed_removes_dead_rows() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        // Live row (kept).
+        let live_dc = format!("dc_live_{}", uuid::Uuid::new_v4());
+        insert_pending_registration(
+            &repo,
+            &live_dc,
+            Some("pin"),
+            Utc::now() + chrono::Duration::hours(24),
+        )
+        .await;
+
+        // Expired row (removed).
+        let expired_dc = format!("dc_exp_{}", uuid::Uuid::new_v4());
+        insert_pending_registration(
+            &repo,
+            &expired_dc,
+            Some("pin"),
+            Utc::now() - chrono::Duration::hours(1),
+        )
+        .await;
+
+        // Live-but-consumed row (removed).
+        let consumed_dc = format!("dc_con_{}", uuid::Uuid::new_v4());
+        insert_pending_registration(
+            &repo,
+            &consumed_dc,
+            Some("pin"),
+            Utc::now() + chrono::Duration::hours(24),
+        )
+        .await;
+        let consumed = repo
+            .find_by_device_code(&consumed_dc, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        repo.mark_pending_consumed(1, &consumed.user_pubkey, &consumed.client_id)
+            .await
+            .unwrap();
+
+        let removed = repo.delete_expired_and_consumed().await.unwrap();
+        assert!(removed >= 2, "expired and consumed rows should be deleted");
+
+        // find_by_device_code filters expired, so query the raw row for the expired case.
+        let expired_still_present: Option<(String,)> =
+            sqlx::query_as("SELECT device_code FROM oauth_codes WHERE device_code = $1")
+                .bind(&expired_dc)
+                .fetch_optional(&pool)
+                .await
+                .unwrap();
+        assert!(expired_still_present.is_none(), "expired row removed");
+        let consumed_still_present: Option<(String,)> =
+            sqlx::query_as("SELECT device_code FROM oauth_codes WHERE device_code = $1")
+                .bind(&consumed_dc)
+                .fetch_optional(&pool)
+                .await
+                .unwrap();
+        assert!(consumed_still_present.is_none(), "consumed row removed");
+        assert!(
+            repo.find_by_device_code(&live_dc, 1)
+                .await
+                .unwrap()
+                .is_some(),
+            "live un-consumed row retained"
+        );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&live_dc)
             .execute(&pool)
             .await
             .unwrap();

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -905,6 +905,7 @@ impl OAuthCodeRepository {
 #[cfg(all(test, feature = "integration-tests"))]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     fn assert_localhost_db() {
         let url = std::env::var("DATABASE_URL").unwrap_or_default();
@@ -1044,6 +1045,9 @@ mod tests {
             .unwrap();
     }
 
+    // Serialized against `test_delete_expired_and_consumed_removes_dead_rows`: that cleanup is
+    // global by design, so an expired fixture is fair game for it while both run concurrently.
+    #[serial]
     #[tokio::test]
     async fn test_find_by_device_code_returns_expired_rows_for_the_caller_to_judge() {
         let pool = setup_pool().await;
@@ -1294,6 +1298,9 @@ mod tests {
     /// on the caller's earlier snapshot. Without this, a window closing between the caller's check
     /// and the reservation would let a bcrypt comparison run against a dead registration and be
     /// reported as a wrong PIN.
+    // Serialized against `test_delete_expired_and_consumed_removes_dead_rows`: that cleanup is
+    // global by design, so an expired fixture is fair game for it while both run concurrently.
+    #[serial]
     #[tokio::test]
     async fn test_reserve_pin_attempt_refuses_an_expired_registration() {
         let pool = setup_pool().await;
@@ -2013,6 +2020,9 @@ mod tests {
             .unwrap();
     }
 
+    // Serialized against `test_delete_expired_and_consumed_removes_dead_rows`: that cleanup is
+    // global by design, so an expired fixture is fair game for it while both run concurrently.
+    #[serial]
     #[tokio::test]
     async fn test_delete_expired_and_consumed_removes_dead_rows() {
         let pool = setup_pool().await;

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -431,52 +431,103 @@ impl OAuthCodeRepository {
     /// window. Otherwise repeated resends could extend a pending row indefinitely, defeating the
     /// row's finite lifecycle (keycast#262).
     ///
-    /// Deliberately NOT scoped to the pending row (unlike [`Self::reserve_pin_attempt`] /
-    /// [`Self::reset_pin_attempts`]): this rewrites `pending_email_verification_token`, which
-    /// minted sibling exchange-code rows copy and which redemption correlates on (see
-    /// [`Self::mark_pending_consumed`]). Restricting the UPDATE to the pending row would
-    /// desynchronize the token between a pre-resend minted code and the pending row, so redeeming
-    /// that code would no longer mark the registration consumed. If you need to narrow this,
-    /// change the redemption correlation key first.
+    /// The rewrite is applied to the pending row and to every sibling row sharing the
+    /// `device_code` (unlike [`Self::reserve_pin_attempt`] / [`Self::reset_pin_attempts`], which
+    /// are scoped to the pending row). That is deliberate: this rewrites
+    /// `pending_email_verification_token`, which minted sibling exchange-code rows copy and which
+    /// redemption correlates on (see [`Self::mark_pending_consumed`]). Restricting the rewrite to
+    /// the pending row would desynchronize the token between a pre-resend minted code and the
+    /// pending row, so redeeming that code would no longer mark the registration consumed. If you
+    /// need to narrow this, change the redemption correlation key first.
+    ///
+    /// # Cooldown claim
+    ///
+    /// The cooldown is enforced *here*, as part of the same conditional UPDATE that rotates the
+    /// credentials, and the whole rewrite runs in one transaction. Returns `true` only if this call
+    /// won the claim.
+    ///
+    /// Checking the cooldown with a separate read first would be a time-of-check/time-of-use gap:
+    /// two concurrent resends could both observe an expired cooldown, both mint a PIN, both send an
+    /// email, and leave whichever UPDATE landed last as the only valid PIN — so a user could be
+    /// looking at a freshly delivered code that does not work. Callers may still do a cheap
+    /// pre-check to avoid paying for bcrypt, but this claim is what actually decides.
     pub async fn reset_pin_for_resend(
         &self,
         device_code: &str,
         tenant_id: i64,
         new_verification_token: &str,
         new_pin_hash: &str,
-    ) -> Result<(), RepositoryError> {
-        sqlx::query(
+        cooldown_cutoff: DateTime<Utc>,
+    ) -> Result<bool, RepositoryError> {
+        let mut tx = self.pool.begin().await?;
+        let now = Utc::now();
+
+        // Claim on the pending row only: sibling rows carry no PIN state, so including them here
+        // would make the claim succeed even when the pending row is still within its cooldown.
+        let claimed = sqlx::query(
             "UPDATE oauth_codes \
              SET pending_email_verification_token = $1, pin_hash = $2, pin_attempts = 0, \
                  pin_sent_at = $3, pin_resend_at = $3 \
-             WHERE device_code = $4 AND tenant_id = $5",
+             WHERE device_code = $4 AND tenant_id = $5 \
+               AND pending_email IS NOT NULL AND consumed_at IS NULL \
+               AND (pin_resend_at IS NULL OR pin_resend_at <= $6)",
         )
         .bind(new_verification_token)
         .bind(new_pin_hash)
-        .bind(Utc::now())
+        .bind(now)
         .bind(device_code)
         .bind(tenant_id)
-        .execute(&self.pool)
+        .bind(cooldown_cutoff)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+            > 0;
+
+        if !claimed {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
+        // Keep sibling exchange-code rows correlated with the pending row's new token.
+        sqlx::query(
+            "UPDATE oauth_codes SET pending_email_verification_token = $1 \
+             WHERE device_code = $2 AND tenant_id = $3 AND pending_email IS NULL",
+        )
+        .bind(new_verification_token)
+        .bind(device_code)
+        .bind(tenant_id)
+        .execute(&mut *tx)
         .await?;
-        Ok(())
+
+        tx.commit().await?;
+        Ok(true)
     }
 
     /// Restore PIN resend fields after replacement email delivery fails.
     ///
-    /// Like [`Self::reset_pin_for_resend`], deliberately NOT scoped to the pending row: it must
-    /// undo that call's token rewrite on every row sharing the `device_code` (see the coupling
-    /// note there).
+    /// Like [`Self::reset_pin_for_resend`], the restore covers the pending row and its sibling
+    /// exchange-code rows, so it undoes that call's token rewrite everywhere (see the coupling note
+    /// there).
+    ///
+    /// `expected_pin_hash` is the hash the failing call itself wrote. The restore applies only
+    /// while that value is still current, so a resend whose delivery failed can never roll back
+    /// over a later resend that already succeeded and put a different PIN in the user's inbox.
+    /// Returns `true` if the restore applied.
     pub async fn restore_pin_after_failed_resend(
         &self,
         device_code: &str,
         tenant_id: i64,
         previous: PinResendSnapshot<'_>,
-    ) -> Result<(), RepositoryError> {
-        sqlx::query(
+        expected_pin_hash: &str,
+    ) -> Result<bool, RepositoryError> {
+        let mut tx = self.pool.begin().await?;
+
+        let restored = sqlx::query(
             "UPDATE oauth_codes \
              SET pending_email_verification_token = $1, pin_hash = $2, pin_attempts = $3, \
                  pin_sent_at = $4, pin_resend_at = $5 \
-             WHERE device_code = $6 AND tenant_id = $7",
+             WHERE device_code = $6 AND tenant_id = $7 \
+               AND pending_email IS NOT NULL AND pin_hash = $8",
         )
         .bind(previous.verification_token)
         .bind(previous.pin_hash)
@@ -485,9 +536,29 @@ impl OAuthCodeRepository {
         .bind(previous.pin_resend_at)
         .bind(device_code)
         .bind(tenant_id)
-        .execute(&self.pool)
+        .bind(expected_pin_hash)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+            > 0;
+
+        if !restored {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
+        sqlx::query(
+            "UPDATE oauth_codes SET pending_email_verification_token = $1 \
+             WHERE device_code = $2 AND tenant_id = $3 AND pending_email IS NULL",
+        )
+        .bind(previous.verification_token)
+        .bind(device_code)
+        .bind(tenant_id)
+        .execute(&mut *tx)
         .await?;
-        Ok(())
+
+        tx.commit().await?;
+        Ok(true)
     }
 
     /// Mark that a PIN email was successfully handed to the delivery provider.
@@ -1094,6 +1165,65 @@ mod tests {
             .unwrap();
     }
 
+    /// The cooldown must be claimed by the same statement that rotates the credentials. Checking it
+    /// with a separate read first would let two concurrent resends both mint a PIN and both send an
+    /// email, leaving whichever UPDATE landed last as the only valid one — so a user could be
+    /// holding a code that was just mailed to them and does not work.
+    #[tokio::test]
+    async fn test_concurrent_resends_only_one_wins_the_cooldown_claim() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        insert_pending_registration(
+            &repo,
+            &device_code,
+            Some("oldpin"),
+            Utc::now() + chrono::Duration::hours(12),
+        )
+        .await;
+
+        // Both callers pass the same cutoff, exactly as two requests arriving together would.
+        let cutoff = Utc::now();
+        let token_a = format!("verif_a_{}", uuid::Uuid::new_v4());
+        let token_b = format!("verif_b_{}", uuid::Uuid::new_v4());
+
+        let (a, b) = tokio::join!(
+            repo.reset_pin_for_resend(&device_code, 1, &token_a, "pin_a", cutoff),
+            repo.reset_pin_for_resend(&device_code, 1, &token_b, "pin_b", cutoff),
+        );
+        let (a, b) = (a.unwrap(), b.unwrap());
+
+        assert!(
+            a ^ b,
+            "exactly one concurrent resend may claim the cooldown, got a={a} b={b}"
+        );
+
+        // The row must agree with whichever caller was told it won.
+        let winner_pin = if a { "pin_a" } else { "pin_b" };
+        let winner_token = if a { &token_a } else { &token_b };
+        let data = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .expect("pending row still exists");
+        assert_eq!(
+            data.pin_hash.as_deref(),
+            Some(winner_pin),
+            "the stored PIN must be the one the winning caller was told it installed"
+        );
+        assert_eq!(
+            data.pending_email_verification_token.as_deref(),
+            Some(winner_token.as_str())
+        );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn test_reset_pin_for_resend_rearms_token_pin_and_attempts() {
         let pool = setup_pool().await;
@@ -1115,9 +1245,10 @@ mod tests {
         repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
 
         let new_token = format!("verif_{}", uuid::Uuid::new_v4());
-        repo.reset_pin_for_resend(&device_code, 1, &new_token, "newpin")
+        assert!(repo
+            .reset_pin_for_resend(&device_code, 1, &new_token, "newpin", Utc::now())
             .await
-            .unwrap();
+            .unwrap());
 
         let data = repo
             .find_by_device_code(&device_code, 1)

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -251,7 +251,7 @@ impl OAuthCodeRepository {
         &self,
         params: StoreOAuthCodeWithRegistrationParams<'_>,
     ) -> Result<StoredPendingRegistration, RepositoryError> {
-        let row: (Option<String>,) = sqlx::query_as(
+        let row: Option<(Option<String>,)> = sqlx::query_as(
             "INSERT INTO oauth_codes (tenant_id, code, user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method, expires_at, created_at,
              pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret, state, device_code, is_headless, pin_hash, pin_sent_at)
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
@@ -274,8 +274,17 @@ impl OAuthCodeRepository {
                  pin_hash = EXCLUDED.pin_hash,
                  pin_attempts = 0,
                  pin_sent_at = NULL,
-                 pin_resend_at = NULL
-             RETURNING device_code",
+                 pin_resend_at = NULL,
+                 finalization_claim = NULL,
+                 finalization_claimed_at = NULL
+              WHERE (oauth_codes.finalization_claim IS NULL
+                     OR oauth_codes.finalization_claimed_at < NOW() - INTERVAL '5 minutes')
+                AND NOT EXISTS (
+                    SELECT 1 FROM users
+                    WHERE users.tenant_id = EXCLUDED.tenant_id
+                      AND lower(users.email) = lower(EXCLUDED.pending_email)
+                )
+              RETURNING device_code",
         )
         .bind(params.tenant_id)
         .bind(params.code)
@@ -297,10 +306,28 @@ impl OAuthCodeRepository {
         .bind(params.pin_hash)
         // pin_sent_at tracks confirmed delivery; callers set it after the email send succeeds.
         .bind(None::<DateTime<Utc>>)
-        .fetch_one(&self.pool)
+        .fetch_optional(&self.pool)
         .await?;
 
-        let device_code = row.0;
+        let Some((device_code,)) = row else {
+            let materialized: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM users
+                    WHERE tenant_id = $1 AND lower(email) = lower($2)
+                )",
+            )
+            .bind(params.tenant_id)
+            .bind(params.pending_email)
+            .fetch_one(&self.pool)
+            .await?;
+            return Err(if materialized {
+                RepositoryError::Duplicate
+            } else {
+                RepositoryError::Unavailable(
+                    "pending registration is currently being finalized".to_string(),
+                )
+            });
+        };
         // The UPDATE branch leaves device_code untouched, so a returned value different from the
         // one we offered means we superseded an existing pending registration.
         let superseded = device_code.as_deref() != params.device_code;
@@ -309,6 +336,53 @@ impl OAuthCodeRepository {
             device_code,
             superseded,
         })
+    }
+
+    /// Claim one exact pending generation while its user is materialized.
+    pub async fn claim_pending_finalization(
+        &self,
+        tenant_id: i64,
+        verification_token: &str,
+        claim: &str,
+    ) -> Result<bool, RepositoryError> {
+        let claimed = sqlx::query(
+            "UPDATE oauth_codes
+             SET finalization_claim = $1, finalization_claimed_at = NOW()
+             WHERE tenant_id = $2 AND pending_email_verification_token = $3
+               AND pending_email IS NOT NULL AND consumed_at IS NULL
+               AND expires_at > NOW()
+               AND (finalization_claim IS NULL
+                    OR finalization_claimed_at < NOW() - INTERVAL '5 minutes')",
+        )
+        .bind(claim)
+        .bind(tenant_id)
+        .bind(verification_token)
+        .execute(&self.pool)
+        .await?
+        .rows_affected()
+            > 0;
+        Ok(claimed)
+    }
+
+    /// Release a finalization claim without disturbing a newer claim holder.
+    pub async fn release_pending_finalization(
+        &self,
+        tenant_id: i64,
+        verification_token: &str,
+        claim: &str,
+    ) -> Result<(), RepositoryError> {
+        sqlx::query(
+            "UPDATE oauth_codes
+             SET finalization_claim = NULL, finalization_claimed_at = NULL
+             WHERE tenant_id = $1 AND pending_email_verification_token = $2
+               AND finalization_claim = $3",
+        )
+        .bind(tenant_id)
+        .bind(verification_token)
+        .bind(claim)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     /// Columns selected for every `OAuthCodeData` lookup (matches the struct's `FromRow` fields).
@@ -356,6 +430,26 @@ impl OAuthCodeRepository {
             .fetch_optional(&self.pool)
             .await?;
 
+        Ok(result)
+    }
+
+    /// Find a pending registration token even after its verification window closes.
+    pub async fn find_by_verification_token_including_expired(
+        &self,
+        token: &str,
+        tenant_id: i64,
+    ) -> Result<Option<OAuthCodeData>, RepositoryError> {
+        let query = format!(
+            "SELECT {} FROM oauth_codes
+             WHERE pending_email_verification_token = $1 AND tenant_id = $2
+               AND pending_email IS NOT NULL",
+            Self::SELECT_COLUMNS
+        );
+        let result = sqlx::query_as::<_, OAuthCodeData>(&query)
+            .bind(token)
+            .bind(tenant_id)
+            .fetch_optional(&self.pool)
+            .await?;
         Ok(result)
     }
 
@@ -555,10 +649,11 @@ impl OAuthCodeRepository {
         let claimed = sqlx::query(
             "UPDATE oauth_codes \
              SET pending_email_verification_token = $1, pin_hash = $2, pin_attempts = 0, \
-                 pin_sent_at = $3, pin_resend_at = $3 \
+                 pin_sent_at = NULL, pin_resend_at = $3 \
              WHERE device_code = $4 AND tenant_id = $5 \
-               AND pending_email IS NOT NULL AND consumed_at IS NULL \
-               AND (pin_resend_at IS NULL OR pin_resend_at <= $6)",
+                AND pending_email IS NOT NULL AND consumed_at IS NULL \
+                AND expires_at > $3 \
+                AND (pin_resend_at IS NULL OR pin_resend_at <= $6)",
         )
         .bind(new_verification_token)
         .bind(new_pin_hash)
@@ -654,17 +749,23 @@ impl OAuthCodeRepository {
         &self,
         device_code: &str,
         tenant_id: i64,
-    ) -> Result<(), RepositoryError> {
-        sqlx::query(
+        expected_verification_token: &str,
+    ) -> Result<bool, RepositoryError> {
+        let marked = sqlx::query(
             "UPDATE oauth_codes SET pin_sent_at = $1 \
-             WHERE device_code = $2 AND tenant_id = $3",
+             WHERE device_code = $2 AND tenant_id = $3 \
+               AND pending_email_verification_token = $4 \
+               AND pending_email IS NOT NULL AND consumed_at IS NULL",
         )
         .bind(Utc::now())
         .bind(device_code)
         .bind(tenant_id)
+        .bind(expected_verification_token)
         .execute(&self.pool)
-        .await?;
-        Ok(())
+        .await?
+        .rows_affected()
+            > 0;
+        Ok(marked)
     }
 
     /// Clear the failed-attempt counter for a pending registration after a correct PIN (keycast#262).
@@ -1084,6 +1185,94 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_finalization_claim_blocks_supersession_until_materialization_is_visible() {
+        use nostr_sdk::Keys;
+
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(1);
+        let (token, email) =
+            insert_pending_registration(&repo, &device_code, Some("old-pin"), expires_at).await;
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        let claim = format!("claim_{}", uuid::Uuid::new_v4());
+        assert!(repo
+            .claim_pending_finalization(1, &token, &claim)
+            .await
+            .unwrap());
+
+        let replacement_pubkey = Keys::generate().public_key().to_hex();
+        let replacement_device = format!("replacement_{}", uuid::Uuid::new_v4());
+        let replacement = || StoreOAuthCodeWithRegistrationParams {
+            tenant_id: 1,
+            code: "replacement-code",
+            user_pubkey: &replacement_pubkey,
+            client_id: "replacement-client",
+            redirect_uri: "http://localhost:3000/replacement",
+            scope: "policy:social",
+            code_challenge: None,
+            code_challenge_method: None,
+            expires_at: Utc::now() + chrono::Duration::hours(24),
+            pending_email: &email,
+            pending_password_hash: "replacement-hash",
+            pending_email_verification_token: "replacement-token",
+            pending_encrypted_secret: Some(b"replacement-secret"),
+            state: None,
+            device_code: Some(&replacement_device),
+            is_headless: true,
+            pin_hash: Some("replacement-pin"),
+        };
+        assert!(matches!(
+            repo.store_with_pending_registration(replacement()).await,
+            Err(RepositoryError::Unavailable(_))
+        ));
+
+        sqlx::query(
+            "INSERT INTO users
+                 (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+             VALUES ($1, 1, $2, 'materialized-hash', true, NOW(), NOW())",
+        )
+        .bind(&pending.user_pubkey)
+        .bind(&email)
+        .execute(&pool)
+        .await
+        .unwrap();
+        repo.release_pending_finalization(1, &token, &claim)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            repo.store_with_pending_registration(replacement()).await,
+            Err(RepositoryError::Duplicate)
+        ));
+        let surviving = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(surviving.user_pubkey, pending.user_pubkey);
+        assert_eq!(
+            surviving.pending_email_verification_token.as_deref(),
+            Some(token.as_str())
+        );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn test_reserve_pin_attempt_accumulates_and_enforces_cap() {
         let pool = setup_pool().await;
         let repo = OAuthCodeRepository::new(pool.clone());
@@ -1464,6 +1653,78 @@ mod tests {
             .await
             .unwrap();
         assert!(by_token.is_some(), "new token should resolve to the row");
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_reset_pin_for_resend_refuses_registration_expired_during_hashing() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(1);
+        let (old_token, _) =
+            insert_pending_registration(&repo, &device_code, Some("oldpin"), expires_at).await;
+
+        sqlx::query("UPDATE oauth_codes SET expires_at = NOW() - INTERVAL '1 second' WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        assert!(!repo
+            .reset_pin_for_resend(
+                &device_code,
+                1,
+                "new-token",
+                "new-pin",
+                Utc::now() - chrono::Duration::minutes(5),
+            )
+            .await
+            .unwrap());
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            pending.pending_email_verification_token.as_deref(),
+            Some(old_token.as_str()),
+            "an expired registration must keep its last usable generation"
+        );
+        assert_eq!(pending.pin_hash.as_deref(), Some("oldpin"));
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_mark_pin_sent_only_stamps_the_delivered_generation() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(1);
+        let (token, _) =
+            insert_pending_registration(&repo, &device_code, Some("pinhash"), expires_at).await;
+
+        assert!(!repo
+            .mark_pin_sent(&device_code, 1, "superseded-token")
+            .await
+            .unwrap());
+        assert!(repo.mark_pin_sent(&device_code, 1, &token).await.unwrap());
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(pending.pin_sent_at.is_some());
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -116,6 +116,14 @@ pub struct StoredPendingRegistration {
     pub superseded: bool,
 }
 
+/// Exchange code selected for one pending registration generation.
+#[derive(Debug, Clone)]
+pub struct StoredExchangeCode {
+    pub code: String,
+    pub expires_at: DateTime<Utc>,
+    pub freshly_minted: bool,
+}
+
 /// Result of materializing one exact pending registration generation.
 #[derive(Debug)]
 pub enum MaterializePendingRegistrationOutcome {
@@ -224,6 +232,166 @@ impl OAuthCodeRepository {
         .await?;
 
         Ok(result.rows_affected() == 1)
+    }
+
+    /// Reuse or insert an exchange code while locking one exact pending generation.
+    ///
+    /// The pending row, live-code lookup, and conditional insert share one transaction so
+    /// concurrent finalizers cannot mint separate codes. Returns `None` if the exact generation is
+    /// missing, consumed, or expired.
+    pub async fn get_or_store_exchange_code_for_pending(
+        &self,
+        params: StoreOAuthCodeParams<'_>,
+        pending: &OAuthCodeData,
+    ) -> Result<Option<StoredExchangeCode>, RepositoryError> {
+        let mut tx = self.pool.begin().await?;
+        let locked: Option<(i32,)> = sqlx::query_as(
+            "SELECT 1 FROM oauth_codes pending_row
+             WHERE pending_row.tenant_id = $1
+               AND pending_row.user_pubkey = $2
+               AND pending_row.client_id = $3
+               AND pending_row.redirect_uri = $4
+               AND pending_row.scope = $5
+               AND pending_row.code_challenge IS NOT DISTINCT FROM $6
+               AND pending_row.code_challenge_method IS NOT DISTINCT FROM $7
+               AND pending_row.state IS NOT DISTINCT FROM $8
+               AND pending_row.is_headless = $9
+               AND pending_row.pending_email IS NOT NULL
+               AND pending_row.pending_email_verification_token IS NOT DISTINCT FROM $10
+               AND pending_row.device_code IS NOT DISTINCT FROM $11
+               AND pending_row.consumed_at IS NULL
+               AND pending_row.expires_at > clock_timestamp()
+             FOR UPDATE",
+        )
+        .bind(params.tenant_id)
+        .bind(&pending.user_pubkey)
+        .bind(&pending.client_id)
+        .bind(&pending.redirect_uri)
+        .bind(&pending.scope)
+        .bind(pending.code_challenge.as_deref())
+        .bind(pending.code_challenge_method.as_deref())
+        .bind(pending.state.as_deref())
+        .bind(pending.is_headless)
+        .bind(pending.pending_email_verification_token.as_deref())
+        .bind(pending.device_code.as_deref())
+        .fetch_optional(&mut *tx)
+        .await?;
+        if locked.is_none() {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+
+        // `FOR UPDATE` can wait after selecting its snapshot. Recheck with the database wall clock
+        // after the lock is owned so a generation that expires during that wait cannot mint.
+        let still_live: bool = sqlx::query_scalar(
+            "SELECT EXISTS(
+                SELECT 1 FROM oauth_codes pending_row
+                WHERE pending_row.tenant_id = $1
+                  AND pending_row.user_pubkey = $2
+                  AND pending_row.client_id = $3
+                  AND pending_row.redirect_uri = $4
+                  AND pending_row.scope = $5
+                  AND pending_row.code_challenge IS NOT DISTINCT FROM $6
+                  AND pending_row.code_challenge_method IS NOT DISTINCT FROM $7
+                  AND pending_row.state IS NOT DISTINCT FROM $8
+                  AND pending_row.is_headless = $9
+                  AND pending_row.pending_email IS NOT NULL
+                  AND pending_row.pending_email_verification_token IS NOT DISTINCT FROM $10
+                  AND pending_row.device_code IS NOT DISTINCT FROM $11
+                  AND pending_row.consumed_at IS NULL
+                  AND pending_row.expires_at > clock_timestamp()
+            )",
+        )
+        .bind(params.tenant_id)
+        .bind(&pending.user_pubkey)
+        .bind(&pending.client_id)
+        .bind(&pending.redirect_uri)
+        .bind(&pending.scope)
+        .bind(pending.code_challenge.as_deref())
+        .bind(pending.code_challenge_method.as_deref())
+        .bind(pending.state.as_deref())
+        .bind(pending.is_headless)
+        .bind(pending.pending_email_verification_token.as_deref())
+        .bind(pending.device_code.as_deref())
+        .fetch_one(&mut *tx)
+        .await?;
+        if !still_live {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+
+        let existing: Option<(String, DateTime<Utc>)> = sqlx::query_as(
+            "SELECT exchange.code, exchange.expires_at FROM oauth_codes exchange
+             WHERE exchange.tenant_id = $1
+               AND exchange.user_pubkey = $2
+               AND exchange.client_id = $3
+               AND exchange.redirect_uri = $4
+               AND exchange.scope = $5
+               AND exchange.code_challenge IS NOT DISTINCT FROM $6
+               AND exchange.code_challenge_method IS NOT DISTINCT FROM $7
+               AND exchange.state IS NOT DISTINCT FROM $8
+               AND exchange.is_headless = $9
+               AND exchange.pending_email_verification_token IS NOT DISTINCT FROM $10
+               AND exchange.device_code IS NOT DISTINCT FROM $11
+               AND exchange.pending_email IS NULL
+               AND exchange.consumed_at IS NULL
+               AND exchange.expires_at > clock_timestamp()
+             ORDER BY exchange.created_at DESC
+             LIMIT 1",
+        )
+        .bind(params.tenant_id)
+        .bind(&pending.user_pubkey)
+        .bind(&pending.client_id)
+        .bind(&pending.redirect_uri)
+        .bind(&pending.scope)
+        .bind(pending.code_challenge.as_deref())
+        .bind(pending.code_challenge_method.as_deref())
+        .bind(pending.state.as_deref())
+        .bind(pending.is_headless)
+        .bind(pending.pending_email_verification_token.as_deref())
+        .bind(pending.device_code.as_deref())
+        .fetch_optional(&mut *tx)
+        .await?;
+        if let Some((code, expires_at)) = existing {
+            tx.commit().await?;
+            return Ok(Some(StoredExchangeCode {
+                code,
+                expires_at,
+                freshly_minted: false,
+            }));
+        }
+
+        sqlx::query(
+            "INSERT INTO oauth_codes
+                 (tenant_id, code, user_pubkey, client_id, redirect_uri, scope,
+                  code_challenge, code_challenge_method, expires_at, previous_auth_id, state,
+                  is_headless, created_at, pending_email_verification_token, device_code)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
+        )
+        .bind(params.tenant_id)
+        .bind(params.code)
+        .bind(params.user_pubkey)
+        .bind(params.client_id)
+        .bind(params.redirect_uri)
+        .bind(params.scope)
+        .bind(params.code_challenge)
+        .bind(params.code_challenge_method)
+        .bind(params.expires_at)
+        .bind(params.previous_auth_id)
+        .bind(params.state)
+        .bind(params.is_headless)
+        .bind(Utc::now())
+        .bind(pending.pending_email_verification_token.as_deref())
+        .bind(pending.device_code.as_deref())
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(Some(StoredExchangeCode {
+            code: params.code.to_string(),
+            expires_at: params.expires_at,
+            freshly_minted: true,
+        }))
     }
 
     /// Store OAuth code with pending registration data (deferred user creation).
@@ -532,6 +700,28 @@ impl OAuthCodeRepository {
             }
         };
 
+        if matches!(
+            &outcome,
+            MaterializePendingRegistrationOutcome::Materialized(_)
+        ) {
+            let still_live: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM oauth_codes
+                    WHERE tenant_id = $1 AND pending_email_verification_token = $2
+                      AND pending_email IS NOT NULL AND consumed_at IS NULL
+                      AND expires_at > clock_timestamp()
+                )",
+            )
+            .bind(tenant_id)
+            .bind(verification_token)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !still_live {
+                tx.rollback().await?;
+                return Ok(MaterializePendingRegistrationOutcome::NotFound);
+            }
+        }
+
         tx.commit().await?;
         Ok(outcome)
     }
@@ -714,20 +904,23 @@ impl OAuthCodeRepository {
         &self,
         device_code: &str,
         tenant_id: i64,
+        expected_generation_token: &str,
         max_attempts: i32,
         max_lifetime_attempts: i32,
     ) -> Result<PinAttemptReservation, RepositoryError> {
         let now = Utc::now();
         let row: Option<(i32,)> = sqlx::query_as(
             "UPDATE oauth_codes \
-             SET pin_attempts = pin_attempts + 1, pin_failed_total = pin_failed_total + 1 \
-             WHERE device_code = $1 AND tenant_id = $2 \
-               AND pin_attempts < $3 AND pin_failed_total < $4 \
-               AND pending_email IS NOT NULL AND consumed_at IS NULL AND expires_at > $5 \
-             RETURNING pin_attempts",
+              SET pin_attempts = pin_attempts + 1, pin_failed_total = pin_failed_total + 1 \
+              WHERE device_code = $1 AND tenant_id = $2 \
+                AND pending_email_verification_token = $3 \
+                AND pin_attempts < $4 AND pin_failed_total < $5 \
+                AND pending_email IS NOT NULL AND consumed_at IS NULL AND expires_at > $6 \
+              RETURNING pin_attempts",
         )
         .bind(device_code)
         .bind(tenant_id)
+        .bind(expected_generation_token)
         .bind(max_attempts)
         .bind(max_lifetime_attempts)
         .bind(now)
@@ -742,11 +935,13 @@ impl OAuthCodeRepository {
         // resend helps. Only on the failure path, which already writes an audit record.
         let state: Option<(i32, DateTime<Utc>)> = sqlx::query_as(
             "SELECT pin_failed_total, expires_at FROM oauth_codes \
-             WHERE device_code = $1 AND tenant_id = $2 \
-               AND pending_email IS NOT NULL AND consumed_at IS NULL",
+              WHERE device_code = $1 AND tenant_id = $2 \
+                AND pending_email_verification_token = $3 \
+                AND pending_email IS NOT NULL AND consumed_at IS NULL",
         )
         .bind(device_code)
         .bind(tenant_id)
+        .bind(expected_generation_token)
         .fetch_optional(&self.pool)
         .await?;
 
@@ -775,16 +970,19 @@ impl OAuthCodeRepository {
         &self,
         device_code: &str,
         tenant_id: i64,
+        expected_generation_token: &str,
     ) -> Result<(), RepositoryError> {
         sqlx::query(
             "UPDATE oauth_codes \
              SET pin_attempts = GREATEST(pin_attempts - 1, 0), \
                  pin_failed_total = GREATEST(pin_failed_total - 1, 0) \
-             WHERE device_code = $1 AND tenant_id = $2 \
-               AND pending_email IS NOT NULL AND consumed_at IS NULL",
+              WHERE device_code = $1 AND tenant_id = $2 \
+                AND pending_email_verification_token = $3 \
+                AND pending_email IS NOT NULL AND consumed_at IS NULL",
         )
         .bind(device_code)
         .bind(tenant_id)
+        .bind(expected_generation_token)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -979,15 +1177,18 @@ impl OAuthCodeRepository {
         &self,
         device_code: &str,
         tenant_id: i64,
+        expected_generation_token: &str,
     ) -> Result<(), RepositoryError> {
         sqlx::query(
             "UPDATE oauth_codes \
-             SET pin_attempts = 0, pin_failed_total = GREATEST(pin_failed_total - 1, 0) \
-             WHERE device_code = $1 AND tenant_id = $2 \
-               AND pending_email IS NOT NULL AND consumed_at IS NULL",
+              SET pin_attempts = 0, pin_failed_total = GREATEST(pin_failed_total - 1, 0) \
+              WHERE device_code = $1 AND tenant_id = $2 \
+                AND pending_email_verification_token = $3 \
+                AND pending_email IS NOT NULL AND consumed_at IS NULL",
         )
         .bind(device_code)
         .bind(tenant_id)
+        .bind(expected_generation_token)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -1513,6 +1714,107 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_materialization_rolls_back_if_registration_expires_while_waiting() {
+        use tokio::time::{sleep, Duration};
+
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::milliseconds(300);
+        let (token, _) =
+            insert_pending_registration(&repo, &device_code, Some("pin"), expires_at).await;
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+             VALUES ($1, 1, NOW(), NOW())",
+        )
+        .bind(&pending.user_pubkey)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let mut blocker = pool.begin().await.unwrap();
+        sqlx::query("SELECT pubkey FROM users WHERE pubkey = $1 FOR UPDATE")
+            .bind(&pending.user_pubkey)
+            .fetch_one(&mut *blocker)
+            .await
+            .unwrap();
+
+        let materialize_repo = repo.clone();
+        let materializer = tokio::spawn(async move {
+            materialize_repo
+                .materialize_pending_registration(1, &token)
+                .await
+        });
+        let wait_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let waiting: bool = sqlx::query_scalar(
+                "SELECT EXISTS (
+                    SELECT 1 FROM pg_stat_activity activity
+                    WHERE cardinality(pg_blocking_pids(activity.pid)) > 0
+                      AND activity.query LIKE '%SELECT u.email, u.email_verified%'
+                )",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            if waiting {
+                break;
+            }
+            assert!(tokio::time::Instant::now() < wait_deadline);
+            sleep(Duration::from_millis(10)).await;
+        }
+        loop {
+            let expired: bool = sqlx::query_scalar("SELECT clock_timestamp() >= $1")
+                .bind(expires_at)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+            if expired {
+                break;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+
+        blocker.commit().await.unwrap();
+        assert!(matches!(
+            materializer.await.unwrap().unwrap(),
+            MaterializePendingRegistrationOutcome::NotFound
+        ));
+        let user: (Option<String>, Option<String>, bool) = sqlx::query_as(
+            "SELECT email, password_hash, email_verified FROM users
+             WHERE pubkey = $1 AND tenant_id = 1",
+        )
+        .bind(&pending.user_pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let key_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM personal_keys WHERE user_pubkey = $1")
+                .bind(&pending.user_pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(user, (None, None, false));
+        assert_eq!(key_count, 0);
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn test_materialization_completes_with_one_pool_connection() {
         use sqlx::postgres::PgPoolOptions;
 
@@ -1626,31 +1928,32 @@ mod tests {
 
         let device_code = format!("dc_{}", uuid::Uuid::new_v4());
         let expires_at = Utc::now() + chrono::Duration::hours(24);
-        insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
+        let (token, _) =
+            insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
 
         // Reserve up to the cap; each call returns the post-increment count. The lifetime cap is
         // set far out of the way so this test isolates the per-PIN cap.
         let max = 3;
         const LIFETIME: i32 = 1000;
         let first = repo
-            .reserve_pin_attempt(&device_code, 1, max, LIFETIME)
+            .reserve_pin_attempt(&device_code, 1, &token, max, LIFETIME)
             .await
             .unwrap();
         assert_eq!(first, PinAttemptReservation::Reserved { attempt: 1 });
         let second = repo
-            .reserve_pin_attempt(&device_code, 1, max, LIFETIME)
+            .reserve_pin_attempt(&device_code, 1, &token, max, LIFETIME)
             .await
             .unwrap();
         assert_eq!(second, PinAttemptReservation::Reserved { attempt: 2 });
         let third = repo
-            .reserve_pin_attempt(&device_code, 1, max, LIFETIME)
+            .reserve_pin_attempt(&device_code, 1, &token, max, LIFETIME)
             .await
             .unwrap();
         assert_eq!(third, PinAttemptReservation::Reserved { attempt: 3 });
 
         // At the cap: no slot can be reserved (atomic lockout), and the counter does not grow.
         let locked = repo
-            .reserve_pin_attempt(&device_code, 1, max, LIFETIME)
+            .reserve_pin_attempt(&device_code, 1, &token, max, LIFETIME)
             .await
             .unwrap();
         assert_eq!(
@@ -1667,7 +1970,7 @@ mod tests {
 
         // Unknown device_code reserves nothing.
         let none = repo
-            .reserve_pin_attempt("nonexistent", 1, max, LIFETIME)
+            .reserve_pin_attempt("nonexistent", 1, "missing-token", max, LIFETIME)
             .await
             .unwrap();
         assert_eq!(none, PinAttemptReservation::CurrentPinLocked);
@@ -1686,13 +1989,14 @@ mod tests {
 
         let device_code = format!("dc_{}", uuid::Uuid::new_v4());
         let expires_at = Utc::now() + chrono::Duration::hours(24);
-        insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
+        let (token, _) =
+            insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
 
         // Burn a couple of attempt slots (as a near-success run would), then reset on success.
-        repo.reserve_pin_attempt(&device_code, 1, 5, 1000)
+        repo.reserve_pin_attempt(&device_code, 1, &token, 5, 1000)
             .await
             .unwrap();
-        repo.reserve_pin_attempt(&device_code, 1, 5, 1000)
+        repo.reserve_pin_attempt(&device_code, 1, &token, 5, 1000)
             .await
             .unwrap();
         let before = repo
@@ -1706,7 +2010,9 @@ mod tests {
             "lifetime counter tracked them too"
         );
 
-        repo.reset_pin_attempts(&device_code, 1).await.unwrap();
+        repo.reset_pin_attempts(&device_code, 1, &token)
+            .await
+            .unwrap();
 
         let after = repo
             .find_by_device_code(&device_code, 1)
@@ -1724,6 +2030,77 @@ mod tests {
             after.pin_failed_total, 1,
             "successful verify releases only its own reservation from the lifetime counter"
         );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_stale_pin_generation_cannot_mutate_superseding_counters() {
+        use nostr_sdk::Keys;
+
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let (stale_token, email) = insert_pending_registration(
+            &repo,
+            &device_code,
+            Some("stale-pin"),
+            Utc::now() + chrono::Duration::hours(1),
+        )
+        .await;
+
+        let replacement_pubkey = Keys::generate().public_key().to_hex();
+        let replacement_device = format!("replacement_{}", uuid::Uuid::new_v4());
+        let replacement_token = format!("replacement_{}", uuid::Uuid::new_v4());
+        repo.store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
+            tenant_id: 1,
+            code: "replacement-code",
+            user_pubkey: &replacement_pubkey,
+            client_id: "replacement-client",
+            redirect_uri: "http://localhost:3000/replacement",
+            scope: "policy:social",
+            code_challenge: None,
+            code_challenge_method: None,
+            expires_at: Utc::now() + chrono::Duration::hours(24),
+            pending_email: &email,
+            pending_password_hash: "replacement-hash",
+            pending_email_verification_token: &replacement_token,
+            pending_encrypted_secret: Some(b"replacement-secret"),
+            state: None,
+            device_code: Some(&replacement_device),
+            is_headless: true,
+            pin_hash: Some("replacement-pin"),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            repo.reserve_pin_attempt(&device_code, 1, &stale_token, 5, 50)
+                .await
+                .unwrap(),
+            PinAttemptReservation::CurrentPinLocked
+        );
+        repo.refund_pin_attempt(&device_code, 1, &stale_token)
+            .await
+            .unwrap();
+        repo.reset_pin_attempts(&device_code, 1, &stale_token)
+            .await
+            .unwrap();
+
+        let current = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            current.pending_email_verification_token.as_deref(),
+            Some(replacement_token.as_str())
+        );
+        assert_eq!((current.pin_attempts, current.pin_failed_total), (0, 0));
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
@@ -1783,7 +2160,13 @@ mod tests {
 
         // Reserving an attempt must touch only the pending row, never the minted sibling.
         let reserved = repo
-            .reserve_pin_attempt(&device_code, 1, 5, 1000)
+            .reserve_pin_attempt(
+                &device_code,
+                1,
+                pending.pending_email_verification_token.as_deref().unwrap(),
+                5,
+                1000,
+            )
             .await
             .unwrap();
         assert_eq!(reserved, PinAttemptReservation::Reserved { attempt: 1 });
@@ -1799,7 +2182,13 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
-        repo.reset_pin_attempts(&device_code, 1).await.unwrap();
+        repo.reset_pin_attempts(
+            &device_code,
+            1,
+            pending.pending_email_verification_token.as_deref().unwrap(),
+        )
+        .await
+        .unwrap();
         let pending_after = repo
             .find_by_device_code(&device_code, 1)
             .await
@@ -1820,7 +2209,13 @@ mod tests {
             .await
             .unwrap();
         let after_consumed = repo
-            .reserve_pin_attempt(&device_code, 1, 5, 1000)
+            .reserve_pin_attempt(
+                &device_code,
+                1,
+                pending.pending_email_verification_token.as_deref().unwrap(),
+                5,
+                1000,
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -1849,7 +2244,7 @@ mod tests {
         let repo = OAuthCodeRepository::new(pool.clone());
 
         let device_code = format!("dc_{}", uuid::Uuid::new_v4());
-        insert_pending_registration(
+        let (token, _) = insert_pending_registration(
             &repo,
             &device_code,
             Some("pinhash123"),
@@ -1858,7 +2253,7 @@ mod tests {
         .await;
 
         let outcome = repo
-            .reserve_pin_attempt(&device_code, 1, 5, 50)
+            .reserve_pin_attempt(&device_code, 1, &token, 5, 50)
             .await
             .unwrap();
         assert_eq!(
@@ -1976,10 +2371,10 @@ mod tests {
                 .unwrap();
 
         // Burn two attempts.
-        repo.reserve_pin_attempt(&device_code, 1, 5, 1000)
+        repo.reserve_pin_attempt(&device_code, 1, &old_token, 5, 1000)
             .await
             .unwrap();
-        repo.reserve_pin_attempt(&device_code, 1, 5, 1000)
+        repo.reserve_pin_attempt(&device_code, 1, &old_token, 5, 1000)
             .await
             .unwrap();
 
@@ -2166,6 +2561,187 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(pending.pin_sent_at.is_some());
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_exchange_code_selection_returns_one_code() {
+        use tokio::time::{sleep, Duration};
+
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        insert_pending_registration(
+            &repo,
+            &device_code,
+            Some("pin"),
+            Utc::now() + chrono::Duration::hours(1),
+        )
+        .await;
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        let candidate_a = format!("exchange_a_{}", uuid::Uuid::new_v4());
+        let candidate_b = format!("exchange_b_{}", uuid::Uuid::new_v4());
+        let expires_a = Utc::now() + chrono::Duration::minutes(10);
+        let expires_b = Utc::now() + chrono::Duration::minutes(10);
+
+        let mut blocker = pool.begin().await.unwrap();
+        sqlx::query(
+            "SELECT 1 FROM oauth_codes
+             WHERE device_code = $1 AND pending_email IS NOT NULL FOR UPDATE",
+        )
+        .bind(&device_code)
+        .fetch_one(&mut *blocker)
+        .await
+        .unwrap();
+
+        let first_repo = repo.clone();
+        let first_pending = pending.clone();
+        let first = tokio::spawn(async move {
+            first_repo
+                .get_or_store_exchange_code_for_pending(
+                    StoreOAuthCodeParams {
+                        tenant_id: 1,
+                        code: &candidate_a,
+                        user_pubkey: &first_pending.user_pubkey,
+                        client_id: &first_pending.client_id,
+                        redirect_uri: &first_pending.redirect_uri,
+                        scope: &first_pending.scope,
+                        code_challenge: first_pending.code_challenge.as_deref(),
+                        code_challenge_method: first_pending.code_challenge_method.as_deref(),
+                        expires_at: expires_a,
+                        previous_auth_id: first_pending.previous_auth_id,
+                        state: first_pending.state.as_deref(),
+                        is_headless: first_pending.is_headless,
+                    },
+                    &first_pending,
+                )
+                .await
+        });
+        let second_repo = repo.clone();
+        let second_pending = pending.clone();
+        let second = tokio::spawn(async move {
+            second_repo
+                .get_or_store_exchange_code_for_pending(
+                    StoreOAuthCodeParams {
+                        tenant_id: 1,
+                        code: &candidate_b,
+                        user_pubkey: &second_pending.user_pubkey,
+                        client_id: &second_pending.client_id,
+                        redirect_uri: &second_pending.redirect_uri,
+                        scope: &second_pending.scope,
+                        code_challenge: second_pending.code_challenge.as_deref(),
+                        code_challenge_method: second_pending.code_challenge_method.as_deref(),
+                        expires_at: expires_b,
+                        previous_auth_id: second_pending.previous_auth_id,
+                        state: second_pending.state.as_deref(),
+                        is_headless: second_pending.is_headless,
+                    },
+                    &second_pending,
+                )
+                .await
+        });
+
+        let wait_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let waiting: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM pg_stat_activity activity
+                 WHERE cardinality(pg_blocking_pids(activity.pid)) > 0
+                   AND activity.query LIKE '%SELECT 1 FROM oauth_codes pending_row%'",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            if waiting >= 2 {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < wait_deadline,
+                "both exchange-code selectors must wait on the pending row"
+            );
+            sleep(Duration::from_millis(10)).await;
+        }
+        blocker.commit().await.unwrap();
+
+        let first = first.await.unwrap().unwrap().unwrap();
+        let second = second.await.unwrap().unwrap().unwrap();
+        assert_eq!(first.code, second.code);
+        assert!(first.freshly_minted ^ second.freshly_minted);
+        let code_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE device_code = $1 AND pending_email IS NULL",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(code_count, 1);
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_exchange_code_selection_completes_with_one_pool_connection() {
+        use sqlx::postgres::PgPoolOptions;
+
+        let pool = setup_pool().await;
+        let setup_repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        insert_pending_registration(
+            &setup_repo,
+            &device_code,
+            Some("pin"),
+            Utc::now() + chrono::Duration::hours(1),
+        )
+        .await;
+        let pending = setup_repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        let database_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+        let one_connection_pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&database_url)
+            .await
+            .unwrap();
+        let candidate = format!("exchange_{}", uuid::Uuid::new_v4());
+        let stored = OAuthCodeRepository::new(one_connection_pool)
+            .get_or_store_exchange_code_for_pending(
+                StoreOAuthCodeParams {
+                    tenant_id: 1,
+                    code: &candidate,
+                    user_pubkey: &pending.user_pubkey,
+                    client_id: &pending.client_id,
+                    redirect_uri: &pending.redirect_uri,
+                    scope: &pending.scope,
+                    code_challenge: pending.code_challenge.as_deref(),
+                    code_challenge_method: pending.code_challenge_method.as_deref(),
+                    expires_at: Utc::now() + chrono::Duration::minutes(10),
+                    previous_auth_id: pending.previous_auth_id,
+                    state: pending.state.as_deref(),
+                    is_headless: pending.is_headless,
+                },
+                &pending,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.code, candidate);
+        assert!(stored.freshly_minted);
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -33,8 +33,8 @@ pub struct OAuthCodeData {
     pub pin_attempts: i32,
     /// Timestamp of the last PIN issuance; backs the PIN-resend cooldown
     pub pin_sent_at: Option<DateTime<Utc>>,
-    /// Terminal marker (keycast#262): set when the registration's exchange code is redeemed. Once
-    /// non-NULL, finalize refuses to re-mint and the row is eligible for cleanup.
+    /// Terminal marker (keycast#262): set after the registration's exchange code successfully
+    /// issues tokens. Once non-NULL, finalize refuses to re-mint and the row is eligible for cleanup.
     pub consumed_at: Option<DateTime<Utc>>,
 }
 
@@ -275,7 +275,7 @@ impl OAuthCodeRepository {
     /// Atomically reserve one PIN-verification attempt slot for a pending registration, returning
     /// the new attempt count. Returns `None` when no slot could be reserved — the row is already
     /// at `max_attempts` (locked), no live pending row matches the `device_code`, or the
-    /// registration was already consumed (exchange code redeemed).
+    /// registration already completed token issuance.
     ///
     /// Scoped to the pending registration row itself (`pending_email IS NOT NULL AND consumed_at
     /// IS NULL`): minted exchange-code rows copy `device_code` from the pending row, and a
@@ -320,7 +320,7 @@ impl OAuthCodeRepository {
     /// Deliberately NOT scoped to the pending row (unlike [`Self::reserve_pin_attempt`] /
     /// [`Self::reset_pin_attempts`]): this rewrites `pending_email_verification_token`, which
     /// minted sibling exchange-code rows copy and which redemption correlates on (see
-    /// `redeem_code_and_mark_pending_consumed`). Restricting the UPDATE to the pending row would
+    /// [`Self::mark_pending_consumed`]). Restricting the UPDATE to the pending row would
     /// desynchronize the token between a pre-resend minted code and the pending row, so redeeming
     /// that code would no longer mark the registration consumed. If you need to narrow this,
     /// change the redemption correlation key first.
@@ -483,8 +483,13 @@ impl OAuthCodeRepository {
         Ok(row)
     }
 
-    /// Delete an exchange code and atomically mark the matching pending registration consumed.
-    pub async fn redeem_code_and_mark_pending_consumed(
+    /// Redeem an exchange code while its matching pending registration is still active.
+    ///
+    /// This deliberately does not mark the pending row consumed. Token issuance performs several
+    /// fallible operations after code redemption, so the caller must mark the pending row only
+    /// after issuance succeeds. If issuance fails, the one-shot exchange code stays redeemed, but
+    /// the pending registration remains active and can mint a replacement code.
+    pub async fn redeem_code(
         &self,
         tenant_id: i64,
         code: &str,
@@ -503,23 +508,22 @@ impl OAuthCodeRepository {
         }
 
         if auth_code.pending_email_verification_token.is_some() {
-            let updated = sqlx::query(
-                "UPDATE oauth_codes SET consumed_at = $1
-                 WHERE tenant_id = $2
-                   AND user_pubkey = $3
-                   AND client_id = $4
-                   AND redirect_uri = $5
-                   AND scope = $6
-                   AND code_challenge IS NOT DISTINCT FROM $7
-                   AND code_challenge_method IS NOT DISTINCT FROM $8
-                   AND state IS NOT DISTINCT FROM $9
-                   AND is_headless = $10
+            let pending_exists: Option<(i32,)> = sqlx::query_as(
+                "SELECT 1 FROM oauth_codes
+                 WHERE tenant_id = $1
+                   AND user_pubkey = $2
+                   AND client_id = $3
+                   AND redirect_uri = $4
+                   AND scope = $5
+                   AND code_challenge IS NOT DISTINCT FROM $6
+                   AND code_challenge_method IS NOT DISTINCT FROM $7
+                   AND state IS NOT DISTINCT FROM $8
+                   AND is_headless = $9
                    AND pending_email IS NOT NULL
-                   AND pending_email_verification_token IS NOT DISTINCT FROM $11
-                   AND device_code IS NOT DISTINCT FROM $12
+                   AND pending_email_verification_token IS NOT DISTINCT FROM $10
+                   AND device_code IS NOT DISTINCT FROM $11
                    AND consumed_at IS NULL",
             )
-            .bind(Utc::now())
             .bind(tenant_id)
             .bind(&auth_code.user_pubkey)
             .bind(&auth_code.client_id)
@@ -531,10 +535,10 @@ impl OAuthCodeRepository {
             .bind(auth_code.is_headless)
             .bind(auth_code.pending_email_verification_token.as_deref())
             .bind(auth_code.device_code.as_deref())
-            .execute(&mut *tx)
+            .fetch_optional(&mut *tx)
             .await?;
 
-            if updated.rows_affected() != 1 {
+            if pending_exists.is_none() {
                 tx.rollback().await?;
                 return Ok(false);
             }
@@ -544,8 +548,53 @@ impl OAuthCodeRepository {
         Ok(true)
     }
 
+    /// Mark the pending registration associated with a successfully issued exchange code as
+    /// terminal. Returns `false` if the pending row is missing or already consumed.
+    pub async fn mark_pending_consumed(
+        &self,
+        tenant_id: i64,
+        auth_code: &OAuthCodeData,
+    ) -> Result<bool, RepositoryError> {
+        if auth_code.pending_email_verification_token.is_none() {
+            return Ok(true);
+        }
+
+        let updated = sqlx::query(
+            "UPDATE oauth_codes SET consumed_at = $1
+             WHERE tenant_id = $2
+               AND user_pubkey = $3
+               AND client_id = $4
+               AND redirect_uri = $5
+               AND scope = $6
+               AND code_challenge IS NOT DISTINCT FROM $7
+               AND code_challenge_method IS NOT DISTINCT FROM $8
+               AND state IS NOT DISTINCT FROM $9
+               AND is_headless = $10
+               AND pending_email IS NOT NULL
+               AND pending_email_verification_token IS NOT DISTINCT FROM $11
+               AND device_code IS NOT DISTINCT FROM $12
+               AND consumed_at IS NULL",
+        )
+        .bind(Utc::now())
+        .bind(tenant_id)
+        .bind(&auth_code.user_pubkey)
+        .bind(&auth_code.client_id)
+        .bind(&auth_code.redirect_uri)
+        .bind(&auth_code.scope)
+        .bind(auth_code.code_challenge.as_deref())
+        .bind(auth_code.code_challenge_method.as_deref())
+        .bind(auth_code.state.as_deref())
+        .bind(auth_code.is_headless)
+        .bind(auth_code.pending_email_verification_token.as_deref())
+        .bind(auth_code.device_code.as_deref())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(updated.rows_affected() == 1)
+    }
+
     /// Delete dead rows: anything past its expiry, plus consumed pending registrations (terminal
-    /// once their exchange code was redeemed). Bounds table growth and enforces the pending row's
+    /// once their exchange code successfully issued tokens). Bounds table growth and enforces the pending row's
     /// finite lifecycle (keycast#262). Returns the number of rows removed.
     pub async fn delete_expired_and_consumed(&self) -> Result<u64, RepositoryError> {
         let result =
@@ -913,7 +962,7 @@ mod tests {
             "reset_pin_attempts must not touch the minted sibling row"
         );
 
-        // Once the registration is consumed (exchange code redeemed), no attempt slot may be
+        // Once the registration is consumed (token issuance succeeded), no attempt slot may be
         // reserved: the terminal marker must end the PIN lifecycle too.
         sqlx::query("UPDATE oauth_codes SET consumed_at = NOW() WHERE device_code = $1 AND pending_email IS NOT NULL")
             .bind(&device_code)
@@ -1316,17 +1365,28 @@ mod tests {
             .unwrap());
         let auth_code = repo.find_valid(1, &exchange_code).await.unwrap().unwrap();
 
-        repo.redeem_code_and_mark_pending_consumed(1, &exchange_code, &auth_code)
+        repo.redeem_code(1, &exchange_code, &auth_code)
             .await
             .unwrap();
 
-        let after = repo
+        let after_redeem = repo
             .find_by_device_code(&device_code, 1)
             .await
             .unwrap()
             .unwrap();
         assert!(
-            after.consumed_at.is_some(),
+            after_redeem.consumed_at.is_none(),
+            "redeeming the exchange code must leave recovery possible until issuance succeeds"
+        );
+
+        assert!(repo.mark_pending_consumed(1, &auth_code).await.unwrap());
+        let after_issuance = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            after_issuance.consumed_at.is_some(),
             "pending row should be marked consumed"
         );
 
@@ -1378,11 +1438,12 @@ mod tests {
 
         let auth_code_a = repo.find_valid(1, &exchange_a).await.unwrap().unwrap();
         assert!(
-            repo.redeem_code_and_mark_pending_consumed(1, &exchange_a, &auth_code_a)
+            repo.redeem_code(1, &exchange_a, &auth_code_a)
                 .await
                 .unwrap(),
             "first exchange code should redeem the pending registration"
         );
+        assert!(repo.mark_pending_consumed(1, &auth_code_a).await.unwrap());
 
         let after_first = repo
             .find_by_device_code(&device_code, 1)
@@ -1397,7 +1458,7 @@ mod tests {
         let auth_code_b = repo.find_valid(1, &exchange_b).await.unwrap().unwrap();
         assert!(
             !repo
-                .redeem_code_and_mark_pending_consumed(1, &exchange_b, &auth_code_b)
+                .redeem_code(1, &exchange_b, &auth_code_b)
                 .await
                 .unwrap(),
             "second sibling exchange code must not redeem after pending row is consumed"
@@ -1504,9 +1565,8 @@ mod tests {
             .unwrap());
         let auth_code = repo.find_valid(1, &exchange_a).await.unwrap().unwrap();
 
-        repo.redeem_code_and_mark_pending_consumed(1, &exchange_a, &auth_code)
-            .await
-            .unwrap();
+        repo.redeem_code(1, &exchange_a, &auth_code).await.unwrap();
+        assert!(repo.mark_pending_consumed(1, &auth_code).await.unwrap());
 
         let pending_a = repo
             .find_by_device_code(&device_a, 1)

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -6,7 +6,10 @@ use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 
 /// Data returned when finding an OAuth code
-#[derive(Debug, Clone)]
+///
+/// Field names match `oauth_codes` columns so `sqlx::FromRow` maps by name; queries may
+/// list the columns in any order as long as every field has a matching selected column.
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct OAuthCodeData {
     pub user_pubkey: String,
     pub client_id: String,
@@ -24,6 +27,12 @@ pub struct OAuthCodeData {
     pub device_code: Option<String>,
     /// Whether this code was issued via headless flow (for first_party UCAN fact)
     pub is_headless: bool,
+    /// bcrypt hash of the 6-digit in-app PIN fallback (keycast#262), if one was issued
+    pub pin_hash: Option<String>,
+    /// Failed verify-pin attempts; brute-force cap is enforced against this counter
+    pub pin_attempts: i32,
+    /// Timestamp of the last PIN issuance; backs the PIN-resend cooldown
+    pub pin_sent_at: Option<DateTime<Utc>>,
 }
 
 /// Parameters for storing a basic OAuth code
@@ -65,6 +74,8 @@ pub struct StoreOAuthCodeWithRegistrationParams<'a> {
     pub device_code: Option<&'a str>,
     /// Whether this code is from headless flow (for first_party UCAN fact)
     pub is_headless: bool,
+    /// bcrypt hash of the 6-digit in-app PIN fallback (keycast#262); None for browser OAuth
+    pub pin_hash: Option<&'a str>,
 }
 
 #[derive(Debug, Clone)]
@@ -109,8 +120,8 @@ impl OAuthCodeRepository {
     ) -> Result<(), RepositoryError> {
         sqlx::query(
             "INSERT INTO oauth_codes (tenant_id, code, user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method, expires_at, created_at,
-             pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret, state, device_code, is_headless)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)",
+             pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret, state, device_code, is_headless, pin_hash, pin_sent_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)",
         )
         .bind(params.tenant_id)
         .bind(params.code)
@@ -129,116 +140,138 @@ impl OAuthCodeRepository {
         .bind(params.state)
         .bind(params.device_code)
         .bind(params.is_headless)
+        .bind(params.pin_hash)
+        // pin_sent_at tracks the last PIN issuance for the resend cooldown; set when a PIN is issued.
+        .bind(params.pin_hash.map(|_| Utc::now()))
         .execute(&self.pool)
         .await?;
         Ok(())
     }
 
+    /// Columns selected for every `OAuthCodeData` lookup (matches the struct's `FromRow` fields).
+    const SELECT_COLUMNS: &'static str =
+        "user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method, \
+         pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret, \
+         previous_auth_id, state, device_code, is_headless, pin_hash, pin_attempts, pin_sent_at";
+
     /// Find a valid (non-expired) OAuth code.
-    #[allow(clippy::type_complexity)]
     pub async fn find_valid(
         &self,
         tenant_id: i64,
         code: &str,
     ) -> Result<Option<OAuthCodeData>, RepositoryError> {
-        let result: Option<(
-            String,
-            String,
-            String,
-            String,
-            Option<String>,
-            Option<String>,
-            Option<String>,
-            Option<String>,
-            Option<String>,
-            Option<Vec<u8>>,
-            Option<i32>,
-            Option<String>,
-            Option<String>,
-            bool,
-        )> = sqlx::query_as(
-            "SELECT user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method,
-                    pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret,
-                    previous_auth_id, state, device_code, is_headless
-             FROM oauth_codes
-             WHERE tenant_id = $1 AND code = $2 AND expires_at > $3",
-        )
-        .bind(tenant_id)
-        .bind(code)
-        .bind(Utc::now())
-        .fetch_optional(&self.pool)
-        .await?;
+        let query = format!(
+            "SELECT {} FROM oauth_codes WHERE tenant_id = $1 AND code = $2 AND expires_at > $3",
+            Self::SELECT_COLUMNS
+        );
+        let result = sqlx::query_as::<_, OAuthCodeData>(&query)
+            .bind(tenant_id)
+            .bind(code)
+            .bind(Utc::now())
+            .fetch_optional(&self.pool)
+            .await?;
 
-        Ok(result.map(|row| OAuthCodeData {
-            user_pubkey: row.0,
-            client_id: row.1,
-            redirect_uri: row.2,
-            scope: row.3,
-            code_challenge: row.4,
-            code_challenge_method: row.5,
-            pending_email: row.6,
-            pending_password_hash: row.7,
-            pending_email_verification_token: row.8,
-            pending_encrypted_secret: row.9,
-            previous_auth_id: row.10,
-            state: row.11,
-            device_code: row.12,
-            is_headless: row.13,
-        }))
+        Ok(result)
     }
 
     /// Find a pending OAuth registration by email verification token.
     /// Used when user clicks the email verification link to complete OAuth flow.
-    #[allow(clippy::type_complexity)]
     pub async fn find_by_verification_token(
         &self,
         token: &str,
         tenant_id: i64,
     ) -> Result<Option<OAuthCodeData>, RepositoryError> {
-        let result: Option<(
-            String,
-            String,
-            String,
-            String,
-            Option<String>,
-            Option<String>,
-            Option<String>,
-            Option<String>,
-            Option<String>,
-            Option<Vec<u8>>,
-            Option<i32>,
-            Option<String>,
-            Option<String>,
-            bool,
-        )> = sqlx::query_as(
-            "SELECT user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method,
-                    pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret,
-                    previous_auth_id, state, device_code, is_headless
-             FROM oauth_codes
-             WHERE pending_email_verification_token = $1 AND tenant_id = $2 AND expires_at > $3",
+        let query = format!(
+            "SELECT {} FROM oauth_codes WHERE pending_email_verification_token = $1 AND tenant_id = $2 AND expires_at > $3",
+            Self::SELECT_COLUMNS
+        );
+        let result = sqlx::query_as::<_, OAuthCodeData>(&query)
+            .bind(token)
+            .bind(tenant_id)
+            .bind(Utc::now())
+            .fetch_optional(&self.pool)
+            .await?;
+
+        Ok(result)
+    }
+
+    /// Find a pending registration by its RFC 8628 `device_code` (the 64-char app-held secret).
+    ///
+    /// This is the lookup gate for in-app PIN verification (keycast#262): the `device_code` is the
+    /// real authenticator and the 6-digit PIN is defense-in-depth, so PIN verification MUST resolve
+    /// the pending row by `device_code` rather than by a global PIN scan (which would be brute-forceable
+    /// across all pending registrations). Only pending rows carry a non-null `device_code`, and the PIN
+    /// stays valid for the full 24h verify window, so this filters on `expires_at > now`.
+    pub async fn find_by_device_code(
+        &self,
+        device_code: &str,
+        tenant_id: i64,
+    ) -> Result<Option<OAuthCodeData>, RepositoryError> {
+        let query = format!(
+            "SELECT {} FROM oauth_codes WHERE device_code = $1 AND tenant_id = $2 AND expires_at > $3",
+            Self::SELECT_COLUMNS
+        );
+        let result = sqlx::query_as::<_, OAuthCodeData>(&query)
+            .bind(device_code)
+            .bind(tenant_id)
+            .bind(Utc::now())
+            .fetch_optional(&self.pool)
+            .await?;
+
+        Ok(result)
+    }
+
+    /// Atomically increment the PIN-attempt counter for a pending registration and return the new
+    /// count. Returns `None` when no pending row matches (unknown/expired `device_code`).
+    ///
+    /// The increment is done in a single `UPDATE ... RETURNING` so concurrent verify-pin requests
+    /// across Cloud Run instances cannot race the cap (an in-memory counter would not be shared state).
+    pub async fn increment_pin_attempts(
+        &self,
+        device_code: &str,
+        tenant_id: i64,
+    ) -> Result<Option<i32>, RepositoryError> {
+        let row: Option<(i32,)> = sqlx::query_as(
+            "UPDATE oauth_codes SET pin_attempts = pin_attempts + 1 \
+             WHERE device_code = $1 AND tenant_id = $2 \
+             RETURNING pin_attempts",
         )
-        .bind(token)
+        .bind(device_code)
         .bind(tenant_id)
-        .bind(Utc::now())
         .fetch_optional(&self.pool)
         .await?;
 
-        Ok(result.map(|row| OAuthCodeData {
-            user_pubkey: row.0,
-            client_id: row.1,
-            redirect_uri: row.2,
-            scope: row.3,
-            code_challenge: row.4,
-            code_challenge_method: row.5,
-            pending_email: row.6,
-            pending_password_hash: row.7,
-            pending_email_verification_token: row.8,
-            pending_encrypted_secret: row.9,
-            previous_auth_id: row.10,
-            state: row.11,
-            device_code: row.12,
-            is_headless: row.13,
-        }))
+        Ok(row.map(|r| r.0))
+    }
+
+    /// Re-arm a pending registration for PIN resend: install a fresh verification token + PIN hash,
+    /// reset the attempt counter to zero, refresh `pin_sent_at`, and extend the verify window.
+    ///
+    /// Used by the lockout-recovery path: after the attempt cap is hit, the user must request a resend
+    /// (subject to the cooldown) which mints a new PIN and clears the lockout.
+    pub async fn reset_pin_for_resend(
+        &self,
+        device_code: &str,
+        tenant_id: i64,
+        new_verification_token: &str,
+        new_pin_hash: &str,
+        new_expires_at: DateTime<Utc>,
+    ) -> Result<(), RepositoryError> {
+        sqlx::query(
+            "UPDATE oauth_codes \
+             SET pending_email_verification_token = $1, pin_hash = $2, pin_attempts = 0, \
+                 pin_sent_at = $3, expires_at = $4 \
+             WHERE device_code = $5 AND tenant_id = $6",
+        )
+        .bind(new_verification_token)
+        .bind(new_pin_hash)
+        .bind(Utc::now())
+        .bind(new_expires_at)
+        .bind(device_code)
+        .bind(tenant_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     /// Delete pending OAuth registration by verification token.
@@ -342,5 +375,156 @@ mod tests {
         // Should no longer be found
         let found = repo.find_valid(1, &code).await.unwrap();
         assert!(found.is_none());
+    }
+
+    /// Helper: insert a pending headless registration with a device_code and optional PIN hash.
+    async fn insert_pending_registration(
+        repo: &OAuthCodeRepository,
+        device_code: &str,
+        pin_hash: Option<&str>,
+        expires_at: DateTime<Utc>,
+    ) -> (String, String) {
+        use nostr_sdk::Keys;
+        let user_pubkey = Keys::generate().public_key().to_hex();
+        let code = format!("pending_{}", uuid::Uuid::new_v4());
+        let token = format!("verif_{}", uuid::Uuid::new_v4());
+        let email = format!("pin-test-{}@example.com", uuid::Uuid::new_v4());
+
+        repo.store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
+            tenant_id: 1,
+            code: &code,
+            user_pubkey: &user_pubkey,
+            client_id: "test_client",
+            redirect_uri: "http://localhost:3000/callback",
+            scope: "policy:social",
+            code_challenge: None,
+            code_challenge_method: None,
+            expires_at,
+            pending_email: &email,
+            pending_password_hash: "hashed",
+            pending_email_verification_token: &token,
+            pending_encrypted_secret: Some(b"secret"),
+            state: None,
+            device_code: Some(device_code),
+            is_headless: true,
+            pin_hash,
+        })
+        .await
+        .unwrap();
+
+        (token, email)
+    }
+
+    #[tokio::test]
+    async fn test_find_by_device_code_returns_pending_with_pin() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(24);
+        let (_token, email) =
+            insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
+
+        let found = repo.find_by_device_code(&device_code, 1).await.unwrap();
+        assert!(
+            found.is_some(),
+            "pending row should be found by device_code"
+        );
+        let data = found.unwrap();
+        assert_eq!(data.pin_hash.as_deref(), Some("pinhash123"));
+        assert_eq!(data.pin_attempts, 0);
+        assert_eq!(data.pending_email.as_deref(), Some(email.as_str()));
+        assert!(data.is_headless);
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_find_by_device_code_excludes_expired() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() - chrono::Duration::hours(1); // already expired
+        insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
+
+        let found = repo.find_by_device_code(&device_code, 1).await.unwrap();
+        assert!(found.is_none(), "expired pending row must not be returned");
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_increment_pin_attempts_accumulates_and_returns() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(24);
+        insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
+
+        let first = repo.increment_pin_attempts(&device_code, 1).await.unwrap();
+        assert_eq!(first, Some(1));
+        let second = repo.increment_pin_attempts(&device_code, 1).await.unwrap();
+        assert_eq!(second, Some(2));
+
+        // Unknown device_code returns None (no row updated).
+        let none = repo.increment_pin_attempts("nonexistent", 1).await.unwrap();
+        assert_eq!(none, None);
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_reset_pin_for_resend_rearms_token_pin_and_attempts() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(24);
+        insert_pending_registration(&repo, &device_code, Some("oldpin"), expires_at).await;
+
+        // Burn two attempts.
+        repo.increment_pin_attempts(&device_code, 1).await.unwrap();
+        repo.increment_pin_attempts(&device_code, 1).await.unwrap();
+
+        let new_token = format!("verif_{}", uuid::Uuid::new_v4());
+        let new_expires = Utc::now() + chrono::Duration::hours(24);
+        repo.reset_pin_for_resend(&device_code, 1, &new_token, "newpin", new_expires)
+            .await
+            .unwrap();
+
+        let data = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .expect("row should still exist after resend");
+        assert_eq!(data.pin_hash.as_deref(), Some("newpin"));
+        assert_eq!(data.pin_attempts, 0, "attempts reset on resend");
+
+        // New token is now the live verification token.
+        let by_token = repo
+            .find_by_verification_token(&new_token, 1)
+            .await
+            .unwrap();
+        assert!(by_token.is_some(), "new token should resolve to the row");
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
     }
 }

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -144,8 +144,8 @@ impl OAuthCodeRepository {
         .bind(params.device_code)
         .bind(params.is_headless)
         .bind(params.pin_hash)
-        // pin_sent_at tracks the last PIN issuance for the resend cooldown; set when a PIN is issued.
-        .bind(params.pin_hash.map(|_| Utc::now()))
+        // pin_sent_at tracks confirmed delivery; callers set it after the email send succeeds.
+        .bind(None::<DateTime<Utc>>)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -285,6 +285,51 @@ impl OAuthCodeRepository {
         Ok(())
     }
 
+    /// Restore PIN resend fields after replacement email delivery fails.
+    pub async fn restore_pin_after_failed_resend(
+        &self,
+        device_code: &str,
+        tenant_id: i64,
+        verification_token: Option<&str>,
+        pin_hash: Option<&str>,
+        pin_attempts: i32,
+        pin_sent_at: Option<DateTime<Utc>>,
+    ) -> Result<(), RepositoryError> {
+        sqlx::query(
+            "UPDATE oauth_codes \
+             SET pending_email_verification_token = $1, pin_hash = $2, pin_attempts = $3, \
+                 pin_sent_at = $4 \
+             WHERE device_code = $5 AND tenant_id = $6",
+        )
+        .bind(verification_token)
+        .bind(pin_hash)
+        .bind(pin_attempts)
+        .bind(pin_sent_at)
+        .bind(device_code)
+        .bind(tenant_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Mark that a PIN email was successfully handed to the delivery provider.
+    pub async fn mark_pin_sent(
+        &self,
+        device_code: &str,
+        tenant_id: i64,
+    ) -> Result<(), RepositoryError> {
+        sqlx::query(
+            "UPDATE oauth_codes SET pin_sent_at = $1 \
+             WHERE device_code = $2 AND tenant_id = $3",
+        )
+        .bind(Utc::now())
+        .bind(device_code)
+        .bind(tenant_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Clear the failed-attempt counter for a pending registration after a correct PIN (keycast#262).
     ///
     /// `reserve_pin_attempt` increments `pin_attempts` before every bcrypt compare, including the
@@ -323,8 +368,21 @@ impl OAuthCodeRepository {
         user_pubkey: &str,
         client_id: &str,
     ) -> Result<Option<String>, RepositoryError> {
-        let row: Option<(String,)> = sqlx::query_as(
-            "SELECT code FROM oauth_codes \
+        Ok(self
+            .find_live_exchange_code_with_expiry(tenant_id, user_pubkey, client_id)
+            .await?
+            .map(|row| row.0))
+    }
+
+    /// Find a still-live exchange code with its DB expiry.
+    pub async fn find_live_exchange_code_with_expiry(
+        &self,
+        tenant_id: i64,
+        user_pubkey: &str,
+        client_id: &str,
+    ) -> Result<Option<(String, DateTime<Utc>)>, RepositoryError> {
+        let row: Option<(String, DateTime<Utc>)> = sqlx::query_as(
+            "SELECT code, expires_at FROM oauth_codes \
              WHERE tenant_id = $1 AND user_pubkey = $2 AND client_id = $3 \
                AND device_code IS NULL AND pending_email IS NULL \
                AND consumed_at IS NULL AND expires_at > $4 \
@@ -337,7 +395,7 @@ impl OAuthCodeRepository {
         .bind(Utc::now())
         .fetch_optional(&self.pool)
         .await?;
-        Ok(row.map(|r| r.0))
+        Ok(row)
     }
 
     /// Mark a pending registration row terminal once its exchange code has been redeemed.
@@ -818,6 +876,52 @@ mod tests {
                 .unwrap()
                 .is_none(),
             "expired exchange code must NOT be reused"
+        );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE user_pubkey = $1")
+            .bind(&user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_find_live_exchange_code_with_expiry_returns_remaining_db_lifetime() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let user_pubkey = format!("pk_{}", uuid::Uuid::new_v4());
+        let client_id = format!("client_{}", uuid::Uuid::new_v4());
+        let exchange_code = format!("exch_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::seconds(90);
+
+        repo.store(StoreOAuthCodeParams {
+            tenant_id: 1,
+            code: &exchange_code,
+            user_pubkey: &user_pubkey,
+            client_id: &client_id,
+            redirect_uri: "http://localhost:3000/callback",
+            scope: "policy:social",
+            code_challenge: None,
+            code_challenge_method: None,
+            expires_at,
+            previous_auth_id: None,
+            state: None,
+            is_headless: true,
+        })
+        .await
+        .unwrap();
+
+        let found = repo
+            .find_live_exchange_code_with_expiry(1, &user_pubkey, &client_id)
+            .await
+            .unwrap()
+            .expect("live exchange code should be returned with expiry");
+
+        assert_eq!(found.0, exchange_code);
+        assert!(
+            found.1 <= expires_at && found.1 > Utc::now(),
+            "expiry must come from the DB row so Redis TTL can be bounded"
         );
 
         sqlx::query("DELETE FROM oauth_codes WHERE user_pubkey = $1")

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -31,8 +31,12 @@ pub struct OAuthCodeData {
     pub pin_hash: Option<String>,
     /// Failed verify-pin attempts; brute-force cap is enforced against this counter
     pub pin_attempts: i32,
-    /// Timestamp of the last PIN issuance; backs the PIN-resend cooldown
+    /// When the current PIN was handed to the delivery provider; backs the PIN validity window
     pub pin_sent_at: Option<DateTime<Utc>>,
+    /// When a PIN resend was last performed; backs the resend cooldown. Stays NULL through
+    /// registration so a user's first resend request is never swallowed by a cooldown they
+    /// never started.
+    pub pin_resend_at: Option<DateTime<Utc>>,
     /// Terminal marker (keycast#262): set after the registration's exchange code successfully
     /// issues tokens. Once non-NULL, finalize refuses to re-mint and the row is eligible for cleanup.
     pub consumed_at: Option<DateTime<Utc>>,
@@ -89,6 +93,21 @@ pub struct StoredPendingRegistration {
     pub device_code: Option<String>,
     /// Whether this call re-armed an existing live pending registration instead of creating one.
     pub superseded: bool,
+}
+
+/// The PIN-resend fields of a pending registration as they stood before a resend attempt.
+///
+/// Captured so [`OAuthCodeRepository::restore_pin_after_failed_resend`] can put the row back
+/// exactly as it was when the replacement email could not be delivered — leaving the previous PIN
+/// usable and neither the validity window nor the resend cooldown restamped by a send that never
+/// reached the user.
+#[derive(Debug, Clone, Copy)]
+pub struct PinResendSnapshot<'a> {
+    pub verification_token: Option<&'a str>,
+    pub pin_hash: Option<&'a str>,
+    pub pin_attempts: i32,
+    pub pin_sent_at: Option<DateTime<Utc>>,
+    pub pin_resend_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone)]
@@ -269,7 +288,8 @@ impl OAuthCodeRepository {
     const SELECT_COLUMNS: &'static str =
         "user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method, \
          pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret, \
-         previous_auth_id, state, device_code, is_headless, pin_hash, pin_attempts, pin_sent_at, consumed_at";
+         previous_auth_id, state, device_code, is_headless, pin_hash, pin_attempts, pin_sent_at, \
+         pin_resend_at, consumed_at";
 
     /// Find a valid (non-expired) OAuth code.
     pub async fn find_valid(
@@ -399,10 +419,13 @@ impl OAuthCodeRepository {
     }
 
     /// Re-arm a pending registration for PIN resend: install a fresh verification token + PIN hash,
-    /// reset the attempt counter to zero, and refresh `pin_sent_at`.
+    /// reset the attempt counter to zero, and stamp both `pin_sent_at` (the new PIN's validity
+    /// anchor) and `pin_resend_at` (the resend-cooldown anchor).
     ///
     /// Used by the lockout-recovery path: after the attempt cap is hit, the user must request a resend
-    /// (subject to the cooldown) which mints a new PIN and clears the lockout.
+    /// which mints a new PIN and clears the lockout. Because `pin_resend_at` starts NULL at
+    /// registration and is only stamped here, that first recovery resend is always available;
+    /// the cooldown then bounds the ones after it.
     ///
     /// Deliberately does NOT touch `expires_at`: the pending row keeps its original 24h registration
     /// window. Otherwise repeated resends could extend a pending row indefinitely, defeating the
@@ -425,7 +448,7 @@ impl OAuthCodeRepository {
         sqlx::query(
             "UPDATE oauth_codes \
              SET pending_email_verification_token = $1, pin_hash = $2, pin_attempts = 0, \
-                 pin_sent_at = $3 \
+                 pin_sent_at = $3, pin_resend_at = $3 \
              WHERE device_code = $4 AND tenant_id = $5",
         )
         .bind(new_verification_token)
@@ -447,21 +470,19 @@ impl OAuthCodeRepository {
         &self,
         device_code: &str,
         tenant_id: i64,
-        verification_token: Option<&str>,
-        pin_hash: Option<&str>,
-        pin_attempts: i32,
-        pin_sent_at: Option<DateTime<Utc>>,
+        previous: PinResendSnapshot<'_>,
     ) -> Result<(), RepositoryError> {
         sqlx::query(
             "UPDATE oauth_codes \
              SET pending_email_verification_token = $1, pin_hash = $2, pin_attempts = $3, \
-                 pin_sent_at = $4 \
-             WHERE device_code = $5 AND tenant_id = $6",
+                 pin_sent_at = $4, pin_resend_at = $5 \
+             WHERE device_code = $6 AND tenant_id = $7",
         )
-        .bind(verification_token)
-        .bind(pin_hash)
-        .bind(pin_attempts)
-        .bind(pin_sent_at)
+        .bind(previous.verification_token)
+        .bind(previous.pin_hash)
+        .bind(previous.pin_attempts)
+        .bind(previous.pin_sent_at)
+        .bind(previous.pin_resend_at)
         .bind(device_code)
         .bind(tenant_id)
         .execute(&self.pool)

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -996,9 +996,8 @@ impl OAuthCodeRepository {
     ///
     /// # Cooldown claim
     ///
-    /// The cooldown is enforced *here*, as part of the same conditional UPDATE that rotates the
-    /// credentials, and the whole rewrite runs in one transaction. Returns `true` only if this call
-    /// won the claim.
+    /// The cooldown is enforced *here* by the conditional pending-row lock, and the whole rewrite
+    /// runs in one transaction. Returns `true` only if this call won the claim.
     ///
     /// Checking the cooldown with a separate read first would be a time-of-check/time-of-use gap:
     /// two concurrent resends could both observe an expired cooldown, both mint a PIN, both send an
@@ -1015,30 +1014,62 @@ impl OAuthCodeRepository {
         cooldown_cutoff: DateTime<Utc>,
     ) -> Result<bool, RepositoryError> {
         let mut tx = self.pool.begin().await?;
-        let now = Utc::now();
+        // Lock the exact pending generation before inspecting exchange claims. Under READ
+        // COMMITTED, the separate claim query below then gets a new snapshot after any redemption
+        // that held this lock has committed.
+        let locked: Option<(i32,)> = sqlx::query_as(
+            "SELECT 1 FROM oauth_codes \
+             WHERE device_code = $1 AND tenant_id = $2 \
+               AND pending_email_verification_token = $3 \
+               AND pending_email IS NOT NULL AND consumed_at IS NULL \
+               AND expires_at > clock_timestamp() \
+               AND (pin_resend_at IS NULL OR pin_resend_at <= $4) \
+             FOR UPDATE",
+        )
+        .bind(device_code)
+        .bind(tenant_id)
+        .bind(expected_generation_token)
+        .bind(cooldown_cutoff)
+        .fetch_optional(&mut *tx)
+        .await?;
 
-        // Claim on the pending row only: sibling rows carry no PIN state, so including them here
-        // would make the claim succeed even when the pending row is still within its cooldown.
+        if locked.is_none() {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
+        let consumed_claim: bool = sqlx::query_scalar(
+            "SELECT EXISTS ( \
+                 SELECT 1 FROM oauth_codes exchange \
+                 WHERE exchange.tenant_id = $1 AND exchange.device_code = $2 \
+                   AND exchange.pending_email_verification_token = $3 \
+                   AND exchange.pending_email IS NULL \
+                   AND exchange.consumed_at IS NOT NULL \
+                   AND exchange.expires_at > clock_timestamp() \
+             )",
+        )
+        .bind(tenant_id)
+        .bind(device_code)
+        .bind(expected_generation_token)
+        .fetch_one(&mut *tx)
+        .await?;
+        if consumed_claim {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
         let claimed = sqlx::query(
             "UPDATE oauth_codes \
              SET pending_email_verification_token = $1, pin_hash = $2, pin_attempts = 0, \
-                 pin_sent_at = NULL, pin_resend_at = $3 \
-              WHERE device_code = $4 AND tenant_id = $5 \
-                  AND pending_email_verification_token = $6 \
-                  AND pending_email IS NOT NULL AND consumed_at IS NULL \
-                  AND expires_at > $3 \
-                  AND NOT EXISTS ( \
-                      SELECT 1 FROM oauth_codes exchange \
-                      WHERE exchange.tenant_id = $5 AND exchange.device_code = $4 \
-                        AND exchange.pending_email IS NULL \
-                        AND exchange.consumed_at IS NOT NULL \
-                        AND exchange.expires_at > $3 \
-                  ) \
-                  AND (pin_resend_at IS NULL OR pin_resend_at <= $7)",
+                 pin_sent_at = NULL, pin_resend_at = clock_timestamp() \
+             WHERE device_code = $3 AND tenant_id = $4 \
+               AND pending_email_verification_token = $5 \
+               AND pending_email IS NOT NULL AND consumed_at IS NULL \
+               AND expires_at > clock_timestamp() \
+               AND (pin_resend_at IS NULL OR pin_resend_at <= $6)",
         )
         .bind(new_verification_token)
         .bind(new_pin_hash)
-        .bind(now)
         .bind(device_code)
         .bind(tenant_id)
         .bind(expected_generation_token)
@@ -1046,8 +1077,7 @@ impl OAuthCodeRepository {
         .execute(&mut *tx)
         .await?
         .rows_affected()
-            > 0;
-
+            == 1;
         if !claimed {
             tx.rollback().await?;
             return Ok(false);
@@ -1056,12 +1086,14 @@ impl OAuthCodeRepository {
         // Keep sibling exchange-code rows correlated with the pending row's new token.
         sqlx::query(
             "UPDATE oauth_codes SET pending_email_verification_token = $1 \
-             WHERE device_code = $2 AND tenant_id = $3 \
-               AND pending_email IS NULL AND consumed_at IS NULL",
+              WHERE device_code = $2 AND tenant_id = $3 \
+                AND pending_email_verification_token = $4 \
+                AND pending_email IS NULL AND consumed_at IS NULL",
         )
         .bind(new_verification_token)
         .bind(device_code)
         .bind(tenant_id)
+        .bind(expected_generation_token)
         .execute(&mut *tx)
         .await?;
 
@@ -1075,25 +1107,65 @@ impl OAuthCodeRepository {
     /// exchange-code rows, so it undoes that call's token rewrite everywhere (see the coupling note
     /// there).
     ///
-    /// `expected_pin_hash` is the hash the failing call itself wrote. The restore applies only
-    /// while that value is still current, so a resend whose delivery failed can never roll back
-    /// over a later resend that already succeeded and put a different PIN in the user's inbox.
-    /// Returns `true` if the restore applied.
+    /// `expected_verification_token` and `expected_pin_hash` identify the generation the failing
+    /// call itself wrote. The restore applies only while both values are still current, so a resend
+    /// whose delivery failed can never roll back over a later resend that already succeeded and put
+    /// a different PIN in the user's inbox. Returns `true` if the restore applied.
     pub async fn restore_pin_after_failed_resend(
         &self,
         device_code: &str,
         tenant_id: i64,
         previous: PinResendSnapshot<'_>,
+        expected_verification_token: &str,
         expected_pin_hash: &str,
     ) -> Result<bool, RepositoryError> {
         let mut tx = self.pool.begin().await?;
 
+        let locked: Option<(i32,)> = sqlx::query_as(
+            "SELECT 1 FROM oauth_codes \
+             WHERE device_code = $1 AND tenant_id = $2 \
+               AND pending_email IS NOT NULL AND consumed_at IS NULL \
+               AND pin_hash = $3 AND pending_email_verification_token = $4 \
+             FOR UPDATE",
+        )
+        .bind(device_code)
+        .bind(tenant_id)
+        .bind(expected_pin_hash)
+        .bind(expected_verification_token)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if locked.is_none() {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
+        let consumed_claim: bool = sqlx::query_scalar(
+            "SELECT EXISTS ( \
+                 SELECT 1 FROM oauth_codes exchange \
+                 WHERE exchange.tenant_id = $1 AND exchange.device_code = $2 \
+                   AND exchange.pending_email_verification_token = $3 \
+                   AND exchange.pending_email IS NULL \
+                   AND exchange.consumed_at IS NOT NULL \
+                   AND exchange.expires_at > clock_timestamp() \
+             )",
+        )
+        .bind(tenant_id)
+        .bind(device_code)
+        .bind(expected_verification_token)
+        .fetch_one(&mut *tx)
+        .await?;
+        if consumed_claim {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
         let restored = sqlx::query(
             "UPDATE oauth_codes \
              SET pending_email_verification_token = $1, pin_hash = $2, pin_attempts = $3, \
-                 pin_sent_at = $4, pin_resend_at = $5 \
-             WHERE device_code = $6 AND tenant_id = $7 \
-               AND pending_email IS NOT NULL AND pin_hash = $8",
+                  pin_sent_at = $4, pin_resend_at = $5 \
+              WHERE device_code = $6 AND tenant_id = $7 \
+                AND pending_email IS NOT NULL AND consumed_at IS NULL \
+                AND pin_hash = $8 AND pending_email_verification_token = $9",
         )
         .bind(previous.verification_token)
         .bind(previous.pin_hash)
@@ -1103,6 +1175,7 @@ impl OAuthCodeRepository {
         .bind(device_code)
         .bind(tenant_id)
         .bind(expected_pin_hash)
+        .bind(expected_verification_token)
         .execute(&mut *tx)
         .await?
         .rows_affected()
@@ -1115,11 +1188,14 @@ impl OAuthCodeRepository {
 
         sqlx::query(
             "UPDATE oauth_codes SET pending_email_verification_token = $1 \
-             WHERE device_code = $2 AND tenant_id = $3 AND pending_email IS NULL",
+             WHERE device_code = $2 AND tenant_id = $3 \
+               AND pending_email_verification_token = $4 \
+               AND pending_email IS NULL AND consumed_at IS NULL",
         )
         .bind(previous.verification_token)
         .bind(device_code)
         .bind(tenant_id)
+        .bind(expected_verification_token)
         .execute(&mut *tx)
         .await?;
 
@@ -3390,6 +3466,274 @@ mod tests {
             .unwrap();
         sqlx::query("DELETE FROM users WHERE pubkey = $1")
             .bind(&finalized.pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_queued_resend_observes_redemption_claim_after_pending_lock_wait() {
+        use tokio::time::{sleep, Duration};
+
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let finalized = insert_and_finalize_registration(&repo, &device_code).await;
+        let code = finalized.exchange_code.code.clone();
+        let token = finalized
+            .pending
+            .pending_email_verification_token
+            .clone()
+            .unwrap();
+        let auth_code = repo.find_valid(1, &code).await.unwrap().unwrap();
+
+        let mut redemption = pool.begin().await.unwrap();
+        sqlx::query(
+            "SELECT 1 FROM oauth_codes
+             WHERE tenant_id = 1 AND device_code = $1
+               AND pending_email_verification_token = $2
+               AND pending_email IS NOT NULL
+             FOR UPDATE",
+        )
+        .bind(&device_code)
+        .bind(&token)
+        .fetch_one(&mut *redemption)
+        .await
+        .unwrap();
+
+        let resend_repo = repo.clone();
+        let resend_device = device_code.clone();
+        let resend_token = token.clone();
+        let resend = tokio::spawn(async move {
+            resend_repo
+                .reset_pin_for_resend(
+                    &resend_device,
+                    1,
+                    &resend_token,
+                    "replacement-token",
+                    "replacement-pin",
+                    Utc::now() - chrono::Duration::minutes(5),
+                )
+                .await
+        });
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let waiting: bool = sqlx::query_scalar(
+                "SELECT EXISTS (
+                     SELECT 1 FROM pg_stat_activity activity
+                     WHERE cardinality(pg_blocking_pids(activity.pid)) > 0
+                       AND activity.query LIKE '%pin_resend_at IS NULL OR pin_resend_at <=%FOR UPDATE%'
+                 )",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            if waiting {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "resend did not queue on the pending-generation lock"
+            );
+            sleep(Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(
+            sqlx::query(
+                "UPDATE oauth_codes SET consumed_at = clock_timestamp()
+                 WHERE tenant_id = 1 AND code = $1
+                   AND pending_email_verification_token = $2
+                   AND pending_email IS NULL AND consumed_at IS NULL",
+            )
+            .bind(&code)
+            .bind(&token)
+            .execute(&mut *redemption)
+            .await
+            .unwrap()
+            .rows_affected(),
+            1
+        );
+        redemption.commit().await.unwrap();
+
+        assert!(!resend.await.unwrap().unwrap());
+        let pending_token: Option<String> = sqlx::query_scalar(
+            "SELECT pending_email_verification_token FROM oauth_codes
+             WHERE tenant_id = 1 AND device_code = $1 AND pending_email IS NOT NULL",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let (exchange_token, exchange_consumed): (Option<String>, bool) = sqlx::query_as(
+            "SELECT pending_email_verification_token, consumed_at IS NOT NULL
+             FROM oauth_codes WHERE tenant_id = 1 AND code = $1",
+        )
+        .bind(&code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(pending_token.as_deref(), Some(token.as_str()));
+        assert_eq!(exchange_token, pending_token);
+        assert!(exchange_consumed);
+        assert!(repo
+            .mark_pending_consumed(1, &code, &auth_code)
+            .await
+            .unwrap());
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&finalized.pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_queued_failed_resend_restore_observes_redemption_claim() {
+        use tokio::time::{sleep, Duration};
+
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let finalized = insert_and_finalize_registration(&repo, &device_code).await;
+        let code = finalized.exchange_code.code.clone();
+        let old_token = finalized
+            .pending
+            .pending_email_verification_token
+            .clone()
+            .unwrap();
+        let old_pin_hash = finalized.pending.pin_hash.clone().unwrap();
+        let replacement_token = format!("replacement_{}", uuid::Uuid::new_v4());
+        let replacement_pin_hash = format!("replacement_pin_{}", uuid::Uuid::new_v4());
+
+        assert!(repo
+            .reset_pin_for_resend(
+                &device_code,
+                1,
+                &old_token,
+                &replacement_token,
+                &replacement_pin_hash,
+                Utc::now() - chrono::Duration::minutes(5),
+            )
+            .await
+            .unwrap());
+        let auth_code = repo.find_valid(1, &code).await.unwrap().unwrap();
+
+        let mut redemption = pool.begin().await.unwrap();
+        sqlx::query(
+            "SELECT 1 FROM oauth_codes
+             WHERE tenant_id = 1 AND device_code = $1
+               AND pending_email_verification_token = $2
+               AND pending_email IS NOT NULL
+             FOR UPDATE",
+        )
+        .bind(&device_code)
+        .bind(&replacement_token)
+        .fetch_one(&mut *redemption)
+        .await
+        .unwrap();
+
+        let restore_repo = repo.clone();
+        let restore_device = device_code.clone();
+        let restore_old_token = old_token.clone();
+        let restore_old_pin_hash = old_pin_hash.clone();
+        let restore_token = replacement_token.clone();
+        let restore_pin_hash = replacement_pin_hash.clone();
+        let restore = tokio::spawn(async move {
+            restore_repo
+                .restore_pin_after_failed_resend(
+                    &restore_device,
+                    1,
+                    PinResendSnapshot {
+                        verification_token: Some(&restore_old_token),
+                        pin_hash: Some(&restore_old_pin_hash),
+                        pin_attempts: finalized.pending.pin_attempts,
+                        pin_sent_at: finalized.pending.pin_sent_at,
+                        pin_resend_at: finalized.pending.pin_resend_at,
+                    },
+                    &restore_token,
+                    &restore_pin_hash,
+                )
+                .await
+        });
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let waiting: bool = sqlx::query_scalar(
+                "SELECT EXISTS (
+                     SELECT 1 FROM pg_stat_activity activity
+                     WHERE cardinality(pg_blocking_pids(activity.pid)) > 0
+                       AND activity.query LIKE '%pin_hash = $3 AND pending_email_verification_token = $4%FOR UPDATE%'
+                 )",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            if waiting {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "failed-resend restore did not queue on the pending-generation lock"
+            );
+            sleep(Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(
+            sqlx::query(
+                "UPDATE oauth_codes SET consumed_at = clock_timestamp()
+                 WHERE tenant_id = 1 AND code = $1
+                   AND pending_email_verification_token = $2
+                   AND pending_email IS NULL AND consumed_at IS NULL",
+            )
+            .bind(&code)
+            .bind(&replacement_token)
+            .execute(&mut *redemption)
+            .await
+            .unwrap()
+            .rows_affected(),
+            1
+        );
+        redemption.commit().await.unwrap();
+
+        assert!(!restore.await.unwrap().unwrap());
+        let (pending_token, pending_pin): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT pending_email_verification_token, pin_hash FROM oauth_codes
+             WHERE tenant_id = 1 AND device_code = $1 AND pending_email IS NOT NULL",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let (exchange_token, exchange_consumed): (Option<String>, bool) = sqlx::query_as(
+            "SELECT pending_email_verification_token, consumed_at IS NOT NULL
+             FROM oauth_codes WHERE tenant_id = 1 AND code = $1",
+        )
+        .bind(&code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(pending_token.as_deref(), Some(replacement_token.as_str()));
+        assert_eq!(pending_pin.as_deref(), Some(replacement_pin_hash.as_str()));
+        assert_eq!(exchange_token, pending_token);
+        assert!(exchange_consumed);
+        assert!(repo
+            .mark_pending_consumed(1, &code, &auth_code)
+            .await
+            .unwrap());
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&auth_code.user_pubkey)
             .execute(&pool)
             .await
             .unwrap();

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -273,8 +273,13 @@ impl OAuthCodeRepository {
     }
 
     /// Atomically reserve one PIN-verification attempt slot for a pending registration, returning
-    /// the new attempt count. Returns `None` when no slot could be reserved — either the row is
-    /// already at `max_attempts` (locked) or no pending row matches the `device_code`.
+    /// the new attempt count. Returns `None` when no slot could be reserved — the row is already
+    /// at `max_attempts` (locked), no live pending row matches the `device_code`, or the
+    /// registration was already consumed (exchange code redeemed).
+    ///
+    /// Scoped to the pending registration row itself (`pending_email IS NOT NULL AND consumed_at
+    /// IS NULL`): minted exchange-code rows copy `device_code` from the pending row, and a
+    /// device_code-only UPDATE would mutate those siblings too.
     ///
     /// The increment happens in a single conditional `UPDATE ... WHERE pin_attempts < $max
     /// RETURNING`, so the cap is enforced by the database rather than by a snapshot read. This is
@@ -290,6 +295,7 @@ impl OAuthCodeRepository {
         let row: Option<(i32,)> = sqlx::query_as(
             "UPDATE oauth_codes SET pin_attempts = pin_attempts + 1 \
              WHERE device_code = $1 AND tenant_id = $2 AND pin_attempts < $3 \
+               AND pending_email IS NOT NULL AND consumed_at IS NULL \
              RETURNING pin_attempts",
         )
         .bind(device_code)
@@ -310,6 +316,14 @@ impl OAuthCodeRepository {
     /// Deliberately does NOT touch `expires_at`: the pending row keeps its original 24h registration
     /// window. Otherwise repeated resends could extend a pending row indefinitely, defeating the
     /// row's finite lifecycle (keycast#262).
+    ///
+    /// Deliberately NOT scoped to the pending row (unlike [`Self::reserve_pin_attempt`] /
+    /// [`Self::reset_pin_attempts`]): this rewrites `pending_email_verification_token`, which
+    /// minted sibling exchange-code rows copy and which redemption correlates on (see
+    /// `redeem_code_and_mark_pending_consumed`). Restricting the UPDATE to the pending row would
+    /// desynchronize the token between a pre-resend minted code and the pending row, so redeeming
+    /// that code would no longer mark the registration consumed. If you need to narrow this,
+    /// change the redemption correlation key first.
     pub async fn reset_pin_for_resend(
         &self,
         device_code: &str,
@@ -334,6 +348,10 @@ impl OAuthCodeRepository {
     }
 
     /// Restore PIN resend fields after replacement email delivery fails.
+    ///
+    /// Like [`Self::reset_pin_for_resend`], deliberately NOT scoped to the pending row: it must
+    /// undo that call's token rewrite on every row sharing the `device_code` (see the coupling
+    /// note there).
     pub async fn restore_pin_after_failed_resend(
         &self,
         device_code: &str,
@@ -385,6 +403,9 @@ impl OAuthCodeRepository {
     /// lockout cap and a duplicate/retried verify of the same correct PIN could spuriously lock out.
     /// Resetting to zero on success keeps the invariant that only *failed* attempts lock, without
     /// weakening the brute-force cap: this is reachable only with a correct PIN.
+    ///
+    /// Scoped to the live pending registration row like [`Self::reserve_pin_attempt`]; minted
+    /// sibling exchange-code rows share the `device_code` and must not be touched.
     pub async fn reset_pin_attempts(
         &self,
         device_code: &str,
@@ -392,7 +413,8 @@ impl OAuthCodeRepository {
     ) -> Result<(), RepositoryError> {
         sqlx::query(
             "UPDATE oauth_codes SET pin_attempts = 0 \
-             WHERE device_code = $1 AND tenant_id = $2",
+             WHERE device_code = $1 AND tenant_id = $2 \
+               AND pending_email IS NOT NULL AND consumed_at IS NULL",
         )
         .bind(device_code)
         .bind(tenant_id)
@@ -805,6 +827,103 @@ mod tests {
         assert_eq!(
             after.pin_attempts, 0,
             "successful verify must clear the failed-attempt counter"
+        );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_pin_attempt_ops_target_only_live_pending_row() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(24);
+        insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Mint a sibling exchange-code row: it copies device_code (and the verification token)
+        // from the pending row but is not itself a pending registration (pending_email is NULL).
+        let minted_code = format!("minted_{}", uuid::Uuid::new_v4());
+        let stored = repo
+            .store_for_pending_registration(
+                StoreOAuthCodeParams {
+                    tenant_id: 1,
+                    code: &minted_code,
+                    user_pubkey: &pending.user_pubkey,
+                    client_id: &pending.client_id,
+                    redirect_uri: &pending.redirect_uri,
+                    scope: &pending.scope,
+                    code_challenge: None,
+                    code_challenge_method: None,
+                    expires_at: Utc::now() + chrono::Duration::minutes(10),
+                    previous_auth_id: None,
+                    state: None,
+                    is_headless: true,
+                },
+                &pending,
+            )
+            .await
+            .unwrap();
+        assert!(stored, "sibling exchange code should be minted");
+
+        let sibling_attempts = |pool: PgPool, code: String| async move {
+            let row: (i32,) =
+                sqlx::query_as("SELECT pin_attempts FROM oauth_codes WHERE code = $1")
+                    .bind(&code)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            row.0
+        };
+
+        // Reserving an attempt must touch only the pending row, never the minted sibling.
+        let reserved = repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
+        assert_eq!(reserved, Some(1));
+        assert_eq!(
+            sibling_attempts(pool.clone(), minted_code.clone()).await,
+            0,
+            "reserve_pin_attempt must not increment the minted sibling row"
+        );
+
+        // Resetting on success must also leave the sibling row alone.
+        sqlx::query("UPDATE oauth_codes SET pin_attempts = 2 WHERE code = $1")
+            .bind(&minted_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        repo.reset_pin_attempts(&device_code, 1).await.unwrap();
+        let pending_after = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(pending_after.pin_attempts, 0);
+        assert_eq!(
+            sibling_attempts(pool.clone(), minted_code.clone()).await,
+            2,
+            "reset_pin_attempts must not touch the minted sibling row"
+        );
+
+        // Once the registration is consumed (exchange code redeemed), no attempt slot may be
+        // reserved: the terminal marker must end the PIN lifecycle too.
+        sqlx::query("UPDATE oauth_codes SET consumed_at = NOW() WHERE device_code = $1 AND pending_email IS NOT NULL")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let after_consumed = repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
+        assert_eq!(
+            after_consumed, None,
+            "reserve_pin_attempt must not reserve a slot on a consumed registration"
         );
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -480,40 +480,42 @@ impl OAuthCodeRepository {
             return Ok(false);
         }
 
-        let updated = sqlx::query(
-            "UPDATE oauth_codes SET consumed_at = $1
-             WHERE tenant_id = $2
-               AND user_pubkey = $3
-               AND client_id = $4
-               AND redirect_uri = $5
-               AND scope = $6
-               AND code_challenge IS NOT DISTINCT FROM $7
-               AND code_challenge_method IS NOT DISTINCT FROM $8
-               AND state IS NOT DISTINCT FROM $9
-               AND is_headless = $10
-               AND pending_email IS NOT NULL
-               AND pending_email_verification_token IS NOT DISTINCT FROM $11
-               AND device_code IS NOT DISTINCT FROM $12
-               AND consumed_at IS NULL",
-        )
-        .bind(Utc::now())
-        .bind(tenant_id)
-        .bind(&auth_code.user_pubkey)
-        .bind(&auth_code.client_id)
-        .bind(&auth_code.redirect_uri)
-        .bind(&auth_code.scope)
-        .bind(auth_code.code_challenge.as_deref())
-        .bind(auth_code.code_challenge_method.as_deref())
-        .bind(auth_code.state.as_deref())
-        .bind(auth_code.is_headless)
-        .bind(auth_code.pending_email_verification_token.as_deref())
-        .bind(auth_code.device_code.as_deref())
-        .execute(&mut *tx)
-        .await?;
+        if auth_code.pending_email_verification_token.is_some() {
+            let updated = sqlx::query(
+                "UPDATE oauth_codes SET consumed_at = $1
+                 WHERE tenant_id = $2
+                   AND user_pubkey = $3
+                   AND client_id = $4
+                   AND redirect_uri = $5
+                   AND scope = $6
+                   AND code_challenge IS NOT DISTINCT FROM $7
+                   AND code_challenge_method IS NOT DISTINCT FROM $8
+                   AND state IS NOT DISTINCT FROM $9
+                   AND is_headless = $10
+                   AND pending_email IS NOT NULL
+                   AND pending_email_verification_token IS NOT DISTINCT FROM $11
+                   AND device_code IS NOT DISTINCT FROM $12
+                   AND consumed_at IS NULL",
+            )
+            .bind(Utc::now())
+            .bind(tenant_id)
+            .bind(&auth_code.user_pubkey)
+            .bind(&auth_code.client_id)
+            .bind(&auth_code.redirect_uri)
+            .bind(&auth_code.scope)
+            .bind(auth_code.code_challenge.as_deref())
+            .bind(auth_code.code_challenge_method.as_deref())
+            .bind(auth_code.state.as_deref())
+            .bind(auth_code.is_headless)
+            .bind(auth_code.pending_email_verification_token.as_deref())
+            .bind(auth_code.device_code.as_deref())
+            .execute(&mut *tx)
+            .await?;
 
-        if updated.rows_affected() != 1 {
-            tx.rollback().await?;
-            return Ok(false);
+            if updated.rows_affected() != 1 {
+                tx.rollback().await?;
+                return Ok(false);
+            }
         }
 
         tx.commit().await?;

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -1290,6 +1290,52 @@ mod tests {
             .unwrap();
     }
 
+    /// The reservation itself refuses an expired registration, so the expiry decision does not rest
+    /// on the caller's earlier snapshot. Without this, a window closing between the caller's check
+    /// and the reservation would let a bcrypt comparison run against a dead registration and be
+    /// reported as a wrong PIN.
+    #[tokio::test]
+    async fn test_reserve_pin_attempt_refuses_an_expired_registration() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        insert_pending_registration(
+            &repo,
+            &device_code,
+            Some("pinhash123"),
+            Utc::now() - chrono::Duration::minutes(1),
+        )
+        .await;
+
+        let outcome = repo
+            .reserve_pin_attempt(&device_code, 1, 5, 50)
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome,
+            PinAttemptReservation::Expired,
+            "an expired registration must be refused, and named as expired rather than as locked"
+        );
+
+        let after = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            (after.pin_attempts, after.pin_failed_total),
+            (0, 0),
+            "a refused reservation must not charge either counter"
+        );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
     /// The cooldown must be claimed by the same statement that rotates the credentials. Checking it
     /// with a separate read first would let two concurrent resends both mint a PIN and both send an
     /// email, leaving whichever UPDATE landed last as the only valid one — so a user could be

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -115,6 +115,54 @@ impl OAuthCodeRepository {
         Ok(())
     }
 
+    /// Store an exchange code only while the matching pending registration is still active.
+    pub async fn store_for_pending_registration(
+        &self,
+        params: StoreOAuthCodeParams<'_>,
+        pending: &OAuthCodeData,
+    ) -> Result<bool, RepositoryError> {
+        let result = sqlx::query(
+            "INSERT INTO oauth_codes (tenant_id, code, user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method, expires_at, previous_auth_id, state, is_headless, created_at)
+             SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
+             WHERE EXISTS (
+                 SELECT 1 FROM oauth_codes pending
+                 WHERE pending.tenant_id = $1
+                   AND pending.user_pubkey = $3
+                   AND pending.client_id = $4
+                   AND pending.redirect_uri = $5
+                   AND pending.scope = $6
+                   AND pending.code_challenge IS NOT DISTINCT FROM $7
+                   AND pending.code_challenge_method IS NOT DISTINCT FROM $8
+                   AND pending.state IS NOT DISTINCT FROM $11
+                   AND pending.is_headless = $12
+                   AND pending.pending_email IS NOT NULL
+                   AND pending.pending_email_verification_token IS NOT DISTINCT FROM $14
+                   AND pending.device_code IS NOT DISTINCT FROM $15
+                   AND pending.consumed_at IS NULL
+                   AND pending.expires_at > $13
+             )",
+        )
+        .bind(params.tenant_id)
+        .bind(params.code)
+        .bind(params.user_pubkey)
+        .bind(params.client_id)
+        .bind(params.redirect_uri)
+        .bind(params.scope)
+        .bind(params.code_challenge)
+        .bind(params.code_challenge_method)
+        .bind(params.expires_at)
+        .bind(params.previous_auth_id)
+        .bind(params.state)
+        .bind(params.is_headless)
+        .bind(Utc::now())
+        .bind(pending.pending_email_verification_token.as_deref())
+        .bind(pending.device_code.as_deref())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() == 1)
+    }
+
     /// Store OAuth code with pending registration data (deferred user creation).
     /// Used by oauth_register to defer user creation until token exchange.
     pub async fn store_with_pending_registration(
@@ -353,74 +401,113 @@ impl OAuthCodeRepository {
         Ok(())
     }
 
-    /// Find a still-live, un-redeemed exchange code already minted for a finalized registration, if
-    /// one exists (keycast#262).
-    ///
-    /// Lets finalize re-arm idempotently: a re-click or mail-prefetch within the exchange window
-    /// reuses the code the polling app may already hold rather than minting a replacement and
-    /// stranding the delivered one. Exchange codes are produced by [`Self::store`] and carry neither
-    /// a `device_code` nor a `pending_email`, which distinguishes them from the pending registration
-    /// row; redeemed codes are deleted at token exchange, so a row that still matches is un-redeemed.
-    /// Returns the most recently minted live code when several exist (a rare double-mint race).
-    pub async fn find_live_exchange_code(
+    /// Find a still-live exchange code matching the same pending registration semantics.
+    pub async fn find_live_exchange_code_with_expiry_for_pending(
         &self,
         tenant_id: i64,
-        user_pubkey: &str,
-        client_id: &str,
-    ) -> Result<Option<String>, RepositoryError> {
-        Ok(self
-            .find_live_exchange_code_with_expiry(tenant_id, user_pubkey, client_id)
-            .await?
-            .map(|row| row.0))
-    }
-
-    /// Find a still-live exchange code with its DB expiry.
-    pub async fn find_live_exchange_code_with_expiry(
-        &self,
-        tenant_id: i64,
-        user_pubkey: &str,
-        client_id: &str,
+        pending: &OAuthCodeData,
     ) -> Result<Option<(String, DateTime<Utc>)>, RepositoryError> {
+        let now = Utc::now();
         let row: Option<(String, DateTime<Utc>)> = sqlx::query_as(
-            "SELECT code, expires_at FROM oauth_codes \
-             WHERE tenant_id = $1 AND user_pubkey = $2 AND client_id = $3 \
-               AND device_code IS NULL AND pending_email IS NULL \
-               AND consumed_at IS NULL AND expires_at > $4 \
-             ORDER BY created_at DESC \
+            "SELECT exchange.code, exchange.expires_at FROM oauth_codes exchange
+             WHERE exchange.tenant_id = $1
+               AND exchange.user_pubkey = $2
+               AND exchange.client_id = $3
+               AND exchange.redirect_uri = $4
+               AND exchange.scope = $5
+               AND exchange.code_challenge IS NOT DISTINCT FROM $6
+               AND exchange.code_challenge_method IS NOT DISTINCT FROM $7
+               AND exchange.state IS NOT DISTINCT FROM $8
+               AND exchange.is_headless = $9
+               AND exchange.device_code IS NULL
+               AND exchange.pending_email IS NULL
+               AND exchange.consumed_at IS NULL
+               AND exchange.expires_at > $10
+               AND EXISTS (
+                   SELECT 1 FROM oauth_codes pending_row
+                   WHERE pending_row.tenant_id = $1
+                     AND pending_row.user_pubkey = $2
+                     AND pending_row.client_id = $3
+                     AND pending_row.redirect_uri = $4
+                     AND pending_row.scope = $5
+                     AND pending_row.code_challenge IS NOT DISTINCT FROM $6
+                     AND pending_row.code_challenge_method IS NOT DISTINCT FROM $7
+                     AND pending_row.state IS NOT DISTINCT FROM $8
+                     AND pending_row.is_headless = $9
+                     AND pending_row.pending_email IS NOT NULL
+                     AND pending_row.pending_email_verification_token IS NOT DISTINCT FROM $11
+                     AND pending_row.device_code IS NOT DISTINCT FROM $12
+                     AND pending_row.consumed_at IS NULL
+                     AND pending_row.expires_at > $10
+               )
+             ORDER BY exchange.created_at DESC
              LIMIT 1",
         )
         .bind(tenant_id)
-        .bind(user_pubkey)
-        .bind(client_id)
-        .bind(Utc::now())
+        .bind(&pending.user_pubkey)
+        .bind(&pending.client_id)
+        .bind(&pending.redirect_uri)
+        .bind(&pending.scope)
+        .bind(pending.code_challenge.as_deref())
+        .bind(pending.code_challenge_method.as_deref())
+        .bind(pending.state.as_deref())
+        .bind(pending.is_headless)
+        .bind(now)
+        .bind(pending.pending_email_verification_token.as_deref())
+        .bind(pending.device_code.as_deref())
         .fetch_optional(&self.pool)
         .await?;
         Ok(row)
     }
 
-    /// Mark a pending registration row terminal once its exchange code has been redeemed.
-    ///
-    /// Targets only the pending row (`device_code IS NOT NULL`) for this user + client, and only if
-    /// not already consumed. After this, finalize refuses to re-mint (keycast#262). A no-op for
-    /// normal token exchanges that have no pending row.
-    pub async fn mark_pending_consumed(
+    /// Delete an exchange code and atomically mark the matching pending registration consumed.
+    pub async fn redeem_code_and_mark_pending_consumed(
         &self,
         tenant_id: i64,
-        user_pubkey: &str,
-        client_id: &str,
-    ) -> Result<(), RepositoryError> {
+        code: &str,
+        auth_code: &OAuthCodeData,
+    ) -> Result<bool, RepositoryError> {
+        let mut tx = self.pool.begin().await?;
+        let deleted = sqlx::query("DELETE FROM oauth_codes WHERE tenant_id = $1 AND code = $2")
+            .bind(tenant_id)
+            .bind(code)
+            .execute(&mut *tx)
+            .await?;
+
+        if deleted.rows_affected() != 1 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
         sqlx::query(
-            "UPDATE oauth_codes SET consumed_at = $1 \
-             WHERE tenant_id = $2 AND user_pubkey = $3 AND client_id = $4 \
-               AND device_code IS NOT NULL AND consumed_at IS NULL",
+            "UPDATE oauth_codes SET consumed_at = $1
+             WHERE tenant_id = $2
+               AND user_pubkey = $3
+               AND client_id = $4
+               AND redirect_uri = $5
+               AND scope = $6
+               AND code_challenge IS NOT DISTINCT FROM $7
+               AND code_challenge_method IS NOT DISTINCT FROM $8
+               AND state IS NOT DISTINCT FROM $9
+               AND is_headless = $10
+               AND pending_email IS NOT NULL
+               AND consumed_at IS NULL",
         )
         .bind(Utc::now())
         .bind(tenant_id)
-        .bind(user_pubkey)
-        .bind(client_id)
-        .execute(&self.pool)
+        .bind(&auth_code.user_pubkey)
+        .bind(&auth_code.client_id)
+        .bind(&auth_code.redirect_uri)
+        .bind(&auth_code.scope)
+        .bind(auth_code.code_challenge.as_deref())
+        .bind(auth_code.code_challenge_method.as_deref())
+        .bind(auth_code.state.as_deref())
+        .bind(auth_code.is_headless)
+        .execute(&mut *tx)
         .await?;
-        Ok(())
+
+        tx.commit().await?;
+        Ok(true)
     }
 
     /// Delete dead rows: anything past its expiry, plus consumed pending registrations (terminal
@@ -793,7 +880,7 @@ mod tests {
 
         // No exchange code minted yet: the pending row must not be mistaken for one.
         assert!(
-            repo.find_live_exchange_code(1, &user_pubkey, &client_id)
+            repo.find_live_exchange_code_with_expiry_for_pending(1, &pending)
                 .await
                 .unwrap()
                 .is_none(),
@@ -821,10 +908,11 @@ mod tests {
 
         // The live exchange code is now found and reused; the pending row is still untouched.
         assert_eq!(
-            repo.find_live_exchange_code(1, &user_pubkey, &client_id)
+            repo.find_live_exchange_code_with_expiry_for_pending(1, &pending)
                 .await
                 .unwrap()
-                .as_deref(),
+                .as_ref()
+                .map(|row| row.0.as_str()),
             Some(exchange_code.as_str()),
             "live exchange code must be returned for reuse"
         );
@@ -848,16 +936,22 @@ mod tests {
         let pool = setup_pool().await;
         let repo = OAuthCodeRepository::new(pool.clone());
 
-        let user_pubkey = format!("pk_{}", uuid::Uuid::new_v4());
-        let client_id = format!("client_{}", uuid::Uuid::new_v4());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(24);
+        insert_pending_registration(&repo, &device_code, Some("pinhash"), expires_at).await;
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
 
         // An already-expired exchange code must not be reused.
         let expired_code = format!("exch_{}", uuid::Uuid::new_v4());
         repo.store(StoreOAuthCodeParams {
             tenant_id: 1,
             code: &expired_code,
-            user_pubkey: &user_pubkey,
-            client_id: &client_id,
+            user_pubkey: &pending.user_pubkey,
+            client_id: &pending.client_id,
             redirect_uri: "http://localhost:3000/callback",
             scope: "policy:social",
             code_challenge: None,
@@ -871,7 +965,7 @@ mod tests {
         .unwrap();
 
         assert!(
-            repo.find_live_exchange_code(1, &user_pubkey, &client_id)
+            repo.find_live_exchange_code_with_expiry_for_pending(1, &pending)
                 .await
                 .unwrap()
                 .is_none(),
@@ -879,7 +973,7 @@ mod tests {
         );
 
         sqlx::query("DELETE FROM oauth_codes WHERE user_pubkey = $1")
-            .bind(&user_pubkey)
+            .bind(&pending.user_pubkey)
             .execute(&pool)
             .await
             .unwrap();
@@ -890,16 +984,22 @@ mod tests {
         let pool = setup_pool().await;
         let repo = OAuthCodeRepository::new(pool.clone());
 
-        let user_pubkey = format!("pk_{}", uuid::Uuid::new_v4());
-        let client_id = format!("client_{}", uuid::Uuid::new_v4());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let pending_expires_at = Utc::now() + chrono::Duration::hours(24);
+        insert_pending_registration(&repo, &device_code, Some("pinhash"), pending_expires_at).await;
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
         let exchange_code = format!("exch_{}", uuid::Uuid::new_v4());
         let expires_at = Utc::now() + chrono::Duration::seconds(90);
 
         repo.store(StoreOAuthCodeParams {
             tenant_id: 1,
             code: &exchange_code,
-            user_pubkey: &user_pubkey,
-            client_id: &client_id,
+            user_pubkey: &pending.user_pubkey,
+            client_id: &pending.client_id,
             redirect_uri: "http://localhost:3000/callback",
             scope: "policy:social",
             code_challenge: None,
@@ -913,7 +1013,7 @@ mod tests {
         .unwrap();
 
         let found = repo
-            .find_live_exchange_code_with_expiry(1, &user_pubkey, &client_id)
+            .find_live_exchange_code_with_expiry_for_pending(1, &pending)
             .await
             .unwrap()
             .expect("live exchange code should be returned with expiry");
@@ -922,6 +1022,105 @@ mod tests {
         assert!(
             found.1 <= expires_at && found.1 > Utc::now(),
             "expiry must come from the DB row so Redis TTL can be bounded"
+        );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE user_pubkey = $1")
+            .bind(&pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_find_live_exchange_code_does_not_cross_pending_oauth_semantics() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let user_pubkey = nostr_sdk::Keys::generate().public_key().to_hex();
+        let client_id = format!("client_{}", uuid::Uuid::new_v4());
+        let device_a = format!("dc_a_{}", uuid::Uuid::new_v4());
+        let device_b = format!("dc_b_{}", uuid::Uuid::new_v4());
+        let pending_a_code = format!("pending_a_{}", uuid::Uuid::new_v4());
+        let pending_b_code = format!("pending_b_{}", uuid::Uuid::new_v4());
+        let token_a = format!("token_a_{}", uuid::Uuid::new_v4());
+        let token_b = format!("token_b_{}", uuid::Uuid::new_v4());
+        let email_a = format!("same-user-a-{}@example.com", uuid::Uuid::new_v4());
+        let email_b = format!("same-user-b-{}@example.com", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(24);
+
+        repo.store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
+            tenant_id: 1,
+            code: &pending_a_code,
+            user_pubkey: &user_pubkey,
+            client_id: &client_id,
+            redirect_uri: "http://localhost:3000/callback",
+            scope: "policy:social",
+            code_challenge: Some("challenge-a"),
+            code_challenge_method: Some("S256"),
+            expires_at,
+            pending_email: &email_a,
+            pending_password_hash: "hashed",
+            pending_email_verification_token: &token_a,
+            pending_encrypted_secret: Some(b"secret-a"),
+            state: Some("state-a"),
+            device_code: Some(&device_a),
+            is_headless: true,
+            pin_hash: Some("pin-a"),
+        })
+        .await
+        .unwrap();
+        repo.store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
+            tenant_id: 1,
+            code: &pending_b_code,
+            user_pubkey: &user_pubkey,
+            client_id: &client_id,
+            redirect_uri: "http://localhost:3000/callback",
+            scope: "policy:social",
+            code_challenge: Some("challenge-b"),
+            code_challenge_method: Some("S256"),
+            expires_at,
+            pending_email: &email_b,
+            pending_password_hash: "hashed",
+            pending_email_verification_token: &token_b,
+            pending_encrypted_secret: Some(b"secret-b"),
+            state: Some("state-b"),
+            device_code: Some(&device_b),
+            is_headless: true,
+            pin_hash: Some("pin-b"),
+        })
+        .await
+        .unwrap();
+
+        let exchange_a = format!("exch_a_{}", uuid::Uuid::new_v4());
+        repo.store(StoreOAuthCodeParams {
+            tenant_id: 1,
+            code: &exchange_a,
+            user_pubkey: &user_pubkey,
+            client_id: &client_id,
+            redirect_uri: "http://localhost:3000/callback",
+            scope: "policy:social",
+            code_challenge: Some("challenge-a"),
+            code_challenge_method: Some("S256"),
+            expires_at: Utc::now() + chrono::Duration::minutes(10),
+            previous_auth_id: None,
+            state: Some("state-a"),
+            is_headless: true,
+        })
+        .await
+        .unwrap();
+
+        let pending_b = repo
+            .find_by_device_code(&device_b, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        let found = repo
+            .find_live_exchange_code_with_expiry_for_pending(1, &pending_b)
+            .await
+            .unwrap();
+        assert!(
+            found.is_none(),
+            "second same-user/client pending registration must not receive first registration's exchange code"
         );
 
         sqlx::query("DELETE FROM oauth_codes WHERE user_pubkey = $1")
@@ -946,7 +1145,26 @@ mod tests {
             .unwrap();
         assert!(pending.consumed_at.is_none(), "starts un-consumed");
 
-        repo.mark_pending_consumed(1, &pending.user_pubkey, &pending.client_id)
+        let exchange_code = format!("exch_{}", uuid::Uuid::new_v4());
+        repo.store(StoreOAuthCodeParams {
+            tenant_id: 1,
+            code: &exchange_code,
+            user_pubkey: &pending.user_pubkey,
+            client_id: &pending.client_id,
+            redirect_uri: &pending.redirect_uri,
+            scope: &pending.scope,
+            code_challenge: pending.code_challenge.as_deref(),
+            code_challenge_method: pending.code_challenge_method.as_deref(),
+            expires_at: Utc::now() + chrono::Duration::minutes(10),
+            previous_auth_id: pending.previous_auth_id,
+            state: pending.state.as_deref(),
+            is_headless: pending.is_headless,
+        })
+        .await
+        .unwrap();
+        let auth_code = repo.find_valid(1, &exchange_code).await.unwrap().unwrap();
+
+        repo.redeem_code_and_mark_pending_consumed(1, &exchange_code, &auth_code)
             .await
             .unwrap();
 
@@ -962,6 +1180,116 @@ mod tests {
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_mark_pending_consumed_does_not_cross_pending_oauth_semantics() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let user_pubkey = nostr_sdk::Keys::generate().public_key().to_hex();
+        let client_id = format!("client_{}", uuid::Uuid::new_v4());
+        let device_a = format!("dc_a_{}", uuid::Uuid::new_v4());
+        let device_b = format!("dc_b_{}", uuid::Uuid::new_v4());
+        let pending_a_code = format!("pending_a_{}", uuid::Uuid::new_v4());
+        let pending_b_code = format!("pending_b_{}", uuid::Uuid::new_v4());
+        let token_a = format!("token_a_{}", uuid::Uuid::new_v4());
+        let token_b = format!("token_b_{}", uuid::Uuid::new_v4());
+        let email_a = format!("consume-a-{}@example.com", uuid::Uuid::new_v4());
+        let email_b = format!("consume-b-{}@example.com", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(24);
+
+        repo.store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
+            tenant_id: 1,
+            code: &pending_a_code,
+            user_pubkey: &user_pubkey,
+            client_id: &client_id,
+            redirect_uri: "http://localhost:3000/callback",
+            scope: "policy:social",
+            code_challenge: Some("challenge-a"),
+            code_challenge_method: Some("S256"),
+            expires_at,
+            pending_email: &email_a,
+            pending_password_hash: "hashed",
+            pending_email_verification_token: &token_a,
+            pending_encrypted_secret: Some(b"secret-a"),
+            state: Some("state-a"),
+            device_code: Some(&device_a),
+            is_headless: true,
+            pin_hash: Some("pin-a"),
+        })
+        .await
+        .unwrap();
+        repo.store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
+            tenant_id: 1,
+            code: &pending_b_code,
+            user_pubkey: &user_pubkey,
+            client_id: &client_id,
+            redirect_uri: "http://localhost:3000/callback",
+            scope: "policy:social",
+            code_challenge: Some("challenge-b"),
+            code_challenge_method: Some("S256"),
+            expires_at,
+            pending_email: &email_b,
+            pending_password_hash: "hashed",
+            pending_email_verification_token: &token_b,
+            pending_encrypted_secret: Some(b"secret-b"),
+            state: Some("state-b"),
+            device_code: Some(&device_b),
+            is_headless: true,
+            pin_hash: Some("pin-b"),
+        })
+        .await
+        .unwrap();
+
+        let exchange_a = format!("exch_a_{}", uuid::Uuid::new_v4());
+        repo.store(StoreOAuthCodeParams {
+            tenant_id: 1,
+            code: &exchange_a,
+            user_pubkey: &user_pubkey,
+            client_id: &client_id,
+            redirect_uri: "http://localhost:3000/callback",
+            scope: "policy:social",
+            code_challenge: Some("challenge-a"),
+            code_challenge_method: Some("S256"),
+            expires_at: Utc::now() + chrono::Duration::minutes(10),
+            previous_auth_id: None,
+            state: Some("state-a"),
+            is_headless: true,
+        })
+        .await
+        .unwrap();
+        let auth_code = repo.find_valid(1, &exchange_a).await.unwrap().unwrap();
+
+        repo.redeem_code_and_mark_pending_consumed(1, &exchange_a, &auth_code)
+            .await
+            .unwrap();
+
+        let pending_a = repo
+            .find_by_device_code(&device_a, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        let pending_b = repo
+            .find_by_device_code(&device_b, 1)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            pending_a.consumed_at.is_some(),
+            "the intended pending registration should be consumed"
+        );
+        assert!(
+            pending_b.consumed_at.is_none(),
+            "a different same-user/client pending registration must remain active"
+        );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE user_pubkey = $1")
+            .bind(&user_pubkey)
             .execute(&pool)
             .await
             .unwrap();
@@ -1001,12 +1329,15 @@ mod tests {
             Utc::now() + chrono::Duration::hours(24),
         )
         .await;
-        let consumed = repo
+        let _consumed = repo
             .find_by_device_code(&consumed_dc, 1)
             .await
             .unwrap()
             .unwrap();
-        repo.mark_pending_consumed(1, &consumed.user_pubkey, &consumed.client_id)
+        sqlx::query("UPDATE oauth_codes SET consumed_at = $1 WHERE device_code = $2")
+            .bind(Utc::now())
+            .bind(&consumed_dc)
+            .execute(&pool)
             .await
             .unwrap();
 

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -59,6 +59,8 @@ pub enum PinAttemptReservation {
     /// The registration has spent its lifetime cap across every PIN it has issued. A resend does
     /// not clear this; the emailed link remains the way in.
     LifetimeExhausted,
+    /// The registration's verification window has closed.
+    Expired,
 }
 
 /// Parameters for storing a basic OAuth code
@@ -401,6 +403,23 @@ impl OAuthCodeRepository {
     /// forever, so the only real limit becomes the resend cooldown. `max_lifetime_attempts` closes
     /// that by counting failures across every PIN the registration has issued, and nothing resets
     /// it. Exhausting it disables PIN entry for this registration; the emailed link still works.
+    ///
+    /// # Expiry
+    ///
+    /// The reservation also refuses an expired registration, so this statement is authoritative
+    /// rather than relying on the caller's earlier snapshot. Callers still check expiry up front to
+    /// classify it before paying for bcrypt, but a window that closes between that check and this
+    /// call is caught here instead of letting a comparison run against a dead registration.
+    ///
+    /// # Concurrency
+    ///
+    /// The increment and both caps are one conditional UPDATE, so row locking serializes concurrent
+    /// reservations and neither cap can be exceeded. The follow-up classification is a separate
+    /// read and is deliberately *not* serialized with it: it only chooses which recovery message
+    /// the user sees, and under concurrency it can transiently name a cap that a simultaneous
+    /// refund or resend has just reopened. That is accepted. Making the message choice
+    /// transactional would add contention to the hot path to fix wording, and the caps themselves
+    /// are already exact.
     pub async fn reserve_pin_attempt(
         &self,
         device_code: &str,
@@ -408,18 +427,20 @@ impl OAuthCodeRepository {
         max_attempts: i32,
         max_lifetime_attempts: i32,
     ) -> Result<PinAttemptReservation, RepositoryError> {
+        let now = Utc::now();
         let row: Option<(i32,)> = sqlx::query_as(
             "UPDATE oauth_codes \
              SET pin_attempts = pin_attempts + 1, pin_failed_total = pin_failed_total + 1 \
              WHERE device_code = $1 AND tenant_id = $2 \
                AND pin_attempts < $3 AND pin_failed_total < $4 \
-               AND pending_email IS NOT NULL AND consumed_at IS NULL \
+               AND pending_email IS NOT NULL AND consumed_at IS NULL AND expires_at > $5 \
              RETURNING pin_attempts",
         )
         .bind(device_code)
         .bind(tenant_id)
         .bind(max_attempts)
         .bind(max_lifetime_attempts)
+        .bind(now)
         .fetch_optional(&self.pool)
         .await?;
 
@@ -427,10 +448,10 @@ impl OAuthCodeRepository {
             return Ok(PinAttemptReservation::Reserved { attempt });
         }
 
-        // The reservation failed. Re-read to say which cap did it, so the caller can tell the user
-        // whether a resend helps. Only on the failure path, which already writes an audit record.
-        let state: Option<(i32,)> = sqlx::query_as(
-            "SELECT pin_failed_total FROM oauth_codes \
+        // The reservation failed. Re-read to say why, so the caller can tell the user whether a
+        // resend helps. Only on the failure path, which already writes an audit record.
+        let state: Option<(i32, DateTime<Utc>)> = sqlx::query_as(
+            "SELECT pin_failed_total, expires_at FROM oauth_codes \
              WHERE device_code = $1 AND tenant_id = $2 \
                AND pending_email IS NOT NULL AND consumed_at IS NULL",
         )
@@ -440,7 +461,8 @@ impl OAuthCodeRepository {
         .await?;
 
         match state {
-            Some((failed_total,)) if failed_total >= max_lifetime_attempts => {
+            Some((_, expires_at)) if expires_at <= now => Ok(PinAttemptReservation::Expired),
+            Some((failed_total, _)) if failed_total >= max_lifetime_attempts => {
                 Ok(PinAttemptReservation::LifetimeExhausted)
             }
             // Includes the row vanishing between the two statements: treating that as a per-PIN
@@ -1133,6 +1155,10 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(before.pin_attempts, 2, "attempts accumulated before reset");
+        assert_eq!(
+            before.pin_failed_total, 2,
+            "lifetime counter tracked them too"
+        );
 
         repo.reset_pin_attempts(&device_code, 1).await.unwrap();
 
@@ -1144,6 +1170,13 @@ mod tests {
         assert_eq!(
             after.pin_attempts, 0,
             "successful verify must clear the failed-attempt counter"
+        );
+        // The lifetime counter gives back exactly the one slot the successful attempt reserved. It
+        // must not be zeroed: a correct PIN cannot be allowed to wipe the registration's record of
+        // how much guessing it has already absorbed.
+        assert_eq!(
+            after.pin_failed_total, 1,
+            "successful verify releases only its own reservation from the lifetime counter"
         );
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -221,23 +221,29 @@ impl OAuthCodeRepository {
         Ok(result)
     }
 
-    /// Atomically increment the PIN-attempt counter for a pending registration and return the new
-    /// count. Returns `None` when no pending row matches (unknown/expired `device_code`).
+    /// Atomically reserve one PIN-verification attempt slot for a pending registration, returning
+    /// the new attempt count. Returns `None` when no slot could be reserved — either the row is
+    /// already at `max_attempts` (locked) or no pending row matches the `device_code`.
     ///
-    /// The increment is done in a single `UPDATE ... RETURNING` so concurrent verify-pin requests
-    /// across Cloud Run instances cannot race the cap (an in-memory counter would not be shared state).
-    pub async fn increment_pin_attempts(
+    /// The increment happens in a single conditional `UPDATE ... WHERE pin_attempts < $max
+    /// RETURNING`, so the cap is enforced by the database rather than by a snapshot read. This is
+    /// what bounds brute force: callers reserve a slot BEFORE running the (expensive) bcrypt
+    /// comparison, so at most `max_attempts` comparisons can ever run for a given `device_code`,
+    /// even across concurrent verify-pin requests on different Cloud Run instances.
+    pub async fn reserve_pin_attempt(
         &self,
         device_code: &str,
         tenant_id: i64,
+        max_attempts: i32,
     ) -> Result<Option<i32>, RepositoryError> {
         let row: Option<(i32,)> = sqlx::query_as(
             "UPDATE oauth_codes SET pin_attempts = pin_attempts + 1 \
-             WHERE device_code = $1 AND tenant_id = $2 \
+             WHERE device_code = $1 AND tenant_id = $2 AND pin_attempts < $3 \
              RETURNING pin_attempts",
         )
         .bind(device_code)
         .bind(tenant_id)
+        .bind(max_attempts)
         .fetch_optional(&self.pool)
         .await?;
 
@@ -463,7 +469,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_increment_pin_attempts_accumulates_and_returns() {
+    async fn test_reserve_pin_attempt_accumulates_and_enforces_cap() {
         let pool = setup_pool().await;
         let repo = OAuthCodeRepository::new(pool.clone());
 
@@ -471,13 +477,42 @@ mod tests {
         let expires_at = Utc::now() + chrono::Duration::hours(24);
         insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
 
-        let first = repo.increment_pin_attempts(&device_code, 1).await.unwrap();
+        // Reserve up to the cap; each call returns the post-increment count.
+        let max = 3;
+        let first = repo
+            .reserve_pin_attempt(&device_code, 1, max)
+            .await
+            .unwrap();
         assert_eq!(first, Some(1));
-        let second = repo.increment_pin_attempts(&device_code, 1).await.unwrap();
+        let second = repo
+            .reserve_pin_attempt(&device_code, 1, max)
+            .await
+            .unwrap();
         assert_eq!(second, Some(2));
+        let third = repo
+            .reserve_pin_attempt(&device_code, 1, max)
+            .await
+            .unwrap();
+        assert_eq!(third, Some(3));
+
+        // At the cap: no slot can be reserved (atomic lockout), and the counter does not grow.
+        let locked = repo
+            .reserve_pin_attempt(&device_code, 1, max)
+            .await
+            .unwrap();
+        assert_eq!(locked, None, "reserve must return None once at the cap");
+        let after = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.pin_attempts, max, "counter must not exceed the cap");
 
         // Unknown device_code returns None (no row updated).
-        let none = repo.increment_pin_attempts("nonexistent", 1).await.unwrap();
+        let none = repo
+            .reserve_pin_attempt("nonexistent", 1, max)
+            .await
+            .unwrap();
         assert_eq!(none, None);
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
@@ -497,8 +532,8 @@ mod tests {
         insert_pending_registration(&repo, &device_code, Some("oldpin"), expires_at).await;
 
         // Burn two attempts.
-        repo.increment_pin_attempts(&device_code, 1).await.unwrap();
-        repo.increment_pin_attempts(&device_code, 1).await.unwrap();
+        repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
+        repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
 
         let new_token = format!("verif_{}", uuid::Uuid::new_v4());
         let new_expires = Utc::now() + chrono::Duration::hours(24);

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -124,17 +124,48 @@ pub struct StoredExchangeCode {
     pub freshly_minted: bool,
 }
 
+/// Pending registration and exchange code committed by one finalization transaction.
+#[derive(Debug)]
+pub struct FinalizedPendingRegistration {
+    pub pending: OAuthCodeData,
+    pub exchange_code: StoredExchangeCode,
+}
+
 /// Result of materializing one exact pending registration generation.
 #[derive(Debug)]
 pub enum MaterializePendingRegistrationOutcome {
-    /// The exact generation was locked and its user state is ready for code minting.
-    Materialized(Box<OAuthCodeData>),
+    /// User/key materialization and exchange-code selection committed together.
+    Ready(Box<FinalizedPendingRegistration>),
+    /// A live exchange code is currently claimed by token issuance.
+    Processing,
     /// The generation was superseded, consumed, expired, or removed before it could be locked.
     NotFound,
     /// The pending pubkey is already bound to another email.
     DuplicateKey,
     /// Another pubkey already owns the pending email.
     EmailAlreadyExists,
+}
+
+enum UserMaterializationOutcome {
+    Materialized(Box<OAuthCodeData>),
+    DuplicateKey,
+    EmailAlreadyExists,
+}
+
+enum ExchangeSelection {
+    Ready(StoredExchangeCode),
+    Processing,
+}
+
+/// Result of releasing a PIN-attempt reservation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinAttemptRelease {
+    /// The reservation still belonged to the current generation.
+    CurrentGeneration,
+    /// A newer generation replaced it; only the lineage lifetime counter was compensated.
+    GenerationChanged,
+    /// No live pending lineage remained to compensate.
+    Missing,
 }
 
 /// The PIN-resend fields of a pending registration as they stood before a resend attempt.
@@ -232,166 +263,6 @@ impl OAuthCodeRepository {
         .await?;
 
         Ok(result.rows_affected() == 1)
-    }
-
-    /// Reuse or insert an exchange code while locking one exact pending generation.
-    ///
-    /// The pending row, live-code lookup, and conditional insert share one transaction so
-    /// concurrent finalizers cannot mint separate codes. Returns `None` if the exact generation is
-    /// missing, consumed, or expired.
-    pub async fn get_or_store_exchange_code_for_pending(
-        &self,
-        params: StoreOAuthCodeParams<'_>,
-        pending: &OAuthCodeData,
-    ) -> Result<Option<StoredExchangeCode>, RepositoryError> {
-        let mut tx = self.pool.begin().await?;
-        let locked: Option<(i32,)> = sqlx::query_as(
-            "SELECT 1 FROM oauth_codes pending_row
-             WHERE pending_row.tenant_id = $1
-               AND pending_row.user_pubkey = $2
-               AND pending_row.client_id = $3
-               AND pending_row.redirect_uri = $4
-               AND pending_row.scope = $5
-               AND pending_row.code_challenge IS NOT DISTINCT FROM $6
-               AND pending_row.code_challenge_method IS NOT DISTINCT FROM $7
-               AND pending_row.state IS NOT DISTINCT FROM $8
-               AND pending_row.is_headless = $9
-               AND pending_row.pending_email IS NOT NULL
-               AND pending_row.pending_email_verification_token IS NOT DISTINCT FROM $10
-               AND pending_row.device_code IS NOT DISTINCT FROM $11
-               AND pending_row.consumed_at IS NULL
-               AND pending_row.expires_at > clock_timestamp()
-             FOR UPDATE",
-        )
-        .bind(params.tenant_id)
-        .bind(&pending.user_pubkey)
-        .bind(&pending.client_id)
-        .bind(&pending.redirect_uri)
-        .bind(&pending.scope)
-        .bind(pending.code_challenge.as_deref())
-        .bind(pending.code_challenge_method.as_deref())
-        .bind(pending.state.as_deref())
-        .bind(pending.is_headless)
-        .bind(pending.pending_email_verification_token.as_deref())
-        .bind(pending.device_code.as_deref())
-        .fetch_optional(&mut *tx)
-        .await?;
-        if locked.is_none() {
-            tx.rollback().await?;
-            return Ok(None);
-        }
-
-        // `FOR UPDATE` can wait after selecting its snapshot. Recheck with the database wall clock
-        // after the lock is owned so a generation that expires during that wait cannot mint.
-        let still_live: bool = sqlx::query_scalar(
-            "SELECT EXISTS(
-                SELECT 1 FROM oauth_codes pending_row
-                WHERE pending_row.tenant_id = $1
-                  AND pending_row.user_pubkey = $2
-                  AND pending_row.client_id = $3
-                  AND pending_row.redirect_uri = $4
-                  AND pending_row.scope = $5
-                  AND pending_row.code_challenge IS NOT DISTINCT FROM $6
-                  AND pending_row.code_challenge_method IS NOT DISTINCT FROM $7
-                  AND pending_row.state IS NOT DISTINCT FROM $8
-                  AND pending_row.is_headless = $9
-                  AND pending_row.pending_email IS NOT NULL
-                  AND pending_row.pending_email_verification_token IS NOT DISTINCT FROM $10
-                  AND pending_row.device_code IS NOT DISTINCT FROM $11
-                  AND pending_row.consumed_at IS NULL
-                  AND pending_row.expires_at > clock_timestamp()
-            )",
-        )
-        .bind(params.tenant_id)
-        .bind(&pending.user_pubkey)
-        .bind(&pending.client_id)
-        .bind(&pending.redirect_uri)
-        .bind(&pending.scope)
-        .bind(pending.code_challenge.as_deref())
-        .bind(pending.code_challenge_method.as_deref())
-        .bind(pending.state.as_deref())
-        .bind(pending.is_headless)
-        .bind(pending.pending_email_verification_token.as_deref())
-        .bind(pending.device_code.as_deref())
-        .fetch_one(&mut *tx)
-        .await?;
-        if !still_live {
-            tx.rollback().await?;
-            return Ok(None);
-        }
-
-        let existing: Option<(String, DateTime<Utc>)> = sqlx::query_as(
-            "SELECT exchange.code, exchange.expires_at FROM oauth_codes exchange
-             WHERE exchange.tenant_id = $1
-               AND exchange.user_pubkey = $2
-               AND exchange.client_id = $3
-               AND exchange.redirect_uri = $4
-               AND exchange.scope = $5
-               AND exchange.code_challenge IS NOT DISTINCT FROM $6
-               AND exchange.code_challenge_method IS NOT DISTINCT FROM $7
-               AND exchange.state IS NOT DISTINCT FROM $8
-               AND exchange.is_headless = $9
-               AND exchange.pending_email_verification_token IS NOT DISTINCT FROM $10
-               AND exchange.device_code IS NOT DISTINCT FROM $11
-               AND exchange.pending_email IS NULL
-               AND exchange.consumed_at IS NULL
-               AND exchange.expires_at > clock_timestamp()
-             ORDER BY exchange.created_at DESC
-             LIMIT 1",
-        )
-        .bind(params.tenant_id)
-        .bind(&pending.user_pubkey)
-        .bind(&pending.client_id)
-        .bind(&pending.redirect_uri)
-        .bind(&pending.scope)
-        .bind(pending.code_challenge.as_deref())
-        .bind(pending.code_challenge_method.as_deref())
-        .bind(pending.state.as_deref())
-        .bind(pending.is_headless)
-        .bind(pending.pending_email_verification_token.as_deref())
-        .bind(pending.device_code.as_deref())
-        .fetch_optional(&mut *tx)
-        .await?;
-        if let Some((code, expires_at)) = existing {
-            tx.commit().await?;
-            return Ok(Some(StoredExchangeCode {
-                code,
-                expires_at,
-                freshly_minted: false,
-            }));
-        }
-
-        sqlx::query(
-            "INSERT INTO oauth_codes
-                 (tenant_id, code, user_pubkey, client_id, redirect_uri, scope,
-                  code_challenge, code_challenge_method, expires_at, previous_auth_id, state,
-                  is_headless, created_at, pending_email_verification_token, device_code)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
-        )
-        .bind(params.tenant_id)
-        .bind(params.code)
-        .bind(params.user_pubkey)
-        .bind(params.client_id)
-        .bind(params.redirect_uri)
-        .bind(params.scope)
-        .bind(params.code_challenge)
-        .bind(params.code_challenge_method)
-        .bind(params.expires_at)
-        .bind(params.previous_auth_id)
-        .bind(params.state)
-        .bind(params.is_headless)
-        .bind(Utc::now())
-        .bind(pending.pending_email_verification_token.as_deref())
-        .bind(pending.device_code.as_deref())
-        .execute(&mut *tx)
-        .await?;
-
-        tx.commit().await?;
-        Ok(Some(StoredExchangeCode {
-            code: params.code.to_string(),
-            expires_at: params.expires_at,
-            freshly_minted: true,
-        }))
     }
 
     /// Store OAuth code with pending registration data (deferred user creation).
@@ -531,6 +402,7 @@ impl OAuthCodeRepository {
         &self,
         tenant_id: i64,
         verification_token: &str,
+        candidate_code: &str,
     ) -> Result<MaterializePendingRegistrationOutcome, RepositoryError> {
         let mut tx = self.pool.begin().await?;
         let query = format!(
@@ -575,7 +447,7 @@ impl OAuthCodeRepository {
             match existing_email.as_deref() {
                 Some(bound_email) if bound_email != email => {
                     Self::delete_pending_generation(&mut tx, tenant_id, verification_token).await?;
-                    MaterializePendingRegistrationOutcome::DuplicateKey
+                    UserMaterializationOutcome::DuplicateKey
                 }
                 _ => {
                     let email_owner: Option<(String,)> = sqlx::query_as(
@@ -591,7 +463,7 @@ impl OAuthCodeRepository {
                     if email_owner.is_some() {
                         Self::delete_pending_generation(&mut tx, tenant_id, verification_token)
                             .await?;
-                        MaterializePendingRegistrationOutcome::EmailAlreadyExists
+                        UserMaterializationOutcome::EmailAlreadyExists
                     } else {
                         if existing_email.is_none() || !email_verified || !has_password_hash {
                             sqlx::query(
@@ -612,7 +484,7 @@ impl OAuthCodeRepository {
                         }
                         Self::insert_pending_personal_key(&mut tx, tenant_id, &pending, now)
                             .await?;
-                        MaterializePendingRegistrationOutcome::Materialized(Box::new(pending))
+                        UserMaterializationOutcome::Materialized(Box::new(pending))
                     }
                 }
             }
@@ -636,7 +508,7 @@ impl OAuthCodeRepository {
 
             if inserted.is_some() {
                 Self::insert_pending_personal_key(&mut tx, tenant_id, &pending, now).await?;
-                MaterializePendingRegistrationOutcome::Materialized(Box::new(pending))
+                UserMaterializationOutcome::Materialized(Box::new(pending))
             } else {
                 let pubkey_state: Option<(Option<String>, bool, bool)> = sqlx::query_as(
                     "SELECT email, email_verified,
@@ -651,7 +523,7 @@ impl OAuthCodeRepository {
                     Some((Some(bound_email), _, _)) if bound_email != email => {
                         Self::delete_pending_generation(&mut tx, tenant_id, verification_token)
                             .await?;
-                        MaterializePendingRegistrationOutcome::DuplicateKey
+                        UserMaterializationOutcome::DuplicateKey
                     }
                     Some((existing_email, email_verified, has_password_hash)) => {
                         let email_owner: Option<(String,)> = sqlx::query_as(
@@ -667,7 +539,7 @@ impl OAuthCodeRepository {
                         if email_owner.is_some() {
                             Self::delete_pending_generation(&mut tx, tenant_id, verification_token)
                                 .await?;
-                            MaterializePendingRegistrationOutcome::EmailAlreadyExists
+                            UserMaterializationOutcome::EmailAlreadyExists
                         } else {
                             if existing_email.is_none() || !email_verified || !has_password_hash {
                                 sqlx::query(
@@ -688,42 +560,134 @@ impl OAuthCodeRepository {
                             }
                             Self::insert_pending_personal_key(&mut tx, tenant_id, &pending, now)
                                 .await?;
-                            MaterializePendingRegistrationOutcome::Materialized(Box::new(pending))
+                            UserMaterializationOutcome::Materialized(Box::new(pending))
                         }
                     }
                     None => {
                         Self::delete_pending_generation(&mut tx, tenant_id, verification_token)
                             .await?;
-                        MaterializePendingRegistrationOutcome::EmailAlreadyExists
+                        UserMaterializationOutcome::EmailAlreadyExists
                     }
                 }
             }
         };
 
-        if matches!(
-            &outcome,
-            MaterializePendingRegistrationOutcome::Materialized(_)
-        ) {
-            let still_live: bool = sqlx::query_scalar(
-                "SELECT EXISTS(
-                    SELECT 1 FROM oauth_codes
-                    WHERE tenant_id = $1 AND pending_email_verification_token = $2
-                      AND pending_email IS NOT NULL AND consumed_at IS NULL
-                      AND expires_at > clock_timestamp()
-                )",
-            )
-            .bind(tenant_id)
-            .bind(verification_token)
-            .fetch_one(&mut *tx)
-            .await?;
-            if !still_live {
-                tx.rollback().await?;
-                return Ok(MaterializePendingRegistrationOutcome::NotFound);
+        let pending = match outcome {
+            UserMaterializationOutcome::DuplicateKey => {
+                tx.commit().await?;
+                return Ok(MaterializePendingRegistrationOutcome::DuplicateKey);
             }
+            UserMaterializationOutcome::EmailAlreadyExists => {
+                tx.commit().await?;
+                return Ok(MaterializePendingRegistrationOutcome::EmailAlreadyExists);
+            }
+            UserMaterializationOutcome::Materialized(pending) => pending,
+        };
+
+        let existing: Option<(String, DateTime<Utc>, Option<DateTime<Utc>>)> = sqlx::query_as(
+            "SELECT exchange.code, exchange.expires_at, exchange.consumed_at
+             FROM oauth_codes exchange
+             WHERE exchange.tenant_id = $1
+               AND exchange.user_pubkey = $2
+               AND exchange.client_id = $3
+               AND exchange.redirect_uri = $4
+               AND exchange.scope = $5
+               AND exchange.code_challenge IS NOT DISTINCT FROM $6
+               AND exchange.code_challenge_method IS NOT DISTINCT FROM $7
+               AND exchange.state IS NOT DISTINCT FROM $8
+               AND exchange.is_headless = $9
+               AND exchange.pending_email_verification_token IS NOT DISTINCT FROM $10
+               AND exchange.device_code IS NOT DISTINCT FROM $11
+               AND exchange.pending_email IS NULL
+               AND exchange.expires_at > clock_timestamp()
+             ORDER BY (exchange.consumed_at IS NOT NULL) DESC, exchange.created_at DESC
+             LIMIT 1",
+        )
+        .bind(tenant_id)
+        .bind(&pending.user_pubkey)
+        .bind(&pending.client_id)
+        .bind(&pending.redirect_uri)
+        .bind(&pending.scope)
+        .bind(pending.code_challenge.as_deref())
+        .bind(pending.code_challenge_method.as_deref())
+        .bind(pending.state.as_deref())
+        .bind(pending.is_headless)
+        .bind(pending.pending_email_verification_token.as_deref())
+        .bind(pending.device_code.as_deref())
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let selection = match existing {
+            Some((_, _, Some(_))) => ExchangeSelection::Processing,
+            Some((code, expires_at, None)) => ExchangeSelection::Ready(StoredExchangeCode {
+                code,
+                expires_at,
+                freshly_minted: false,
+            }),
+            None => {
+                let expires_at: DateTime<Utc> = sqlx::query_scalar(
+                    "INSERT INTO oauth_codes
+                         (tenant_id, code, user_pubkey, client_id, redirect_uri, scope,
+                          code_challenge, code_challenge_method, expires_at, previous_auth_id, state,
+                          is_headless, created_at, pending_email_verification_token, device_code)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8,
+                             clock_timestamp() + INTERVAL '10 minutes', $9, $10, $11,
+                             clock_timestamp(), $12, $13)
+                     RETURNING expires_at",
+                )
+                .bind(tenant_id)
+                .bind(candidate_code)
+                .bind(&pending.user_pubkey)
+                .bind(&pending.client_id)
+                .bind(&pending.redirect_uri)
+                .bind(&pending.scope)
+                .bind(pending.code_challenge.as_deref())
+                .bind(pending.code_challenge_method.as_deref())
+                .bind(pending.previous_auth_id)
+                .bind(pending.state.as_deref())
+                .bind(pending.is_headless)
+                .bind(pending.pending_email_verification_token.as_deref())
+                .bind(pending.device_code.as_deref())
+                .fetch_one(&mut *tx)
+                .await?;
+                ExchangeSelection::Ready(StoredExchangeCode {
+                    code: candidate_code.to_string(),
+                    expires_at,
+                    freshly_minted: true,
+                })
+            }
+        };
+
+        let still_live: bool = sqlx::query_scalar(
+            "SELECT EXISTS(
+                SELECT 1 FROM oauth_codes
+                WHERE tenant_id = $1 AND pending_email_verification_token = $2
+                  AND pending_email IS NOT NULL AND consumed_at IS NULL
+                  AND expires_at > clock_timestamp()
+            )",
+        )
+        .bind(tenant_id)
+        .bind(verification_token)
+        .fetch_one(&mut *tx)
+        .await?;
+        if !still_live {
+            tx.rollback().await?;
+            return Ok(MaterializePendingRegistrationOutcome::NotFound);
         }
 
+        let result = match selection {
+            ExchangeSelection::Ready(exchange_code) => {
+                MaterializePendingRegistrationOutcome::Ready(Box::new(
+                    FinalizedPendingRegistration {
+                        pending: *pending,
+                        exchange_code,
+                    },
+                ))
+            }
+            ExchangeSelection::Processing => MaterializePendingRegistrationOutcome::Processing,
+        };
         tx.commit().await?;
-        Ok(outcome)
+        Ok(result)
     }
 
     async fn insert_pending_personal_key(
@@ -971,8 +935,9 @@ impl OAuthCodeRepository {
         device_code: &str,
         tenant_id: i64,
         expected_generation_token: &str,
-    ) -> Result<(), RepositoryError> {
-        sqlx::query(
+    ) -> Result<PinAttemptRelease, RepositoryError> {
+        let mut tx = self.pool.begin().await?;
+        let current = sqlx::query(
             "UPDATE oauth_codes \
              SET pin_attempts = GREATEST(pin_attempts - 1, 0), \
                  pin_failed_total = GREATEST(pin_failed_total - 1, 0) \
@@ -983,9 +948,28 @@ impl OAuthCodeRepository {
         .bind(device_code)
         .bind(tenant_id)
         .bind(expected_generation_token)
-        .execute(&self.pool)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+            == 1;
+        if current {
+            tx.commit().await?;
+            return Ok(PinAttemptRelease::CurrentGeneration);
+        }
+
+        let changed = Self::compensate_changed_pin_generation(
+            &mut tx,
+            device_code,
+            tenant_id,
+            expected_generation_token,
+        )
         .await?;
-        Ok(())
+        tx.commit().await?;
+        Ok(if changed {
+            PinAttemptRelease::GenerationChanged
+        } else {
+            PinAttemptRelease::Missing
+        })
     }
 
     /// Re-arm a pending registration for PIN resend: install a fresh verification token + PIN hash,
@@ -1040,10 +1024,17 @@ impl OAuthCodeRepository {
              SET pending_email_verification_token = $1, pin_hash = $2, pin_attempts = 0, \
                  pin_sent_at = NULL, pin_resend_at = $3 \
               WHERE device_code = $4 AND tenant_id = $5 \
-                 AND pending_email_verification_token = $6 \
-                 AND pending_email IS NOT NULL AND consumed_at IS NULL \
-                 AND expires_at > $3 \
-                 AND (pin_resend_at IS NULL OR pin_resend_at <= $7)",
+                  AND pending_email_verification_token = $6 \
+                  AND pending_email IS NOT NULL AND consumed_at IS NULL \
+                  AND expires_at > $3 \
+                  AND NOT EXISTS ( \
+                      SELECT 1 FROM oauth_codes exchange \
+                      WHERE exchange.tenant_id = $5 AND exchange.device_code = $4 \
+                        AND exchange.pending_email IS NULL \
+                        AND exchange.consumed_at IS NOT NULL \
+                        AND exchange.expires_at > $3 \
+                  ) \
+                  AND (pin_resend_at IS NULL OR pin_resend_at <= $7)",
         )
         .bind(new_verification_token)
         .bind(new_pin_hash)
@@ -1065,7 +1056,8 @@ impl OAuthCodeRepository {
         // Keep sibling exchange-code rows correlated with the pending row's new token.
         sqlx::query(
             "UPDATE oauth_codes SET pending_email_verification_token = $1 \
-             WHERE device_code = $2 AND tenant_id = $3 AND pending_email IS NULL",
+             WHERE device_code = $2 AND tenant_id = $3 \
+               AND pending_email IS NULL AND consumed_at IS NULL",
         )
         .bind(new_verification_token)
         .bind(device_code)
@@ -1178,8 +1170,9 @@ impl OAuthCodeRepository {
         device_code: &str,
         tenant_id: i64,
         expected_generation_token: &str,
-    ) -> Result<(), RepositoryError> {
-        sqlx::query(
+    ) -> Result<PinAttemptRelease, RepositoryError> {
+        let mut tx = self.pool.begin().await?;
+        let current = sqlx::query(
             "UPDATE oauth_codes \
               SET pin_attempts = 0, pin_failed_total = GREATEST(pin_failed_total - 1, 0) \
               WHERE device_code = $1 AND tenant_id = $2 \
@@ -1189,9 +1182,51 @@ impl OAuthCodeRepository {
         .bind(device_code)
         .bind(tenant_id)
         .bind(expected_generation_token)
-        .execute(&self.pool)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+            == 1;
+        if current {
+            tx.commit().await?;
+            return Ok(PinAttemptRelease::CurrentGeneration);
+        }
+
+        let changed = Self::compensate_changed_pin_generation(
+            &mut tx,
+            device_code,
+            tenant_id,
+            expected_generation_token,
+        )
         .await?;
-        Ok(())
+        tx.commit().await?;
+        Ok(if changed {
+            PinAttemptRelease::GenerationChanged
+        } else {
+            PinAttemptRelease::Missing
+        })
+    }
+
+    async fn compensate_changed_pin_generation(
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        device_code: &str,
+        tenant_id: i64,
+        expected_generation_token: &str,
+    ) -> Result<bool, RepositoryError> {
+        let compensated = sqlx::query(
+            "UPDATE oauth_codes
+             SET pin_failed_total = GREATEST(pin_failed_total - 1, 0)
+             WHERE device_code = $1 AND tenant_id = $2
+               AND pending_email_verification_token IS DISTINCT FROM $3
+               AND pending_email IS NOT NULL AND consumed_at IS NULL",
+        )
+        .bind(device_code)
+        .bind(tenant_id)
+        .bind(expected_generation_token)
+        .execute(&mut **tx)
+        .await?
+        .rows_affected()
+            == 1;
+        Ok(compensated)
     }
 
     /// Find a still-live exchange code matching the same pending registration semantics.
@@ -1254,12 +1289,7 @@ impl OAuthCodeRepository {
         Ok(row)
     }
 
-    /// Redeem an exchange code while its matching pending registration is still active.
-    ///
-    /// This deliberately does not mark the pending row consumed. Token issuance performs several
-    /// fallible operations after code redemption, so the caller must mark the pending row only
-    /// after issuance succeeds. If issuance fails, the one-shot exchange code stays redeemed, but
-    /// the pending registration remains active and can mint a replacement code.
+    /// Claim an exchange code while locking its exact pending generation.
     pub async fn redeem_code(
         &self,
         tenant_id: i64,
@@ -1267,16 +1297,6 @@ impl OAuthCodeRepository {
         auth_code: &OAuthCodeData,
     ) -> Result<bool, RepositoryError> {
         let mut tx = self.pool.begin().await?;
-        let deleted = sqlx::query("DELETE FROM oauth_codes WHERE tenant_id = $1 AND code = $2")
-            .bind(tenant_id)
-            .bind(code)
-            .execute(&mut *tx)
-            .await?;
-
-        if deleted.rows_affected() != 1 {
-            tx.rollback().await?;
-            return Ok(false);
-        }
 
         if auth_code.pending_email_verification_token.is_some() {
             let pending_exists: Option<(i32,)> = sqlx::query_as(
@@ -1291,9 +1311,11 @@ impl OAuthCodeRepository {
                    AND state IS NOT DISTINCT FROM $8
                    AND is_headless = $9
                    AND pending_email IS NOT NULL
-                   AND pending_email_verification_token IS NOT DISTINCT FROM $10
-                   AND device_code IS NOT DISTINCT FROM $11
-                   AND consumed_at IS NULL",
+                    AND pending_email_verification_token IS NOT DISTINCT FROM $10
+                    AND device_code IS NOT DISTINCT FROM $11
+                    AND consumed_at IS NULL
+                    AND expires_at > clock_timestamp()
+                  FOR UPDATE",
             )
             .bind(tenant_id)
             .bind(&auth_code.user_pubkey)
@@ -1315,8 +1337,109 @@ impl OAuthCodeRepository {
             }
         }
 
+        let claimed = sqlx::query(
+            "UPDATE oauth_codes
+             SET consumed_at = clock_timestamp()
+             WHERE tenant_id = $1 AND code = $2
+               AND user_pubkey = $3 AND client_id = $4 AND redirect_uri = $5 AND scope = $6
+               AND code_challenge IS NOT DISTINCT FROM $7
+               AND code_challenge_method IS NOT DISTINCT FROM $8
+               AND state IS NOT DISTINCT FROM $9 AND is_headless = $10
+               AND pending_email_verification_token IS NOT DISTINCT FROM $11
+               AND device_code IS NOT DISTINCT FROM $12
+               AND pending_email IS NULL AND consumed_at IS NULL
+               AND expires_at > clock_timestamp()",
+        )
+        .bind(tenant_id)
+        .bind(code)
+        .bind(&auth_code.user_pubkey)
+        .bind(&auth_code.client_id)
+        .bind(&auth_code.redirect_uri)
+        .bind(&auth_code.scope)
+        .bind(auth_code.code_challenge.as_deref())
+        .bind(auth_code.code_challenge_method.as_deref())
+        .bind(auth_code.state.as_deref())
+        .bind(auth_code.is_headless)
+        .bind(auth_code.pending_email_verification_token.as_deref())
+        .bind(auth_code.device_code.as_deref())
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+            == 1;
+
+        if !claimed {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
         tx.commit().await?;
         Ok(true)
+    }
+
+    /// Release a failed token-issuance claim so the same code can retry.
+    pub async fn release_redeemed_code(
+        &self,
+        tenant_id: i64,
+        code: &str,
+        auth_code: &OAuthCodeData,
+    ) -> Result<bool, RepositoryError> {
+        let mut tx = self.pool.begin().await?;
+        if auth_code.pending_email_verification_token.is_some() {
+            let locked: Option<(i32,)> = sqlx::query_as(
+                "SELECT 1 FROM oauth_codes
+                 WHERE tenant_id = $1 AND user_pubkey = $2 AND client_id = $3
+                   AND redirect_uri = $4 AND scope = $5
+                   AND code_challenge IS NOT DISTINCT FROM $6
+                   AND code_challenge_method IS NOT DISTINCT FROM $7
+                   AND state IS NOT DISTINCT FROM $8 AND is_headless = $9
+                   AND pending_email IS NOT NULL
+                   AND pending_email_verification_token IS NOT DISTINCT FROM $10
+                   AND device_code IS NOT DISTINCT FROM $11
+                   AND consumed_at IS NULL AND expires_at > clock_timestamp()
+                 FOR UPDATE",
+            )
+            .bind(tenant_id)
+            .bind(&auth_code.user_pubkey)
+            .bind(&auth_code.client_id)
+            .bind(&auth_code.redirect_uri)
+            .bind(&auth_code.scope)
+            .bind(auth_code.code_challenge.as_deref())
+            .bind(auth_code.code_challenge_method.as_deref())
+            .bind(auth_code.state.as_deref())
+            .bind(auth_code.is_headless)
+            .bind(auth_code.pending_email_verification_token.as_deref())
+            .bind(auth_code.device_code.as_deref())
+            .fetch_optional(&mut *tx)
+            .await?;
+            if locked.is_none() {
+                tx.rollback().await?;
+                return Ok(false);
+            }
+        }
+
+        let released = sqlx::query(
+            "UPDATE oauth_codes SET consumed_at = NULL
+             WHERE tenant_id = $1 AND code = $2
+               AND user_pubkey = $3 AND client_id = $4 AND redirect_uri = $5 AND scope = $6
+               AND pending_email_verification_token IS NOT DISTINCT FROM $7
+               AND device_code IS NOT DISTINCT FROM $8
+               AND pending_email IS NULL AND consumed_at IS NOT NULL
+               AND expires_at > clock_timestamp()",
+        )
+        .bind(tenant_id)
+        .bind(code)
+        .bind(&auth_code.user_pubkey)
+        .bind(&auth_code.client_id)
+        .bind(&auth_code.redirect_uri)
+        .bind(&auth_code.scope)
+        .bind(auth_code.pending_email_verification_token.as_deref())
+        .bind(auth_code.device_code.as_deref())
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+            == 1;
+        tx.commit().await?;
+        Ok(released)
     }
 
     /// Mark the pending registration associated with a successfully issued exchange code as
@@ -1324,6 +1447,7 @@ impl OAuthCodeRepository {
     pub async fn mark_pending_consumed(
         &self,
         tenant_id: i64,
+        code: &str,
         auth_code: &OAuthCodeData,
     ) -> Result<bool, RepositoryError> {
         if auth_code.pending_email_verification_token.is_none() {
@@ -1342,9 +1466,18 @@ impl OAuthCodeRepository {
                AND state IS NOT DISTINCT FROM $9
                AND is_headless = $10
                AND pending_email IS NOT NULL
-               AND pending_email_verification_token IS NOT DISTINCT FROM $11
-               AND device_code IS NOT DISTINCT FROM $12
-               AND consumed_at IS NULL",
+                AND pending_email_verification_token IS NOT DISTINCT FROM $11
+                AND device_code IS NOT DISTINCT FROM $12
+                AND consumed_at IS NULL
+                AND EXISTS (
+                    SELECT 1 FROM oauth_codes exchange
+                    WHERE exchange.tenant_id = $2 AND exchange.code = $13
+                      AND exchange.pending_email IS NULL
+                      AND exchange.pending_email_verification_token IS NOT DISTINCT FROM $11
+                      AND exchange.device_code IS NOT DISTINCT FROM $12
+                      AND exchange.consumed_at IS NOT NULL
+                      AND exchange.expires_at > clock_timestamp()
+                )",
         )
         .bind(Utc::now())
         .bind(tenant_id)
@@ -1358,6 +1491,7 @@ impl OAuthCodeRepository {
         .bind(auth_code.is_headless)
         .bind(auth_code.pending_email_verification_token.as_deref())
         .bind(auth_code.device_code.as_deref())
+        .bind(code)
         .execute(&self.pool)
         .await?;
 
@@ -1368,11 +1502,14 @@ impl OAuthCodeRepository {
     /// once their exchange code successfully issued tokens). Bounds table growth and enforces the pending row's
     /// finite lifecycle (keycast#262). Returns the number of rows removed.
     pub async fn delete_expired_and_consumed(&self) -> Result<u64, RepositoryError> {
-        let result =
-            sqlx::query("DELETE FROM oauth_codes WHERE expires_at < $1 OR consumed_at IS NOT NULL")
-                .bind(Utc::now())
-                .execute(&self.pool)
-                .await?;
+        let result = sqlx::query(
+            "DELETE FROM oauth_codes
+             WHERE expires_at < $1
+                OR (pending_email IS NOT NULL AND consumed_at IS NOT NULL)",
+        )
+        .bind(Utc::now())
+        .execute(&self.pool)
+        .await?;
         Ok(result.rows_affected())
     }
 
@@ -1518,6 +1655,28 @@ mod tests {
         (token, email)
     }
 
+    async fn insert_and_finalize_registration(
+        repo: &OAuthCodeRepository,
+        device_code: &str,
+    ) -> FinalizedPendingRegistration {
+        let (token, _) = insert_pending_registration(
+            repo,
+            device_code,
+            Some("pin"),
+            Utc::now() + chrono::Duration::hours(1),
+        )
+        .await;
+        let candidate = format!("exchange_{}", uuid::Uuid::new_v4());
+        let outcome = repo
+            .materialize_pending_registration(1, &token, &candidate)
+            .await
+            .unwrap();
+        let MaterializePendingRegistrationOutcome::Ready(finalized) = outcome else {
+            panic!("test registration must finalize");
+        };
+        *finalized
+    }
+
     #[tokio::test]
     async fn test_find_by_device_code_returns_pending_with_pin() {
         let pool = setup_pool().await;
@@ -1614,9 +1773,10 @@ mod tests {
 
         let materialize_repo = repo.clone();
         let materialize_token = token.clone();
+        let candidate = format!("exchange_{}", uuid::Uuid::new_v4());
         let materializer = tokio::spawn(async move {
             materialize_repo
-                .materialize_pending_registration(1, &materialize_token)
+                .materialize_pending_registration(1, &materialize_token, &candidate)
                 .await
         });
 
@@ -1682,7 +1842,7 @@ mod tests {
         blocker.commit().await.unwrap();
         assert!(matches!(
             materializer.await.unwrap().unwrap(),
-            MaterializePendingRegistrationOutcome::Materialized(_)
+            MaterializePendingRegistrationOutcome::Ready(_)
         ));
 
         let supersession_result = supersession.await.unwrap();
@@ -1745,9 +1905,10 @@ mod tests {
             .unwrap();
 
         let materialize_repo = repo.clone();
+        let candidate = format!("exchange_{}", uuid::Uuid::new_v4());
         let materializer = tokio::spawn(async move {
             materialize_repo
-                .materialize_pending_registration(1, &token)
+                .materialize_pending_registration(1, &token, &candidate)
                 .await
         });
         let wait_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
@@ -1799,8 +1960,17 @@ mod tests {
                 .fetch_one(&pool)
                 .await
                 .unwrap();
+        let exchange_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE device_code = $1 AND pending_email IS NULL",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
         assert_eq!(user, (None, None, false));
         assert_eq!(key_count, 0);
+        assert_eq!(exchange_count, 0);
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
@@ -1842,12 +2012,12 @@ mod tests {
             .await
             .unwrap();
         let outcome = OAuthCodeRepository::new(one_connection_pool)
-            .materialize_pending_registration(1, &token)
+            .materialize_pending_registration(1, &token, "one-connection-exchange")
             .await
             .unwrap();
         assert!(matches!(
             outcome,
-            MaterializePendingRegistrationOutcome::Materialized(_)
+            MaterializePendingRegistrationOutcome::Ready(_)
         ));
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
@@ -1880,18 +2050,19 @@ mod tests {
             .unwrap()
             .unwrap();
 
+        let candidate_a = format!("exchange_a_{}", uuid::Uuid::new_v4());
+        let candidate_b = format!("exchange_b_{}", uuid::Uuid::new_v4());
         let (first, second) = tokio::join!(
-            repo.materialize_pending_registration(1, &token),
-            repo.materialize_pending_registration(1, &token),
+            repo.materialize_pending_registration(1, &token, &candidate_a),
+            repo.materialize_pending_registration(1, &token, &candidate_b),
         );
-        assert!(matches!(
-            first.unwrap(),
-            MaterializePendingRegistrationOutcome::Materialized(_)
-        ));
-        assert!(matches!(
-            second.unwrap(),
-            MaterializePendingRegistrationOutcome::Materialized(_)
-        ));
+        let MaterializePendingRegistrationOutcome::Ready(first) = first.unwrap() else {
+            panic!("first finalizer must be ready");
+        };
+        let MaterializePendingRegistrationOutcome::Ready(second) = second.unwrap() else {
+            panic!("second finalizer must be ready");
+        };
+        assert_eq!(first.exchange_code.code, second.exchange_code.code);
 
         let user_count: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM users WHERE pubkey = $1 AND tenant_id = 1")
@@ -2039,7 +2210,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_stale_pin_generation_cannot_mutate_superseding_counters() {
+    async fn test_queue_rejection_after_supersession_compensates_lifetime_only() {
         use nostr_sdk::Keys;
 
         let pool = setup_pool().await;
@@ -2052,6 +2223,12 @@ mod tests {
             Utc::now() + chrono::Duration::hours(1),
         )
         .await;
+        assert_eq!(
+            repo.reserve_pin_attempt(&device_code, 1, &stale_token, 5, 50)
+                .await
+                .unwrap(),
+            PinAttemptReservation::Reserved { attempt: 1 }
+        );
 
         let replacement_pubkey = Keys::generate().public_key().to_hex();
         let replacement_device = format!("replacement_{}", uuid::Uuid::new_v4());
@@ -2079,17 +2256,11 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            repo.reserve_pin_attempt(&device_code, 1, &stale_token, 5, 50)
+            repo.refund_pin_attempt(&device_code, 1, &stale_token)
                 .await
                 .unwrap(),
-            PinAttemptReservation::CurrentPinLocked
+            PinAttemptRelease::GenerationChanged
         );
-        repo.refund_pin_attempt(&device_code, 1, &stale_token)
-            .await
-            .unwrap();
-        repo.reset_pin_attempts(&device_code, 1, &stale_token)
-            .await
-            .unwrap();
 
         let current = repo
             .find_by_device_code(&device_code, 1)
@@ -2100,6 +2271,73 @@ mod tests {
             current.pending_email_verification_token.as_deref(),
             Some(replacement_token.as_str())
         );
+        assert_eq!((current.pin_attempts, current.pin_failed_total), (0, 0));
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_correct_old_pin_after_supersession_compensates_lifetime_only() {
+        use nostr_sdk::Keys;
+
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let (stale_token, email) = insert_pending_registration(
+            &repo,
+            &device_code,
+            Some("stale-pin"),
+            Utc::now() + chrono::Duration::hours(1),
+        )
+        .await;
+        assert_eq!(
+            repo.reserve_pin_attempt(&device_code, 1, &stale_token, 5, 50)
+                .await
+                .unwrap(),
+            PinAttemptReservation::Reserved { attempt: 1 }
+        );
+
+        let replacement_pubkey = Keys::generate().public_key().to_hex();
+        let replacement_device = format!("replacement_{}", uuid::Uuid::new_v4());
+        let replacement_token = format!("replacement_{}", uuid::Uuid::new_v4());
+        repo.store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
+            tenant_id: 1,
+            code: "replacement-code-correct-pin",
+            user_pubkey: &replacement_pubkey,
+            client_id: "replacement-client",
+            redirect_uri: "http://localhost:3000/replacement",
+            scope: "policy:social",
+            code_challenge: None,
+            code_challenge_method: None,
+            expires_at: Utc::now() + chrono::Duration::hours(24),
+            pending_email: &email,
+            pending_password_hash: "replacement-hash",
+            pending_email_verification_token: &replacement_token,
+            pending_encrypted_secret: Some(b"replacement-secret"),
+            state: None,
+            device_code: Some(&replacement_device),
+            is_headless: true,
+            pin_hash: Some("replacement-pin"),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            repo.reset_pin_attempts(&device_code, 1, &stale_token)
+                .await
+                .unwrap(),
+            PinAttemptRelease::GenerationChanged
+        );
+        let current = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(current.pin_hash.as_deref(), Some("replacement-pin"));
         assert_eq!((current.pin_attempts, current.pin_failed_total), (0, 0));
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
@@ -2576,7 +2814,7 @@ mod tests {
         let pool = setup_pool().await;
         let repo = OAuthCodeRepository::new(pool.clone());
         let device_code = format!("dc_{}", uuid::Uuid::new_v4());
-        insert_pending_registration(
+        let (token, _) = insert_pending_registration(
             &repo,
             &device_code,
             Some("pin"),
@@ -2590,8 +2828,6 @@ mod tests {
             .unwrap();
         let candidate_a = format!("exchange_a_{}", uuid::Uuid::new_v4());
         let candidate_b = format!("exchange_b_{}", uuid::Uuid::new_v4());
-        let expires_a = Utc::now() + chrono::Duration::minutes(10);
-        let expires_b = Utc::now() + chrono::Duration::minutes(10);
 
         let mut blocker = pool.begin().await.unwrap();
         sqlx::query(
@@ -2604,49 +2840,17 @@ mod tests {
         .unwrap();
 
         let first_repo = repo.clone();
-        let first_pending = pending.clone();
+        let first_token = token.clone();
         let first = tokio::spawn(async move {
             first_repo
-                .get_or_store_exchange_code_for_pending(
-                    StoreOAuthCodeParams {
-                        tenant_id: 1,
-                        code: &candidate_a,
-                        user_pubkey: &first_pending.user_pubkey,
-                        client_id: &first_pending.client_id,
-                        redirect_uri: &first_pending.redirect_uri,
-                        scope: &first_pending.scope,
-                        code_challenge: first_pending.code_challenge.as_deref(),
-                        code_challenge_method: first_pending.code_challenge_method.as_deref(),
-                        expires_at: expires_a,
-                        previous_auth_id: first_pending.previous_auth_id,
-                        state: first_pending.state.as_deref(),
-                        is_headless: first_pending.is_headless,
-                    },
-                    &first_pending,
-                )
+                .materialize_pending_registration(1, &first_token, &candidate_a)
                 .await
         });
         let second_repo = repo.clone();
-        let second_pending = pending.clone();
+        let second_token = token.clone();
         let second = tokio::spawn(async move {
             second_repo
-                .get_or_store_exchange_code_for_pending(
-                    StoreOAuthCodeParams {
-                        tenant_id: 1,
-                        code: &candidate_b,
-                        user_pubkey: &second_pending.user_pubkey,
-                        client_id: &second_pending.client_id,
-                        redirect_uri: &second_pending.redirect_uri,
-                        scope: &second_pending.scope,
-                        code_challenge: second_pending.code_challenge.as_deref(),
-                        code_challenge_method: second_pending.code_challenge_method.as_deref(),
-                        expires_at: expires_b,
-                        previous_auth_id: second_pending.previous_auth_id,
-                        state: second_pending.state.as_deref(),
-                        is_headless: second_pending.is_headless,
-                    },
-                    &second_pending,
-                )
+                .materialize_pending_registration(1, &second_token, &candidate_b)
                 .await
         });
 
@@ -2655,7 +2859,7 @@ mod tests {
             let waiting: i64 = sqlx::query_scalar(
                 "SELECT COUNT(*) FROM pg_stat_activity activity
                  WHERE cardinality(pg_blocking_pids(activity.pid)) > 0
-                   AND activity.query LIKE '%SELECT 1 FROM oauth_codes pending_row%'",
+                   AND activity.query LIKE '%pending_email_verification_token = $2%FOR UPDATE%'",
             )
             .fetch_one(&pool)
             .await
@@ -2671,10 +2875,16 @@ mod tests {
         }
         blocker.commit().await.unwrap();
 
-        let first = first.await.unwrap().unwrap().unwrap();
-        let second = second.await.unwrap().unwrap().unwrap();
-        assert_eq!(first.code, second.code);
-        assert!(first.freshly_minted ^ second.freshly_minted);
+        let MaterializePendingRegistrationOutcome::Ready(first) = first.await.unwrap().unwrap()
+        else {
+            panic!("first finalizer must be ready");
+        };
+        let MaterializePendingRegistrationOutcome::Ready(second) = second.await.unwrap().unwrap()
+        else {
+            panic!("second finalizer must be ready");
+        };
+        assert_eq!(first.exchange_code.code, second.exchange_code.code);
+        assert!(first.exchange_code.freshly_minted ^ second.exchange_code.freshly_minted);
         let code_count: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM oauth_codes
              WHERE device_code = $1 AND pending_email IS NULL",
@@ -2690,6 +2900,11 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -2699,7 +2914,7 @@ mod tests {
         let pool = setup_pool().await;
         let setup_repo = OAuthCodeRepository::new(pool.clone());
         let device_code = format!("dc_{}", uuid::Uuid::new_v4());
-        insert_pending_registration(
+        let (token, _) = insert_pending_registration(
             &setup_repo,
             &device_code,
             Some("pin"),
@@ -2719,32 +2934,23 @@ mod tests {
             .await
             .unwrap();
         let candidate = format!("exchange_{}", uuid::Uuid::new_v4());
-        let stored = OAuthCodeRepository::new(one_connection_pool)
-            .get_or_store_exchange_code_for_pending(
-                StoreOAuthCodeParams {
-                    tenant_id: 1,
-                    code: &candidate,
-                    user_pubkey: &pending.user_pubkey,
-                    client_id: &pending.client_id,
-                    redirect_uri: &pending.redirect_uri,
-                    scope: &pending.scope,
-                    code_challenge: pending.code_challenge.as_deref(),
-                    code_challenge_method: pending.code_challenge_method.as_deref(),
-                    expires_at: Utc::now() + chrono::Duration::minutes(10),
-                    previous_auth_id: pending.previous_auth_id,
-                    state: pending.state.as_deref(),
-                    is_headless: pending.is_headless,
-                },
-                &pending,
-            )
+        let outcome = OAuthCodeRepository::new(one_connection_pool)
+            .materialize_pending_registration(1, &token, &candidate)
             .await
-            .unwrap()
             .unwrap();
-        assert_eq!(stored.code, candidate);
-        assert!(stored.freshly_minted);
+        let MaterializePendingRegistrationOutcome::Ready(finalized) = outcome else {
+            panic!("single-connection finalizer must be ready");
+        };
+        assert_eq!(finalized.exchange_code.code, candidate);
+        assert!(finalized.exchange_code.freshly_minted);
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pending.user_pubkey)
             .execute(&pool)
             .await
             .unwrap();
@@ -3037,6 +3243,294 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_concurrent_redemptions_only_one_claims_code() {
+        use tokio::time::{sleep, Duration};
+
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let finalized = insert_and_finalize_registration(&repo, &device_code).await;
+        let code = finalized.exchange_code.code;
+        let auth_code = repo.find_valid(1, &code).await.unwrap().unwrap();
+
+        let mut blocker = pool.begin().await.unwrap();
+        sqlx::query(
+            "SELECT 1 FROM oauth_codes
+             WHERE device_code = $1 AND pending_email IS NOT NULL FOR UPDATE",
+        )
+        .bind(&device_code)
+        .fetch_one(&mut *blocker)
+        .await
+        .unwrap();
+
+        let first_repo = repo.clone();
+        let first_code = code.clone();
+        let first_auth = auth_code.clone();
+        let first =
+            tokio::spawn(async move { first_repo.redeem_code(1, &first_code, &first_auth).await });
+        let second_repo = repo.clone();
+        let second_code = code.clone();
+        let second_auth = auth_code.clone();
+        let second =
+            tokio::spawn(
+                async move { second_repo.redeem_code(1, &second_code, &second_auth).await },
+            );
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let waiting: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM pg_stat_activity activity
+                 WHERE cardinality(pg_blocking_pids(activity.pid)) > 0
+                   AND activity.query LIKE '%pending_email IS NOT NULL%FOR UPDATE%'",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            if waiting >= 2 {
+                break;
+            }
+            assert!(tokio::time::Instant::now() < deadline);
+            sleep(Duration::from_millis(10)).await;
+        }
+        blocker.commit().await.unwrap();
+
+        let first = first.await.unwrap().unwrap();
+        let second = second.await.unwrap().unwrap();
+        assert!(first ^ second);
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&finalized.pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_failed_issuance_release_makes_same_code_redeemable() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let finalized = insert_and_finalize_registration(&repo, &device_code).await;
+        let code = finalized.exchange_code.code;
+        let auth_code = repo.find_valid(1, &code).await.unwrap().unwrap();
+
+        assert!(repo.redeem_code(1, &code, &auth_code).await.unwrap());
+        assert!(repo
+            .release_redeemed_code(1, &code, &auth_code)
+            .await
+            .unwrap());
+        assert!(repo.redeem_code(1, &code, &auth_code).await.unwrap());
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&finalized.pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_resend_does_not_rotate_an_in_progress_exchange_claim() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let finalized = insert_and_finalize_registration(&repo, &device_code).await;
+        let code = finalized.exchange_code.code.clone();
+        let auth_code = repo.find_valid(1, &code).await.unwrap().unwrap();
+        let token = finalized
+            .pending
+            .pending_email_verification_token
+            .as_deref()
+            .unwrap();
+
+        assert!(repo.redeem_code(1, &code, &auth_code).await.unwrap());
+        assert!(!repo
+            .reset_pin_for_resend(
+                &device_code,
+                1,
+                token,
+                "replacement-token",
+                "replacement-pin",
+                Utc::now() - chrono::Duration::minutes(5),
+            )
+            .await
+            .unwrap());
+
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            pending.pending_email_verification_token.as_deref(),
+            Some(token)
+        );
+        let exchange_token: Option<String> = sqlx::query_scalar(
+            "SELECT pending_email_verification_token FROM oauth_codes WHERE code = $1",
+        )
+        .bind(&code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(exchange_token.as_deref(), Some(token));
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&finalized.pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_finalizer_and_redemption_never_create_second_live_code() {
+        use tokio::time::{sleep, Duration};
+
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let finalized = insert_and_finalize_registration(&repo, &device_code).await;
+        let code = finalized.exchange_code.code.clone();
+        let auth_code = repo.find_valid(1, &code).await.unwrap().unwrap();
+        let token = finalized
+            .pending
+            .pending_email_verification_token
+            .clone()
+            .unwrap();
+
+        let mut blocker = pool.begin().await.unwrap();
+        sqlx::query(
+            "SELECT 1 FROM oauth_codes
+             WHERE device_code = $1 AND pending_email IS NOT NULL FOR UPDATE",
+        )
+        .bind(&device_code)
+        .fetch_one(&mut *blocker)
+        .await
+        .unwrap();
+        let redeem_repo = repo.clone();
+        let redeem_code = code.clone();
+        let redeem_auth = auth_code.clone();
+        let redemption =
+            tokio::spawn(
+                async move { redeem_repo.redeem_code(1, &redeem_code, &redeem_auth).await },
+            );
+        let finalize_repo = repo.clone();
+        let replacement = format!("replacement_{}", uuid::Uuid::new_v4());
+        let finalizer = tokio::spawn(async move {
+            finalize_repo
+                .materialize_pending_registration(1, &token, &replacement)
+                .await
+        });
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let waiting: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM pg_stat_activity activity
+                 WHERE cardinality(pg_blocking_pids(activity.pid)) > 0",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            if waiting >= 2 {
+                break;
+            }
+            assert!(tokio::time::Instant::now() < deadline);
+            sleep(Duration::from_millis(10)).await;
+        }
+        blocker.commit().await.unwrap();
+
+        assert!(redemption.await.unwrap().unwrap());
+        match finalizer.await.unwrap().unwrap() {
+            MaterializePendingRegistrationOutcome::Ready(result) => {
+                assert_eq!(result.exchange_code.code, code)
+            }
+            MaterializePendingRegistrationOutcome::Processing => {}
+            other => panic!("unexpected finalizer outcome: {other:?}"),
+        }
+        let live_codes: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE device_code = $1 AND pending_email IS NULL
+               AND expires_at > clock_timestamp()",
+        )
+        .bind(&device_code)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(live_codes, 1);
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&finalized.pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_finalizer_reports_processing_then_recovers_after_claim_expiry() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let finalized = insert_and_finalize_registration(&repo, &device_code).await;
+        let code = finalized.exchange_code.code.clone();
+        let token = finalized
+            .pending
+            .pending_email_verification_token
+            .clone()
+            .unwrap();
+        let auth_code = repo.find_valid(1, &code).await.unwrap().unwrap();
+        assert!(repo.redeem_code(1, &code, &auth_code).await.unwrap());
+
+        assert!(matches!(
+            repo.materialize_pending_registration(1, &token, "must-not-mint")
+                .await
+                .unwrap(),
+            MaterializePendingRegistrationOutcome::Processing
+        ));
+        sqlx::query("UPDATE oauth_codes SET expires_at = clock_timestamp() - INTERVAL '1 second' WHERE code = $1")
+            .bind(&code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let recovered = repo
+            .materialize_pending_registration(1, &token, "recovered-code")
+            .await
+            .unwrap();
+        let MaterializePendingRegistrationOutcome::Ready(recovered) = recovered else {
+            panic!("expired claim must allow a replacement code");
+        };
+        assert_eq!(recovered.exchange_code.code, "recovered-code");
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&finalized.pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn test_mark_pending_consumed_sets_marker_on_pending_row_only() {
         let pool = setup_pool().await;
         let repo = OAuthCodeRepository::new(pool.clone());
@@ -3088,7 +3582,10 @@ mod tests {
             "redeeming the exchange code must leave recovery possible until issuance succeeds"
         );
 
-        assert!(repo.mark_pending_consumed(1, &auth_code).await.unwrap());
+        assert!(repo
+            .mark_pending_consumed(1, &exchange_code, &auth_code)
+            .await
+            .unwrap());
         let after_issuance = repo
             .find_by_device_code(&device_code, 1)
             .await
@@ -3152,7 +3649,10 @@ mod tests {
                 .unwrap(),
             "first exchange code should redeem the pending registration"
         );
-        assert!(repo.mark_pending_consumed(1, &auth_code_a).await.unwrap());
+        assert!(repo
+            .mark_pending_consumed(1, &exchange_a, &auth_code_a)
+            .await
+            .unwrap());
 
         let after_first = repo
             .find_by_device_code(&device_code, 1)
@@ -3174,7 +3674,7 @@ mod tests {
         );
         assert!(
             repo.find_valid(1, &exchange_b).await.unwrap().is_some(),
-            "failed redemption should roll back the exchange-code delete"
+            "failed redemption should leave the exchange-code tombstone"
         );
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1 OR code IN ($2, $3)")
@@ -3275,7 +3775,10 @@ mod tests {
         let auth_code = repo.find_valid(1, &exchange_a).await.unwrap().unwrap();
 
         repo.redeem_code(1, &exchange_a, &auth_code).await.unwrap();
-        assert!(repo.mark_pending_consumed(1, &auth_code).await.unwrap());
+        assert!(repo
+            .mark_pending_consumed(1, &exchange_a, &auth_code)
+            .await
+            .unwrap());
 
         let pending_a = repo
             .find_by_device_code(&device_a, 1)
@@ -3353,6 +3856,31 @@ mod tests {
             .await
             .unwrap();
 
+        // A consumed exchange row is an in-progress issuance tombstone and must survive until its
+        // own expiry so verification cannot mint a concurrent replacement.
+        let exchange_code = format!("exchange_claim_{}", uuid::Uuid::new_v4());
+        repo.store(StoreOAuthCodeParams {
+            tenant_id: 1,
+            code: &exchange_code,
+            user_pubkey: "exchange-claim-user",
+            client_id: "exchange-claim-client",
+            redirect_uri: "https://example.com/callback",
+            scope: "policy:social",
+            code_challenge: None,
+            code_challenge_method: None,
+            expires_at: Utc::now() + chrono::Duration::minutes(10),
+            previous_auth_id: None,
+            state: None,
+            is_headless: true,
+        })
+        .await
+        .unwrap();
+        sqlx::query("UPDATE oauth_codes SET consumed_at = NOW() WHERE code = $1")
+            .bind(&exchange_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+
         let removed = repo.delete_expired_and_consumed().await.unwrap();
         assert!(removed >= 2, "expired and consumed rows should be deleted");
 
@@ -3371,6 +3899,16 @@ mod tests {
                 .await
                 .unwrap();
         assert!(consumed_still_present.is_none(), "consumed row removed");
+        let exchange_claim_present: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM oauth_codes WHERE code = $1)")
+                .bind(&exchange_code)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            exchange_claim_present,
+            "live exchange claim must be retained"
+        );
         assert!(
             repo.find_by_device_code(&live_dc, 1)
                 .await
@@ -3381,6 +3919,11 @@ mod tests {
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&live_dc)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM oauth_codes WHERE code = $1")
+            .bind(&exchange_code)
             .execute(&pool)
             .await
             .unwrap();

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -116,6 +116,19 @@ pub struct StoredPendingRegistration {
     pub superseded: bool,
 }
 
+/// Result of materializing one exact pending registration generation.
+#[derive(Debug)]
+pub enum MaterializePendingRegistrationOutcome {
+    /// The exact generation was locked and its user state is ready for code minting.
+    Materialized(Box<OAuthCodeData>),
+    /// The generation was superseded, consumed, expired, or removed before it could be locked.
+    NotFound,
+    /// The pending pubkey is already bound to another email.
+    DuplicateKey,
+    /// Another pubkey already owns the pending email.
+    EmailAlreadyExists,
+}
+
 /// The PIN-resend fields of a pending registration as they stood before a resend attempt.
 ///
 /// Captured so [`OAuthCodeRepository::restore_pin_after_failed_resend`] can put the row back
@@ -251,6 +264,7 @@ impl OAuthCodeRepository {
         &self,
         params: StoreOAuthCodeWithRegistrationParams<'_>,
     ) -> Result<StoredPendingRegistration, RepositoryError> {
+        let mut tx = self.pool.begin().await?;
         let row: Option<(Option<String>,)> = sqlx::query_as(
             "INSERT INTO oauth_codes (tenant_id, code, user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method, expires_at, created_at,
              pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret, state, device_code, is_headless, pin_hash, pin_sent_at)
@@ -274,15 +288,11 @@ impl OAuthCodeRepository {
                  pin_hash = EXCLUDED.pin_hash,
                  pin_attempts = 0,
                  pin_sent_at = NULL,
-                 pin_resend_at = NULL,
-                 finalization_claim = NULL,
-                 finalization_claimed_at = NULL
-              WHERE (oauth_codes.finalization_claim IS NULL
-                     OR oauth_codes.finalization_claimed_at < NOW() - INTERVAL '5 minutes')
-                AND NOT EXISTS (
-                    SELECT 1 FROM users
-                    WHERE users.tenant_id = EXCLUDED.tenant_id
-                      AND lower(users.email) = lower(EXCLUDED.pending_email)
+                 pin_resend_at = NULL
+               WHERE NOT EXISTS (
+                     SELECT 1 FROM users
+                     WHERE users.tenant_id = EXCLUDED.tenant_id
+                       AND lower(users.email) = lower(EXCLUDED.pending_email)
                 )
               RETURNING device_code",
         )
@@ -306,31 +316,37 @@ impl OAuthCodeRepository {
         .bind(params.pin_hash)
         // pin_sent_at tracks confirmed delivery; callers set it after the email send succeeds.
         .bind(None::<DateTime<Utc>>)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *tx)
         .await?;
 
+        // An upsert that was already waiting on the pending-row lock uses the snapshot from before
+        // materialization committed. Recheck in a new statement and roll back any stale-snapshot
+        // rewrite before exposing success.
+        let materialized: bool = sqlx::query_scalar(
+            "SELECT EXISTS(
+                SELECT 1 FROM users
+                WHERE tenant_id = $1 AND lower(email) = lower($2)
+            )",
+        )
+        .bind(params.tenant_id)
+        .bind(params.pending_email)
+        .fetch_one(&mut *tx)
+        .await?;
+        if materialized {
+            tx.rollback().await?;
+            return Err(RepositoryError::Duplicate);
+        }
+
         let Some((device_code,)) = row else {
-            let materialized: bool = sqlx::query_scalar(
-                "SELECT EXISTS(
-                    SELECT 1 FROM users
-                    WHERE tenant_id = $1 AND lower(email) = lower($2)
-                )",
-            )
-            .bind(params.tenant_id)
-            .bind(params.pending_email)
-            .fetch_one(&self.pool)
-            .await?;
-            return Err(if materialized {
-                RepositoryError::Duplicate
-            } else {
-                RepositoryError::Unavailable(
-                    "pending registration is currently being finalized".to_string(),
-                )
-            });
+            tx.rollback().await?;
+            return Err(RepositoryError::Unavailable(
+                "pending registration could not be superseded".to_string(),
+            ));
         };
         // The UPDATE branch leaves device_code untouched, so a returned value different from the
         // one we offered means we superseded an existing pending registration.
         let superseded = device_code.as_deref() != params.device_code;
+        tx.commit().await?;
 
         Ok(StoredPendingRegistration {
             device_code,
@@ -338,49 +354,223 @@ impl OAuthCodeRepository {
         })
     }
 
-    /// Claim one exact pending generation while its user is materialized.
-    pub async fn claim_pending_finalization(
+    /// Lock and materialize one exact pending registration generation atomically.
+    ///
+    /// The pending row lock serializes exact-generation finalizers and blocks the in-place
+    /// supersession upsert until the users row is visible. No pool acquisition occurs while this
+    /// transaction is held.
+    pub async fn materialize_pending_registration(
         &self,
         tenant_id: i64,
         verification_token: &str,
-        claim: &str,
-    ) -> Result<bool, RepositoryError> {
-        let claimed = sqlx::query(
-            "UPDATE oauth_codes
-             SET finalization_claim = $1, finalization_claimed_at = NOW()
-             WHERE tenant_id = $2 AND pending_email_verification_token = $3
-               AND pending_email IS NOT NULL AND consumed_at IS NULL
-               AND expires_at > NOW()
-               AND (finalization_claim IS NULL
-                    OR finalization_claimed_at < NOW() - INTERVAL '5 minutes')",
+    ) -> Result<MaterializePendingRegistrationOutcome, RepositoryError> {
+        let mut tx = self.pool.begin().await?;
+        let query = format!(
+            "SELECT {} FROM oauth_codes
+             WHERE tenant_id = $1 AND pending_email_verification_token = $2
+               AND pending_email IS NOT NULL AND consumed_at IS NULL AND expires_at > $3
+             FOR UPDATE",
+            Self::SELECT_COLUMNS
+        );
+        let Some(pending) = sqlx::query_as::<_, OAuthCodeData>(&query)
+            .bind(tenant_id)
+            .bind(verification_token)
+            .bind(Utc::now())
+            .fetch_optional(&mut *tx)
+            .await?
+        else {
+            tx.rollback().await?;
+            return Ok(MaterializePendingRegistrationOutcome::NotFound);
+        };
+
+        let email = pending.pending_email.as_deref().ok_or_else(|| {
+            RepositoryError::Integrity("pending registration has no email".to_string())
+        })?;
+        let password_hash = pending.pending_password_hash.as_deref().ok_or_else(|| {
+            RepositoryError::Integrity("pending registration has no password hash".to_string())
+        })?;
+        let now = Utc::now();
+
+        let existing: Option<(Option<String>, bool, bool)> = sqlx::query_as(
+            "SELECT u.email, u.email_verified,
+                    u.password_hash IS NOT NULL AS has_password_hash
+             FROM users u
+             WHERE u.pubkey = $1 AND u.tenant_id = $2
+             FOR UPDATE",
         )
-        .bind(claim)
+        .bind(&pending.user_pubkey)
         .bind(tenant_id)
-        .bind(verification_token)
-        .execute(&self.pool)
-        .await?
-        .rows_affected()
-            > 0;
-        Ok(claimed)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let outcome = if let Some((existing_email, email_verified, has_password_hash)) = existing {
+            match existing_email.as_deref() {
+                Some(bound_email) if bound_email != email => {
+                    Self::delete_pending_generation(&mut tx, tenant_id, verification_token).await?;
+                    MaterializePendingRegistrationOutcome::DuplicateKey
+                }
+                _ => {
+                    let email_owner: Option<(String,)> = sqlx::query_as(
+                        "SELECT pubkey FROM users
+                         WHERE tenant_id = $1 AND email = $2 AND pubkey <> $3
+                         FOR UPDATE",
+                    )
+                    .bind(tenant_id)
+                    .bind(email)
+                    .bind(&pending.user_pubkey)
+                    .fetch_optional(&mut *tx)
+                    .await?;
+                    if email_owner.is_some() {
+                        Self::delete_pending_generation(&mut tx, tenant_id, verification_token)
+                            .await?;
+                        MaterializePendingRegistrationOutcome::EmailAlreadyExists
+                    } else {
+                        if existing_email.is_none() || !email_verified || !has_password_hash {
+                            sqlx::query(
+                                "UPDATE users
+                                 SET email = $1, password_hash = COALESCE(password_hash, $2),
+                                     email_verified = true, email_verification_token = $3,
+                                     updated_at = $4
+                                 WHERE pubkey = $5 AND tenant_id = $6",
+                            )
+                            .bind(email)
+                            .bind(password_hash)
+                            .bind(verification_token)
+                            .bind(now)
+                            .bind(&pending.user_pubkey)
+                            .bind(tenant_id)
+                            .execute(&mut *tx)
+                            .await?;
+                        }
+                        Self::insert_pending_personal_key(&mut tx, tenant_id, &pending, now)
+                            .await?;
+                        MaterializePendingRegistrationOutcome::Materialized(Box::new(pending))
+                    }
+                }
+            }
+        } else {
+            let inserted: Option<(String,)> = sqlx::query_as(
+                "INSERT INTO users
+                     (pubkey, tenant_id, email, password_hash, email_verified,
+                      email_verification_token, created_at, updated_at)
+                 VALUES ($1, $2, $3, $4, true, $5, $6, $6)
+                 ON CONFLICT DO NOTHING
+                 RETURNING pubkey",
+            )
+            .bind(&pending.user_pubkey)
+            .bind(tenant_id)
+            .bind(email)
+            .bind(password_hash)
+            .bind(verification_token)
+            .bind(now)
+            .fetch_optional(&mut *tx)
+            .await?;
+
+            if inserted.is_some() {
+                Self::insert_pending_personal_key(&mut tx, tenant_id, &pending, now).await?;
+                MaterializePendingRegistrationOutcome::Materialized(Box::new(pending))
+            } else {
+                let pubkey_state: Option<(Option<String>, bool, bool)> = sqlx::query_as(
+                    "SELECT email, email_verified,
+                            password_hash IS NOT NULL AS has_password_hash
+                     FROM users WHERE pubkey = $1 AND tenant_id = $2 FOR UPDATE",
+                )
+                .bind(&pending.user_pubkey)
+                .bind(tenant_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                match pubkey_state {
+                    Some((Some(bound_email), _, _)) if bound_email != email => {
+                        Self::delete_pending_generation(&mut tx, tenant_id, verification_token)
+                            .await?;
+                        MaterializePendingRegistrationOutcome::DuplicateKey
+                    }
+                    Some((existing_email, email_verified, has_password_hash)) => {
+                        let email_owner: Option<(String,)> = sqlx::query_as(
+                            "SELECT pubkey FROM users
+                             WHERE tenant_id = $1 AND email = $2 AND pubkey <> $3
+                             FOR UPDATE",
+                        )
+                        .bind(tenant_id)
+                        .bind(email)
+                        .bind(&pending.user_pubkey)
+                        .fetch_optional(&mut *tx)
+                        .await?;
+                        if email_owner.is_some() {
+                            Self::delete_pending_generation(&mut tx, tenant_id, verification_token)
+                                .await?;
+                            MaterializePendingRegistrationOutcome::EmailAlreadyExists
+                        } else {
+                            if existing_email.is_none() || !email_verified || !has_password_hash {
+                                sqlx::query(
+                                    "UPDATE users
+                                     SET email = $1, password_hash = COALESCE(password_hash, $2),
+                                         email_verified = true, email_verification_token = $3,
+                                         updated_at = $4
+                                     WHERE pubkey = $5 AND tenant_id = $6",
+                                )
+                                .bind(email)
+                                .bind(password_hash)
+                                .bind(verification_token)
+                                .bind(now)
+                                .bind(&pending.user_pubkey)
+                                .bind(tenant_id)
+                                .execute(&mut *tx)
+                                .await?;
+                            }
+                            Self::insert_pending_personal_key(&mut tx, tenant_id, &pending, now)
+                                .await?;
+                            MaterializePendingRegistrationOutcome::Materialized(Box::new(pending))
+                        }
+                    }
+                    None => {
+                        Self::delete_pending_generation(&mut tx, tenant_id, verification_token)
+                            .await?;
+                        MaterializePendingRegistrationOutcome::EmailAlreadyExists
+                    }
+                }
+            }
+        };
+
+        tx.commit().await?;
+        Ok(outcome)
     }
 
-    /// Release a finalization claim without disturbing a newer claim holder.
-    pub async fn release_pending_finalization(
-        &self,
+    async fn insert_pending_personal_key(
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        tenant_id: i64,
+        pending: &OAuthCodeData,
+        now: DateTime<Utc>,
+    ) -> Result<(), RepositoryError> {
+        if let Some(secret) = pending.pending_encrypted_secret.as_deref() {
+            sqlx::query(
+                "INSERT INTO personal_keys
+                     (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
+                 VALUES ($1, $2, $3, $4, $4)
+                 ON CONFLICT (user_pubkey) DO NOTHING",
+            )
+            .bind(&pending.user_pubkey)
+            .bind(secret)
+            .bind(tenant_id)
+            .bind(now)
+            .execute(&mut **tx)
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn delete_pending_generation(
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         tenant_id: i64,
         verification_token: &str,
-        claim: &str,
     ) -> Result<(), RepositoryError> {
         sqlx::query(
-            "UPDATE oauth_codes
-             SET finalization_claim = NULL, finalization_claimed_at = NULL
-             WHERE tenant_id = $1 AND pending_email_verification_token = $2
-               AND finalization_claim = $3",
+            "DELETE FROM oauth_codes
+             WHERE tenant_id = $1 AND pending_email_verification_token = $2",
         )
         .bind(tenant_id)
         .bind(verification_token)
-        .bind(claim)
-        .execute(&self.pool)
+        .execute(&mut **tx)
         .await?;
         Ok(())
     }
@@ -637,6 +827,7 @@ impl OAuthCodeRepository {
         &self,
         device_code: &str,
         tenant_id: i64,
+        expected_generation_token: &str,
         new_verification_token: &str,
         new_pin_hash: &str,
         cooldown_cutoff: DateTime<Utc>,
@@ -650,16 +841,18 @@ impl OAuthCodeRepository {
             "UPDATE oauth_codes \
              SET pending_email_verification_token = $1, pin_hash = $2, pin_attempts = 0, \
                  pin_sent_at = NULL, pin_resend_at = $3 \
-             WHERE device_code = $4 AND tenant_id = $5 \
-                AND pending_email IS NOT NULL AND consumed_at IS NULL \
-                AND expires_at > $3 \
-                AND (pin_resend_at IS NULL OR pin_resend_at <= $6)",
+              WHERE device_code = $4 AND tenant_id = $5 \
+                 AND pending_email_verification_token = $6 \
+                 AND pending_email IS NOT NULL AND consumed_at IS NULL \
+                 AND expires_at > $3 \
+                 AND (pin_resend_at IS NULL OR pin_resend_at <= $7)",
         )
         .bind(new_verification_token)
         .bind(new_pin_hash)
         .bind(now)
         .bind(device_code)
         .bind(tenant_id)
+        .bind(expected_generation_token)
         .bind(cooldown_cutoff)
         .execute(&mut *tx)
         .await?
@@ -1185,8 +1378,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_finalization_claim_blocks_supersession_until_materialization_is_visible() {
+    async fn test_materialization_lock_blocks_then_rejects_supersession() {
         use nostr_sdk::Keys;
+        use tokio::time::{sleep, timeout, Duration};
 
         let pool = setup_pool().await;
         let repo = OAuthCodeRepository::new(pool.clone());
@@ -1199,56 +1393,102 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        let claim = format!("claim_{}", uuid::Uuid::new_v4());
-        assert!(repo
-            .claim_pending_finalization(1, &token, &claim)
-            .await
-            .unwrap());
-
-        let replacement_pubkey = Keys::generate().public_key().to_hex();
-        let replacement_device = format!("replacement_{}", uuid::Uuid::new_v4());
-        let replacement = || StoreOAuthCodeWithRegistrationParams {
-            tenant_id: 1,
-            code: "replacement-code",
-            user_pubkey: &replacement_pubkey,
-            client_id: "replacement-client",
-            redirect_uri: "http://localhost:3000/replacement",
-            scope: "policy:social",
-            code_challenge: None,
-            code_challenge_method: None,
-            expires_at: Utc::now() + chrono::Duration::hours(24),
-            pending_email: &email,
-            pending_password_hash: "replacement-hash",
-            pending_email_verification_token: "replacement-token",
-            pending_encrypted_secret: Some(b"replacement-secret"),
-            state: None,
-            device_code: Some(&replacement_device),
-            is_headless: true,
-            pin_hash: Some("replacement-pin"),
-        };
-        assert!(matches!(
-            repo.store_with_pending_registration(replacement()).await,
-            Err(RepositoryError::Unavailable(_))
-        ));
 
         sqlx::query(
-            "INSERT INTO users
-                 (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
-             VALUES ($1, 1, $2, 'materialized-hash', true, NOW(), NOW())",
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+             VALUES ($1, 1, NOW(), NOW())",
         )
         .bind(&pending.user_pubkey)
-        .bind(&email)
         .execute(&pool)
         .await
         .unwrap();
-        repo.release_pending_finalization(1, &token, &claim)
+
+        // Hold the users row so materialization pauses after acquiring the pending-row lock.
+        let mut blocker = pool.begin().await.unwrap();
+        sqlx::query("SELECT pubkey FROM users WHERE pubkey = $1 FOR UPDATE")
+            .bind(&pending.user_pubkey)
+            .fetch_one(&mut *blocker)
             .await
             .unwrap();
 
+        let materialize_repo = repo.clone();
+        let materialize_token = token.clone();
+        let materializer = tokio::spawn(async move {
+            materialize_repo
+                .materialize_pending_registration(1, &materialize_token)
+                .await
+        });
+
+        // Wait until PostgreSQL confirms materialization is blocked on the users row. At this
+        // point its transaction already owns the pending-row FOR UPDATE lock.
+        let wait_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let waiting: bool = sqlx::query_scalar(
+                "SELECT EXISTS (
+                    SELECT 1 FROM pg_stat_activity activity
+                    WHERE cardinality(pg_blocking_pids(activity.pid)) > 0
+                      AND activity.query LIKE '%SELECT u.email, u.email_verified%'
+                )",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            if waiting {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < wait_deadline,
+                "materialization did not reach the users-row lock"
+            );
+            sleep(Duration::from_millis(10)).await;
+        }
+
+        let replacement_pubkey = Keys::generate().public_key().to_hex();
+        let replacement_device = format!("replacement_{}", uuid::Uuid::new_v4());
+        let supersede_repo = repo.clone();
+        let supersede_email = email.clone();
+        let mut supersession = tokio::spawn(async move {
+            supersede_repo
+                .store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
+                    tenant_id: 1,
+                    code: "replacement-code",
+                    user_pubkey: &replacement_pubkey,
+                    client_id: "replacement-client",
+                    redirect_uri: "http://localhost:3000/replacement",
+                    scope: "policy:social",
+                    code_challenge: None,
+                    code_challenge_method: None,
+                    expires_at: Utc::now() + chrono::Duration::hours(24),
+                    pending_email: &supersede_email,
+                    pending_password_hash: "replacement-hash",
+                    pending_email_verification_token: "replacement-token",
+                    pending_encrypted_secret: Some(b"replacement-secret"),
+                    state: None,
+                    device_code: Some(&replacement_device),
+                    is_headless: true,
+                    pin_hash: Some("replacement-pin"),
+                })
+                .await
+        });
+
+        assert!(
+            timeout(Duration::from_millis(100), &mut supersession)
+                .await
+                .is_err(),
+            "supersession must wait on the pending row while materialization is in progress"
+        );
+
+        blocker.commit().await.unwrap();
         assert!(matches!(
-            repo.store_with_pending_registration(replacement()).await,
-            Err(RepositoryError::Duplicate)
+            materializer.await.unwrap().unwrap(),
+            MaterializePendingRegistrationOutcome::Materialized(_)
         ));
+
+        let supersession_result = supersession.await.unwrap();
+        assert!(
+            matches!(supersession_result, Err(RepositoryError::Duplicate)),
+            "supersession must be rejected after materialization, got {supersession_result:?}"
+        );
         let surviving = repo
             .find_by_device_code(&device_code, 1)
             .await
@@ -1259,6 +1499,113 @@ mod tests {
             surviving.pending_email_verification_token.as_deref(),
             Some(token.as_str())
         );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_materialization_completes_with_one_pool_connection() {
+        use sqlx::postgres::PgPoolOptions;
+
+        let pool = setup_pool().await;
+        let setup_repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let (token, _) = insert_pending_registration(
+            &setup_repo,
+            &device_code,
+            Some("pin"),
+            Utc::now() + chrono::Duration::hours(1),
+        )
+        .await;
+        let pending = setup_repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let database_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+        let one_connection_pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&database_url)
+            .await
+            .unwrap();
+        let outcome = OAuthCodeRepository::new(one_connection_pool)
+            .materialize_pending_registration(1, &token)
+            .await
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            MaterializePendingRegistrationOutcome::Materialized(_)
+        ));
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pending.user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_exact_generation_materializers_are_idempotent() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let (token, _) = insert_pending_registration(
+            &repo,
+            &device_code,
+            Some("pin"),
+            Utc::now() + chrono::Duration::hours(1),
+        )
+        .await;
+        let pending = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let (first, second) = tokio::join!(
+            repo.materialize_pending_registration(1, &token),
+            repo.materialize_pending_registration(1, &token),
+        );
+        assert!(matches!(
+            first.unwrap(),
+            MaterializePendingRegistrationOutcome::Materialized(_)
+        ));
+        assert!(matches!(
+            second.unwrap(),
+            MaterializePendingRegistrationOutcome::Materialized(_)
+        ));
+
+        let user_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM users WHERE pubkey = $1 AND tenant_id = 1")
+                .bind(&pending.user_pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        let key_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM personal_keys WHERE user_pubkey = $1 AND tenant_id = 1",
+        )
+        .bind(&pending.user_pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(user_count, 1);
+        assert_eq!(key_count, 1);
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
@@ -1548,7 +1895,7 @@ mod tests {
         let repo = OAuthCodeRepository::new(pool.clone());
 
         let device_code = format!("dc_{}", uuid::Uuid::new_v4());
-        insert_pending_registration(
+        let (expected_generation, _) = insert_pending_registration(
             &repo,
             &device_code,
             Some("oldpin"),
@@ -1562,8 +1909,22 @@ mod tests {
         let token_b = format!("verif_b_{}", uuid::Uuid::new_v4());
 
         let (a, b) = tokio::join!(
-            repo.reset_pin_for_resend(&device_code, 1, &token_a, "pin_a", cutoff),
-            repo.reset_pin_for_resend(&device_code, 1, &token_b, "pin_b", cutoff),
+            repo.reset_pin_for_resend(
+                &device_code,
+                1,
+                &expected_generation,
+                &token_a,
+                "pin_a",
+                cutoff
+            ),
+            repo.reset_pin_for_resend(
+                &device_code,
+                1,
+                &expected_generation,
+                &token_b,
+                "pin_b",
+                cutoff
+            ),
         );
         let (a, b) = (a.unwrap(), b.unwrap());
 
@@ -1605,7 +1966,8 @@ mod tests {
         let device_code = format!("dc_{}", uuid::Uuid::new_v4());
         // Original registration window: an exact, known expiry we can assert stays put.
         let expires_at = Utc::now() + chrono::Duration::hours(12);
-        insert_pending_registration(&repo, &device_code, Some("oldpin"), expires_at).await;
+        let (old_token, _) =
+            insert_pending_registration(&repo, &device_code, Some("oldpin"), expires_at).await;
         let original_expiry: DateTime<Utc> =
             sqlx::query_scalar("SELECT expires_at FROM oauth_codes WHERE device_code = $1")
                 .bind(&device_code)
@@ -1623,7 +1985,14 @@ mod tests {
 
         let new_token = format!("verif_{}", uuid::Uuid::new_v4());
         assert!(repo
-            .reset_pin_for_resend(&device_code, 1, &new_token, "newpin", Utc::now())
+            .reset_pin_for_resend(
+                &device_code,
+                1,
+                &old_token,
+                &new_token,
+                "newpin",
+                Utc::now(),
+            )
             .await
             .unwrap());
 
@@ -1662,6 +2031,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_reset_pin_for_resend_refuses_superseded_generation() {
+        use nostr_sdk::Keys;
+
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let (stale_token, email) = insert_pending_registration(
+            &repo,
+            &device_code,
+            Some("stale-pin"),
+            Utc::now() + chrono::Duration::hours(12),
+        )
+        .await;
+
+        // This is the resend snapshot. A fresh registration supersedes it while bcrypt would run.
+        let replacement_pubkey = Keys::generate().public_key().to_hex();
+        let replacement_device = format!("replacement_{}", uuid::Uuid::new_v4());
+        let replacement_token = format!("replacement_{}", uuid::Uuid::new_v4());
+        repo.store_with_pending_registration(StoreOAuthCodeWithRegistrationParams {
+            tenant_id: 1,
+            code: "replacement-code",
+            user_pubkey: &replacement_pubkey,
+            client_id: "replacement-client",
+            redirect_uri: "http://localhost:3000/replacement",
+            scope: "policy:social",
+            code_challenge: None,
+            code_challenge_method: None,
+            expires_at: Utc::now() + chrono::Duration::hours(24),
+            pending_email: &email,
+            pending_password_hash: "replacement-hash",
+            pending_email_verification_token: &replacement_token,
+            pending_encrypted_secret: Some(b"replacement-secret"),
+            state: None,
+            device_code: Some(&replacement_device),
+            is_headless: true,
+            pin_hash: Some("replacement-pin"),
+        })
+        .await
+        .unwrap();
+
+        assert!(!repo
+            .reset_pin_for_resend(
+                &device_code,
+                1,
+                &stale_token,
+                "stale-resend-token",
+                "stale-resend-pin",
+                Utc::now(),
+            )
+            .await
+            .unwrap());
+
+        let current = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            current.pending_email_verification_token.as_deref(),
+            Some(replacement_token.as_str())
+        );
+        assert_eq!(current.pin_hash.as_deref(), Some("replacement-pin"));
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn test_reset_pin_for_resend_refuses_registration_expired_during_hashing() {
         let pool = setup_pool().await;
         let repo = OAuthCodeRepository::new(pool.clone());
@@ -1680,6 +2120,7 @@ mod tests {
             .reset_pin_for_resend(
                 &device_code,
                 1,
+                &old_token,
                 "new-token",
                 "new-pin",
                 Utc::now() - chrono::Duration::minutes(5),

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -29,8 +29,12 @@ pub struct OAuthCodeData {
     pub is_headless: bool,
     /// bcrypt hash of the 6-digit in-app PIN fallback (keycast#262), if one was issued
     pub pin_hash: Option<String>,
-    /// Failed verify-pin attempts; brute-force cap is enforced against this counter
+    /// Failed attempts against the *current* PIN; a resend clears this, which is what makes a
+    /// resend the recovery path out of a lockout
     pub pin_attempts: i32,
+    /// Failed attempts across every PIN this registration has issued; never reset, so it bounds
+    /// guessing over the registration's whole life even though resends clear `pin_attempts`
+    pub pin_failed_total: i32,
     /// When the current PIN was handed to the delivery provider; backs the PIN validity window
     pub pin_sent_at: Option<DateTime<Utc>>,
     /// When a PIN resend was last performed; backs the resend cooldown. Stays NULL through
@@ -40,6 +44,21 @@ pub struct OAuthCodeData {
     /// Terminal marker (keycast#262): set after the registration's exchange code successfully
     /// issues tokens. Once non-NULL, finalize refuses to re-mint and the row is eligible for cleanup.
     pub consumed_at: Option<DateTime<Utc>>,
+    /// End of the registration's verification window. Lookups that need to tell an expired
+    /// registration apart from an absent one select this and decide for themselves.
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Outcome of trying to reserve one PIN-verification attempt slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinAttemptReservation {
+    /// A slot was reserved; carries the resulting count against the current PIN.
+    Reserved { attempt: i32 },
+    /// The current PIN has spent its per-PIN cap. A resend clears this.
+    CurrentPinLocked,
+    /// The registration has spent its lifetime cap across every PIN it has issued. A resend does
+    /// not clear this; the emailed link remains the way in.
+    LifetimeExhausted,
 }
 
 /// Parameters for storing a basic OAuth code
@@ -288,8 +307,8 @@ impl OAuthCodeRepository {
     const SELECT_COLUMNS: &'static str =
         "user_pubkey, client_id, redirect_uri, scope, code_challenge, code_challenge_method, \
          pending_email, pending_password_hash, pending_email_verification_token, pending_encrypted_secret, \
-         previous_auth_id, state, device_code, is_headless, pin_hash, pin_attempts, pin_sent_at, \
-         pin_resend_at, consumed_at";
+         previous_auth_id, state, device_code, is_headless, pin_hash, pin_attempts, \
+         pin_failed_total, pin_sent_at, pin_resend_at, consumed_at, expires_at";
 
     /// Find a valid (non-expired) OAuth code.
     pub async fn find_valid(
@@ -336,67 +355,106 @@ impl OAuthCodeRepository {
     ///
     /// This is the lookup gate for in-app PIN verification (keycast#262): the `device_code` is the
     /// real authenticator and the 6-digit PIN is defense-in-depth, so PIN verification MUST resolve
-    /// the pending row by `device_code` rather than by a global PIN scan (which would be brute-forceable
-    /// across all pending registrations). Only pending rows carry a non-null `device_code`, and the PIN
-    /// stays valid for the full 24h verify window, so this filters on `expires_at > now`.
+    /// the pending row by `device_code` rather than by a global PIN scan (which would be
+    /// brute-forceable across all pending registrations). Only pending rows carry a non-null
+    /// `device_code`.
+    ///
+    /// Deliberately does **not** filter on `expires_at`: an expired registration and an unknown
+    /// `device_code` are different situations for the user, and filtering here would collapse them
+    /// into one. Callers get `expires_at` on the returned row and decide. Every caller must
+    /// therefore check it — reaching a registration past its window must not let the flow proceed.
     pub async fn find_by_device_code(
         &self,
         device_code: &str,
         tenant_id: i64,
     ) -> Result<Option<OAuthCodeData>, RepositoryError> {
         let query = format!(
-            "SELECT {} FROM oauth_codes WHERE device_code = $1 AND tenant_id = $2 AND pending_email IS NOT NULL AND expires_at > $3",
+            "SELECT {} FROM oauth_codes WHERE device_code = $1 AND tenant_id = $2 AND pending_email IS NOT NULL",
             Self::SELECT_COLUMNS
         );
         let result = sqlx::query_as::<_, OAuthCodeData>(&query)
             .bind(device_code)
             .bind(tenant_id)
-            .bind(Utc::now())
             .fetch_optional(&self.pool)
             .await?;
 
         Ok(result)
     }
 
-    /// Atomically reserve one PIN-verification attempt slot for a pending registration, returning
-    /// the new attempt count. Returns `None` when no slot could be reserved — the row is already
-    /// at `max_attempts` (locked), no live pending row matches the `device_code`, or the
-    /// registration already completed token issuance.
+    /// Atomically reserve one PIN-verification attempt slot for a pending registration.
     ///
     /// Scoped to the pending registration row itself (`pending_email IS NOT NULL AND consumed_at
     /// IS NULL`): minted exchange-code rows copy `device_code` from the pending row, and a
     /// device_code-only UPDATE would mutate those siblings too.
     ///
-    /// The increment happens in a single conditional `UPDATE ... WHERE pin_attempts < $max
-    /// RETURNING`, so the cap is enforced by the database rather than by a snapshot read. This is
-    /// what bounds brute force: callers reserve a slot BEFORE running the (expensive) bcrypt
-    /// comparison, so at most `max_attempts` comparisons can ever run for a given `device_code`,
-    /// even across concurrent verify-pin requests on different Cloud Run instances.
+    /// The increment happens in a single conditional `UPDATE ... RETURNING`, so both caps are
+    /// enforced by the database rather than by a snapshot read. This is what bounds brute force:
+    /// callers reserve a slot BEFORE running the (expensive) bcrypt comparison, so no more
+    /// comparisons can ever run for a given `device_code` than the caps allow, even across
+    /// concurrent verify-pin requests on different instances.
+    ///
+    /// # Why two caps
+    ///
+    /// `max_attempts` bounds guesses against the current PIN, and a resend clears it — that reset
+    /// is what makes a resend the way out of a lockout. On its own, though, it is escapable: an
+    /// attacker who resends whenever the per-PIN cap is spent gets a fresh PIN and a fresh cap
+    /// forever, so the only real limit becomes the resend cooldown. `max_lifetime_attempts` closes
+    /// that by counting failures across every PIN the registration has issued, and nothing resets
+    /// it. Exhausting it disables PIN entry for this registration; the emailed link still works.
     pub async fn reserve_pin_attempt(
         &self,
         device_code: &str,
         tenant_id: i64,
         max_attempts: i32,
-    ) -> Result<Option<i32>, RepositoryError> {
+        max_lifetime_attempts: i32,
+    ) -> Result<PinAttemptReservation, RepositoryError> {
         let row: Option<(i32,)> = sqlx::query_as(
-            "UPDATE oauth_codes SET pin_attempts = pin_attempts + 1 \
-             WHERE device_code = $1 AND tenant_id = $2 AND pin_attempts < $3 \
+            "UPDATE oauth_codes \
+             SET pin_attempts = pin_attempts + 1, pin_failed_total = pin_failed_total + 1 \
+             WHERE device_code = $1 AND tenant_id = $2 \
+               AND pin_attempts < $3 AND pin_failed_total < $4 \
                AND pending_email IS NOT NULL AND consumed_at IS NULL \
              RETURNING pin_attempts",
         )
         .bind(device_code)
         .bind(tenant_id)
         .bind(max_attempts)
+        .bind(max_lifetime_attempts)
         .fetch_optional(&self.pool)
         .await?;
 
-        Ok(row.map(|r| r.0))
+        if let Some((attempt,)) = row {
+            return Ok(PinAttemptReservation::Reserved { attempt });
+        }
+
+        // The reservation failed. Re-read to say which cap did it, so the caller can tell the user
+        // whether a resend helps. Only on the failure path, which already writes an audit record.
+        let state: Option<(i32,)> = sqlx::query_as(
+            "SELECT pin_failed_total FROM oauth_codes \
+             WHERE device_code = $1 AND tenant_id = $2 \
+               AND pending_email IS NOT NULL AND consumed_at IS NULL",
+        )
+        .bind(device_code)
+        .bind(tenant_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match state {
+            Some((failed_total,)) if failed_total >= max_lifetime_attempts => {
+                Ok(PinAttemptReservation::LifetimeExhausted)
+            }
+            // Includes the row vanishing between the two statements: treating that as a per-PIN
+            // lockout is the conservative reading, and the caller has already established the row
+            // existed.
+            _ => Ok(PinAttemptReservation::CurrentPinLocked),
+        }
     }
 
     /// Refund a reserved PIN attempt when no bcrypt comparison ran.
     ///
-    /// The decrement is atomic so a concurrent failed comparison remains counted. The lower bound
-    /// protects the counter if a successful verification reset it before this refund completed.
+    /// Decrements both counters, since [`Self::reserve_pin_attempt`] incremented both. The
+    /// decrement is atomic so a concurrent failed comparison remains counted. The lower bounds
+    /// protect the counters if a successful verification reset them before this refund completed.
     ///
     /// # Errors
     ///
@@ -407,7 +465,9 @@ impl OAuthCodeRepository {
         tenant_id: i64,
     ) -> Result<(), RepositoryError> {
         sqlx::query(
-            "UPDATE oauth_codes SET pin_attempts = GREATEST(pin_attempts - 1, 0) \
+            "UPDATE oauth_codes \
+             SET pin_attempts = GREATEST(pin_attempts - 1, 0), \
+                 pin_failed_total = GREATEST(pin_failed_total - 1, 0) \
              WHERE device_code = $1 AND tenant_id = $2 \
                AND pending_email IS NOT NULL AND consumed_at IS NULL",
         )
@@ -587,6 +647,10 @@ impl OAuthCodeRepository {
     /// Resetting to zero on success keeps the invariant that only *failed* attempts lock, without
     /// weakening the brute-force cap: this is reachable only with a correct PIN.
     ///
+    /// Both counters are decremented by one rather than zeroed, undoing exactly the increment this
+    /// successful attempt made. Zeroing `pin_failed_total` would let a correct PIN wipe the
+    /// registration's lifetime guessing record, and that record is meant to survive everything.
+    ///
     /// Scoped to the live pending registration row like [`Self::reserve_pin_attempt`]; minted
     /// sibling exchange-code rows share the `device_code` and must not be touched.
     pub async fn reset_pin_attempts(
@@ -595,7 +659,8 @@ impl OAuthCodeRepository {
         tenant_id: i64,
     ) -> Result<(), RepositoryError> {
         sqlx::query(
-            "UPDATE oauth_codes SET pin_attempts = 0 \
+            "UPDATE oauth_codes \
+             SET pin_attempts = 0, pin_failed_total = GREATEST(pin_failed_total - 1, 0) \
              WHERE device_code = $1 AND tenant_id = $2 \
                AND pending_email IS NOT NULL AND consumed_at IS NULL",
         )
@@ -958,7 +1023,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_find_by_device_code_excludes_expired() {
+    async fn test_find_by_device_code_returns_expired_rows_for_the_caller_to_judge() {
         let pool = setup_pool().await;
         let repo = OAuthCodeRepository::new(pool.clone());
 
@@ -966,8 +1031,18 @@ mod tests {
         let expires_at = Utc::now() - chrono::Duration::hours(1); // already expired
         insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
 
-        let found = repo.find_by_device_code(&device_code, 1).await.unwrap();
-        assert!(found.is_none(), "expired pending row must not be returned");
+        // The lookup returns the expired row and reports its window, rather than hiding it. An
+        // expired registration and an unknown device_code are different situations for the user,
+        // and filtering here would collapse them into one — so callers decide instead.
+        let found = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .expect("an expired pending row is still returned, so callers can tell it apart");
+        assert!(
+            found.expires_at <= Utc::now(),
+            "the caller must be able to see that the window has closed"
+        );
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
@@ -985,30 +1060,36 @@ mod tests {
         let expires_at = Utc::now() + chrono::Duration::hours(24);
         insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
 
-        // Reserve up to the cap; each call returns the post-increment count.
+        // Reserve up to the cap; each call returns the post-increment count. The lifetime cap is
+        // set far out of the way so this test isolates the per-PIN cap.
         let max = 3;
+        const LIFETIME: i32 = 1000;
         let first = repo
-            .reserve_pin_attempt(&device_code, 1, max)
+            .reserve_pin_attempt(&device_code, 1, max, LIFETIME)
             .await
             .unwrap();
-        assert_eq!(first, Some(1));
+        assert_eq!(first, PinAttemptReservation::Reserved { attempt: 1 });
         let second = repo
-            .reserve_pin_attempt(&device_code, 1, max)
+            .reserve_pin_attempt(&device_code, 1, max, LIFETIME)
             .await
             .unwrap();
-        assert_eq!(second, Some(2));
+        assert_eq!(second, PinAttemptReservation::Reserved { attempt: 2 });
         let third = repo
-            .reserve_pin_attempt(&device_code, 1, max)
+            .reserve_pin_attempt(&device_code, 1, max, LIFETIME)
             .await
             .unwrap();
-        assert_eq!(third, Some(3));
+        assert_eq!(third, PinAttemptReservation::Reserved { attempt: 3 });
 
         // At the cap: no slot can be reserved (atomic lockout), and the counter does not grow.
         let locked = repo
-            .reserve_pin_attempt(&device_code, 1, max)
+            .reserve_pin_attempt(&device_code, 1, max, LIFETIME)
             .await
             .unwrap();
-        assert_eq!(locked, None, "reserve must return None once at the cap");
+        assert_eq!(
+            locked,
+            PinAttemptReservation::CurrentPinLocked,
+            "reserve must refuse once at the per-PIN cap"
+        );
         let after = repo
             .find_by_device_code(&device_code, 1)
             .await
@@ -1016,12 +1097,12 @@ mod tests {
             .unwrap();
         assert_eq!(after.pin_attempts, max, "counter must not exceed the cap");
 
-        // Unknown device_code returns None (no row updated).
+        // Unknown device_code reserves nothing.
         let none = repo
-            .reserve_pin_attempt("nonexistent", 1, max)
+            .reserve_pin_attempt("nonexistent", 1, max, LIFETIME)
             .await
             .unwrap();
-        assert_eq!(none, None);
+        assert_eq!(none, PinAttemptReservation::CurrentPinLocked);
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)
@@ -1040,8 +1121,12 @@ mod tests {
         insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
 
         // Burn a couple of attempt slots (as a near-success run would), then reset on success.
-        repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
-        repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
+        repo.reserve_pin_attempt(&device_code, 1, 5, 1000)
+            .await
+            .unwrap();
+        repo.reserve_pin_attempt(&device_code, 1, 5, 1000)
+            .await
+            .unwrap();
         let before = repo
             .find_by_device_code(&device_code, 1)
             .await
@@ -1118,8 +1203,11 @@ mod tests {
         };
 
         // Reserving an attempt must touch only the pending row, never the minted sibling.
-        let reserved = repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
-        assert_eq!(reserved, Some(1));
+        let reserved = repo
+            .reserve_pin_attempt(&device_code, 1, 5, 1000)
+            .await
+            .unwrap();
+        assert_eq!(reserved, PinAttemptReservation::Reserved { attempt: 1 });
         assert_eq!(
             sibling_attempts(pool.clone(), minted_code.clone()).await,
             0,
@@ -1152,9 +1240,13 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
-        let after_consumed = repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
+        let after_consumed = repo
+            .reserve_pin_attempt(&device_code, 1, 5, 1000)
+            .await
+            .unwrap();
         assert_eq!(
-            after_consumed, None,
+            after_consumed,
+            PinAttemptReservation::CurrentPinLocked,
             "reserve_pin_attempt must not reserve a slot on a consumed registration"
         );
 
@@ -1241,8 +1333,12 @@ mod tests {
                 .unwrap();
 
         // Burn two attempts.
-        repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
-        repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
+        repo.reserve_pin_attempt(&device_code, 1, 5, 1000)
+            .await
+            .unwrap();
+        repo.reserve_pin_attempt(&device_code, 1, 5, 1000)
+            .await
+            .unwrap();
 
         let new_token = format!("verif_{}", uuid::Uuid::new_v4());
         assert!(repo

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -32,8 +32,8 @@ pub struct OAuthCodeData {
     /// Failed attempts against the *current* PIN; a resend clears this, which is what makes a
     /// resend the recovery path out of a lockout
     pub pin_attempts: i32,
-    /// Failed attempts across every PIN this registration has issued; never reset, so it bounds
-    /// guessing over the registration's whole life even though resends clear `pin_attempts`
+    /// Failed attempts across every PIN this email's live registration lineage has issued; never
+    /// reset by resend or same-email supersession, so it is the adversarial guessing bound
     pub pin_failed_total: i32,
     /// When the current PIN was handed to the delivery provider; backs the PIN validity window
     pub pin_sent_at: Option<DateTime<Utc>>,
@@ -240,6 +240,11 @@ impl OAuthCodeRepository {
     /// row would block its own email from ever registering again, since the unique index has no
     /// expiry predicate.
     ///
+    /// Supersession resets the current-PIN lockout and resend cooldown for usability, so neither is
+    /// a security boundary: a caller can always register again. `pin_failed_total` is deliberately
+    /// omitted from `DO UPDATE` below so the guessing budget survives that route. This also means
+    /// repeated registration can extend time, but cannot grant additional PIN guesses.
+    ///
     /// Race-proofed by `idx_oauth_codes_live_pending_email`; the insert-or-supersede decision is a
     /// single statement, so concurrent duplicate registers cannot both create a row.
     pub async fn store_with_pending_registration(
@@ -268,7 +273,8 @@ impl OAuthCodeRepository {
                  is_headless = EXCLUDED.is_headless,
                  pin_hash = EXCLUDED.pin_hash,
                  pin_attempts = 0,
-                 pin_sent_at = NULL
+                 pin_sent_at = NULL,
+                 pin_resend_at = NULL
              RETURNING device_code",
         )
         .bind(params.tenant_id)

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -285,30 +285,36 @@ impl OAuthCodeRepository {
         Ok(())
     }
 
-    /// Delete previously minted, un-redeemed exchange codes for a finalized registration so at most
-    /// one exchange code is ever live for it (keycast#262).
+    /// Find a still-live, un-redeemed exchange code already minted for a finalized registration, if
+    /// one exists (keycast#262).
     ///
-    /// Re-verifying within the window (link re-click, link + PIN) mints a fresh exchange code; this
-    /// removes the prior one. Exchange codes are produced by [`Self::store`] and carry neither a
-    /// `device_code` nor a `pending_email`, which is what distinguishes them from the pending
-    /// registration row — so this never deletes the pending row itself.
-    pub async fn delete_unredeemed_exchange_codes(
+    /// Lets finalize re-arm idempotently: a re-click or mail-prefetch within the exchange window
+    /// reuses the code the polling app may already hold rather than minting a replacement and
+    /// stranding the delivered one. Exchange codes are produced by [`Self::store`] and carry neither
+    /// a `device_code` nor a `pending_email`, which distinguishes them from the pending registration
+    /// row; redeemed codes are deleted at token exchange, so a row that still matches is un-redeemed.
+    /// Returns the most recently minted live code when several exist (a rare double-mint race).
+    pub async fn find_live_exchange_code(
         &self,
         tenant_id: i64,
         user_pubkey: &str,
         client_id: &str,
-    ) -> Result<(), RepositoryError> {
-        sqlx::query(
-            "DELETE FROM oauth_codes \
+    ) -> Result<Option<String>, RepositoryError> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT code FROM oauth_codes \
              WHERE tenant_id = $1 AND user_pubkey = $2 AND client_id = $3 \
-               AND device_code IS NULL AND pending_email IS NULL",
+               AND device_code IS NULL AND pending_email IS NULL \
+               AND consumed_at IS NULL AND expires_at > $4 \
+             ORDER BY created_at DESC \
+             LIMIT 1",
         )
         .bind(tenant_id)
         .bind(user_pubkey)
         .bind(client_id)
-        .execute(&self.pool)
+        .bind(Utc::now())
+        .fetch_optional(&self.pool)
         .await?;
-        Ok(())
+        Ok(row.map(|r| r.0))
     }
 
     /// Mark a pending registration row terminal once its exchange code has been redeemed.
@@ -650,7 +656,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_delete_unredeemed_exchange_codes_spares_pending_row() {
+    async fn test_find_live_exchange_code_reuses_not_pending_row() {
         let pool = setup_pool().await;
         let repo = OAuthCodeRepository::new(pool.clone());
 
@@ -665,6 +671,15 @@ mod tests {
             .unwrap();
         let user_pubkey = pending.user_pubkey.clone();
         let client_id = pending.client_id.clone();
+
+        // No exchange code minted yet: the pending row must not be mistaken for one.
+        assert!(
+            repo.find_live_exchange_code(1, &user_pubkey, &client_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "pending registration row must NOT be returned as an exchange code"
+        );
 
         // A previously minted exchange code for the same user+client (no device_code/pending_email).
         let exchange_code = format!("exch_{}", uuid::Uuid::new_v4());
@@ -685,21 +700,63 @@ mod tests {
         .await
         .unwrap();
 
-        repo.delete_unredeemed_exchange_codes(1, &user_pubkey, &client_id)
-            .await
-            .unwrap();
-
-        // Exchange code is gone; pending registration row survives.
-        assert!(
-            repo.find_valid(1, &exchange_code).await.unwrap().is_none(),
-            "prior exchange code must be deleted"
+        // The live exchange code is now found and reused; the pending row is still untouched.
+        assert_eq!(
+            repo.find_live_exchange_code(1, &user_pubkey, &client_id)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(exchange_code.as_str()),
+            "live exchange code must be returned for reuse"
         );
         assert!(
             repo.find_by_device_code(&device_code, 1)
                 .await
                 .unwrap()
                 .is_some(),
-            "pending registration row must NOT be deleted"
+            "pending registration row must NOT be consumed by the lookup"
+        );
+
+        sqlx::query("DELETE FROM oauth_codes WHERE user_pubkey = $1")
+            .bind(&user_pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_find_live_exchange_code_skips_expired() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let user_pubkey = format!("pk_{}", uuid::Uuid::new_v4());
+        let client_id = format!("client_{}", uuid::Uuid::new_v4());
+
+        // An already-expired exchange code must not be reused.
+        let expired_code = format!("exch_{}", uuid::Uuid::new_v4());
+        repo.store(StoreOAuthCodeParams {
+            tenant_id: 1,
+            code: &expired_code,
+            user_pubkey: &user_pubkey,
+            client_id: &client_id,
+            redirect_uri: "http://localhost:3000/callback",
+            scope: "policy:social",
+            code_challenge: None,
+            code_challenge_method: None,
+            expires_at: Utc::now() - chrono::Duration::minutes(1),
+            previous_auth_id: None,
+            state: None,
+            is_headless: true,
+        })
+        .await
+        .unwrap();
+
+        assert!(
+            repo.find_live_exchange_code(1, &user_pubkey, &client_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "expired exchange code must NOT be reused"
         );
 
         sqlx::query("DELETE FROM oauth_codes WHERE user_pubkey = $1")

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -285,6 +285,29 @@ impl OAuthCodeRepository {
         Ok(())
     }
 
+    /// Clear the failed-attempt counter for a pending registration after a correct PIN (keycast#262).
+    ///
+    /// `reserve_pin_attempt` increments `pin_attempts` before every bcrypt compare, including the
+    /// successful one, so a verified registration would otherwise carry that success toward the
+    /// lockout cap and a duplicate/retried verify of the same correct PIN could spuriously lock out.
+    /// Resetting to zero on success keeps the invariant that only *failed* attempts lock, without
+    /// weakening the brute-force cap: this is reachable only with a correct PIN.
+    pub async fn reset_pin_attempts(
+        &self,
+        device_code: &str,
+        tenant_id: i64,
+    ) -> Result<(), RepositoryError> {
+        sqlx::query(
+            "UPDATE oauth_codes SET pin_attempts = 0 \
+             WHERE device_code = $1 AND tenant_id = $2",
+        )
+        .bind(device_code)
+        .bind(tenant_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Find a still-live, un-redeemed exchange code already minted for a finalized registration, if
     /// one exists (keycast#262).
     ///
@@ -588,6 +611,44 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(none, None);
+
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_reset_pin_attempts_clears_counter() {
+        let pool = setup_pool().await;
+        let repo = OAuthCodeRepository::new(pool.clone());
+
+        let device_code = format!("dc_{}", uuid::Uuid::new_v4());
+        let expires_at = Utc::now() + chrono::Duration::hours(24);
+        insert_pending_registration(&repo, &device_code, Some("pinhash123"), expires_at).await;
+
+        // Burn a couple of attempt slots (as a near-success run would), then reset on success.
+        repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
+        repo.reserve_pin_attempt(&device_code, 1, 5).await.unwrap();
+        let before = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(before.pin_attempts, 2, "attempts accumulated before reset");
+
+        repo.reset_pin_attempts(&device_code, 1).await.unwrap();
+
+        let after = repo
+            .find_by_device_code(&device_code, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            after.pin_attempts, 0,
+            "successful verify must clear the failed-attempt counter"
+        );
 
         sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
             .bind(&device_code)

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -4134,8 +4134,8 @@ mod tests {
             Some(&token),
             Some(&secret),
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         let row: (Option<String>, Option<String>, bool, Option<String>) = sqlx::query_as(
             "SELECT email, password_hash, email_verified, email_verification_token

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -691,6 +691,12 @@ impl UserRepository {
     }
 
     /// Create a new user with email/password and pre-verified status.
+    ///
+    /// Idempotent on `pubkey`: concurrent finalize of the same pending registration may call this
+    /// twice for the same pubkey, so a pubkey conflict is a no-op (`ON CONFLICT (pubkey) DO
+    /// NOTHING`) rather than an error — the caller then proceeds as "user already exists". A
+    /// genuine duplicate *email* on a different pubkey still surfaces via the email unique
+    /// constraint, which the caller maps to a 409 (keycast#262 finalize-race).
     pub async fn create_with_password_verified(
         &self,
         pubkey: &str,
@@ -702,7 +708,8 @@ impl UserRepository {
     ) -> Result<(), RepositoryError> {
         sqlx::query(
             "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, email_verification_token, created_at, updated_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+             ON CONFLICT (pubkey) DO NOTHING",
         )
         .bind(pubkey)
         .bind(tenant_id)
@@ -2975,6 +2982,34 @@ mod tests {
         .execute(pool)
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_create_with_password_verified_is_idempotent_on_pubkey() {
+        // Concurrent finalize of the same pending registration can call this twice for the same
+        // pubkey; the second call must be a no-op rather than a unique-violation error so finalize
+        // can proceed to re-mint a fresh exchange code (keycast#262 finalize-race).
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let pubkey = Keys::generate().public_key().to_hex();
+        let email = format!("idem-{}@example.com", test_suffix());
+
+        repo.create_with_password_verified(&pubkey, 1, &email, "hash", true, None)
+            .await
+            .expect("first create should succeed");
+
+        // Second identical create must NOT error (ON CONFLICT (pubkey) DO NOTHING).
+        repo.create_with_password_verified(&pubkey, 1, &email, "hash", true, None)
+            .await
+            .expect("second create on same pubkey must be a no-op, not an error");
+
+        assert!(repo.exists(&pubkey, 1).await.unwrap());
+
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1948,13 +1948,17 @@ impl UserRepository {
     /// Returns [`RepositoryError::NotFound`] if no row exists for this pubkey.
     /// Returns [`RepositoryError::Duplicate`] if the email is owned by another
     /// user or the row is already bound to a different email.
+    ///
+    /// `verification_token` is the token kept on the materialized row so the
+    /// email link stays idempotently re-resolvable; pass `None` when the
+    /// pending registration carries no token.
     pub async fn complete_pending_oauth_registration(
         &self,
         pubkey: &str,
         tenant_id: i64,
         email: &str,
         password_hash: &str,
-        verification_token: &str,
+        verification_token: Option<&str>,
         encrypted_secret: Option<&[u8]>,
     ) -> Result<(), RepositoryError> {
         let mut tx = self.pool.begin().await?;
@@ -4087,7 +4091,14 @@ mod tests {
 
         create_bare_user(&pool, &pubkey).await;
 
-        repo.complete_pending_oauth_registration(&pubkey, 1, &email, "hash", &token, Some(&secret))
+        repo.complete_pending_oauth_registration(
+            &pubkey,
+            1,
+            &email,
+            "hash",
+            Some(&token),
+            Some(&secret),
+        )
             .await
             .unwrap();
 
@@ -4140,7 +4151,7 @@ mod tests {
             1,
             &email,
             "hash",
-            "token",
+            Some("token"),
             Some(&[1_u8; 32]),
         )
         .await
@@ -4207,7 +4218,7 @@ mod tests {
         create_bare_user(&pool, &pubkey).await;
 
         let result = repo
-            .complete_pending_oauth_registration(&pubkey, 1, &email, "hash", "token", None)
+            .complete_pending_oauth_registration(&pubkey, 1, &email, "hash", Some("token"), None)
             .await;
         assert!(
             matches!(result, Err(RepositoryError::Duplicate)),
@@ -4253,7 +4264,7 @@ mod tests {
                 1,
                 &pending_email,
                 "pending-hash",
-                "token",
+                Some("token"),
                 Some(&[1_u8; 32]),
             )
             .await;
@@ -4309,7 +4320,7 @@ mod tests {
             1,
             &email,
             "pending-hash",
-            "token",
+            Some("token"),
             Some(&secret),
         )
         .await
@@ -4366,7 +4377,7 @@ mod tests {
             1,
             &email,
             "pending-hash",
-            "token",
+            Some("token"),
             Some(&secret),
         )
         .await
@@ -4409,7 +4420,7 @@ mod tests {
                 1,
                 "oauth-missing@example.com",
                 "hash",
-                "token",
+                Some("token"),
                 None,
             )
             .await;

--- a/core/tests/pool_nesting_test.rs
+++ b/core/tests/pool_nesting_test.rs
@@ -364,7 +364,7 @@ async fn complete_pending_oauth_registration_uses_one_connection() {
                     TENANT_ID,
                     &probe_email,
                     "hash",
-                    &Uuid::new_v4().to_string(),
+                    Some(&Uuid::new_v4().to_string()),
                     Some(b"encrypted"),
                 )
                 .await

--- a/database/migrations/20260807120000_add_pin_to_oauth_codes.sql
+++ b/database/migrations/20260807120000_add_pin_to_oauth_codes.sql
@@ -1,18 +1,28 @@
 -- Add in-app PIN fallback fields to oauth_codes (keycast#262).
 --
 -- Headless registrations email a 6-digit PIN alongside the verification link as a
--- second transport for the same proof of email control. The PIN is stored hashed,
--- bounded by an attempt cap (brute-force protection), and re-armable via resend.
+-- second transport for the same proof of email control. The PIN is stored hashed
+-- and bounded by two attempt caps: a per-PIN cap that a resend clears, and a
+-- lifetime cap across the whole registration that nothing clears.
 --
--- pin_hash:      bcrypt hash of the 6-digit PIN (NULL when no PIN was issued).
--- pin_attempts:  failed verify-pin attempts; cap enforced at 5, reset on resend.
--- pin_sent_at:   when the *current* PIN was handed to the delivery provider. Backs the PIN's own
---                validity window, which is much shorter than the row's 24h registration window.
--- pin_resend_at: when a PIN resend was last performed. Backs the resend cooldown, and is
---                deliberately separate from pin_sent_at: it stays NULL through registration so the
---                first resend a user asks for is never swallowed by a cooldown they never started.
+-- pin_hash:          bcrypt hash of the 6-digit PIN (NULL when no PIN was issued).
+-- pin_attempts:      failed attempts against the CURRENT PIN. Reset to 0 by a resend, which is
+--                    what makes a resend the recovery path out of a lockout.
+-- pin_failed_total:  failed attempts across every PIN this registration has issued. Never reset,
+--                    so it bounds guessing over the registration's whole life. Without it the
+--                    per-PIN cap would be escapable indefinitely by resending.
+-- pin_sent_at:       when the current PIN was handed to the delivery provider. Distinguishes a PIN
+--                    the user could be holding from one that was never delivered.
+-- pin_resend_at:     when a PIN resend was last performed. Backs the resend cooldown, and is
+--                    deliberately separate from pin_sent_at: it stays NULL through registration so
+--                    the first resend a user asks for is never swallowed by a cooldown they never
+--                    started.
+--
+-- The PIN itself carries no separate expiry: it is one of two presentations of the same
+-- confirmation code as the emailed link, and expires with the registration row's own window.
 ALTER TABLE oauth_codes
-    ADD COLUMN IF NOT EXISTS pin_hash      TEXT,
-    ADD COLUMN IF NOT EXISTS pin_attempts  INTEGER NOT NULL DEFAULT 0,
-    ADD COLUMN IF NOT EXISTS pin_sent_at   TIMESTAMPTZ,
-    ADD COLUMN IF NOT EXISTS pin_resend_at TIMESTAMPTZ;
+    ADD COLUMN IF NOT EXISTS pin_hash         TEXT,
+    ADD COLUMN IF NOT EXISTS pin_attempts     INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS pin_failed_total INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS pin_sent_at      TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS pin_resend_at    TIMESTAMPTZ;

--- a/database/migrations/20260807120000_add_pin_to_oauth_codes.sql
+++ b/database/migrations/20260807120000_add_pin_to_oauth_codes.sql
@@ -1,0 +1,14 @@
+-- Add in-app PIN fallback fields to oauth_codes (keycast#262).
+--
+-- Headless registrations email a 6-digit PIN alongside the verification link as a
+-- second transport for the same proof of email control. The PIN is stored hashed,
+-- bounded by an attempt cap (brute-force protection), and re-armable via resend.
+--
+-- pin_hash:     bcrypt hash of the 6-digit PIN (NULL when no PIN was issued).
+-- pin_attempts: failed verify-pin attempts; cap enforced at 5, reset on resend.
+-- pin_sent_at:  backs the 5-minute PIN-resend cooldown (mirrors users.email_verification_sent_at,
+--               but lives on the pending oauth_codes row since headless users have no users row yet).
+ALTER TABLE oauth_codes
+    ADD COLUMN IF NOT EXISTS pin_hash     TEXT,
+    ADD COLUMN IF NOT EXISTS pin_attempts INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS pin_sent_at  TIMESTAMPTZ;

--- a/database/migrations/20260807120000_add_pin_to_oauth_codes.sql
+++ b/database/migrations/20260807120000_add_pin_to_oauth_codes.sql
@@ -4,11 +4,15 @@
 -- second transport for the same proof of email control. The PIN is stored hashed,
 -- bounded by an attempt cap (brute-force protection), and re-armable via resend.
 --
--- pin_hash:     bcrypt hash of the 6-digit PIN (NULL when no PIN was issued).
--- pin_attempts: failed verify-pin attempts; cap enforced at 5, reset on resend.
--- pin_sent_at:  backs the 5-minute PIN-resend cooldown (mirrors users.email_verification_sent_at,
---               but lives on the pending oauth_codes row since headless users have no users row yet).
+-- pin_hash:      bcrypt hash of the 6-digit PIN (NULL when no PIN was issued).
+-- pin_attempts:  failed verify-pin attempts; cap enforced at 5, reset on resend.
+-- pin_sent_at:   when the *current* PIN was handed to the delivery provider. Backs the PIN's own
+--                validity window, which is much shorter than the row's 24h registration window.
+-- pin_resend_at: when a PIN resend was last performed. Backs the resend cooldown, and is
+--                deliberately separate from pin_sent_at: it stays NULL through registration so the
+--                first resend a user asks for is never swallowed by a cooldown they never started.
 ALTER TABLE oauth_codes
-    ADD COLUMN IF NOT EXISTS pin_hash     TEXT,
-    ADD COLUMN IF NOT EXISTS pin_attempts INTEGER NOT NULL DEFAULT 0,
-    ADD COLUMN IF NOT EXISTS pin_sent_at  TIMESTAMPTZ;
+    ADD COLUMN IF NOT EXISTS pin_hash      TEXT,
+    ADD COLUMN IF NOT EXISTS pin_attempts  INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS pin_sent_at   TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS pin_resend_at TIMESTAMPTZ;

--- a/database/migrations/20260807120100_add_consumed_at_to_oauth_codes.sql
+++ b/database/migrations/20260807120100_add_consumed_at_to_oauth_codes.sql
@@ -1,0 +1,10 @@
+-- Add a terminal "consumed" marker to oauth_codes (keycast#262).
+--
+-- A pending email-verification registration row is re-clickable within its 24h window: re-verifying
+-- re-arms a fresh 10-minute exchange code (which makes link prefetch/preview harmless). Once the
+-- user actually redeems an exchange code for tokens, the registration is complete and must not be
+-- re-minted again. `consumed_at` records that terminal transition: it is set when the exchange code
+-- is redeemed at the token endpoint, and finalize refuses to re-mint once it is set. Cleanup deletes
+-- consumed (and expired) rows so the pending row has a finite lifecycle.
+ALTER TABLE oauth_codes
+    ADD COLUMN IF NOT EXISTS consumed_at TIMESTAMPTZ;

--- a/database/migrations/20260810120000_unique_live_pending_registration_email.sql
+++ b/database/migrations/20260810120000_unique_live_pending_registration_email.sql
@@ -1,0 +1,32 @@
+-- One live pending registration per (tenant, email).
+--
+-- The mobile app can POST /api/headless/register twice for a single signup (measured in
+-- production: two calls 2.9s apart, and ~25 emails hit the endpoint 2+ times in 8 days, some
+-- 1.2s apart). Each call minted a separate pending row, device_code, verification token and
+-- email, so the user could open the older link and get a 409 that deleted the stale row,
+-- followed by a 401 "Invalid or expired token". Registering twice must supersede the first
+-- attempt in place instead of racing a second row into existence.
+--
+-- Only pending rows are covered: minted exchange-code rows carry pending_email = NULL, and a
+-- completed registration is marked consumed_at, so neither participates in the constraint.
+
+-- Collapse pre-existing duplicates so the unique index can be created. The newest row is the
+-- one the app is polling (it holds the device_code returned by the last register call); older
+-- rows are already unreachable. Their short-lived minted exchange codes, if any, expire on
+-- their own 10-minute window.
+WITH ranked AS (
+    SELECT code,
+           ROW_NUMBER() OVER (
+               PARTITION BY tenant_id, lower(pending_email)
+               ORDER BY created_at DESC, code DESC
+           ) AS dup_rank
+    FROM oauth_codes
+    WHERE pending_email IS NOT NULL
+      AND consumed_at IS NULL
+)
+DELETE FROM oauth_codes
+WHERE code IN (SELECT code FROM ranked WHERE dup_rank > 1);
+
+CREATE UNIQUE INDEX idx_oauth_codes_live_pending_email
+    ON oauth_codes (tenant_id, lower(pending_email))
+    WHERE pending_email IS NOT NULL AND consumed_at IS NULL;

--- a/database/migrations/20260810120000_unique_live_pending_registration_email.sql
+++ b/database/migrations/20260810120000_unique_live_pending_registration_email.sql
@@ -10,6 +10,12 @@
 -- Only pending rows are covered: minted exchange-code rows carry pending_email = NULL, and a
 -- completed registration is marked consumed_at, so neither participates in the constraint.
 
+-- The migration job runs before the new service rollout while old instances may still insert
+-- duplicates. Serialize writes before choosing survivors so a row cannot commit between the
+-- DELETE snapshot and unique-index creation. The table is small and the index build is bounded;
+-- this brief write pause is safer than a load-dependent migration failure.
+LOCK TABLE oauth_codes IN SHARE ROW EXCLUSIVE MODE;
+
 -- Collapse pre-existing duplicates so the unique index can be created. The newest row is the
 -- one the app is polling (it holds the device_code returned by the last register call); older
 -- rows are already unreachable. Their short-lived minted exchange codes, if any, expire on

--- a/database/migrations/20260811120000_guard_pending_registration_finalization.sql
+++ b/database/migrations/20260811120000_guard_pending_registration_finalization.sql
@@ -1,0 +1,9 @@
+-- Serialize in-place registration supersession with user materialization.
+--
+-- A verification handler reads a pending generation before creating its users row. Without a
+-- claim, a new registration can rewrite that same oauth_codes row between the read and creation,
+-- causing the superseded generation to materialize. The claim is leased so a crashed handler does
+-- not permanently block a fresh registration.
+ALTER TABLE oauth_codes
+    ADD COLUMN finalization_claim TEXT,
+    ADD COLUMN finalization_claimed_at TIMESTAMPTZ;

--- a/database/migrations/20260811120000_guard_pending_registration_finalization.sql
+++ b/database/migrations/20260811120000_guard_pending_registration_finalization.sql
@@ -1,9 +1,0 @@
--- Serialize in-place registration supersession with user materialization.
---
--- A verification handler reads a pending generation before creating its users row. Without a
--- claim, a new registration can rewrite that same oauth_codes row between the read and creation,
--- causing the superseded generation to materialize. The claim is leased so a crashed handler does
--- not permanently block a fresh registration.
-ALTER TABLE oauth_codes
-    ADD COLUMN finalization_claim TEXT,
-    ADD COLUMN finalization_claimed_at TIMESTAMPTZ;

--- a/web/src/lib/keycast_api.svelte.ts
+++ b/web/src/lib/keycast_api.svelte.ts
@@ -3,9 +3,14 @@ import { getViteDomain } from "$lib/utils/env";
 
 export class ApiError extends Error {
     status: number;
-    constructor(message: string, status: number) {
+    /// Machine-readable error code from the response body, when the endpoint sends one
+    /// (e.g. VERIFICATION_LINK_SUPERSEDED). Callers should branch on this rather than on
+    /// message text.
+    code?: string;
+    constructor(message: string, status: number, code?: string) {
         super(message);
         this.status = status;
+        this.code = code;
         this.name = 'ApiError';
     }
 }
@@ -42,14 +47,16 @@ export class KeycastApi {
         if (!response.ok) {
             // Try to get the error message from the response body
             let errorMessage: string;
+            let errorCode: string | undefined;
             try {
                 const errorBody = await response.json();
                 errorMessage = errorBody.error || errorBody.message || `Something went wrong. Please try again.`;
+                errorCode = typeof errorBody.code === 'string' ? errorBody.code : undefined;
             } catch {
                 // If we can't parse JSON, use a generic message
                 errorMessage = 'Something went wrong. Please try again.';
             }
-            throw new ApiError(errorMessage, response.status);
+            throw new ApiError(errorMessage, response.status, errorCode);
         }
 
         if (response.status === 204) {

--- a/web/src/routes/verify-email/+page.svelte
+++ b/web/src/routes/verify-email/+page.svelte
@@ -8,7 +8,7 @@
 
 	const api = new KeycastApi();
 
-	let status = $state<'loading' | 'processing' | 'success' | 'oauth_redirect' | 'headless_verified' | 'error' | 'no-token'>('loading');
+	let status = $state<'loading' | 'processing' | 'success' | 'oauth_redirect' | 'headless_verified' | 'error' | 'superseded' | 'no-token'>('loading');
 	let message = $state('');
 	let redirectUrl = $state('');
 
@@ -103,6 +103,14 @@
 				}
 				return; // Exit after successful handling
 			} catch (err: any) {
+				// The link was already used or a newer verification email replaced it. Telling the
+				// user to "log in again" is a dead end - they have no session and no account yet
+				// - so give the one instruction that resolves it (keycast#268).
+				if (err.code === 'VERIFICATION_LINK_SUPERSEDED') {
+					status = 'superseded';
+					message = err.message;
+					return;
+				}
 				// Check for 410 Gone (registration expired)
 				if (err.status === 410) {
 					status = 'error';
@@ -215,6 +223,18 @@
 			<div class="actions">
 				<a href="/login" class="btn-secondary">Go to Login</a>
 				<a href="/register" class="btn-primary">Create New Account</a>
+			</div>
+
+		{:else if status === 'superseded'}
+			<div class="status-icon error">
+				<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="currentColor" viewBox="0 0 256 256">
+					<path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm-8,56a8,8,0,0,1,16,0v56a8,8,0,0,1-16,0Zm8,104a12,12,0,1,1,12-12A12,12,0,0,1,128,184Z"></path>
+				</svg>
+			</div>
+			<h1>Link no longer valid</h1>
+			<p class="subtitle">{message}</p>
+			<div class="actions">
+				<a href="/login" class="btn-secondary">Go to Login</a>
 			</div>
 
 		{:else if status === 'no-token'}


### PR DESCRIPTION
## Summary

Some email-opening environments never finish the client-side verification flow, so registration stalls after the user taps the link.
This change verifies on the server when the link is opened (no page JavaScript required), adds a 6-digit in-app PIN fallback, and hardens pending-registration rows for production concurrency and replay.
It also reconciles the duplicate-pending-registration dedupe work with the revised PIN contract and normalizes a few terminal OAuth error codes.

Closes #262

## Motivation

Email verification is the registration-completion step for app sign-up.
Some mail clients and in-app browsers open the link in a context that does not complete the SPA flow, and App Links do not always escalate out of that context either.
Production does not corroborate a single Gmail-Custom-Tab root cause, so the safer claim is environmental: server-side GET removes dependence on page JavaScript and app-link handoff.

Measured load that makes the concurrency work load-bearing rather than defensive:

- Of 587 repeat registrations, **77 arrived within ten seconds** of the previous attempt (dedupe justification).
- Samsung Internet fetched each verification link about **fifteen times**, measured across thirty days of production request logs (`consumed_at` and idempotent re-arm are load-bearing).
- Migration backfill (measured 2026-08-11): the `DELETE` removes **587 superseded duplicate rows** of **2,976** unconsumed pending registrations, keeping the newest per tenant and normalized email so **2,389** survive and no email loses its most recent registration. Re-measure immediately before deploy; that table is live.

## What Changed

Verification is shared through `finalize_pending_registration` so the link and PIN paths behave the same.

- `GET /api/auth/verify-email` verifies on the server and returns HTML (headless), a redirect (third-party OAuth), or a session cookie (first-party). POST and the SPA page remain for in-flight emails.
- `POST /api/headless/verify-pin` and `POST /api/headless/resend-pin` for the in-app PIN transport.
- Duplicate pending registrations for the same tenant + normalized email are superseded instead of minting a second live row; superseded links get a clear page.
- PIN contract: `401 PIN_INVALID`, `423 PIN_LOCKED`, `410 PIN_EXPIRED`, `403 PIN_UNAVAILABLE`, `409 EMAIL_ALREADY_EXISTS`; separate `pin_resend_at`; lifetime `pin_failed_total`; atomic resend claim.
- Terminal OAuth errors: register duplicates return `409 EMAIL_ALREADY_EXISTS`; spent or unknown authorization codes return RFC 6749 `invalid_grant` instead of password-style copy.
- Concurrency/replay: idempotent exchange-code re-arm, `consumed_at` terminal marker, atomic PIN attempt reservation, uniform bcrypt timing on verify-pin 401 paths, `ON CONFLICT` user materialization.

## Testing

Independent validation at `e10464e`:

- **42/42** server-side assertions against a fresh image built from that SHA (link states and dedupe, JS-less GET materializing the user, full PIN contract including correct-PIN-accepted, supersession preserving `pin_failed_total` while resetting `pin_attempts` and `pin_resend_at`, first-resend-not-swallowed, four concurrent finalizations minting exactly one exchange code and one user, expired distinct from superseded, both `invalid_grant` paths).
- Android app leg on a headless emulator: PIN entry completed sign-in to the feed.
- Dedupe migration proven against seeded production-shaped data.
- Pre-push: `cargo fmt`, clippy (`-D warnings -A deprecated`), `cargo test --workspace`, release build.

Not included: a formal independent code review frozen at `e10464e`. The last independent review was frozen at `193d844`. Green checks do not replace that.

JS-less curl against the verification GET is a reproduction of the failure mode (client JS never runs), not proof that any one mail client causes it.

## Review / approval note

The existing APPROVED review was given against `fb87d0d`.
This force-push replaces that lineage with `e10464e`, so that approval does not refer to the code that will merge.
Maintainer is merging on their own local testing; no re-review requested from this update.

## Risks

- Migration backfill deletes superseded duplicate pending rows; re-measure counts immediately before deploy.
- Pending rows live the full registration window and can mint short-lived exchange codes; `consumed_at` stops re-mint after token redemption.
- PIN guessing is bounded by per-PIN and lifetime caps; resend clears only the per-PIN counter.

## Visuals

- [x] No visual change in `web/`
- [x] New surface is a minimal server-side HTML status page for webviews that open the GET link
