### PR TITLE
feat(minor-safety): verified_minor lifecycle - clear primitive + revocation endpoint (#265)

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -1963,8 +1963,10 @@ fn is_unsafe_format_char(c: char) -> bool {
         '\u{200B}'..='\u{200F}'   // zero-width space .. right-to-left mark
         | '\u{2028}'..='\u{2029}' // line / paragraph separator
         | '\u{202A}'..='\u{202E}' // bidi embeddings / overrides
+        | '\u{2060}'..='\u{2064}' // word joiner + invisible math operators
         | '\u{2066}'..='\u{2069}' // bidi isolates
         | '\u{FEFF}'              // zero-width no-break space / BOM
+        | '\u{FFF9}'..='\u{FFFB}' // interlinear annotation anchors
     )
 }
 

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -1954,11 +1954,27 @@ pub struct ClearVerifiedMinorParams {
     pub reason: Option<String>,
 }
 
-/// Bound and strip control characters from a caller-supplied reason before it
-/// is logged or persisted (prevents log injection and unbounded audit rows).
-/// Returns None when empty after cleaning.
+/// True for Unicode bidi/zero-width format characters that `char::is_control`
+/// (category Cc) misses. Stripping these prevents log/console display spoofing
+/// via right-to-left overrides and invisible characters.
+fn is_bidi_or_zero_width(c: char) -> bool {
+    matches!(c,
+        '\u{200B}'..='\u{200F}'   // zero-width space .. right-to-left mark
+        | '\u{202A}'..='\u{202E}' // bidi embeddings / overrides
+        | '\u{2066}'..='\u{2069}' // bidi isolates
+        | '\u{FEFF}'              // zero-width no-break space / BOM
+    )
+}
+
+/// Bound and strip control + bidi/zero-width characters from a caller-supplied
+/// reason before it is logged or persisted (prevents log injection, display
+/// spoofing, and unbounded audit rows). Returns None when empty after cleaning.
 fn sanitize_reason(raw: Option<String>) -> Option<String> {
-    let cleaned: String = raw?.chars().filter(|c| !c.is_control()).take(500).collect();
+    let cleaned: String = raw?
+        .chars()
+        .filter(|c| !c.is_control() && !is_bidi_or_zero_width(*c))
+        .take(500)
+        .collect();
     let trimmed = cleaned.trim();
     if trimmed.is_empty() {
         None

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -1958,11 +1958,7 @@ pub struct ClearVerifiedMinorParams {
 /// is logged or persisted (prevents log injection and unbounded audit rows).
 /// Returns None when empty after cleaning.
 fn sanitize_reason(raw: Option<String>) -> Option<String> {
-    let cleaned: String = raw?
-        .chars()
-        .filter(|c| !c.is_control())
-        .take(500)
-        .collect();
+    let cleaned: String = raw?.chars().filter(|c| !c.is_control()).take(500).collect();
     let trimmed = cleaned.trim();
     if trimmed.is_empty() {
         None

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -1954,12 +1954,14 @@ pub struct ClearVerifiedMinorParams {
     pub reason: Option<String>,
 }
 
-/// True for Unicode bidi/zero-width format characters that `char::is_control`
-/// (category Cc) misses. Stripping these prevents log/console display spoofing
-/// via right-to-left overrides and invisible characters.
-fn is_bidi_or_zero_width(c: char) -> bool {
+/// True for Unicode bidi / zero-width / line-separator characters that
+/// `char::is_control` (category Cc) misses. Stripping these prevents log/console
+/// display spoofing via right-to-left overrides, invisible characters, and
+/// newline-equivalent separators (U+2028/U+2029).
+fn is_unsafe_format_char(c: char) -> bool {
     matches!(c,
         '\u{200B}'..='\u{200F}'   // zero-width space .. right-to-left mark
+        | '\u{2028}'..='\u{2029}' // line / paragraph separator
         | '\u{202A}'..='\u{202E}' // bidi embeddings / overrides
         | '\u{2066}'..='\u{2069}' // bidi isolates
         | '\u{FEFF}'              // zero-width no-break space / BOM
@@ -1972,7 +1974,7 @@ fn is_bidi_or_zero_width(c: char) -> bool {
 fn sanitize_reason(raw: Option<String>) -> Option<String> {
     let cleaned: String = raw?
         .chars()
-        .filter(|c| !c.is_control() && !is_bidi_or_zero_width(*c))
+        .filter(|c| !c.is_control() && !is_unsafe_format_char(*c))
         .take(500)
         .collect();
     let trimmed = cleaned.trim();

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -1944,6 +1944,106 @@ pub async fn set_user_status_admin(
     }))
 }
 
+// --- Clear verified_minor (service-token auth: age-up / revocation) ---
+
+/// Query params for the clear-verified_minor endpoint. Both optional; `actor`
+/// (the moderator's hex pubkey) drives the durable audit row.
+#[derive(Debug, Deserialize)]
+pub struct ClearVerifiedMinorParams {
+    pub actor: Option<String>,
+    pub reason: Option<String>,
+}
+
+/// Bound and strip control characters from a caller-supplied reason before it
+/// is logged or persisted (prevents log injection and unbounded audit rows).
+/// Returns None when empty after cleaning.
+fn sanitize_reason(raw: Option<String>) -> Option<String> {
+    let cleaned: String = raw?
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(500)
+        .collect();
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+pub async fn clear_verified_minor_admin(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    headers: HeaderMap,
+    Path(pubkey): Path<String>,
+    Query(params): Query<ClearVerifiedMinorParams>,
+) -> ApiResult<Json<UserStatusResponse>> {
+    authorize_service_token(&headers)?;
+    let tenant_id = tenant.0.id;
+
+    // Validate the optional actor as a 64-char hex pubkey so a T&S action never
+    // silently loses its audit trail to a malformed actor.
+    if let Some(actor) = params.actor.as_deref() {
+        if actor.len() != 64 || !actor.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(ApiError::bad_request(
+                "actor must be a 64-character hex pubkey",
+            ));
+        }
+    }
+
+    let reason_clean = sanitize_reason(params.reason);
+
+    let user_repo = UserRepository::new(auth_state.state.db.clone());
+    user_repo.clear_verified_minor(&pubkey, tenant_id).await?;
+
+    tracing::info!(
+        event = "verified_minor_cleared",
+        pubkey = %pubkey,
+        actor = ?params.actor,
+        reason = ?reason_clean,
+        "Admin cleared verified_minor"
+    );
+
+    // Durable audit row (best-effort) when an actor is supplied. The table's
+    // actor_pubkey is NOT NULL, so no actor -> log-only. A failed insert logs
+    // and the clear still succeeds. (keycast#279 raises the same bar for status changes.)
+    if let Some(actor) = params.actor.as_deref() {
+        let audit_repo = AdminAuditEventRepository::new(auth_state.state.db.clone());
+        if let Err(error) = audit_repo
+            .record(AdminAuditEventRecord {
+                tenant_id,
+                actor_pubkey: actor.to_string(),
+                action: "clear_verified_minor".to_string(),
+                target_resource_type: "user".to_string(),
+                target_resource_id: Some(pubkey.clone()),
+                target_client_id: None,
+                metadata_json: serde_json::json!({ "reason": reason_clean }),
+            })
+            .await
+        {
+            tracing::error!(
+                pubkey = %pubkey,
+                error = %error,
+                "Failed to write admin_audit_events row for verified_minor clear"
+            );
+        }
+    }
+
+    let (status, suspended_reason, suspended_at, verified_minor, verified_minor_at) = user_repo
+        .get_full_admin_status(&pubkey, tenant_id)
+        .await?
+        .ok_or_else(|| ApiError::not_found("User not found"))?;
+
+    Ok(Json(UserStatusResponse {
+        pubkey,
+        status: status.as_str().to_string(),
+        suspended_reason,
+        suspended_at,
+        verified_minor,
+        verified_minor_at,
+    }))
+}
+
 // --- Create approved minor account (service-token auth) ---
 
 #[derive(Debug, Deserialize)]

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -2008,39 +2008,86 @@ pub async fn clear_verified_minor_admin(
     let reason_clean = sanitize_reason(params.reason);
 
     let user_repo = UserRepository::new(auth_state.state.db.clone());
-    user_repo.clear_verified_minor(&pubkey, tenant_id).await?;
+    let transitioned = user_repo.clear_verified_minor(&pubkey, tenant_id).await?;
 
     tracing::info!(
         event = "verified_minor_cleared",
         pubkey = %pubkey,
         actor = ?params.actor,
         reason = ?reason_clean,
+        transitioned,
         "Admin cleared verified_minor"
     );
 
-    // Durable audit row (best-effort) when an actor is supplied. The table's
-    // actor_pubkey is NOT NULL, so no actor -> log-only. A failed insert logs
-    // and the clear still succeeds. (keycast#279 raises the same bar for status changes.)
-    if let Some(actor) = params.actor.as_deref() {
-        let audit_repo = AdminAuditEventRepository::new(auth_state.state.db.clone());
-        if let Err(error) = audit_repo
-            .record(AdminAuditEventRecord {
-                tenant_id,
-                actor_pubkey: actor.to_string(),
-                action: "clear_verified_minor".to_string(),
-                target_resource_type: "user".to_string(),
-                target_resource_id: Some(pubkey.clone()),
-                target_client_id: None,
-                metadata_json: serde_json::json!({ "reason": reason_clean }),
-            })
-            .await
-        {
+    // Durable audit row (best-effort) only for a real transition and only when an
+    // actor is supplied. Gating on `transitioned` keeps a relay-manager retry after
+    // a lost response, or a duplicate revocation, from appending a second event
+    // asserting a state change that never happened. The table's actor_pubkey is
+    // NOT NULL, so no actor -> log-only. A failed insert logs and the clear still
+    // succeeds. (keycast#279 raises the same bar for status changes.)
+    if transitioned {
+        if let Some(actor) = params.actor.as_deref() {
+            let audit_repo = AdminAuditEventRepository::new(auth_state.state.db.clone());
+            if let Err(error) = audit_repo
+                .record(AdminAuditEventRecord {
+                    tenant_id,
+                    actor_pubkey: actor.to_string(),
+                    action: "clear_verified_minor".to_string(),
+                    target_resource_type: "user".to_string(),
+                    target_resource_id: Some(pubkey.clone()),
+                    target_client_id: None,
+                    metadata_json: serde_json::json!({ "reason": reason_clean }),
+                })
+                .await
+            {
+                tracing::error!(
+                    pubkey = %pubkey,
+                    error = %error,
+                    "Failed to write admin_audit_events row for verified_minor clear"
+                );
+            }
+        }
+    }
+
+    // Close the revocation door. Clearing the flag alone leaves any claim link
+    // issued before the clear live, and claim redemption gates only on token
+    // validity -- not on status or verified_minor -- so a minor account revoked
+    // before it is claimed could still be claimed and land as a normal account
+    // with no minor protections. Invalidate outstanding tokens so that path is
+    // shut regardless of whether relay-manager also changes status.
+    //
+    // Run this unconditionally, not just on a transition: a retry after a
+    // mid-request crash (flag already cleared, tokens not yet invalidated) must
+    // still close the door. `invalidate_valid_for_user` only touches still-valid,
+    // unused tokens, so it is idempotent and a no-op for an already-claimed
+    // (age-up) account. Unlike the best-effort audit row this is a safety
+    // invariant: a failure fails the request so the idempotent caller retries
+    // rather than silently leaving the link open.
+    let claim_token_repo = ClaimTokenRepository::new(auth_state.state.db.clone());
+    let invalidated_by = params
+        .actor
+        .as_deref()
+        .unwrap_or("system:verified_minor_clear");
+    let invalidated = match claim_token_repo
+        .invalidate_valid_for_user(&pubkey, tenant_id, invalidated_by, reason_clean.as_deref())
+        .await
+    {
+        Ok(count) => count,
+        Err(error) => {
             tracing::error!(
                 pubkey = %pubkey,
                 error = %error,
-                "Failed to write admin_audit_events row for verified_minor clear"
+                "Failed to invalidate outstanding claim tokens on verified_minor clear"
             );
+            return Err(error.into());
         }
+    };
+    if invalidated > 0 {
+        tracing::info!(
+            pubkey = %pubkey,
+            invalidated,
+            "Invalidated outstanding claim tokens on verified_minor clear"
+        );
     }
 
     let (status, suspended_reason, suspended_at, verified_minor, verified_minor_at) = user_repo

--- a/api/src/api/http/claim.rs
+++ b/api/src/api/http/claim.rs
@@ -363,22 +363,52 @@ pub async fn claim_post(
     let password_hash = bcrypt::hash(&form.password, bcrypt::DEFAULT_COST)
         .map_err(|e| ClaimError::Internal(format!("Password hashing failed: {}", e)))?;
 
-    // Update user with email and password_hash
-    user_repo
-        .claim_account(
-            &claim_token.user_pubkey,
-            tenant_id,
-            &form.email,
-            &password_hash,
-        )
+    // Consume the token and claim the account atomically (#280 review): the
+    // classification above is a point-in-time read, so an admin invalidation
+    // (e.g. clear-verified-minor revoking this account's outstanding link) can
+    // land between it and this point. The single-transaction consume re-checks
+    // validity under the row lock and only mutates the user if it wins, so a
+    // revoked link can never complete a claim.
+    use keycast_core::repositories::ClaimConsumeOutcome;
+    let outcome = user_repo
+        .claim_account_consuming_token(&form.token, tenant_id, &form.email, &password_hash)
         .await
         .map_err(|e| ClaimError::Internal(format!("Database error: {}", e)))?;
 
-    // Mark token as used
-    claim_token_repo
-        .mark_used(&form.token)
-        .await
-        .map_err(|e| ClaimError::Internal(format!("Database error: {}", e)))?;
+    match outcome {
+        ClaimConsumeOutcome::Claimed { user_pubkey } if user_pubkey == claim_token.user_pubkey => {}
+        ClaimConsumeOutcome::Claimed { user_pubkey } => {
+            return Err(ClaimError::Internal(format!(
+                "Claimed pubkey mismatch: token row {} vs classified {}",
+                user_pubkey, claim_token.user_pubkey
+            )));
+        }
+        ClaimConsumeOutcome::TokenNotConsumable => {
+            // Token died between classification and consume — re-classify so
+            // the user gets the state-specific error page.
+            return Err(
+                match claim_token_repo
+                    .classify(&form.token, tenant_id)
+                    .await
+                    .map_err(|e| ClaimError::Internal(format!("Database error: {}", e)))?
+                {
+                    ClaimTokenState::AlreadyClaimed(_) => ClaimError::TokenAlreadyClaimed,
+                    ClaimTokenState::AdminInvalidated(_) => ClaimError::TokenAdminInvalidated,
+                    ClaimTokenState::Replaced { .. } => ClaimError::TokenReplaced,
+                    ClaimTokenState::Expired(_) => ClaimError::TokenExpired,
+                    ClaimTokenState::Unrecognized => ClaimError::TokenUnrecognized,
+                    // A token that failed the consume cannot classify Valid
+                    // (used/invalidated/expired are one-way); treat as internal.
+                    ClaimTokenState::Valid(_) => ClaimError::Internal(
+                        "Token consume failed but token classifies as valid".to_string(),
+                    ),
+                },
+            );
+        }
+        ClaimConsumeOutcome::UserNotClaimable => {
+            return Err(ClaimError::TokenAlreadyClaimed);
+        }
+    }
 
     tracing::info!(
         "Account claimed: pubkey={}, email={}",

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -240,6 +240,10 @@ pub fn api_routes(
             "/admin/users/:pubkey/status",
             get(admin::get_user_status_admin).put(admin::set_user_status_admin),
         )
+        .route(
+            "/admin/users/:pubkey/verified-minor",
+            delete(admin::clear_verified_minor_admin),
+        )
         .route("/admin/users/batch-lookup", post(admin::batch_lookup_users))
         .route(
             "/admin/create-minor-account",

--- a/api/tests/claim_consume_race_test.rs
+++ b/api/tests/claim_consume_race_test.rs
@@ -1,0 +1,284 @@
+// ABOUTME: Regression tests for the claim-token consume race (#280 review)
+// ABOUTME: Token consumption must be atomic with validity; a dead token must never mutate the user
+
+#![cfg(feature = "integration-tests")]
+
+mod common;
+
+use keycast_core::repositories::{ClaimConsumeOutcome, ClaimTokenRepository, UserRepository};
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+
+const TENANT_ID: i64 = 1;
+const ADMIN_PUBKEY: &str = "adminadminadminadminadminadminadminadminadminadminadminadmin1234";
+
+fn generate_token() -> String {
+    Keys::generate().public_key().to_hex()
+}
+
+/// Unique per-user email — the users table has a unique email index and the
+/// test database is shared across (parallel) tests and runs.
+fn email_for(pubkey: &str) -> String {
+    format!("{}@example.com", &pubkey[..12])
+}
+
+/// Unclaimed verified-minor user: the population the clear-verified-minor
+/// endpoint revokes, and whose outstanding claim link it invalidates.
+async fn create_unclaimed_minor(pool: &PgPool) -> String {
+    let pubkey = Keys::generate().public_key().to_hex();
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, verified_minor, verified_minor_at, created_at, updated_at) \
+         VALUES ($1, $2, TRUE, NOW(), NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .bind(TENANT_ID)
+    .execute(pool)
+    .await
+    .expect("create unclaimed minor user");
+    pubkey
+}
+
+async fn create_token_for(pool: &PgPool, pubkey: &str) -> String {
+    let token = generate_token();
+    ClaimTokenRepository::new(pool.clone())
+        .create(&token, pubkey, Some(ADMIN_PUBKEY), TENANT_ID)
+        .await
+        .expect("create claim token");
+    token
+}
+
+async fn user_email(pool: &PgPool, pubkey: &str) -> Option<String> {
+    sqlx::query_scalar("SELECT email FROM users WHERE pubkey = $1 AND tenant_id = $2")
+        .bind(pubkey)
+        .bind(TENANT_ID)
+        .fetch_one(pool)
+        .await
+        .expect("read user email")
+}
+
+/// (used_at set?, invalidated_at set?)
+async fn token_flags(pool: &PgPool, token: &str) -> (bool, bool) {
+    let row: (
+        Option<chrono::DateTime<chrono::Utc>>,
+        Option<chrono::DateTime<chrono::Utc>>,
+    ) = sqlx::query_as("SELECT used_at, invalidated_at FROM account_claim_tokens WHERE token = $1")
+        .bind(token)
+        .fetch_one(pool)
+        .await
+        .expect("read token flags");
+    (row.0.is_some(), row.1.is_some())
+}
+
+#[tokio::test]
+async fn test_valid_token_consumed_and_account_claimed() {
+    common::assert_test_database_url();
+    let pool = common::setup_test_db().await;
+    let pubkey = create_unclaimed_minor(&pool).await;
+    let token = create_token_for(&pool, &pubkey).await;
+
+    let outcome = UserRepository::new(pool.clone())
+        .claim_account_consuming_token(&token, TENANT_ID, &email_for(&pubkey), "hash")
+        .await
+        .expect("consume+claim");
+
+    match outcome {
+        ClaimConsumeOutcome::Claimed { user_pubkey } => assert_eq!(user_pubkey, pubkey),
+        other => panic!("expected Claimed, got {:?}", other),
+    }
+    assert_eq!(
+        user_email(&pool, &pubkey).await.as_deref(),
+        Some(email_for(&pubkey).as_str())
+    );
+    let (used, invalidated) = token_flags(&pool, &token).await;
+    assert!(used, "token must be consumed");
+    assert!(!invalidated);
+}
+
+/// Liz's exact sequence (#280 review): token classifies Valid, admin
+/// invalidation lands (clear-verified-minor revoking the outstanding link),
+/// then the claim flow tries to proceed. The consume must fail and the user
+/// must be untouched.
+#[tokio::test]
+async fn test_invalidated_token_not_consumed_user_untouched() {
+    common::assert_test_database_url();
+    let pool = common::setup_test_db().await;
+    let pubkey = create_unclaimed_minor(&pool).await;
+    let token = create_token_for(&pool, &pubkey).await;
+
+    let claim_repo = ClaimTokenRepository::new(pool.clone());
+
+    // Mimic the handler: token is Valid at classification time.
+    use keycast_core::types::claim_token::ClaimTokenState;
+    assert!(matches!(
+        claim_repo
+            .classify(&token, TENANT_ID)
+            .await
+            .expect("classify"),
+        ClaimTokenState::Valid(_)
+    ));
+
+    // Concurrent admin action: revoke invalidates the outstanding link.
+    let invalidated = claim_repo
+        .invalidate_valid_for_user(&pubkey, TENANT_ID, ADMIN_PUBKEY, Some("revoked"))
+        .await
+        .expect("invalidate");
+    assert_eq!(invalidated, 1);
+
+    // The claim flow proceeds — and must be refused with no side effects.
+    let outcome = UserRepository::new(pool.clone())
+        .claim_account_consuming_token(&token, TENANT_ID, &email_for(&pubkey), "hash")
+        .await
+        .expect("consume attempt");
+
+    assert!(matches!(outcome, ClaimConsumeOutcome::TokenNotConsumable));
+    assert_eq!(
+        user_email(&pool, &pubkey).await,
+        None,
+        "user must not be mutated"
+    );
+    let (used, invalidated) = token_flags(&pool, &token).await;
+    assert!(!used, "dead token must not be marked used");
+    assert!(invalidated);
+}
+
+#[tokio::test]
+async fn test_expired_token_not_consumed() {
+    common::assert_test_database_url();
+    let pool = common::setup_test_db().await;
+    let pubkey = create_unclaimed_minor(&pool).await;
+    let token = create_token_for(&pool, &pubkey).await;
+    sqlx::query(
+        "UPDATE account_claim_tokens SET expires_at = NOW() - INTERVAL '1 hour' WHERE token = $1",
+    )
+    .bind(&token)
+    .execute(&pool)
+    .await
+    .expect("expire token");
+
+    let outcome = UserRepository::new(pool.clone())
+        .claim_account_consuming_token(&token, TENANT_ID, &email_for(&pubkey), "hash")
+        .await
+        .expect("consume attempt");
+
+    assert!(matches!(outcome, ClaimConsumeOutcome::TokenNotConsumable));
+    assert_eq!(user_email(&pool, &pubkey).await, None);
+    let (used, _) = token_flags(&pool, &token).await;
+    assert!(!used);
+}
+
+#[tokio::test]
+async fn test_used_token_not_consumed_again() {
+    common::assert_test_database_url();
+    let pool = common::setup_test_db().await;
+    let pubkey = create_unclaimed_minor(&pool).await;
+    let token = create_token_for(&pool, &pubkey).await;
+
+    let repo = UserRepository::new(pool.clone());
+    let first = repo
+        .claim_account_consuming_token(&token, TENANT_ID, &email_for(&pubkey), "hash")
+        .await
+        .expect("first consume");
+    assert!(matches!(first, ClaimConsumeOutcome::Claimed { .. }));
+
+    let second = repo
+        .claim_account_consuming_token(
+            &token,
+            TENANT_ID,
+            &format!("other-{}", email_for(&pubkey)),
+            "hash2",
+        )
+        .await
+        .expect("second consume attempt");
+    assert!(matches!(second, ClaimConsumeOutcome::TokenNotConsumable));
+    assert_eq!(
+        user_email(&pool, &pubkey).await.as_deref(),
+        Some(email_for(&pubkey).as_str()),
+        "second attempt must not overwrite the claim"
+    );
+}
+
+/// If the user row is not claimable (already has an email), the token consume
+/// must ROLL BACK — a failed claim must not burn the token.
+#[tokio::test]
+async fn test_unclaimable_user_rolls_back_token_consume() {
+    common::assert_test_database_url();
+    let pool = common::setup_test_db().await;
+    let pubkey = create_unclaimed_minor(&pool).await;
+    let token = create_token_for(&pool, &pubkey).await;
+    let existing_email = format!("existing-{}", email_for(&pubkey));
+    sqlx::query("UPDATE users SET email = $3 WHERE pubkey = $1 AND tenant_id = $2")
+        .bind(&pubkey)
+        .bind(TENANT_ID)
+        .bind(&existing_email)
+        .execute(&pool)
+        .await
+        .expect("pre-claim user");
+
+    let outcome = UserRepository::new(pool.clone())
+        .claim_account_consuming_token(&token, TENANT_ID, &email_for(&pubkey), "hash")
+        .await
+        .expect("consume attempt");
+
+    assert!(matches!(outcome, ClaimConsumeOutcome::UserNotClaimable));
+    let (used, invalidated) = token_flags(&pool, &token).await;
+    assert!(
+        !used,
+        "token consume must roll back when the user claim fails"
+    );
+    assert!(!invalidated);
+    assert_eq!(
+        user_email(&pool, &pubkey).await.as_deref(),
+        Some(existing_email.as_str())
+    );
+}
+
+/// True concurrency: revoke-invalidation racing the claim consume. Exactly one
+/// side may win, and the user is mutated iff the consume won. Run several
+/// rounds to exercise both orderings.
+#[tokio::test]
+async fn test_concurrent_invalidate_vs_claim_exactly_one_wins() {
+    common::assert_test_database_url();
+    let pool = common::setup_test_db().await;
+
+    for round in 0..20 {
+        let pubkey = create_unclaimed_minor(&pool).await;
+        let token = create_token_for(&pool, &pubkey).await;
+
+        let user_repo = UserRepository::new(pool.clone());
+        let claim_repo = ClaimTokenRepository::new(pool.clone());
+        let (t, pk) = (token.clone(), pubkey.clone());
+
+        let claim_email = email_for(&pubkey);
+        let claim_task = tokio::spawn(async move {
+            user_repo
+                .claim_account_consuming_token(&t, TENANT_ID, &claim_email, "hash")
+                .await
+                .expect("consume attempt")
+        });
+        let pk2 = pubkey.clone();
+        let invalidate_task = tokio::spawn(async move {
+            claim_repo
+                .invalidate_valid_for_user(&pk2, TENANT_ID, ADMIN_PUBKEY, Some("revoked"))
+                .await
+                .expect("invalidate attempt")
+        });
+
+        let (claim_outcome, invalidated_rows) =
+            (claim_task.await.unwrap(), invalidate_task.await.unwrap());
+
+        let consumed = matches!(claim_outcome, ClaimConsumeOutcome::Claimed { .. });
+        assert!(
+            consumed ^ (invalidated_rows == 1),
+            "round {}: exactly one side must win (consumed={}, invalidated_rows={})",
+            round,
+            consumed,
+            invalidated_rows
+        );
+        assert_eq!(
+            user_email(&pool, &pk).await.is_some(),
+            consumed,
+            "round {}: user mutated iff consume won",
+            round
+        );
+    }
+}

--- a/api/tests/clear_verified_minor_test.rs
+++ b/api/tests/clear_verified_minor_test.rs
@@ -439,3 +439,116 @@ async fn test_clear_empty_actor_is_400() {
         .unwrap();
     assert!(row.0);
 }
+
+#[tokio::test]
+async fn test_clear_retry_writes_no_second_audit_row() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let pubkey = create_verified_minor_user(&pool).await;
+    let actor = Keys::generate().public_key().to_hex();
+
+    let uri = format!(
+        "/admin/users/{}/verified-minor?actor={}&reason=revoked",
+        pubkey, actor
+    );
+
+    // First call is a real transition -> exactly one audit row.
+    let resp = build_app(create_test_auth_state(pool.clone()))
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(uri.clone())
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Retry after the flag is already cleared: no-op, must not append a second
+    // row asserting a transition that never happened.
+    let resp = build_app(create_test_auth_state(pool.clone()))
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(uri.clone())
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let rows = read_audit_rows(&pool, &actor).await;
+    assert_eq!(
+        rows.len(),
+        1,
+        "a no-op retry must not write a second audit row"
+    );
+}
+
+#[tokio::test]
+async fn test_clear_invalidates_outstanding_claim_token() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    // A live claim link issued before the account is revoked.
+    let token = format!("tok_{}", Keys::generate().public_key().to_hex());
+    sqlx::query(
+        "INSERT INTO account_claim_tokens (token, user_pubkey, expires_at, created_at, tenant_id) \
+         VALUES ($1, $2, NOW() + INTERVAL '7 days', NOW(), $3)",
+    )
+    .bind(&token)
+    .bind(&pubkey)
+    .bind(TENANT_ID)
+    .execute(&pool)
+    .await
+    .expect("create claim token");
+
+    let actor = Keys::generate().public_key().to_hex();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/admin/users/{}/verified-minor?actor={}&reason=revoked",
+                    pubkey, actor
+                ))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // The outstanding link must no longer be redeemable, so a revoked-before-claim
+    // account can never be claimed into a normal account with no minor protections.
+    let valid_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM account_claim_tokens \
+         WHERE user_pubkey = $1 AND used_at IS NULL AND invalidated_at IS NULL AND expires_at > NOW()",
+    )
+    .bind(&pubkey)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        valid_count.0, 0,
+        "revoking verified_minor must invalidate the outstanding claim link"
+    );
+
+    // Invalidation is attributed to the moderator that drove the revoke.
+    let invalidated_by: (Option<String>,) =
+        sqlx::query_as("SELECT invalidated_by FROM account_claim_tokens WHERE token = $1")
+            .bind(&token)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(invalidated_by.0.as_deref(), Some(actor.as_str()));
+}

--- a/api/tests/clear_verified_minor_test.rs
+++ b/api/tests/clear_verified_minor_test.rs
@@ -44,7 +44,10 @@ impl KeyManager for TestKeyManager {
     async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
         Ok(plaintext_bytes.to_vec())
     }
-    async fn decrypt(&self, ciphertext_bytes: &[u8]) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
         Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
     }
 }
@@ -310,7 +313,10 @@ async fn test_clear_malformed_actor_400_and_flag_intact() {
         .oneshot(
             Request::builder()
                 .method("DELETE")
-                .uri(format!("/admin/users/{}/verified-minor?actor=not-hex", pubkey))
+                .uri(format!(
+                    "/admin/users/{}/verified-minor?actor=not-hex",
+                    pubkey
+                ))
                 .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
                 .body(Body::empty())
                 .unwrap(),
@@ -357,6 +363,8 @@ async fn test_clear_reason_sanitized_in_audit() {
     let rows = read_audit_rows(&pool, &actor).await;
     let reason = rows[0].metadata_json["reason"].as_str().unwrap();
     assert!(!reason.contains('\n'), "control chars must be stripped");
-    assert!(reason.chars().count() <= 500, "reason must be bounded to 500");
+    assert!(
+        reason.chars().count() <= 500,
+        "reason must be bounded to 500"
+    );
 }
-

--- a/api/tests/clear_verified_minor_test.rs
+++ b/api/tests/clear_verified_minor_test.rs
@@ -1,0 +1,362 @@
+// ABOUTME: HTTP-layer tests for the service-token clear-verified_minor endpoint
+// ABOUTME: Tests DELETE /admin/users/:pubkey/verified-minor auth, clear, audit
+
+#![cfg(feature = "integration-tests")]
+
+mod common;
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    routing::delete,
+    Router,
+};
+use chrono::Utc;
+use http_body_util::BodyExt;
+use keycast_api::{
+    api::http::{
+        admin::{clear_verified_minor_admin, ClearVerifiedMinorParams, UserStatusResponse},
+        routes::AuthState,
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tower::ServiceExt;
+use zeroize::Zeroizing;
+
+const TENANT_ID: i64 = 1;
+const SERVICE_TOKEN: &str = "test-service-token-secret";
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+    async fn decrypt(&self, ciphertext_bytes: &[u8]) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn create_test_auth_state(pool: PgPool) -> AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+    AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+fn build_app(auth_state: AuthState) -> Router {
+    use keycast_api::api::tenant::{Tenant, TenantExtractor};
+    let del_state = auth_state.clone();
+    Router::new().route(
+        "/admin/users/:pubkey/verified-minor",
+        delete(
+            move |axum::extract::Path(pubkey): axum::extract::Path<String>,
+                  headers: axum::http::HeaderMap,
+                  axum::extract::Query(params): axum::extract::Query<ClearVerifiedMinorParams>| {
+                let state = del_state.clone();
+                let tenant = TenantExtractor(Arc::new(Tenant {
+                    id: TENANT_ID,
+                    domain: "localhost".to_string(),
+                    name: "Test".to_string(),
+                    settings: None,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                }));
+                async move {
+                    clear_verified_minor_admin(
+                        tenant,
+                        State(state),
+                        headers,
+                        axum::extract::Path(pubkey),
+                        axum::extract::Query(params),
+                    )
+                    .await
+                }
+            },
+        ),
+    )
+}
+
+async fn create_verified_minor_user(pool: &PgPool) -> String {
+    let pubkey = Keys::generate().public_key().to_hex();
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, verified_minor, verified_minor_at, created_at, updated_at) \
+         VALUES ($1, $2, TRUE, NOW(), NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .bind(TENANT_ID)
+    .execute(pool)
+    .await
+    .expect("create verified minor");
+    pubkey
+}
+
+#[tokio::test]
+async fn test_clear_verified_minor_clears_and_returns_status() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let status: UserStatusResponse = serde_json::from_slice(&body).unwrap();
+    assert!(!status.verified_minor);
+    assert!(status.verified_minor_at.is_none());
+}
+
+#[tokio::test]
+async fn test_clear_verified_minor_missing_auth() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor", pubkey))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_clear_verified_minor_wrong_token() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor", pubkey))
+                .header("authorization", "Bearer wrong-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_clear_verified_minor_unknown_pubkey_404() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let fake = Keys::generate().public_key().to_hex();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor", fake))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[derive(sqlx::FromRow)]
+struct AuditRow {
+    actor_pubkey: String,
+    action: String,
+    target_resource_type: String,
+    target_resource_id: Option<String>,
+    metadata_json: serde_json::Value,
+}
+
+async fn read_audit_rows(pool: &PgPool, actor_pubkey: &str) -> Vec<AuditRow> {
+    sqlx::query_as::<_, AuditRow>(
+        "SELECT actor_pubkey, action, target_resource_type, target_resource_id, metadata_json \
+         FROM admin_audit_events WHERE tenant_id = $1 AND actor_pubkey = $2",
+    )
+    .bind(TENANT_ID)
+    .bind(actor_pubkey)
+    .fetch_all(pool)
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_clear_with_actor_writes_audit_row() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+    let actor = Keys::generate().public_key().to_hex();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/admin/users/{}/verified-minor?actor={}&reason=re-review%20denied",
+                    pubkey, actor
+                ))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let rows = read_audit_rows(&pool, &actor).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].action, "clear_verified_minor");
+    assert_eq!(rows[0].actor_pubkey, actor);
+    assert_eq!(rows[0].target_resource_type, "user");
+    assert_eq!(rows[0].target_resource_id.as_deref(), Some(pubkey.as_str()));
+    assert_eq!(rows[0].metadata_json["reason"], "re-review denied");
+}
+
+#[tokio::test]
+async fn test_clear_without_actor_writes_no_audit_row() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM admin_audit_events WHERE target_resource_id = $1 AND action = 'clear_verified_minor'",
+    )
+    .bind(&pubkey)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count.0, 0);
+}
+
+#[tokio::test]
+async fn test_clear_malformed_actor_400_and_flag_intact() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor?actor=not-hex", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let row: (bool,) = sqlx::query_as("SELECT verified_minor FROM users WHERE pubkey = $1")
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(row.0);
+}
+
+#[tokio::test]
+async fn test_clear_reason_sanitized_in_audit() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+    let actor = Keys::generate().public_key().to_hex();
+
+    let long = "x".repeat(600);
+    let raw_reason = format!("line1%0Aline2{}", long); // %0A = \n url-encoded
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/admin/users/{}/verified-minor?actor={}&reason={}",
+                    pubkey, actor, raw_reason
+                ))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let rows = read_audit_rows(&pool, &actor).await;
+    let reason = rows[0].metadata_json["reason"].as_str().unwrap();
+    assert!(!reason.contains('\n'), "control chars must be stripped");
+    assert!(reason.chars().count() <= 500, "reason must be bounded to 500");
+}
+

--- a/api/tests/clear_verified_minor_test.rs
+++ b/api/tests/clear_verified_minor_test.rs
@@ -378,8 +378,9 @@ async fn test_clear_reason_strips_bidi_format_chars() {
     let pubkey = create_verified_minor_user(&pool).await;
     let actor = Keys::generate().public_key().to_hex();
 
-    // reason with U+202E RIGHT-TO-LEFT OVERRIDE (%E2%80%AE) + U+200B ZERO WIDTH SPACE (%E2%80%8B).
-    let raw_reason = "spoof%E2%80%AEdaen%E2%80%8B";
+    // reason with U+202E RIGHT-TO-LEFT OVERRIDE (%E2%80%AE), U+200B ZERO WIDTH SPACE (%E2%80%8B),
+    // and U+2028/U+2029 LINE/PARAGRAPH SEPARATOR (%E2%80%A8 / %E2%80%A9).
+    let raw_reason = "spoof%E2%80%AEda%E2%80%A8en%E2%80%A9x%E2%80%8B";
     let resp = app
         .oneshot(
             Request::builder()
@@ -399,8 +400,11 @@ async fn test_clear_reason_strips_bidi_format_chars() {
     let rows = read_audit_rows(&pool, &actor).await;
     let reason = rows[0].metadata_json["reason"].as_str().unwrap();
     assert!(
-        !reason.contains('\u{202E}') && !reason.contains('\u{200B}'),
-        "bidi/zero-width format chars must be stripped, got {:?}",
+        !reason.contains('\u{202E}')
+            && !reason.contains('\u{200B}')
+            && !reason.contains('\u{2028}')
+            && !reason.contains('\u{2029}'),
+        "bidi / zero-width / line-separator format chars must be stripped, got {:?}",
         reason
     );
 }

--- a/api/tests/clear_verified_minor_test.rs
+++ b/api/tests/clear_verified_minor_test.rs
@@ -368,3 +368,70 @@ async fn test_clear_reason_sanitized_in_audit() {
         "reason must be bounded to 500"
     );
 }
+
+#[tokio::test]
+async fn test_clear_reason_strips_bidi_format_chars() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+    let actor = Keys::generate().public_key().to_hex();
+
+    // reason with U+202E RIGHT-TO-LEFT OVERRIDE (%E2%80%AE) + U+200B ZERO WIDTH SPACE (%E2%80%8B).
+    let raw_reason = "spoof%E2%80%AEdaen%E2%80%8B";
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/admin/users/{}/verified-minor?actor={}&reason={}",
+                    pubkey, actor, raw_reason
+                ))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let rows = read_audit_rows(&pool, &actor).await;
+    let reason = rows[0].metadata_json["reason"].as_str().unwrap();
+    assert!(
+        !reason.contains('\u{202E}') && !reason.contains('\u{200B}'),
+        "bidi/zero-width format chars must be stripped, got {:?}",
+        reason
+    );
+}
+
+#[tokio::test]
+async fn test_clear_empty_actor_is_400() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    // An empty ?actor= is treated as malformed (fail loud) rather than silently
+    // dropping the audit trail. The flag must survive.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor?actor=", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let row: (bool,) = sqlx::query_as("SELECT verified_minor FROM users WHERE pubkey = $1")
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(row.0);
+}

--- a/api/tests/clear_verified_minor_test.rs
+++ b/api/tests/clear_verified_minor_test.rs
@@ -379,8 +379,9 @@ async fn test_clear_reason_strips_bidi_format_chars() {
     let actor = Keys::generate().public_key().to_hex();
 
     // reason with U+202E RIGHT-TO-LEFT OVERRIDE (%E2%80%AE), U+200B ZERO WIDTH SPACE (%E2%80%8B),
-    // and U+2028/U+2029 LINE/PARAGRAPH SEPARATOR (%E2%80%A8 / %E2%80%A9).
-    let raw_reason = "spoof%E2%80%AEda%E2%80%A8en%E2%80%A9x%E2%80%8B";
+    // U+2028/U+2029 LINE/PARAGRAPH SEPARATOR (%E2%80%A8 / %E2%80%A9), U+2060 WORD JOINER
+    // (%E2%81%A0), and U+FFF9 INTERLINEAR ANNOTATION ANCHOR (%EF%BF%B9).
+    let raw_reason = "spoof%E2%80%AEda%E2%80%A8en%E2%80%A9x%E2%80%8Bj%E2%81%A0a%EF%BF%B9b";
     let resp = app
         .oneshot(
             Request::builder()
@@ -403,8 +404,10 @@ async fn test_clear_reason_strips_bidi_format_chars() {
         !reason.contains('\u{202E}')
             && !reason.contains('\u{200B}')
             && !reason.contains('\u{2028}')
-            && !reason.contains('\u{2029}'),
-        "bidi / zero-width / line-separator format chars must be stripped, got {:?}",
+            && !reason.contains('\u{2029}')
+            && !reason.contains('\u{2060}')
+            && !reason.contains('\u{FFF9}'),
+        "bidi / zero-width / line-separator / word-joiner / annotation format chars must be stripped, got {:?}",
         reason
     );
 }
@@ -551,4 +554,117 @@ async fn test_clear_invalidates_outstanding_claim_token() {
             .await
             .unwrap();
     assert_eq!(invalidated_by.0.as_deref(), Some(actor.as_str()));
+}
+
+/// Claim-link closure is a safety invariant that must hold even without a
+/// moderator actor (e.g. an automated age-up clear). Invalidation runs
+/// unconditionally, and the actor-less path attributes the invalidation to the
+/// `system:verified_minor_clear` sentinel. Without this test a future refactor
+/// that accidentally gated invalidation on `actor` would leave the door open
+/// with green tests.
+#[tokio::test]
+async fn test_clear_without_actor_still_invalidates_claim_token() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    let token = format!("tok_{}", Keys::generate().public_key().to_hex());
+    sqlx::query(
+        "INSERT INTO account_claim_tokens (token, user_pubkey, expires_at, created_at, tenant_id) \
+         VALUES ($1, $2, NOW() + INTERVAL '7 days', NOW(), $3)",
+    )
+    .bind(&token)
+    .bind(&pubkey)
+    .bind(TENANT_ID)
+    .execute(&pool)
+    .await
+    .expect("create claim token");
+
+    // No `actor` query param: still a valid clear, still must close the door.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let (invalidated_at, invalidated_by): (Option<chrono::DateTime<Utc>>, Option<String>) =
+        sqlx::query_as(
+            "SELECT invalidated_at, invalidated_by FROM account_claim_tokens WHERE token = $1",
+        )
+        .bind(&token)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(
+        invalidated_at.is_some(),
+        "an actor-less clear must still invalidate the outstanding claim link"
+    );
+    assert_eq!(
+        invalidated_by.as_deref(),
+        Some("system:verified_minor_clear"),
+        "actor-less invalidation is attributed to the system sentinel"
+    );
+}
+
+/// Token invalidation is tenant-scoped. `invalidate_valid_for_user` filters on
+/// `tenant_id`, so a token row carrying a different tenant must survive a clear
+/// driven under tenant 1 (the endpoint's tenant). The claim-token FK is only on
+/// `user_pubkey`, not `(user_pubkey, tenant_id)`, so a same-pubkey row under a
+/// foreign tenant is representable and must not be swept.
+#[tokio::test]
+async fn test_clear_does_not_invalidate_other_tenant_claim_token() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    // Same pubkey, but the token belongs to a different tenant's view.
+    const OTHER_TENANT_ID: i64 = 2;
+    let foreign_token = format!("tok_{}", Keys::generate().public_key().to_hex());
+    sqlx::query(
+        "INSERT INTO account_claim_tokens (token, user_pubkey, expires_at, created_at, tenant_id) \
+         VALUES ($1, $2, NOW() + INTERVAL '7 days', NOW(), $3)",
+    )
+    .bind(&foreign_token)
+    .bind(&pubkey)
+    .bind(OTHER_TENANT_ID)
+    .execute(&pool)
+    .await
+    .expect("create foreign-tenant claim token");
+
+    // Clear runs under tenant 1 (build_app's TenantExtractor).
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // The tenant-2 token must be untouched: still valid, never invalidated.
+    let (invalidated_at,): (Option<chrono::DateTime<Utc>>,) =
+        sqlx::query_as("SELECT invalidated_at FROM account_claim_tokens WHERE token = $1")
+            .bind(&foreign_token)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        invalidated_at.is_none(),
+        "a clear under tenant 1 must not invalidate another tenant's claim token"
+    );
 }

--- a/core/src/repositories/claim_token.rs
+++ b/core/src/repositories/claim_token.rs
@@ -72,6 +72,11 @@ impl ClaimTokenRepository {
 
     /// Mark a claim token as used.
     /// Returns the updated token, or None if token not found or already used.
+    ///
+    /// NOTE: the claim flow itself must NOT use this — it re-checks only
+    /// `used_at`, not `invalidated_at`/`expires_at`. `claim_post` consumes
+    /// tokens via `UserRepository::claim_account_consuming_token`, which is
+    /// atomic with full validity (#280 review). Kept for tests/fixtures.
     pub async fn mark_used(&self, token: &str) -> Result<Option<ClaimToken>, RepositoryError> {
         sqlx::query_as::<_, ClaimToken>(
             "UPDATE account_claim_tokens

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -39,6 +39,6 @@ pub use registered_client::{
 pub use stored_key::StoredKeyRepository;
 pub use team::TeamRepository;
 pub use user::{
-    AdminUserDetails, DeleteAccountResult, FinalizeEmailOutcome, PendingEmailChange,
-    PendingEmailSide, UserRepository, VerificationTokenData,
+    AdminUserDetails, ClaimConsumeOutcome, DeleteAccountResult, FinalizeEmailOutcome,
+    PendingEmailChange, PendingEmailSide, UserRepository, VerificationTokenData,
 };

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -71,6 +71,21 @@ pub struct AdminUserDetails {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Outcome of atomically consuming a claim token and claiming the account.
+/// Only `Claimed` mutates anything; the other outcomes guarantee both the
+/// token and the user row are untouched (see
+/// `UserRepository::claim_account_consuming_token`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimConsumeOutcome {
+    /// Token consumed and account claimed in one transaction.
+    Claimed { user_pubkey: String },
+    /// Token was used, admin-invalidated, expired, or unknown — nothing mutated.
+    TokenNotConsumable,
+    /// Token was valid but the user row was not claimable (already has an
+    /// email) — the token consume was rolled back, nothing mutated.
+    UserNotClaimable,
+}
+
 /// Repository for user-related database operations.
 #[derive(Debug, Clone)]
 pub struct UserRepository {
@@ -1635,6 +1650,68 @@ impl UserRepository {
         .fetch_optional(&self.pool)
         .await
         .map_err(Into::into)
+    }
+
+    /// Atomically consume a still-valid claim token and claim the account in
+    /// one transaction (#280 review). The consume re-checks full validity
+    /// (`used_at IS NULL AND invalidated_at IS NULL AND expires_at > NOW()`)
+    /// under the row lock, mirroring the predicates of
+    /// `ClaimTokenRepository::invalidate_valid_for_user`. A concurrent admin
+    /// invalidation (e.g. clear-verified-minor revoking an unclaimed minor's
+    /// outstanding link) therefore either commits first — we consume nothing
+    /// and the user is untouched — or blocks on the row lock and matches
+    /// nothing after we commit. The user mutation only happens if the token
+    /// consume succeeded, and rolls back if the user row itself is not
+    /// claimable, so a failed claim never burns the token.
+    pub async fn claim_account_consuming_token(
+        &self,
+        token: &str,
+        tenant_id: i64,
+        email: &str,
+        password_hash: &str,
+    ) -> Result<ClaimConsumeOutcome, RepositoryError> {
+        let mut tx = self.pool.begin().await?;
+
+        let consumed: Option<(String,)> = sqlx::query_as(
+            "UPDATE account_claim_tokens
+             SET used_at = NOW()
+             WHERE token = $1
+               AND tenant_id = $2
+               AND used_at IS NULL
+               AND invalidated_at IS NULL
+               AND expires_at > NOW()
+             RETURNING user_pubkey",
+        )
+        .bind(token)
+        .bind(tenant_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some((user_pubkey,)) = consumed else {
+            tx.rollback().await?;
+            return Ok(ClaimConsumeOutcome::TokenNotConsumable);
+        };
+
+        let result = sqlx::query(
+            "UPDATE users
+             SET email = $1, password_hash = $2, email_verified = true, updated_at = $3
+             WHERE pubkey = $4 AND tenant_id = $5 AND email IS NULL",
+        )
+        .bind(email)
+        .bind(password_hash)
+        .bind(Utc::now())
+        .bind(&user_pubkey)
+        .bind(tenant_id)
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Ok(ClaimConsumeOutcome::UserNotClaimable);
+        }
+
+        tx.commit().await?;
+        Ok(ClaimConsumeOutcome::Claimed { user_pubkey })
     }
 
     /// Claim a preloaded account by setting email and password.

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -2395,8 +2395,11 @@ mod tests {
 
         repo.clear_verified_minor(&pubkey, 1).await.unwrap();
 
-        let (status, suspended_reason, suspended_at, verified_minor, _) =
-            repo.get_full_admin_status(&pubkey, 1).await.unwrap().unwrap();
+        let (status, suspended_reason, suspended_at, verified_minor, _) = repo
+            .get_full_admin_status(&pubkey, 1)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(status.as_str(), "suspended");
         assert_eq!(suspended_reason.as_deref(), Some("age_review"));
         assert!(suspended_at.is_some());

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -2369,6 +2369,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_clear_verified_minor_is_tenant_scoped() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let pubkey = Keys::generate().public_key().to_hex();
+
+        // verified-minor under tenant 1
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, verified_minor, verified_minor_at, created_at, updated_at) \
+             VALUES ($1, 1, TRUE, NOW(), NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Clearing under a different tenant must not match the row.
+        let result = repo.clear_verified_minor(&pubkey, 2).await;
+        assert!(matches!(result, Err(RepositoryError::NotFound(_))));
+
+        // Tenant-1 flag is untouched.
+        let (verified_minor, verified_minor_at) =
+            repo.get_verified_minor(&pubkey, 1).await.unwrap().unwrap();
+        assert!(
+            verified_minor,
+            "tenant-1 flag must survive a tenant-2 clear attempt"
+        );
+        assert!(verified_minor_at.is_some());
+
+        cleanup_user(&pool, &pubkey).await;
+    }
+
+    #[tokio::test]
     async fn test_clear_verified_minor_unknown_pubkey_not_found() {
         let pool = setup_pool().await;
         let repo = UserRepository::new(pool);

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1405,6 +1405,31 @@ impl UserRepository {
         .map_err(Into::into)
     }
 
+    /// Clear the verified_minor designation (age-up or revocation).
+    /// Idempotent: clearing an already-cleared or never-minor account succeeds.
+    /// Returns NotFound only when the user does not exist. Touches only the two
+    /// minor columns plus updated_at; never alters status/suspended_reason/suspended_at.
+    pub async fn clear_verified_minor(
+        &self,
+        pubkey: &str,
+        tenant_id: i64,
+    ) -> Result<(), RepositoryError> {
+        let result = sqlx::query(
+            "UPDATE users SET verified_minor = FALSE, verified_minor_at = NULL, updated_at = $3 \
+             WHERE pubkey = $1 AND tenant_id = $2",
+        )
+        .bind(pubkey)
+        .bind(tenant_id)
+        .bind(Utc::now())
+        .execute(&self.pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(RepositoryError::NotFound("user not found".to_string()));
+        }
+        Ok(())
+    }
+
     /// Combined status + verified_minor query for admin status endpoints.
     pub async fn get_full_admin_status(
         &self,
@@ -2296,5 +2321,87 @@ mod tests {
         cleanup_user(&pool, &h1).await;
         cleanup_user(&pool, &h2).await;
         cleanup_user(&pool, &h3).await;
+    }
+
+    #[tokio::test]
+    async fn test_clear_verified_minor_clears_flag_and_timestamp() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let pubkey = Keys::generate().public_key().to_hex();
+
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, verified_minor, verified_minor_at, created_at, updated_at) \
+             VALUES ($1, 1, TRUE, NOW(), NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        repo.clear_verified_minor(&pubkey, 1).await.unwrap();
+
+        let (verified_minor, verified_minor_at) =
+            repo.get_verified_minor(&pubkey, 1).await.unwrap().unwrap();
+        assert!(!verified_minor);
+        assert!(verified_minor_at.is_none());
+
+        cleanup_user(&pool, &pubkey).await;
+    }
+
+    #[tokio::test]
+    async fn test_clear_verified_minor_idempotent_on_already_cleared() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let pubkey = Keys::generate().public_key().to_hex();
+
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at) VALUES ($1, 1, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        repo.clear_verified_minor(&pubkey, 1).await.unwrap();
+        repo.clear_verified_minor(&pubkey, 1).await.unwrap();
+
+        cleanup_user(&pool, &pubkey).await;
+    }
+
+    #[tokio::test]
+    async fn test_clear_verified_minor_unknown_pubkey_not_found() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool);
+        let pubkey = Keys::generate().public_key().to_hex();
+
+        let result = repo.clear_verified_minor(&pubkey, 1).await;
+        assert!(matches!(result, Err(RepositoryError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_clear_verified_minor_leaves_status_untouched() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let pubkey = Keys::generate().public_key().to_hex();
+
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, verified_minor, verified_minor_at, status, suspended_reason, suspended_at, created_at, updated_at) \
+             VALUES ($1, 1, TRUE, NOW(), 'suspended', 'age_review', NOW(), NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        repo.clear_verified_minor(&pubkey, 1).await.unwrap();
+
+        let (status, suspended_reason, suspended_at, verified_minor, _) =
+            repo.get_full_admin_status(&pubkey, 1).await.unwrap().unwrap();
+        assert_eq!(status.as_str(), "suspended");
+        assert_eq!(suspended_reason.as_deref(), Some("age_review"));
+        assert!(suspended_at.is_some());
+        assert!(!verified_minor);
+
+        cleanup_user(&pool, &pubkey).await;
     }
 }

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1714,37 +1714,6 @@ impl UserRepository {
         Ok(ClaimConsumeOutcome::Claimed { user_pubkey })
     }
 
-    /// Claim a preloaded account by setting email and password.
-    /// Also marks email as verified (claim link is proof of ownership).
-    pub async fn claim_account(
-        &self,
-        pubkey: &str,
-        tenant_id: i64,
-        email: &str,
-        password_hash: &str,
-    ) -> Result<(), RepositoryError> {
-        let result = sqlx::query(
-            "UPDATE users
-             SET email = $1, password_hash = $2, email_verified = true, updated_at = $3
-             WHERE pubkey = $4 AND tenant_id = $5 AND email IS NULL",
-        )
-        .bind(email)
-        .bind(password_hash)
-        .bind(Utc::now())
-        .bind(pubkey)
-        .bind(tenant_id)
-        .execute(&self.pool)
-        .await?;
-
-        if result.rows_affected() == 0 {
-            return Err(RepositoryError::NotFound(
-                "User not found or already claimed".to_string(),
-            ));
-        }
-
-        Ok(())
-    }
-
     /// Check if email is already in use.
     pub async fn email_exists(&self, email: &str, tenant_id: i64) -> Result<bool, RepositoryError> {
         let result: Option<(String,)> =

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1409,25 +1409,42 @@ impl UserRepository {
     /// Idempotent: clearing an already-cleared or never-minor account succeeds.
     /// Returns NotFound only when the user does not exist. Touches only the two
     /// minor columns plus updated_at; never alters status/suspended_reason/suspended_at.
+    ///
+    /// Returns `true` only when a real transition happened (the flag was set and
+    /// is now cleared). A no-op clear (already-cleared or never-minor) returns
+    /// `false` and leaves `updated_at` untouched, so callers can audit exactly
+    /// the transitions that actually occurred rather than every retry.
+    ///
+    /// The three cases are distinguished in a single statement so that a missing
+    /// user (NotFound) never collapses into an already-cleared no-op: `existing`
+    /// probes for the row, `changed` conditionally updates only a set flag, and
+    /// the outer SELECT reports both.
     pub async fn clear_verified_minor(
         &self,
         pubkey: &str,
         tenant_id: i64,
-    ) -> Result<(), RepositoryError> {
-        let result = sqlx::query(
-            "UPDATE users SET verified_minor = FALSE, verified_minor_at = NULL, updated_at = $3 \
-             WHERE pubkey = $1 AND tenant_id = $2",
+    ) -> Result<bool, RepositoryError> {
+        let (user_exists, transitioned): (bool, bool) = sqlx::query_as(
+            "WITH existing AS ( \
+                 SELECT 1 FROM users WHERE pubkey = $1 AND tenant_id = $2 \
+             ), changed AS ( \
+                 UPDATE users \
+                 SET verified_minor = FALSE, verified_minor_at = NULL, updated_at = $3 \
+                 WHERE pubkey = $1 AND tenant_id = $2 AND verified_minor = TRUE \
+                 RETURNING 1 \
+             ) \
+             SELECT EXISTS (SELECT 1 FROM existing), EXISTS (SELECT 1 FROM changed)",
         )
         .bind(pubkey)
         .bind(tenant_id)
         .bind(Utc::now())
-        .execute(&self.pool)
+        .fetch_one(&self.pool)
         .await?;
 
-        if result.rows_affected() == 0 {
+        if !user_exists {
             return Err(RepositoryError::NotFound("user not found".to_string()));
         }
-        Ok(())
+        Ok(transitioned)
     }
 
     /// Combined status + verified_minor query for admin status endpoints.
@@ -2338,7 +2355,8 @@ mod tests {
         .await
         .unwrap();
 
-        repo.clear_verified_minor(&pubkey, 1).await.unwrap();
+        let transitioned = repo.clear_verified_minor(&pubkey, 1).await.unwrap();
+        assert!(transitioned, "clearing a set flag is a real transition");
 
         let (verified_minor, verified_minor_at) =
             repo.get_verified_minor(&pubkey, 1).await.unwrap().unwrap();
@@ -2362,8 +2380,47 @@ mod tests {
         .await
         .unwrap();
 
-        repo.clear_verified_minor(&pubkey, 1).await.unwrap();
-        repo.clear_verified_minor(&pubkey, 1).await.unwrap();
+        // A never-minor / already-cleared account clears successfully but is not
+        // a real transition, so both calls report `false`.
+        assert!(!repo.clear_verified_minor(&pubkey, 1).await.unwrap());
+        assert!(!repo.clear_verified_minor(&pubkey, 1).await.unwrap());
+
+        cleanup_user(&pool, &pubkey).await;
+    }
+
+    #[tokio::test]
+    async fn test_clear_verified_minor_noop_does_not_bump_updated_at() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let pubkey = Keys::generate().public_key().to_hex();
+
+        // Never-minor account with a fixed, in-the-past updated_at.
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at) \
+             VALUES ($1, 1, NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day')",
+        )
+        .bind(&pubkey)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let before: chrono::DateTime<chrono::Utc> =
+            sqlx::query_scalar("SELECT updated_at FROM users WHERE pubkey = $1")
+                .bind(&pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        // No-op clear: must not report a transition and must not touch updated_at.
+        assert!(!repo.clear_verified_minor(&pubkey, 1).await.unwrap());
+
+        let after: chrono::DateTime<chrono::Utc> =
+            sqlx::query_scalar("SELECT updated_at FROM users WHERE pubkey = $1")
+                .bind(&pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(before, after, "a no-op clear must not bump updated_at");
 
         cleanup_user(&pool, &pubkey).await;
     }
@@ -2425,7 +2482,7 @@ mod tests {
         .await
         .unwrap();
 
-        repo.clear_verified_minor(&pubkey, 1).await.unwrap();
+        assert!(repo.clear_verified_minor(&pubkey, 1).await.unwrap());
 
         let (status, suspended_reason, suspended_at, verified_minor, _) = repo
             .get_full_admin_status(&pubkey, 1)

--- a/docs/superpowers/plans/2026-07-01-verified-minor-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-01-verified-minor-lifecycle.md
@@ -1,0 +1,747 @@
+# verified_minor lifecycle (clear primitive + revocation endpoint) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the missing path that clears `verified_minor`, plus a service-token admin endpoint relay-manager calls on revocation, with a durable audit trail.
+
+**Architecture:** A single-purpose repository method (`clear_verified_minor`) sets the two minor columns false/null and nothing else; a `DELETE` admin endpoint wraps it with service-token auth, optional `actor`/`reason` query params, reason sanitization, and a best-effort `admin_audit_events` row. Clear-only by design so it serves both age-up (status untouched) and revocation (caller sets status separately).
+
+**Tech Stack:** Rust, axum, sqlx (Postgres), tokio, existing keycast test harness (`integration-tests` feature).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-01-verified-minor-lifecycle-design.md`. This plan implements it verbatim.
+- No schema migration (`verified_minor`, `verified_minor_at` already exist).
+- Multi-tenant: every query is scoped by `tenant_id`.
+- Clear-only: the primitive and endpoint MUST NOT alter `status`, `suspended_reason`, or `suspended_at`.
+- Idempotent: clearing an already-cleared or never-minor account succeeds; unknown pubkey → 404.
+- Audit row is best-effort enrichment: a failed insert logs an error and the clear still succeeds.
+- Repo integration tests need `DATABASE_URL` pointing at a localhost Postgres; API tests run under `--features integration-tests` and use `common::setup_test_db()`.
+
+---
+
+### Task 1: Repository primitive `clear_verified_minor`
+
+**Files:**
+- Modify: `core/src/repositories/user.rs` (add method near `get_verified_minor`, ~line 1392; add tests in the existing `#[cfg(test)] mod tests`, ~line 1900)
+
+**Interfaces:**
+- Produces: `UserRepository::clear_verified_minor(&self, pubkey: &str, tenant_id: i64) -> Result<(), RepositoryError>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `mod tests` block in `core/src/repositories/user.rs`. These mirror the existing `setup_pool()` / `Keys::generate()` pattern already in that module.
+
+```rust
+#[tokio::test]
+async fn test_clear_verified_minor_clears_flag_and_timestamp() {
+    let pool = setup_pool().await;
+    let repo = UserRepository::new(pool.clone());
+    let pubkey = Keys::generate().public_key().to_hex();
+
+    // Create a verified-minor user directly.
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, verified_minor, verified_minor_at, created_at, updated_at) \
+         VALUES ($1, 1, TRUE, NOW(), NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    repo.clear_verified_minor(&pubkey, 1).await.unwrap();
+
+    let (verified_minor, verified_minor_at) =
+        repo.get_verified_minor(&pubkey, 1).await.unwrap().unwrap();
+    assert!(!verified_minor);
+    assert!(verified_minor_at.is_none());
+}
+
+#[tokio::test]
+async fn test_clear_verified_minor_idempotent_on_already_cleared() {
+    let pool = setup_pool().await;
+    let repo = UserRepository::new(pool.clone());
+    let pubkey = Keys::generate().public_key().to_hex();
+
+    // Plain user, verified_minor already FALSE (column default).
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at) VALUES ($1, 1, NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Clearing a never-minor / already-cleared account succeeds (no-op).
+    repo.clear_verified_minor(&pubkey, 1).await.unwrap();
+    repo.clear_verified_minor(&pubkey, 1).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_clear_verified_minor_unknown_pubkey_not_found() {
+    let pool = setup_pool().await;
+    let repo = UserRepository::new(pool);
+    let pubkey = Keys::generate().public_key().to_hex();
+
+    let result = repo.clear_verified_minor(&pubkey, 1).await;
+    assert!(matches!(result, Err(RepositoryError::NotFound(_))));
+}
+
+#[tokio::test]
+async fn test_clear_verified_minor_leaves_status_untouched() {
+    let pool = setup_pool().await;
+    let repo = UserRepository::new(pool.clone());
+    let pubkey = Keys::generate().public_key().to_hex();
+
+    // Suspended verified-minor.
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, verified_minor, verified_minor_at, status, suspended_reason, suspended_at, created_at, updated_at) \
+         VALUES ($1, 1, TRUE, NOW(), 'suspended', 'age_review', NOW(), NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    repo.clear_verified_minor(&pubkey, 1).await.unwrap();
+
+    let (status, suspended_reason, suspended_at, verified_minor, _) =
+        repo.get_full_admin_status(&pubkey, 1).await.unwrap().unwrap();
+    assert_eq!(status.as_str(), "suspended");
+    assert_eq!(suspended_reason.as_deref(), Some("age_review"));
+    assert!(suspended_at.is_some());
+    assert!(!verified_minor);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd core && DATABASE_URL="postgres://postgres:postgres@localhost/keycast_test" cargo test clear_verified_minor -- --test-threads=1`
+Expected: FAIL to compile with `no method named clear_verified_minor found`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add to `core/src/repositories/user.rs`, immediately after `get_verified_minor` (before `get_full_admin_status`):
+
+```rust
+/// Clear the verified_minor designation (age-up or revocation).
+/// Idempotent: clearing an already-cleared or never-minor account succeeds.
+/// Returns NotFound only when the user does not exist. Touches only the two
+/// minor columns plus updated_at; never alters status/suspended_reason/suspended_at.
+pub async fn clear_verified_minor(
+    &self,
+    pubkey: &str,
+    tenant_id: i64,
+) -> Result<(), RepositoryError> {
+    let result = sqlx::query(
+        "UPDATE users SET verified_minor = FALSE, verified_minor_at = NULL, updated_at = $3 \
+         WHERE pubkey = $1 AND tenant_id = $2",
+    )
+    .bind(pubkey)
+    .bind(tenant_id)
+    .bind(Utc::now())
+    .execute(&self.pool)
+    .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(RepositoryError::NotFound("user not found".to_string()));
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd core && DATABASE_URL="postgres://postgres:postgres@localhost/keycast_test" cargo test clear_verified_minor -- --test-threads=1`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/src/repositories/user.rs
+git commit -m "feat(minor-safety): add clear_verified_minor repository primitive (#265)"
+```
+
+---
+
+### Task 2: `DELETE` clear endpoint (auth, clear, 404, response)
+
+**Files:**
+- Modify: `api/src/api/http/admin.rs` (add `ClearVerifiedMinorParams`, helper `sanitize_reason`, handler `clear_verified_minor_admin` near `set_user_status_admin`, ~line 1945)
+- Modify: `api/src/api/http/routes.rs:238-248` (register the route in `service_admin_routes`)
+- Create: `api/tests/clear_verified_minor_test.rs`
+
+**Interfaces:**
+- Consumes: `UserRepository::clear_verified_minor` (Task 1); `UserRepository::get_full_admin_status`; `UserStatusResponse`; `authorize_service_token`.
+- Produces: `pub async fn clear_verified_minor_admin(tenant, State(auth_state), headers, Path(pubkey), Query(params)) -> ApiResult<Json<UserStatusResponse>>`; `pub struct ClearVerifiedMinorParams { pub actor: Option<String>, pub reason: Option<String> }`; `fn sanitize_reason(Option<String>) -> Option<String>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `api/tests/clear_verified_minor_test.rs`. This reuses the exact harness pattern from `api/tests/user_status_admin_test.rs` (TestKeyManager, `create_test_auth_state`, service-token auth, `common::setup_test_db`).
+
+```rust
+// ABOUTME: HTTP-layer tests for the service-token clear-verified_minor endpoint
+// ABOUTME: Tests DELETE /admin/users/:pubkey/verified-minor auth, clear, audit
+
+#![cfg(feature = "integration-tests")]
+
+mod common;
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    routing::delete,
+    Router,
+};
+use chrono::Utc;
+use http_body_util::BodyExt;
+use keycast_api::{
+    api::http::{
+        admin::{clear_verified_minor_admin, ClearVerifiedMinorParams, UserStatusResponse},
+        routes::AuthState,
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tower::ServiceExt;
+use zeroize::Zeroizing;
+
+const TENANT_ID: i64 = 1;
+const SERVICE_TOKEN: &str = "test-service-token-secret";
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+    async fn decrypt(&self, ciphertext_bytes: &[u8]) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn create_test_auth_state(pool: PgPool) -> AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+    AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+fn build_app(auth_state: AuthState) -> Router {
+    use keycast_api::api::tenant::{Tenant, TenantExtractor};
+    let del_state = auth_state.clone();
+    Router::new().route(
+        "/admin/users/:pubkey/verified-minor",
+        delete(
+            move |axum::extract::Path(pubkey): axum::extract::Path<String>,
+                  headers: axum::http::HeaderMap,
+                  axum::extract::Query(params): axum::extract::Query<ClearVerifiedMinorParams>| {
+                let state = del_state.clone();
+                let tenant = TenantExtractor(Arc::new(Tenant {
+                    id: TENANT_ID,
+                    domain: "localhost".to_string(),
+                    name: "Test".to_string(),
+                    settings: None,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                }));
+                async move {
+                    clear_verified_minor_admin(
+                        tenant,
+                        State(state),
+                        headers,
+                        axum::extract::Path(pubkey),
+                        axum::extract::Query(params),
+                    )
+                    .await
+                }
+            },
+        ),
+    )
+}
+
+async fn create_verified_minor_user(pool: &PgPool) -> String {
+    let pubkey = Keys::generate().public_key().to_hex();
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, verified_minor, verified_minor_at, created_at, updated_at) \
+         VALUES ($1, $2, TRUE, NOW(), NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .bind(TENANT_ID)
+    .execute(pool)
+    .await
+    .expect("create verified minor");
+    pubkey
+}
+
+#[tokio::test]
+async fn test_clear_verified_minor_clears_and_returns_status() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let status: UserStatusResponse = serde_json::from_slice(&body).unwrap();
+    assert!(!status.verified_minor);
+    assert!(status.verified_minor_at.is_none());
+}
+
+#[tokio::test]
+async fn test_clear_verified_minor_missing_auth() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor", pubkey))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_clear_verified_minor_wrong_token() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor", pubkey))
+                .header("authorization", "Bearer wrong-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_clear_verified_minor_unknown_pubkey_404() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let fake = Keys::generate().public_key().to_hex();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor", fake))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd api && cargo test --features integration-tests --test clear_verified_minor_test 2>&1 | head -30`
+Expected: FAIL to compile — `clear_verified_minor_admin` and `ClearVerifiedMinorParams` do not exist.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `api/src/api/http/admin.rs`, add after `set_user_status_admin` (before `create_minor_account`). `Query` must be imported from `axum::extract` (add to the existing axum use if absent).
+
+```rust
+/// Query params for the clear-verified_minor endpoint. Both optional; `actor`
+/// (the moderator's hex pubkey) drives the durable audit row.
+#[derive(Debug, Deserialize)]
+pub struct ClearVerifiedMinorParams {
+    pub actor: Option<String>,
+    pub reason: Option<String>,
+}
+
+/// Bound and strip control characters from a caller-supplied reason before it
+/// is logged or persisted (prevents log injection and unbounded audit rows).
+/// Returns None when empty after cleaning.
+fn sanitize_reason(raw: Option<String>) -> Option<String> {
+    let cleaned: String = raw?
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(500)
+        .collect();
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+pub async fn clear_verified_minor_admin(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    headers: HeaderMap,
+    Path(pubkey): Path<String>,
+    axum::extract::Query(params): axum::extract::Query<ClearVerifiedMinorParams>,
+) -> ApiResult<Json<UserStatusResponse>> {
+    authorize_service_token(&headers)?;
+    let tenant_id = tenant.0.id;
+
+    // Validate the optional actor as a 64-char hex pubkey so a T&S action never
+    // silently loses its audit trail to a malformed actor.
+    if let Some(actor) = params.actor.as_deref() {
+        if actor.len() != 64 || !actor.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(ApiError::bad_request(
+                "actor must be a 64-character hex pubkey",
+            ));
+        }
+    }
+
+    let reason_clean = sanitize_reason(params.reason);
+
+    let user_repo = UserRepository::new(auth_state.state.db.clone());
+    user_repo.clear_verified_minor(&pubkey, tenant_id).await?;
+
+    tracing::info!(
+        event = "verified_minor_cleared",
+        pubkey = %pubkey,
+        actor = ?params.actor,
+        reason = ?reason_clean,
+        "Admin cleared verified_minor"
+    );
+
+    let (status, suspended_reason, suspended_at, verified_minor, verified_minor_at) = user_repo
+        .get_full_admin_status(&pubkey, tenant_id)
+        .await?
+        .ok_or_else(|| ApiError::not_found("User not found"))?;
+
+    Ok(Json(UserStatusResponse {
+        pubkey,
+        status: status.as_str().to_string(),
+        suspended_reason,
+        suspended_at,
+        verified_minor,
+        verified_minor_at,
+    }))
+}
+```
+
+Register the route in `api/src/api/http/routes.rs` inside `service_admin_routes` (after the `/status` route, ~line 242):
+
+```rust
+.route(
+    "/admin/users/:pubkey/verified-minor",
+    delete(admin::clear_verified_minor_admin),
+)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd api && cargo test --features integration-tests --test clear_verified_minor_test 2>&1 | tail -20`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/api/http/admin.rs api/src/api/http/routes.rs api/tests/clear_verified_minor_test.rs
+git commit -m "feat(minor-safety): add DELETE clear-verified_minor endpoint (#265)"
+```
+
+---
+
+### Task 3: Durable audit row on clear (with actor)
+
+**Files:**
+- Modify: `api/src/api/http/admin.rs` (add the best-effort audit write inside `clear_verified_minor_admin`)
+- Modify: `api/tests/clear_verified_minor_test.rs` (add audit + sanitization tests)
+
+**Interfaces:**
+- Consumes: `AdminAuditEventRepository`, `AdminAuditEventRecord` (already imported in admin.rs at line 17).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `api/tests/clear_verified_minor_test.rs`. Add the audit-row reader (mirrors `read_audit_rows` in `registered_clients_audit_test.rs`).
+
+```rust
+#[derive(sqlx::FromRow)]
+struct AuditRow {
+    actor_pubkey: String,
+    action: String,
+    target_resource_type: String,
+    target_resource_id: Option<String>,
+    metadata_json: serde_json::Value,
+}
+
+async fn read_audit_rows(pool: &PgPool, actor_pubkey: &str) -> Vec<AuditRow> {
+    sqlx::query_as::<_, AuditRow>(
+        "SELECT actor_pubkey, action, target_resource_type, target_resource_id, metadata_json \
+         FROM admin_audit_events WHERE tenant_id = $1 AND actor_pubkey = $2",
+    )
+    .bind(TENANT_ID)
+    .bind(actor_pubkey)
+    .fetch_all(pool)
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_clear_with_actor_writes_audit_row() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+    let actor = Keys::generate().public_key().to_hex();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/admin/users/{}/verified-minor?actor={}&reason=re-review%20denied",
+                    pubkey, actor
+                ))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let rows = read_audit_rows(&pool, &actor).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].action, "clear_verified_minor");
+    assert_eq!(rows[0].actor_pubkey, actor);
+    assert_eq!(rows[0].target_resource_type, "user");
+    assert_eq!(rows[0].target_resource_id.as_deref(), Some(pubkey.as_str()));
+    assert_eq!(rows[0].metadata_json["reason"], "re-review denied");
+}
+
+#[tokio::test]
+async fn test_clear_without_actor_writes_no_audit_row() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    // No audit row keyed to any actor for this pubkey (target_resource_id).
+    let count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM admin_audit_events WHERE target_resource_id = $1 AND action = 'clear_verified_minor'",
+    )
+    .bind(&pubkey)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count.0, 0);
+}
+
+#[tokio::test]
+async fn test_clear_malformed_actor_400_and_flag_intact() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/admin/users/{}/verified-minor?actor=not-hex", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    // Flag must NOT have been cleared (validation happens before the clear).
+    let row: (bool,) = sqlx::query_as("SELECT verified_minor FROM users WHERE pubkey = $1")
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(row.0);
+}
+
+#[tokio::test]
+async fn test_clear_reason_sanitized_in_audit() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_verified_minor_user(&pool).await;
+    let actor = Keys::generate().public_key().to_hex();
+
+    // reason with an embedded newline (control char) + long padding.
+    let long = "x".repeat(600);
+    let raw_reason = format!("line1%0Aline2{}", long); // %0A = \n url-encoded
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/admin/users/{}/verified-minor?actor={}&reason={}",
+                    pubkey, actor, raw_reason
+                ))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let rows = read_audit_rows(&pool, &actor).await;
+    let reason = rows[0].metadata_json["reason"].as_str().unwrap();
+    assert!(!reason.contains('\n'), "control chars must be stripped");
+    assert!(reason.chars().count() <= 500, "reason must be bounded to 500");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd api && cargo test --features integration-tests --test clear_verified_minor_test 2>&1 | tail -20`
+Expected: `test_clear_with_actor_writes_audit_row` and `test_clear_reason_sanitized_in_audit` FAIL (no audit row written); the malformed-actor and no-actor tests already pass from Task 2.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `clear_verified_minor_admin` (admin.rs), insert the best-effort audit write between the `tracing::info!` line and the `get_full_admin_status` call:
+
+```rust
+    // Durable audit row (best-effort) when an actor is supplied. The table's
+    // actor_pubkey is NOT NULL, so no actor -> log-only. A failed insert logs
+    // and the clear still succeeds. (keycast#279 raises the same bar for status changes.)
+    if let Some(actor) = params.actor.as_deref() {
+        let audit_repo = AdminAuditEventRepository::new(auth_state.state.db.clone());
+        if let Err(error) = audit_repo
+            .record(AdminAuditEventRecord {
+                tenant_id,
+                actor_pubkey: actor.to_string(),
+                action: "clear_verified_minor".to_string(),
+                target_resource_type: "user".to_string(),
+                target_resource_id: Some(pubkey.clone()),
+                target_client_id: None,
+                metadata_json: serde_json::json!({ "reason": reason_clean }),
+            })
+            .await
+        {
+            tracing::error!(
+                pubkey = %pubkey,
+                error = %error,
+                "Failed to write admin_audit_events row for verified_minor clear"
+            );
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd api && cargo test --features integration-tests --test clear_verified_minor_test 2>&1 | tail -20`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/api/http/admin.rs api/tests/clear_verified_minor_test.rs
+git commit -m "feat(minor-safety): durable audit row on verified_minor clear (#265)"
+```
+
+---
+
+### Task 4: Full-suite check + lint
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Clippy + fmt**
+
+Run: `cargo fmt --all && cargo clippy --all-targets --features integration-tests -- -D warnings 2>&1 | tail -20`
+Expected: no warnings.
+
+- [ ] **Step 2: Run the touched test suites green**
+
+Run: `cd core && DATABASE_URL="postgres://postgres:postgres@localhost/keycast_test" cargo test clear_verified_minor -- --test-threads=1` then `cd api && cargo test --features integration-tests --test clear_verified_minor_test`
+Expected: all PASS.
+
+- [ ] **Step 3: Commit any fmt changes**
+
+```bash
+git add -A && git commit -m "style(minor-safety): fmt/clippy for verified_minor lifecycle (#265)" || echo "nothing to commit"
+```
+
+## Self-Review
+
+**Spec coverage:** repo primitive (Task 1) ✔; endpoint + auth + 404 + response (Task 2) ✔; actor validation, reason sanitization, durable audit, log-only fallback (Tasks 2-3) ✔; 11 spec tests map to Task1×4 + Task2×4 + Task3×4 (12; the extra splits spec test 6 into missing-auth + wrong-token) ✔; no-migration honored ✔; clear-only / status-untouched enforced + tested (Task1 test 4) ✔. Deferrals (#147, #179, #279) are out-of-scope by design.
+
+**Placeholder scan:** none — every code step carries full code.
+
+**Type consistency:** `clear_verified_minor(&str, i64) -> Result<(), RepositoryError>`, `ClearVerifiedMinorParams { actor, reason }`, `clear_verified_minor_admin(...) -> ApiResult<Json<UserStatusResponse>>`, and the `AdminAuditEventRecord` fields match `admin.rs:1566` usage and the repo signatures verified in the spec.

--- a/docs/superpowers/specs/2026-07-01-verified-minor-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-01-verified-minor-lifecycle-design.md
@@ -110,6 +110,10 @@ The audit write is best-effort enrichment: a failed `admin_audit_events` insert 
 
 Clearing `verified_minor` alone leaves any claim link issued before the clear live. Claim redemption (`claim.rs::claim_post`) gates only on token validity — it does **not** check `status` or `verified_minor` (status is fetched afterward only to stamp the UCAN fact). So a minor account revoked before it is claimed could still be claimed and land as a normal account with no minor protections, and a relay-manager status change alone would not stop it. The endpoint therefore invalidates outstanding claim tokens itself (via the existing `invalidate_valid_for_user`, which only touches still-valid, unused tokens and is thus idempotent and a no-op for an already-claimed age-up account). Unlike the best-effort audit row, this is a safety invariant: a failure fails the request so the caller retries rather than silently leaving the link open. This keeps the door closed independent of relay-manager#147.
 
+#### Atomic consume (race closure, #280 review)
+
+The straight-line invalidation above still left a concurrent window (flagged by Liz in review): `claim_post` could classify the token as Valid, the clear endpoint could then invalidate it, and the claim would still complete because `mark_used` re-checked only `used_at IS NULL` — after the user row had already been mutated. Token consumption is therefore atomic with validity: `UserRepository::claim_account_consuming_token` runs a single transaction whose consume step re-checks the full validity predicate (`used_at IS NULL AND invalidated_at IS NULL AND expires_at > NOW()`) under the row lock — deliberately mirroring `invalidate_valid_for_user`'s predicate, so under concurrency exactly one side can win — and only then claims the user row, rolling back the consume if the user is not claimable (a failed claim never burns the token). `claim_post` treats this consume as the authoritative gate; the upfront classification remains only for friendly pre-password error pages, and a token that dies between classification and consume is re-classified to render its state-specific page. Regression coverage: `api/tests/claim_consume_race_test.rs` (invalidated-between-classify-and-consume, expired, reuse, rollback, and a concurrent invalidate-vs-claim exactly-one-wins invariant).
+
 Route registration in `routes.rs`:
 
 ```rust
@@ -144,6 +148,7 @@ Route registration in `routes.rs`:
 12. `reason` containing control / bidi / zero-width chars or exceeding 500 chars is sanitized (bounded and stripped) in both the log line and the stored `metadata_json`.
 13. A no-op retry (a second `DELETE` with `actor` after the flag is already cleared) writes no second audit row.
 14. `DELETE` invalidates an outstanding claim token for the pubkey (no valid token remains; `invalidated_by == actor`), so a revoked-before-claim account can no longer be claimed.
+15. Claim-consume race (`claim_consume_race_test.rs`): a token invalidated after classification is refused with no user mutation and no `used_at`; an expired or already-used token is refused; a failed user claim rolls back the token consume; under a true concurrent invalidate-vs-claim, exactly one side wins and the user is mutated iff the consume won.
 
 ## Acceptance
 

--- a/docs/superpowers/specs/2026-07-01-verified-minor-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-01-verified-minor-lifecycle-design.md
@@ -47,30 +47,39 @@ Folding a status change into the clear would make it unusable for age-up and wou
 ```rust
 /// Clear the verified_minor designation (age-up or revocation).
 /// Idempotent: clearing an already-cleared or never-minor account succeeds.
-/// Returns NotFound only when the user does not exist.
+/// Returns NotFound only when the user does not exist. Returns `true` only on a
+/// real transition (flag was set, now cleared); a no-op returns `false` and
+/// leaves `updated_at` untouched, so callers audit only real transitions.
 pub async fn clear_verified_minor(
     &self,
     pubkey: &str,
     tenant_id: i64,
-) -> Result<(), RepositoryError> {
-    let result = sqlx::query(
-        "UPDATE users SET verified_minor = FALSE, verified_minor_at = NULL, updated_at = $3 \
-         WHERE pubkey = $1 AND tenant_id = $2",
+) -> Result<bool, RepositoryError> {
+    let (user_exists, transitioned): (bool, bool) = sqlx::query_as(
+        "WITH existing AS ( \
+             SELECT 1 FROM users WHERE pubkey = $1 AND tenant_id = $2 \
+         ), changed AS ( \
+             UPDATE users \
+             SET verified_minor = FALSE, verified_minor_at = NULL, updated_at = $3 \
+             WHERE pubkey = $1 AND tenant_id = $2 AND verified_minor = TRUE \
+             RETURNING 1 \
+         ) \
+         SELECT EXISTS (SELECT 1 FROM existing), EXISTS (SELECT 1 FROM changed)",
     )
     .bind(pubkey)
     .bind(tenant_id)
     .bind(Utc::now())
-    .execute(&self.pool)
+    .fetch_one(&self.pool)
     .await?;
 
-    if result.rows_affected() == 0 {
+    if !user_exists {
         return Err(RepositoryError::NotFound("user not found".to_string()));
     }
-    Ok(())
+    Ok(transitioned)
 }
 ```
 
-Idempotency rests on Postgres counting every WHERE-matched row as affected by an UPDATE even when column values are unchanged: an existing user yields `rows_affected() == 1` regardless of the prior flag value (success no-op when already false), and a missing user yields `0` (NotFound). The method touches only the two minor columns plus `updated_at`; it never alters `status`, `suspended_reason`, or `suspended_at`.
+The three cases are distinguished in one statement so a missing user (NotFound) never collapses into an already-cleared no-op — the trap of a bare `WHERE verified_minor = TRUE` on the `UPDATE`, which would report `rows_affected() == 0` for both. `existing` probes for the row (existence, independent of flag value), `changed` conditionally updates only a set flag and reports via `RETURNING` whether a real transition happened, and the outer `SELECT` returns both. A no-op clear (already-cleared or never-minor) therefore does **not** bump `updated_at` and reports `false`, so the endpoint can write an audit row for exactly the transitions that occurred rather than for every retry. The method touches only the two minor columns plus `updated_at`; it never alters `status`, `suspended_reason`, or `suspended_at`.
 
 ### Endpoint
 
@@ -88,13 +97,18 @@ Handler `clear_verified_minor_admin`:
 2. Extract `tenant_id` from `TenantExtractor`.
 3. If `actor` is present, validate it as a 64-char hex pubkey (`len() == 64 && chars().all(|c| c.is_ascii_hexdigit())`, the idiom already used at admin.rs:1475). Reject with 400 on a malformed actor, so a T&S action never silently loses its audit trail.
 4. Sanitize `reason` before it is logged or stored: bound to 500 chars and strip control characters (newlines and CR included), per the standing "sanitize caller-supplied values before logging" rule. Call the result `reason_clean`.
-5. `user_repo.clear_verified_minor(&pubkey, tenant_id).await?` (maps `RepositoryError::NotFound` to 404 via error.rs:45).
+5. `let transitioned = user_repo.clear_verified_minor(&pubkey, tenant_id).await?` (maps `RepositoryError::NotFound` to 404 via error.rs:45).
 6. Audit the action:
-   - Always emit a structured log line: `tracing::info!(event = "verified_minor_cleared", pubkey = %pubkey, actor = ?actor, reason = ?reason_clean, "Admin cleared verified_minor")`.
-   - When `actor` is present, also write a durable `admin_audit_events` row, best-effort (log-and-continue on failure, mirroring `record_registered_client_audit` at admin.rs:1554): action `clear_verified_minor`, `actor_pubkey = actor`, `target_resource_type = "user"`, `target_resource_id = Some(pubkey)`, `metadata_json = { "reason": reason_clean }`. The table's `actor_pubkey` is `NOT NULL`, so a durable row is written only when an actor is supplied; without one we fall back to log-only. (keycast#279 raises the same durable-audit bar for suspend/ban so the two enforcement actions match.)
-7. `user_repo.get_full_admin_status(&pubkey, tenant_id).await?` and return the existing `UserStatusResponse` (so the caller sees `verified_minor: false`, `verified_minor_at: null`, and the unchanged status). Reusing `UserStatusResponse` keeps the response contract identical to `GET`/`PUT .../status`.
+   - Always emit a structured log line: `tracing::info!(event = "verified_minor_cleared", pubkey = %pubkey, actor = ?actor, reason = ?reason_clean, transitioned, "Admin cleared verified_minor")`.
+   - When `transitioned` **and** `actor` is present, also write a durable `admin_audit_events` row, best-effort (log-and-continue on failure, mirroring `record_registered_client_audit` at admin.rs:1554): action `clear_verified_minor`, `actor_pubkey = actor`, `target_resource_type = "user"`, `target_resource_id = Some(pubkey)`, `metadata_json = { "reason": reason_clean }`. Gating on `transitioned` keeps a relay-manager retry after a lost response, or a duplicate revocation, from appending a second event asserting a state change that never happened. The table's `actor_pubkey` is `NOT NULL`, so a durable row is written only when an actor is supplied; without one we fall back to log-only. (keycast#279 raises the same durable-audit bar for suspend/ban so the two enforcement actions match.)
+7. Close the revocation door: `claim_token_repo.invalidate_valid_for_user(&pubkey, tenant_id, actor.unwrap_or("system:verified_minor_clear"), reason_clean)`. See "Claim-link closure" below. Run this unconditionally (not gated on `transitioned`) so a retry after a mid-request crash still closes the door; on error, log and return the error so the idempotent caller retries.
+8. `user_repo.get_full_admin_status(&pubkey, tenant_id).await?` and return the existing `UserStatusResponse` (so the caller sees `verified_minor: false`, `verified_minor_at: null`, and the unchanged status). Reusing `UserStatusResponse` keeps the response contract identical to `GET`/`PUT .../status`.
 
 The audit write is best-effort enrichment: a failed `admin_audit_events` insert logs an error and the clear still succeeds. The clear is the primary operation.
+
+### Claim-link closure
+
+Clearing `verified_minor` alone leaves any claim link issued before the clear live. Claim redemption (`claim.rs::claim_post`) gates only on token validity — it does **not** check `status` or `verified_minor` (status is fetched afterward only to stamp the UCAN fact). So a minor account revoked before it is claimed could still be claimed and land as a normal account with no minor protections, and a relay-manager status change alone would not stop it. The endpoint therefore invalidates outstanding claim tokens itself (via the existing `invalidate_valid_for_user`, which only touches still-valid, unused tokens and is thus idempotent and a no-op for an already-claimed age-up account). Unlike the best-effort audit row, this is a safety invariant: a failure fails the request so the caller retries rather than silently leaving the link open. This keeps the door closed independent of relay-manager#147.
 
 Route registration in `routes.rs`:
 
@@ -114,20 +128,23 @@ Route registration in `routes.rs`:
 ## Testing (TDD)
 
 **Repository (integration, Postgres, mirrors existing `user.rs` tests):**
-1. Clears a verified minor: after `create_minor_account` then `clear_verified_minor`, `get_verified_minor` returns `(false, None)`.
-2. Idempotent: calling `clear_verified_minor` on an already-cleared user returns `Ok(())`.
-3. Unknown pubkey returns `RepositoryError::NotFound`.
-4. Does not disturb status: a suspended verified-minor keeps `status = suspended` and its `suspended_reason`/`suspended_at` after clearing.
+1. Clears a verified minor: after `create_minor_account` then `clear_verified_minor`, `get_verified_minor` returns `(false, None)`; the call returns `Ok(true)` (real transition).
+2. Idempotent: calling `clear_verified_minor` on an already-cleared / never-minor user returns `Ok(false)` on both calls (no transition).
+3. No-op does not bump `updated_at`: a no-op clear leaves `updated_at` unchanged (and returns `Ok(false)`).
+4. Unknown pubkey returns `RepositoryError::NotFound` (never collapsed into a no-op).
+5. Does not disturb status: a suspended verified-minor keeps `status = suspended` and its `suspended_reason`/`suspended_at` after clearing.
 
 **Endpoint (integration, service-token):**
-5. `DELETE` with a valid service token clears the flag and returns `UserStatusResponse` with `verified_minor == false` and `verified_minor_at == None`.
-6. `DELETE` with a missing/invalid service token returns 401.
-7. `DELETE` on an unknown pubkey returns 404.
-8. `DELETE` with a valid `actor` writes an `admin_audit_events` row: action `clear_verified_minor`, `actor_pubkey == actor`, `target_resource_id == pubkey`, `metadata_json.reason == reason_clean`.
-9. `DELETE` without `actor` writes no audit row and still succeeds (log-only fallback).
-10. `DELETE` with a malformed `actor` (not 64 hex chars) returns 400 and does not clear the flag.
-11. `reason` containing control characters or exceeding 500 chars is sanitized (bounded and stripped) in both the log line and the stored `metadata_json`.
+6. `DELETE` with a valid service token clears the flag and returns `UserStatusResponse` with `verified_minor == false` and `verified_minor_at == None`.
+7. `DELETE` with a missing/invalid service token returns 401.
+8. `DELETE` on an unknown pubkey returns 404.
+9. `DELETE` with a valid `actor` writes an `admin_audit_events` row: action `clear_verified_minor`, `actor_pubkey == actor`, `target_resource_id == pubkey`, `metadata_json.reason == reason_clean`.
+10. `DELETE` without `actor` writes no audit row and still succeeds (log-only fallback).
+11. `DELETE` with a malformed `actor` (not 64 hex chars) returns 400 and does not clear the flag.
+12. `reason` containing control / bidi / zero-width chars or exceeding 500 chars is sanitized (bounded and stripped) in both the log line and the stored `metadata_json`.
+13. A no-op retry (a second `DELETE` with `actor` after the flag is already cleared) writes no second audit row.
+14. `DELETE` invalidates an outstanding claim token for the pubkey (no valid token remains; `invalidated_by == actor`), so a revoked-before-claim account can no longer be claimed.
 
 ## Acceptance
 
-An approved minor account, when cleared through this endpoint, has `verified_minor` set false and `verified_minor_at` set null, with account status untouched, and (when an `actor` is supplied) a durable `admin_audit_events` row recording who cleared it and why, so that via divine-relay-manager#147 revoking approval lifts protections automatically across clients. The "re-apply restrictions" clause and age-up detection are deferred to divine-relay-manager#147 and support-trust-safety#179 respectively.
+An approved minor account, when cleared through this endpoint, has `verified_minor` set false and `verified_minor_at` set null, with account status untouched, any outstanding claim link invalidated, and (when the clear is a real transition and an `actor` is supplied) a durable `admin_audit_events` row recording who cleared it and why, so that via divine-relay-manager#147 revoking approval lifts protections automatically across clients. The "re-apply restrictions" clause and age-up detection are deferred to divine-relay-manager#147 and support-trust-safety#179 respectively.

--- a/docs/superpowers/specs/2026-07-01-verified-minor-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-01-verified-minor-lifecycle-design.md
@@ -1,0 +1,117 @@
+# verified_minor lifecycle: clear primitive + revocation endpoint
+
+**Issue:** divinevideo/keycast#265 (part of the protected-minor epic, divinevideo/support-trust-safety#173; equal sibling of divine-relay-manager#141)
+**Date:** 2026-07-01
+**Status:** design approved, ready for implementation plan
+
+## Problem
+
+`verified_minor` has a three-state lifecycle: SET (`create_minor_account`), READ (admin + `/user/account` responses), and CLEAR. Only SET and READ exist. There is no code path anywhere that clears `verified_minor`, so the flag is a one-way door: once an account is approved as a protected minor, that designation is permanent short of a manual database edit.
+
+The epic requires protections to lift when an approved minor ages up to 16 or has approval revoked. Both transitions reduce to the same missing primitive: clear the flag. This spec builds that primitive and the endpoint relay-manager calls on revocation.
+
+## Scope
+
+**In scope (this ticket, keycast backend only):**
+- A repository method that clears `verified_minor` + `verified_minor_at`.
+- A service-token admin endpoint relay-manager calls to trigger the clear.
+- Tests for both.
+
+**Out of scope (tracked elsewhere, no-stacking keeps them separate):**
+- The relay-manager revoke-action wiring that calls this endpoint: divine-relay-manager#147.
+- The age-up *trigger* (how we detect someone turned 16): support-trust-safety#179. No birthdate or exact age is captured anywhere by design (verified 2026-07-01: web/mobile collect a parent email + a consent video with a verbal "13 to 15"; relay-manager stores only a coarse `suspected_age_band`; keycast stores only `verified_minor` + `verified_minor_at`). Age-up therefore cannot be auto-computed without a policy decision. This ticket delivers the mechanism that makes the lift automatic-on-clear; the trigger is deferred.
+
+## Design
+
+### Why clear-only (not clear-and-suspend)
+
+The same clear primitive must serve both transitions, and they want opposite account-status outcomes:
+- **Age-up** (later): clear the flag, status stays `active` (a normal adult account).
+- **Revocation**: clear the flag, and the account usually goes *more* restricted, but which status depends on the reason (under-13 leads to ban; mistaken approval leads to active/unsuspend).
+
+Folding a status change into the clear would make it unusable for age-up and would bake a fixed status into revocation that does not fit every reason. So the primitive is clear-only. relay-manager composes revocation as `set_user_status(chosen outcome)` + `clear_verified_minor` (see divine-relay-manager#147). This mirrors keycast's existing style, where `set_user_status` is its own single-purpose primitive. Clearing the flag already lifts the protected-minor protections; the status change is a separate, reason-dependent decision owned by the caller.
+
+### Repository method
+
+`core/src/repositories/user.rs`:
+
+```rust
+/// Clear the verified_minor designation (age-up or revocation).
+/// Idempotent: clearing an already-cleared or never-minor account succeeds.
+/// Returns NotFound only when the user does not exist.
+pub async fn clear_verified_minor(
+    &self,
+    pubkey: &str,
+    tenant_id: i64,
+) -> Result<(), RepositoryError> {
+    let result = sqlx::query(
+        "UPDATE users SET verified_minor = FALSE, verified_minor_at = NULL, updated_at = $3 \
+         WHERE pubkey = $1 AND tenant_id = $2",
+    )
+    .bind(pubkey)
+    .bind(tenant_id)
+    .bind(Utc::now())
+    .execute(&self.pool)
+    .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(RepositoryError::NotFound("user not found".to_string()));
+    }
+    Ok(())
+}
+```
+
+Idempotency rests on Postgres counting every WHERE-matched row as affected by an UPDATE even when column values are unchanged: an existing user yields `rows_affected() == 1` regardless of the prior flag value (success no-op when already false), and a missing user yields `0` (NotFound). The method touches only the two minor columns plus `updated_at`; it never alters `status`, `suspended_reason`, or `suspended_at`.
+
+### Endpoint
+
+`api/src/api/http/admin.rs`, registered in `routes.rs` under the existing `service_admin_routes` group (service-token auth, same as the status endpoints):
+
+```
+DELETE /api/admin/users/:pubkey/verified-minor
+DELETE /api/admin/users/:pubkey/verified-minor?reason=<text>   // reason optional
+```
+
+Handler `clear_verified_minor_admin`:
+1. `authorize_service_token(&headers)?` (constant-time compare, same as siblings).
+2. Extract `tenant_id` from `TenantExtractor`.
+3. `user_repo.clear_verified_minor(&pubkey, tenant_id).await?` (maps NotFound to 404).
+4. Structured audit log, matching the `set_user_status_admin` pattern:
+   `tracing::info!(event = "verified_minor_cleared", pubkey = %pubkey, reason = ?reason, "Admin cleared verified_minor")`.
+   The durable `admin_audit_events` table requires an `actor_pubkey`, which the service-token boundary does not carry, so this matches the existing service-endpoint logging approach rather than that table.
+5. `user_repo.get_full_admin_status(&pubkey, tenant_id).await?` and return the existing `UserStatusResponse` (so the caller sees `verified_minor: false`, `verified_minor_at: null`, and the unchanged status). Reusing `UserStatusResponse` keeps the response contract identical to `GET`/`PUT .../status`.
+
+`reason` is an optional `Query` parameter (keeps DELETE bodyless). It feeds only the audit line; relay-manager#147 will pass a revocation reason.
+
+Route registration in `routes.rs`:
+
+```rust
+.route(
+    "/admin/users/:pubkey/verified-minor",
+    delete(admin::clear_verified_minor_admin),
+)
+```
+
+(`delete` is already imported.)
+
+### No migration
+
+`verified_minor` and `verified_minor_at` already exist (migration `20260527120000_add_verified_minor.sql`). No schema change.
+
+## Testing (TDD)
+
+**Repository (integration, Postgres, mirrors existing `user.rs` tests):**
+1. Clears a verified minor: after `create_minor_account` then `clear_verified_minor`, `get_verified_minor` returns `(false, None)`.
+2. Idempotent: calling `clear_verified_minor` on an already-cleared user returns `Ok(())`.
+3. Unknown pubkey returns `RepositoryError::NotFound`.
+4. Does not disturb status: a suspended verified-minor keeps `status = suspended` and its `suspended_reason`/`suspended_at` after clearing.
+
+**Endpoint (integration, service-token):**
+5. `DELETE` with a valid service token clears the flag and returns `UserStatusResponse` with `verified_minor == false` and `verified_minor_at == None`.
+6. `DELETE` with a missing/invalid service token returns 401.
+7. `DELETE` on an unknown pubkey returns 404.
+8. `reason` query param is accepted (no 4xx) and the call still succeeds.
+
+## Acceptance
+
+An approved minor account, when cleared through this endpoint, has `verified_minor` set false and `verified_minor_at` set null, with account status untouched, so that (via divine-relay-manager#147) revoking approval lifts protections automatically across clients. Age-up detection is deferred to support-trust-safety#179.

--- a/docs/superpowers/specs/2026-07-01-verified-minor-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-01-verified-minor-lifecycle-design.md
@@ -18,8 +18,17 @@ The epic requires protections to lift when an approved minor ages up to 16 or ha
 - Tests for both.
 
 **Out of scope (tracked elsewhere, no-stacking keeps them separate):**
-- The relay-manager revoke-action wiring that calls this endpoint: divine-relay-manager#147.
+- The relay-manager revoke-action wiring that calls this endpoint, including the reason-dependent "re-apply restrictions" status change and passing `actor` + `reason` for the audit trail: divine-relay-manager#147.
+- Durable audit for suspend/ban status changes (the same bar-raise applied to `set_user_status_admin`): keycast#279.
 - The age-up *trigger* (how we detect someone turned 16): support-trust-safety#179. No birthdate or exact age is captured anywhere by design (verified 2026-07-01: web/mobile collect a parent email + a consent video with a verbal "13 to 15"; relay-manager stores only a coarse `suspected_age_band`; keycast stores only `verified_minor` + `verified_minor_at`). Age-up therefore cannot be auto-computed without a policy decision. This ticket delivers the mechanism that makes the lift automatic-on-clear; the trigger is deferred.
+
+## Fidelity to the issue
+
+Three points where this spec meets #265/#177 through a deliberate split rather than a single-ticket delivery, called out so the scope reads as intentional:
+
+- **"re-apply restrictions" (letter of #265/#177).** The issues say revocation should "clear `verified_minor` *and re-apply restrictions*." This spec delivers the clear, which lifts the protected-minor protections (content lock, DM limits). The reason-dependent *account* restriction (suspend for a policy call, ban for under-13, or nothing for a mistaken approval) is owned by divine-relay-manager#147, which composes `set_user_status(chosen outcome)` + this clear. Clear-only is deliberate (see "Why clear-only" below): the same primitive serves age-up, which must leave status untouched. So the split is intentional, not an omission, but #265 alone does not close the "re-apply restrictions" clause.
+- **"protections lift automatically across clients" (spirit).** Delivered by the existing client detection (#174) reacting to `verified_minor` flipping to false. Verified against the mobile seam: `isProtectedMinorProvider` reads `.value`, which retains last-known only during load/error and resolves to `false` on a successful fetch, so a positive false releases enforcement (it does not get swallowed by the fail-safe's persist-last-known behavior). This throughline must be re-verified against #174/#175/#176 before the epic acceptance is claimed; #265 itself only guarantees the flag flips.
+- **Scope by construction.** Only accounts that actually carry `verified_minor` (fresh minor-onboarding accounts from `create_minor_account`) are affected. An original account resolved through age-review "Clear" never received the flag, so it is out of scope by construction, not by omission.
 
 ## Design
 
@@ -69,19 +78,23 @@ Idempotency rests on Postgres counting every WHERE-matched row as affected by an
 
 ```
 DELETE /api/admin/users/:pubkey/verified-minor
-DELETE /api/admin/users/:pubkey/verified-minor?reason=<text>   // reason optional
+DELETE /api/admin/users/:pubkey/verified-minor?actor=<hex64>&reason=<text>
 ```
+
+`actor` (the moderator's pubkey) and `reason` are optional `Query` parameters, keeping the DELETE bodyless. `actor` drives the durable audit trail; relay-manager#147 passes both on revocation.
 
 Handler `clear_verified_minor_admin`:
 1. `authorize_service_token(&headers)?` (constant-time compare, same as siblings).
 2. Extract `tenant_id` from `TenantExtractor`.
-3. `user_repo.clear_verified_minor(&pubkey, tenant_id).await?` (maps NotFound to 404).
-4. Structured audit log, matching the `set_user_status_admin` pattern:
-   `tracing::info!(event = "verified_minor_cleared", pubkey = %pubkey, reason = ?reason, "Admin cleared verified_minor")`.
-   The durable `admin_audit_events` table requires an `actor_pubkey`, which the service-token boundary does not carry, so this matches the existing service-endpoint logging approach rather than that table.
-5. `user_repo.get_full_admin_status(&pubkey, tenant_id).await?` and return the existing `UserStatusResponse` (so the caller sees `verified_minor: false`, `verified_minor_at: null`, and the unchanged status). Reusing `UserStatusResponse` keeps the response contract identical to `GET`/`PUT .../status`.
+3. If `actor` is present, validate it as a 64-char hex pubkey (`len() == 64 && chars().all(|c| c.is_ascii_hexdigit())`, the idiom already used at admin.rs:1475). Reject with 400 on a malformed actor, so a T&S action never silently loses its audit trail.
+4. Sanitize `reason` before it is logged or stored: bound to 500 chars and strip control characters (newlines and CR included), per the standing "sanitize caller-supplied values before logging" rule. Call the result `reason_clean`.
+5. `user_repo.clear_verified_minor(&pubkey, tenant_id).await?` (maps `RepositoryError::NotFound` to 404 via error.rs:45).
+6. Audit the action:
+   - Always emit a structured log line: `tracing::info!(event = "verified_minor_cleared", pubkey = %pubkey, actor = ?actor, reason = ?reason_clean, "Admin cleared verified_minor")`.
+   - When `actor` is present, also write a durable `admin_audit_events` row, best-effort (log-and-continue on failure, mirroring `record_registered_client_audit` at admin.rs:1554): action `clear_verified_minor`, `actor_pubkey = actor`, `target_resource_type = "user"`, `target_resource_id = Some(pubkey)`, `metadata_json = { "reason": reason_clean }`. The table's `actor_pubkey` is `NOT NULL`, so a durable row is written only when an actor is supplied; without one we fall back to log-only. (keycast#279 raises the same durable-audit bar for suspend/ban so the two enforcement actions match.)
+7. `user_repo.get_full_admin_status(&pubkey, tenant_id).await?` and return the existing `UserStatusResponse` (so the caller sees `verified_minor: false`, `verified_minor_at: null`, and the unchanged status). Reusing `UserStatusResponse` keeps the response contract identical to `GET`/`PUT .../status`.
 
-`reason` is an optional `Query` parameter (keeps DELETE bodyless). It feeds only the audit line; relay-manager#147 will pass a revocation reason.
+The audit write is best-effort enrichment: a failed `admin_audit_events` insert logs an error and the clear still succeeds. The clear is the primary operation.
 
 Route registration in `routes.rs`:
 
@@ -110,8 +123,11 @@ Route registration in `routes.rs`:
 5. `DELETE` with a valid service token clears the flag and returns `UserStatusResponse` with `verified_minor == false` and `verified_minor_at == None`.
 6. `DELETE` with a missing/invalid service token returns 401.
 7. `DELETE` on an unknown pubkey returns 404.
-8. `reason` query param is accepted (no 4xx) and the call still succeeds.
+8. `DELETE` with a valid `actor` writes an `admin_audit_events` row: action `clear_verified_minor`, `actor_pubkey == actor`, `target_resource_id == pubkey`, `metadata_json.reason == reason_clean`.
+9. `DELETE` without `actor` writes no audit row and still succeeds (log-only fallback).
+10. `DELETE` with a malformed `actor` (not 64 hex chars) returns 400 and does not clear the flag.
+11. `reason` containing control characters or exceeding 500 chars is sanitized (bounded and stripped) in both the log line and the stored `metadata_json`.
 
 ## Acceptance
 
-An approved minor account, when cleared through this endpoint, has `verified_minor` set false and `verified_minor_at` set null, with account status untouched, so that (via divine-relay-manager#147) revoking approval lifts protections automatically across clients. Age-up detection is deferred to support-trust-safety#179.
+An approved minor account, when cleared through this endpoint, has `verified_minor` set false and `verified_minor_at` set null, with account status untouched, and (when an `actor` is supplied) a durable `admin_audit_events` row recording who cleared it and why, so that via divine-relay-manager#147 revoking approval lifts protections automatically across clients. The "re-apply restrictions" clause and age-up detection are deferred to divine-relay-manager#147 and support-trust-safety#179 respectively.


### PR DESCRIPTION
Implements the keycast backend of #265 (part of the protected-minor epic, divinevideo/support-trust-safety#173).

## What this does

Adds the missing path that clears `verified_minor`. Until now the flag was a one-way door: set at minor-account creation, never cleared, so protected-minor protections were permanent-once-granted with no remediation short of a manual DB edit.

- `UserRepository::clear_verified_minor(pubkey, tenant_id)` sets `verified_minor = false`, `verified_minor_at = null`. Idempotent (no-op on already-cleared or never-minor accounts, 404 on unknown user), and never touches account status.
- `DELETE /api/admin/users/:pubkey/verified-minor` (service-token auth) is the endpoint relay-manager calls on revocation. Optional `actor` (moderator hex pubkey, validated) and `reason` query params.
- Writes a durable `admin_audit_events` row when an `actor` is supplied (best-effort, log-only fallback when absent), with `reason` sanitized (bounded to 500 chars, control characters stripped) before it is logged or stored.

## Design

- **Clear-only, not clear-and-suspend.** The primitive serves both lifecycle transitions, which want opposite status outcomes: age-up leaves status active, revocation is reason-dependent (under-13 ban, mistaken approval unsuspend). relay-manager composes `set_user_status(...)` + clear (relay-manager#147). Clearing the flag already lifts the protected-minor protections; the account-status decision belongs to the caller.
- **No migration** (the `verified_minor` columns already exist).
- **Claim-link closure (review follow-ups).** Clearing a still-unclaimed minor also invalidates outstanding claim links, and claim-token consumption is now atomic with validity: the consume re-checks used/invalidated/expired under the row lock in one transaction with the user claim, so a link invalidated mid-flight can never complete a claim, and a failed claim never burns the token. New `UserRepository::claim_account_consuming_token`; `claim_post` treats it as the authoritative gate and re-classifies dead tokens to their state-specific error page.

## Scope and deferrals

- **Automatic age-up (to 16) is deferred to support-trust-safety#179.** No birthdate or exact age is captured anywhere in the age-review flow, by design (parent email plus a consent video with a verbal "13 to 15"; relay-manager stores only a coarse `age_13_15` band; keycast stores only the flag plus the approval timestamp). keycast cannot compute a 16th birthday from that, so automatic age-up needs a policy decision, not a backend change. This PR delivers the mechanism that makes the lift automatic-on-clear.
- **relay-manager revoke wiring** (the reason-dependent "re-apply restrictions" status change, plus passing actor/reason): relay-manager#147.
- **Durable audit for suspend/ban** (the same bar-raise applied to `set_user_status_admin`): keycast#279.

## Tests

- 4 repository tests (clear, idempotent, not-found, status-untouched) and 8 endpoint tests (clear and response, missing/wrong auth, 404, audit-row written, log-only fallback, malformed-actor 400, reason sanitization). The audit and sanitization assertions were mutation-verified.
- 6 claim-consume race regression tests (`claim_consume_race_test.rs`): invalidated-between-classify-and-consume refusal with no user mutation, expired/reused refusal, consume rollback on an unclaimable user, and a concurrent invalidate-vs-claim exactly-one-wins invariant.
- Full `keycast_core` and `keycast_api` integration suites pass locally.

Spec: `docs/superpowers/specs/2026-07-01-verified-minor-lifecycle-design.md`.

