### PR TITLE
fix: correct brand spelling "DiVine" → "Divine" in UI/docs

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -38,7 +38,7 @@ servers:
   - url: https://entryway.divine.video/api
     description: Production ATProto Authorization Server
   - url: https://login.divine.video/api
-    description: Production DiVine and Nostr login server
+    description: Production Divine and Nostr login server
   - url: http://localhost:3000/api
     description: Local development
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -273,7 +273,7 @@ Required env vars to enable it:
 - `ATPROTO_ENTRYWAY_ENABLED=true`
 - `ATPROTO_ENTRYWAY_ORIGIN=https://entryway.divine.video`
 
-`entryway.divine.video` is the only public ATProto Authorization Server host in this setup. `login.divine.video` remains the human-facing DiVine and Nostr login surface.
+`entryway.divine.video` is the only public ATProto Authorization Server host in this setup. `login.divine.video` remains the human-facing Divine and Nostr login surface.
 
 Optional:
 

--- a/web/src/lib/components/AtprotoSettingsCard.svelte
+++ b/web/src/lib/components/AtprotoSettingsCard.svelte
@@ -57,7 +57,7 @@
   <div class="section-header">
     <h2>Bluesky Account</h2>
     <p>
-      Claim your DiVine handle, provision your Bluesky identity, and control whether future
+      Claim your Divine handle, provision your Bluesky identity, and control whether future
       cross-posts are allowed.
     </p>
   </div>


### PR DESCRIPTION
Cosmetic brand-name corrections: **"DiVine" → "Divine"** in three human-facing/documentation strings.

| File | Context |
|------|---------|
| `web/src/lib/components/AtprotoSettingsCard.svelte` | "Claim your **Divine** handle…" (Bluesky settings card copy) |
| `api/openapi.yaml` | Production server `description` |
| `docs/DEPLOYMENT.md` | AtProto/entryway section prose |

The DB seed migrations (`0001_initial_schema.sql` and the `20260423100000_update_tenant_seed_branding.sql` fix migration) intentionally retain the old value and are left untouched, since editing shipped migrations is unsafe and the tenant name is already corrected at runtime by that migration.

No functional change. Companion to divinevideo/divine-iac-coreconfig#1088, which fixes the actual email `FROM_NAME` sender display name across the keycast deployment overlays.