### PR TITLE
feat(web): rename dashboard settings link + page heading to "Account & Security"

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -417,7 +417,7 @@ $effect(() => {
 							{/if}
 							<a href="/settings/security" class="identity-link">
 								<Gear size={16} />
-								<span>Security &amp; Bluesky</span>
+								<span>Account &amp; Security</span>
 							</a>
 						</div>
 					{/if}
@@ -442,7 +442,7 @@ $effect(() => {
 						<div class="learn-block">
 							<h4><Key size={16} weight="fill" /> Your Keys Explained</h4>
 							<p><strong>Your npub</strong> (public key) is like a username. Share it so others can find you across any Nostr app.</p>
-							<p><strong>Your nsec</strong> (private key) proves you own this identity. Keep it safe! Find it in <a href="/settings/security">Security Settings</a> if you need to export it.</p>
+							<p><strong>Your nsec</strong> (private key) proves you own this identity. Keep it safe! Find it in <a href="/settings/security">Account &amp; Security</a> if you need to export it.</p>
 						</div>
 
 						<div class="learn-block">
@@ -458,7 +458,7 @@ $effect(() => {
 
 						<div class="learn-block">
 							<h4><Export size={16} weight="fill" /> Want Full Control of Your Key?</h4>
-							<p>If you started with email and password but want full control, export your nsec from <a href="/settings/security">Security Settings</a> and move it to:</p>
+							<p>If you started with email and password but want full control, export your nsec from <a href="/settings/security">Account &amp; Security</a> and move it to:</p>
 							<ul class="learn-list">
 								<li><strong>Your phone:</strong> <a href="https://primal.net" target="_blank" rel="noopener noreferrer" class="inline-link">Primal <ArrowSquareOut size={12} /></a> (iOS & Android), <a href="https://github.com/greenart7c3/Amber" target="_blank" rel="noopener noreferrer" class="inline-link">Amber <ArrowSquareOut size={12} /></a> (Android), or <a href="https://nsec.app" target="_blank" rel="noopener noreferrer" class="inline-link">nsec.app <ArrowSquareOut size={12} /></a> (any browser) turn your device into a personal signing server. When a Nostr app needs your signature, it asks your device and your key never leaves it.</li>
 								<li><strong>Your browser:</strong> Extensions like <a href="https://getalby.com" target="_blank" rel="noopener noreferrer" class="inline-link">Alby <ArrowSquareOut size={12} /></a> or <a href="https://chromewebstore.google.com/detail/soapboxpub-signer/nnodjkgakfpkckcnbacpcjbpmlmbihdd" target="_blank" rel="noopener noreferrer" class="inline-link">Soapbox Signer <ArrowSquareOut size={12} /></a> (Chrome, Firefox) keep your key in the browser itself. <a href="https://apps.apple.com/app/nostash/id6499558903" target="_blank" rel="noopener noreferrer" class="inline-link">Nostash <ArrowSquareOut size={12} /></a> does the same for Safari on iOS.</li>

--- a/web/src/routes/settings/security/+page.svelte
+++ b/web/src/routes/settings/security/+page.svelte
@@ -229,12 +229,12 @@
 </script>
 
 <svelte:head>
-	<title>Security Settings - {BRAND.name}</title>
+	<title>Account &amp; Security - {BRAND.name}</title>
 </svelte:head>
 
 <div class="security-page">
 	<div class="header">
-		<h1>Security Settings</h1>
+		<h1>Account &amp; Security</h1>
 		<p class="subtitle">Manage your account security and Nostr keys</p>
 	</div>
 


### PR DESCRIPTION
Draft — pending code review before marking ready.

## What

Renames the user-facing dashboard settings entry point (and the destination page heading/title) from **"Security & Bluesky"** to **"Account & Security"**. Label-only; the `/settings/security` route path is unchanged so existing links and bookmarks keep working.

## Why

The gear-icon link on the dashboard read "Security & Bluesky", which enumerates two of the things inside `/settings/security` rather than naming the container. That page actually holds email verification, change password, export private key, change private key, and the Bluesky account card (claim handle, provision atproto identity, cross-posting).

"Account & Security" is the widely-recognized convention for "where I manage my password, email, identity, and keys" (Apple "Sign-In & Security", Microsoft, and Coinbase/Kraken-style "Account & Security" in crypto/custody products — the closest analog for a key-custody app). It leads with the container and keeps "Security" visible, which also stays consistent with the `/security` path and the pages sensitive key operations.

Historical note: the link originally read "Security Settings"; it was changed to "Security & Bluesky" when the atproto card was added (rabble, `6457683`, 2026-03-28) to advertise the new feature. This restores a container-style label.

## Changes

- `web/src/routes/+page.svelte` — gear link label (`Gear` icon + href unchanged).
- `web/src/routes/settings/security/+page.svelte` — `<h1>` and `<svelte:head><title>`.
- `web/src/routes/+page.svelte` — two inline "Your Keys Explained" links that pointed users to "Security Settings" for nsec export, renamed for wayfinding consistency (there is no longer any "Security Settings" label to look for).

Left as-is: the `🔐 Unlock Security Settings` sub-card heading, which names the security-gated key operations specifically and stays coherent since the label keeps "Security".

## Verification

- `svelte-check` clean on the two edited files (no new type errors).
- Visual render not verified locally (the label is behind logged-in identity state and needs the full auth stack); to be confirmed on staging after merge.