### PR TITLE
feat(minor-safety): server-side verified_minor DM containment (sign/encrypt gate)

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -3208,6 +3208,28 @@ pub struct PubkeyResponse {
     pub npub: String,   // bech32 format
 }
 
+/// Apply the verified_minor DM containment gate (support-trust-safety#183) to a
+/// `/user/sign` request, on either the fast or slow path. Refusals surface the
+/// uniform policy-denial message (no account-state leak); the specific reason is
+/// logged server-side only. `keys` is the user's signing keypair (needed to
+/// recover a kind-13 seal's recipient by trial decryption).
+fn enforce_minor_dm_sign(
+    keys: &Keys,
+    unsigned_event: &UnsignedEvent,
+    user_pubkey: &str,
+) -> Result<(), AuthError> {
+    keycast_core::verified_minor_dm::validate_minor_sign(keys, unsigned_event).map_err(|denied| {
+        tracing::warn!(
+            event = "minor_dm_gate.sign_denied",
+            user_pubkey = %user_pubkey,
+            kind = unsigned_event.kind.as_u16(),
+            reason = %denied,
+            "verified_minor DM sign refused (/user/sign)"
+        );
+        AuthError::Forbidden("Operation denied by policy".to_string())
+    })
+}
+
 /// Fast HTTP signing endpoint - sign an event without NIP-46 relay overhead
 /// This is 10-50x faster than NIP-46 for quick operations
 pub async fn sign_event(
@@ -3244,6 +3266,21 @@ pub async fn sign_event(
     )
     .await?;
 
+    // verified_minor DM containment (support-trust-safety#183) applies to BOTH
+    // the fast and slow paths. Fetch the flag once here (only for DM-shaped
+    // kinds) so the hot fast path returns a clean 403 too, rather than the
+    // signer handler's error mapping to a 503. A missing user row fails closed.
+    let verified_minor =
+        if keycast_core::verified_minor_dm::is_minor_gated_kind(unsigned_event.kind) {
+            user_repo
+                .get_verified_minor(&user_pubkey, tenant_id)
+                .await?
+                .ok_or_else(|| AuthError::Forbidden("Operation denied by policy".to_string()))?
+                .0
+        } else {
+            false
+        };
+
     // FAST PATH: Try to use cached signer handler if in unified mode
     if let Some(ref handlers) = auth_state.state.signer_handlers {
         tracing::info!(
@@ -3261,6 +3298,13 @@ pub async fn sign_event(
         if let Some(bunker_key) = bunker_pubkey {
             if let Some(handler) = handlers.get(&bunker_key).await {
                 tracing::info!("✅ Using cached handler for user {}", user_pubkey);
+
+                // DM containment on the fast path returns a clean 403 here; the
+                // signer handler also gates as a backstop, but its error would
+                // map to a 503 through the Internal wrapper below.
+                if verified_minor {
+                    enforce_minor_dm_sign(&handler.get_keys(), &unsigned_event, &user_pubkey)?;
+                }
 
                 let signed_event = handler
                     .sign_event_direct(unsigned_event)
@@ -3307,33 +3351,10 @@ pub async fn sign_event(
         .map_err(|e| AuthError::Internal(format!("Invalid secret key bytes: {}", e)))?;
     let keys = Keys::new(secret_key.into());
 
-    // verified_minor DM containment (support-trust-safety#183). The fast path
-    // above enforces this inside the signer handler; this covers the slow path.
-    // Gated here (after key decryption) because a kind-13 seal's recipient can
-    // only be recovered with the user's conversation keys.
-    if keycast_core::verified_minor_dm::is_minor_gated_kind(unsigned_event.kind) {
-        let verified_minor = user_repo
-            .get_verified_minor(&user_pubkey, tenant_id)
-            .await?
-            // Fail closed: DM-shaped signing with unresolvable minor status
-            // is refused (unreachable in practice — personal_keys FK-cascades
-            // with users — but the gate must not default open).
-            .ok_or_else(|| AuthError::Forbidden("Operation denied by policy".to_string()))?
-            .0;
-        if verified_minor {
-            keycast_core::verified_minor_dm::validate_minor_sign(&keys, &unsigned_event).map_err(
-                |denied| {
-                    tracing::warn!(
-                        event = "minor_dm_gate.sign_denied",
-                        user_pubkey = %user_pubkey,
-                        kind = unsigned_event.kind.as_u16(),
-                        reason = %denied,
-                        "verified_minor DM sign refused (/user/sign slow path)"
-                    );
-                    AuthError::Forbidden("Operation denied by policy".to_string())
-                },
-            )?;
-        }
+    // verified_minor DM containment on the slow path (support-trust-safety#183);
+    // `verified_minor` was resolved once above and shared with the fast path.
+    if verified_minor {
+        enforce_minor_dm_sign(&keys, &unsigned_event, &user_pubkey)?;
     }
 
     // Permission validation already done above (before fast path check)

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -3318,13 +3318,11 @@ pub async fn sign_event(
             // Fail closed: DM-shaped signing with unresolvable minor status
             // is refused (unreachable in practice — personal_keys FK-cascades
             // with users — but the gate must not default open).
-            .ok_or_else(|| {
-                AuthError::Forbidden("Operation denied by policy".to_string())
-            })?
+            .ok_or_else(|| AuthError::Forbidden("Operation denied by policy".to_string()))?
             .0;
         if verified_minor {
-            keycast_core::verified_minor_dm::validate_minor_sign(&keys, &unsigned_event)
-                .map_err(|denied| {
+            keycast_core::verified_minor_dm::validate_minor_sign(&keys, &unsigned_event).map_err(
+                |denied| {
                     tracing::warn!(
                         event = "minor_dm_gate.sign_denied",
                         user_pubkey = %user_pubkey,
@@ -3333,7 +3331,8 @@ pub async fn sign_event(
                         "verified_minor DM sign refused (/user/sign slow path)"
                     );
                     AuthError::Forbidden("Operation denied by policy".to_string())
-                })?;
+                },
+            )?;
         }
     }
 

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -3307,6 +3307,36 @@ pub async fn sign_event(
         .map_err(|e| AuthError::Internal(format!("Invalid secret key bytes: {}", e)))?;
     let keys = Keys::new(secret_key.into());
 
+    // verified_minor DM containment (support-trust-safety#183). The fast path
+    // above enforces this inside the signer handler; this covers the slow path.
+    // Gated here (after key decryption) because a kind-13 seal's recipient can
+    // only be recovered with the user's conversation keys.
+    if keycast_core::verified_minor_dm::is_minor_gated_kind(unsigned_event.kind) {
+        let verified_minor = user_repo
+            .get_verified_minor(&user_pubkey, tenant_id)
+            .await?
+            // Fail closed: DM-shaped signing with unresolvable minor status
+            // is refused (unreachable in practice — personal_keys FK-cascades
+            // with users — but the gate must not default open).
+            .ok_or_else(|| {
+                AuthError::Forbidden("Operation denied by policy".to_string())
+            })?
+            .0;
+        if verified_minor {
+            keycast_core::verified_minor_dm::validate_minor_sign(&keys, &unsigned_event)
+                .map_err(|denied| {
+                    tracing::warn!(
+                        event = "minor_dm_gate.sign_denied",
+                        user_pubkey = %user_pubkey,
+                        kind = unsigned_event.kind.as_u16(),
+                        reason = %denied,
+                        "verified_minor DM sign refused (/user/sign slow path)"
+                    );
+                    AuthError::Forbidden("Operation denied by policy".to_string())
+                })?;
+        }
+    }
+
     // Permission validation already done above (before fast path check)
     // Sign the event
     let signed_event = unsigned_event

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -311,15 +311,14 @@ async fn check_user_status_active(
     user_pubkey_hex: &str,
     tenant_id: i64,
 ) -> Result<bool, RpcError> {
-    let status: Option<(String, bool)> =
-        sqlx::query_as("SELECT status, verified_minor FROM users WHERE pubkey = $1 AND tenant_id = $2")
-            .bind(user_pubkey_hex)
-            .bind(tenant_id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| {
-                RpcError::Internal(format!("Database error checking user status: {}", e))
-            })?;
+    let status: Option<(String, bool)> = sqlx::query_as(
+        "SELECT status, verified_minor FROM users WHERE pubkey = $1 AND tenant_id = $2",
+    )
+    .bind(user_pubkey_hex)
+    .bind(tenant_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| RpcError::Internal(format!("Database error checking user status: {}", e)))?;
 
     match status {
         Some((s, verified_minor)) if s == "active" => Ok(verified_minor),

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -162,10 +162,15 @@ pub async fn nostr_rpc(
 
     // For mutating operations (sign/encrypt/decrypt), check user account status.
     // get_public_key is NOT gated -- suspended users need to retrieve their pubkey.
+    // The same per-request row also carries verified_minor, which drives the DM
+    // containment gate below (support-trust-safety#183); reading it here (not
+    // from the cached handler) means protection flips apply immediately.
     let needs_status_check = !matches!(req.method.as_str(), "get_public_key");
-    if needs_status_check {
-        check_user_status_active(pool, &handler.user_pubkey_hex(), tenant_id).await?;
-    }
+    let verified_minor = if needs_status_check {
+        check_user_status_active(pool, &handler.user_pubkey_hex(), tenant_id).await?
+    } else {
+        false
+    };
 
     // Dispatch based on method - all permission checks use cached data (no DB hits)
     let result = match req.method.as_str() {
@@ -173,6 +178,10 @@ pub async fn nostr_rpc(
 
         "sign_event" => {
             let unsigned_event = parse_unsigned_event(&req.params)?;
+
+            if verified_minor {
+                enforce_minor_dm_sign(&handler, &unsigned_event)?;
+            }
 
             // Handler validates expiration, revocation, and permissions (all cached)
             let signed = handler.sign_event(unsigned_event).await?;
@@ -192,6 +201,10 @@ pub async fn nostr_rpc(
 
         "nip44_encrypt" => {
             let (recipient_pubkey, plaintext) = parse_encrypt_params(&req.params)?;
+
+            if verified_minor {
+                enforce_minor_dm_encrypt(&handler, &recipient_pubkey)?;
+            }
 
             // Handler validates expiration, revocation, and permissions (all cached)
             // Crypto runs on spawn_blocking to avoid blocking async workers
@@ -250,6 +263,10 @@ pub async fn nostr_rpc(
         "nip04_encrypt" => {
             let (recipient_pubkey, plaintext) = parse_encrypt_params(&req.params)?;
 
+            if verified_minor {
+                enforce_minor_dm_encrypt(&handler, &recipient_pubkey)?;
+            }
+
             // Handler validates expiration, revocation, and permissions (all cached)
             // Crypto runs on spawn_blocking to avoid blocking async workers
             let ciphertext = handler.nip04_encrypt(&recipient_pubkey, &plaintext).await?;
@@ -287,13 +304,15 @@ pub async fn nostr_rpc(
 
 /// Check that the user's account is active before allowing mutating operations.
 /// This runs a DB query per request (not cached) so status changes take effect immediately.
+/// Returns the account's `verified_minor` flag (same row, no extra query) for
+/// the DM containment gate; a missing user row is a refusal, never a default.
 async fn check_user_status_active(
     pool: &sqlx::PgPool,
     user_pubkey_hex: &str,
     tenant_id: i64,
-) -> Result<(), RpcError> {
-    let status: Option<(String,)> =
-        sqlx::query_as("SELECT status FROM users WHERE pubkey = $1 AND tenant_id = $2")
+) -> Result<bool, RpcError> {
+    let status: Option<(String, bool)> =
+        sqlx::query_as("SELECT status, verified_minor FROM users WHERE pubkey = $1 AND tenant_id = $2")
             .bind(user_pubkey_hex)
             .bind(tenant_id)
             .fetch_optional(pool)
@@ -303,10 +322,53 @@ async fn check_user_status_active(
             })?;
 
     match status {
-        Some((s,)) if s == "active" => Ok(()),
+        Some((s, verified_minor)) if s == "active" => Ok(verified_minor),
         Some(_) => Err(RpcError::AccountSuspended("Account restricted".to_string())),
         None => Err(RpcError::Auth(AuthError::InvalidToken)),
     }
+}
+
+/// Uniform client-facing message for verified_minor DM gate refusals — matches
+/// the policy-denial message so account state is not leaked through error text.
+const MINOR_DM_DENIED_MSG: &str = "Operation denied by policy";
+
+/// Apply the verified_minor DM containment gate to a sign request
+/// (support-trust-safety#183). The denial detail is logged server-side only.
+fn enforce_minor_dm_sign(
+    handler: &Arc<HttpRpcHandler>,
+    unsigned: &UnsignedEvent,
+) -> Result<(), RpcError> {
+    keycast_core::verified_minor_dm::validate_minor_sign(handler.keys(), unsigned).map_err(
+        |denied| {
+            tracing::warn!(
+                event = "minor_dm_gate.sign_denied",
+                user_pubkey = %handler.user_pubkey_hex(),
+                kind = unsigned.kind.as_u16(),
+                reason = %denied,
+                "verified_minor DM sign refused"
+            );
+            RpcError::Auth(AuthError::Forbidden(MINOR_DM_DENIED_MSG.into()))
+        },
+    )
+}
+
+/// Apply the verified_minor DM containment gate to an encrypt request
+/// (support-trust-safety#183). The denial detail is logged server-side only.
+fn enforce_minor_dm_encrypt(
+    handler: &Arc<HttpRpcHandler>,
+    recipient: &PublicKey,
+) -> Result<(), RpcError> {
+    keycast_core::verified_minor_dm::validate_minor_encrypt(&handler.public_key(), recipient)
+        .map_err(|denied| {
+            tracing::warn!(
+                event = "minor_dm_gate.encrypt_denied",
+                user_pubkey = %handler.user_pubkey_hex(),
+                recipient = %recipient.to_hex(),
+                reason = %denied,
+                "verified_minor DM encrypt refused"
+            );
+            RpcError::Auth(AuthError::Forbidden(MINOR_DM_DENIED_MSG.into()))
+        })
 }
 
 /// Load an HttpRpcHandler on-demand from DB and cache it

--- a/api/tests/verified_minor_dm_gate_test.rs
+++ b/api/tests/verified_minor_dm_gate_test.rs
@@ -22,6 +22,7 @@ use keycast_api::ucan_auth::{nostr_pubkey_to_did, NostrKeyMaterial};
 use keycast_core::encryption::file_key_manager::FileKeyManager;
 use keycast_core::encryption::KeyManager;
 use keycast_core::secret_pool::SecretPool;
+use keycast_core::signing_handler::{SignerHandlersCache, SigningHandler};
 use keycast_core::verified_minor_dm::PINNED_MINOR_CONTACTABLE_PUBKEYS;
 use moka::future::Cache;
 use nostr_sdk::nips::nip44;
@@ -29,6 +30,7 @@ use nostr_sdk::prelude::*;
 use serde_json::{json, Value};
 use serial_test::serial;
 use sqlx::PgPool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use ucan::builder::UcanBuilder;
 use uuid::Uuid;
@@ -216,6 +218,7 @@ struct TestAccount {
     keys: Keys,
     pubkey: String,
     token: String,
+    bunker_pubkey: String,
 }
 
 async fn setup_account(
@@ -237,6 +240,7 @@ async fn setup_account(
         keys,
         pubkey,
         token,
+        bunker_pubkey,
     }
 }
 
@@ -326,7 +330,11 @@ async fn minor_rpc_sign_rumor_to_arbitrary_recipient_refused() {
 
 #[tokio::test]
 #[serial]
-async fn minor_rpc_sign_rumor_to_pinned_official_allowed() {
+async fn minor_rpc_sign_rumor_kind_14_refused_outright_even_to_official() {
+    // A conformant NIP-17 client never signs a kind-14 rumor via a remote
+    // signer (rumors are unsigned); signing one only serves a covert channel,
+    // so it is refused regardless of recipient. The legit DM-to-official path
+    // is nip44_encrypt + the kind-13 seal (see minor_rpc_seal_flow_...).
     let pool = setup_db().await;
     let tenant_id = create_test_tenant(&pool).await;
     let key_manager = FileKeyManager::new().expect("key manager");
@@ -336,7 +344,7 @@ async fn minor_rpc_sign_rumor_to_pinned_official_allowed() {
         Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
     );
 
-    let response = invoke_rpc(
+    let err = invoke_rpc(
         tenant_id,
         auth_state,
         &minor.token,
@@ -344,11 +352,74 @@ async fn minor_rpc_sign_rumor_to_pinned_official_allowed() {
         vec![unsigned_dm_json(14, &minor.keys, &[hq_pubkey()])],
     )
     .await
-    .expect("minor DM rumor to pinned official must sign");
-    let signed: Event =
-        serde_json::from_value(response.result.expect("result present")).expect("valid event");
-    signed.verify().expect("valid signature");
-    assert_eq!(signed.kind.as_u16(), 14);
+    .expect_err("minor kind-14 rumor must be refused even to an official");
+    assert_rpc_denied(err);
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_sign_gift_wrap_with_decoy_official_p_tag_refused() {
+    // The bypass the adversarial review found: a kind-1059 whose content is
+    // ciphertext readable by a colluding non-approved party, hidden behind a
+    // decoy approved `p` tag. Refusing 1059 outright closes it.
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+
+    let err = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "sign_event",
+        vec![unsigned_dm_json(1059, &minor.keys, &[hq_pubkey()])],
+    )
+    .await
+    .expect_err("minor gift wrap with a decoy official p-tag must be refused");
+    assert_rpc_denied(err);
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_sign_nip04_kind_4_gated_by_p_tag() {
+    // NIP-04 kind-4 DM is a real send path (video share, dm NIP-04 helper): the
+    // recipient IS the p tag, so it stays p-tag-gated — allowed to an official,
+    // refused to an arbitrary recipient.
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+
+    let signed = invoke_rpc(
+        tenant_id,
+        auth_state.clone(),
+        &minor.token,
+        "sign_event",
+        vec![unsigned_dm_json(4, &minor.keys, &[hq_pubkey()])],
+    )
+    .await
+    .expect("minor kind-4 DM to an official must sign");
+    assert!(signed.result.is_some());
+
+    let err = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "sign_event",
+        vec![unsigned_dm_json(4, &minor.keys, &[mallory.public_key()])],
+    )
+    .await
+    .expect_err("minor kind-4 DM to an arbitrary recipient must be refused");
+    assert_rpc_denied(err);
 }
 
 #[tokio::test]
@@ -774,7 +845,7 @@ async fn minor_user_sign_endpoint_refuses_dm_to_arbitrary_recipient() {
 
 #[tokio::test]
 #[serial]
-async fn minor_user_sign_endpoint_allows_dm_to_pinned_official() {
+async fn minor_user_sign_endpoint_allows_nip04_dm_to_pinned_official() {
     let pool = setup_db().await;
     let tenant_id = create_test_tenant(&pool).await;
     let key_manager = FileKeyManager::new().expect("key manager");
@@ -788,10 +859,10 @@ async fn minor_user_sign_endpoint_allows_dm_to_pinned_official() {
         tenant_id,
         auth_state,
         &minor.token,
-        unsigned_dm_json(14, &minor.keys, &[hq_pubkey()]),
+        unsigned_dm_json(4, &minor.keys, &[hq_pubkey()]),
     )
     .await
-    .expect("minor DM to pinned official via /user/sign must sign");
+    .expect("minor NIP-04 DM to pinned official via /user/sign must sign");
     let signed: Event = serde_json::from_value(signed).expect("valid event");
     signed.verify().expect("valid signature");
 }
@@ -818,4 +889,101 @@ async fn non_minor_user_sign_endpoint_dm_unaffected() {
     .await
     .expect("non-minor DM via /user/sign must sign");
     assert!(signed.is_object());
+}
+
+// ============================================================================
+// /api/user/sign fast path (signer_handlers: Some) — denial must be a clean 403
+// ============================================================================
+
+/// A cached signing handler that records whether it was invoked. If the fast
+/// path's minor gate fires correctly, `sign_event_direct` is never reached.
+struct RecordingSignerHandler {
+    keys: Keys,
+    signed: Arc<AtomicBool>,
+}
+
+#[async_trait::async_trait]
+impl SigningHandler for RecordingSignerHandler {
+    async fn sign_event_direct(
+        &self,
+        unsigned_event: UnsignedEvent,
+    ) -> Result<Event, Box<dyn std::error::Error + Send + Sync>> {
+        self.signed.store(true, Ordering::SeqCst);
+        unsigned_event
+            .sign(&self.keys)
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+    }
+    fn authorization_id(&self) -> i64 {
+        1
+    }
+    fn user_pubkey(&self) -> String {
+        self.keys.public_key().to_hex()
+    }
+    fn get_keys(&self) -> Keys {
+        self.keys.clone()
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_user_sign_fast_path_denial_is_forbidden_not_503() {
+    // I1: on the hot fast path (cached signer handler present), a minor-gate
+    // denial must return a clean 403 Forbidden with the uniform message, not
+    // the 503 the handler's error mapping would produce — and must refuse
+    // BEFORE the handler signs anything.
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+
+    // Install a cached handler keyed by this account's bunker pubkey so the
+    // fast path is taken.
+    let signed_flag = Arc::new(AtomicBool::new(false));
+    let handlers: SignerHandlersCache = Cache::builder().max_capacity(10).build();
+    handlers
+        .insert(
+            minor.bunker_pubkey.clone(),
+            Arc::new(RecordingSignerHandler {
+                keys: minor.keys.clone(),
+                signed: signed_flag.clone(),
+            }),
+        )
+        .await;
+
+    let mut auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    // Rebuild state with signer_handlers present (fast path enabled).
+    auth_state.state = Arc::new(KeycastState {
+        db: pool.clone(),
+        key_manager: auth_state.state.key_manager.clone(),
+        signer_handlers: Some(handlers),
+        http_handler_cache: new_http_handler_cache(),
+        server_keys: Keys::generate(),
+        tenant_cache: Cache::builder().max_capacity(10).build(),
+        bcrypt_sender: BcryptQueue::new().sender(),
+        redis: None,
+        secret_pool: SecretPool::new(1).receiver(),
+    });
+    let mallory = Keys::generate();
+
+    let err = invoke_user_sign(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        unsigned_dm_json(4, &minor.keys, &[mallory.public_key()]),
+    )
+    .await
+    .expect_err("fast-path minor DM to arbitrary recipient must be refused");
+
+    match err {
+        AuthError::Forbidden(msg) => assert_eq!(msg, DENIED_MSG),
+        other => panic!("expected Forbidden({DENIED_MSG}) on the fast path, got: {other:?}"),
+    }
+    assert!(
+        !signed_flag.load(Ordering::SeqCst),
+        "fast-path gate must refuse BEFORE the handler signs"
+    );
 }

--- a/api/tests/verified_minor_dm_gate_test.rs
+++ b/api/tests/verified_minor_dm_gate_test.rs
@@ -229,9 +229,15 @@ async fn setup_account(
     insert_user(pool, tenant_id, &pubkey, verified_minor).await;
     create_personal_key(pool, tenant_id, &pubkey, &keys, key_manager).await;
     let redirect_origin = format!("https://minor-dm-{}.example.com", Uuid::new_v4());
-    let bunker_pubkey = create_oauth_authorization(pool, tenant_id, &pubkey, &redirect_origin).await;
-    let token = build_self_signed_ucan(&keys, tenant_id, &redirect_origin, Some(&bunker_pubkey)).await;
-    TestAccount { keys, pubkey, token }
+    let bunker_pubkey =
+        create_oauth_authorization(pool, tenant_id, &pubkey, &redirect_origin).await;
+    let token =
+        build_self_signed_ucan(&keys, tenant_id, &redirect_origin, Some(&bunker_pubkey)).await;
+    TestAccount {
+        keys,
+        pubkey,
+        token,
+    }
 }
 
 async fn invoke_rpc(
@@ -280,7 +286,10 @@ const DENIED_MSG: &str = "Operation denied by policy";
 fn assert_rpc_denied(err: RpcError) {
     match err {
         RpcError::Auth(AuthError::Forbidden(msg)) => {
-            assert_eq!(msg, DENIED_MSG, "denial must use the uniform policy message");
+            assert_eq!(
+                msg, DENIED_MSG,
+                "denial must use the uniform policy message"
+            );
         }
         other => panic!("expected Forbidden({DENIED_MSG}), got: {other:?}"),
     }

--- a/api/tests/verified_minor_dm_gate_test.rs
+++ b/api/tests/verified_minor_dm_gate_test.rs
@@ -1,0 +1,812 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration tests for the verified_minor DM containment gate (support-trust-safety#183)
+// ABOUTME: over the HTTP RPC (/api/nostr) and fast-sign (/api/user/sign) paths.
+
+mod common;
+
+use axum::{extract::State, http::HeaderMap, Json};
+use chrono::Utc;
+use keycast_api::api::{
+    http::{
+        auth::{sign_event, AuthError, SignEventRequest},
+        nostr_rpc::{nostr_rpc, NostrRpcRequest, NostrRpcResponse, RpcError},
+        routes::AuthState,
+    },
+    tenant::{Tenant, TenantExtractor},
+};
+use keycast_api::bcrypt_queue::BcryptQueue;
+use keycast_api::handlers::http_rpc_handler::new_http_handler_cache;
+use keycast_api::state::KeycastState;
+use keycast_api::ucan_auth::{nostr_pubkey_to_did, NostrKeyMaterial};
+use keycast_core::encryption::file_key_manager::FileKeyManager;
+use keycast_core::encryption::KeyManager;
+use keycast_core::secret_pool::SecretPool;
+use keycast_core::verified_minor_dm::PINNED_MINOR_CONTACTABLE_PUBKEYS;
+use moka::future::Cache;
+use nostr_sdk::nips::nip44;
+use nostr_sdk::prelude::*;
+use serde_json::{json, Value};
+use serial_test::serial;
+use sqlx::PgPool;
+use std::sync::Arc;
+use ucan::builder::UcanBuilder;
+use uuid::Uuid;
+
+// ============================================================================
+// Test helpers (mirroring nostr_rpc_integration_test.rs)
+// ============================================================================
+
+async fn setup_db() -> PgPool {
+    common::assert_test_database_url();
+
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+async fn create_test_tenant(pool: &PgPool) -> i64 {
+    let domain = format!("test-minor-dm-{}.example.com", Uuid::new_v4());
+    sqlx::query_scalar::<_, i64>(
+        "INSERT INTO tenants (domain, name, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())
+         RETURNING id",
+    )
+    .bind(&domain)
+    .bind("Minor DM Gate Test Tenant")
+    .fetch_one(pool)
+    .await
+    .expect("Failed to create test tenant")
+}
+
+fn tenant_extractor(tenant_id: i64) -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: tenant_id,
+        domain: "login.divine.video".to_string(),
+        name: "Minor DM Gate Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+fn create_test_auth_state(pool: PgPool, key_manager: Arc<Box<dyn KeyManager>>) -> AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+
+    AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+async fn insert_user(pool: &PgPool, tenant_id: i64, pubkey: &str, verified_minor: bool) {
+    if verified_minor {
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, verified_minor, verified_minor_at, created_at, updated_at)
+             VALUES ($1, $2, TRUE, NOW(), NOW(), NOW())",
+        )
+        .bind(pubkey)
+        .bind(tenant_id)
+        .execute(pool)
+        .await
+        .expect("Failed to insert verified_minor user");
+    } else {
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+             VALUES ($1, $2, NOW(), NOW())",
+        )
+        .bind(pubkey)
+        .bind(tenant_id)
+        .execute(pool)
+        .await
+        .expect("Failed to insert user");
+    }
+}
+
+async fn create_personal_key(
+    pool: &PgPool,
+    tenant_id: i64,
+    user_pubkey: &str,
+    user_keys: &Keys,
+    key_manager: &dyn KeyManager,
+) {
+    let user_secret = user_keys.secret_key().secret_bytes();
+    let encrypted_secret = key_manager
+        .encrypt(&user_secret)
+        .await
+        .expect("Failed to encrypt user secret");
+
+    sqlx::query(
+        "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id)
+         VALUES ($1, $2, $3)",
+    )
+    .bind(user_pubkey)
+    .bind(&encrypted_secret)
+    .bind(tenant_id)
+    .execute(pool)
+    .await
+    .expect("Failed to create personal key");
+}
+
+/// Create oauth_authorization and return its bunker_public_key.
+async fn create_oauth_authorization(
+    pool: &PgPool,
+    tenant_id: i64,
+    user_pubkey: &str,
+    redirect_origin: &str,
+) -> String {
+    let bunker_keys = Keys::generate();
+    let bunker_pubkey = bunker_keys.public_key().to_hex();
+    let auth_handle = hex::encode(rand::random::<[u8; 32]>());
+
+    sqlx::query(
+        "INSERT INTO oauth_authorizations
+         (user_pubkey, redirect_origin, bunker_public_key, secret_hash, relays, policy_id, tenant_id, expires_at, revoked_at, authorization_handle, handle_expires_at, created_at, updated_at)
+         VALUES ($1, $2, $3, 'test_hash', $4, NULL, $5, NULL, NULL, $6, NOW() + INTERVAL '30 days', NOW(), NOW())"
+    )
+    .bind(user_pubkey)
+    .bind(redirect_origin)
+    .bind(&bunker_pubkey)
+    .bind(json!(["wss://relay.example.com"]).to_string())
+    .bind(tenant_id)
+    .bind(&auth_handle)
+    .execute(pool)
+    .await
+    .expect("Failed to create oauth authorization");
+
+    bunker_pubkey
+}
+
+async fn build_self_signed_ucan(
+    user_keys: &Keys,
+    tenant_id: i64,
+    redirect_origin: &str,
+    bunker_pubkey: Option<&str>,
+) -> String {
+    let user_did = nostr_pubkey_to_did(&user_keys.public_key());
+    let key_material = NostrKeyMaterial::from_keys(user_keys.clone());
+    let mut facts = json!({
+        "tenant_id": tenant_id,
+        "email": "minor-dm-test@example.com",
+        "redirect_origin": redirect_origin,
+    });
+    if let Some(bpk) = bunker_pubkey {
+        facts["bunker_pubkey"] = json!(bpk);
+    }
+
+    let ucan = UcanBuilder::default()
+        .issued_by(&key_material)
+        .for_audience(&user_did)
+        .with_lifetime(3600)
+        .with_fact(facts)
+        .build()
+        .expect("Failed to build UCAN")
+        .sign()
+        .await
+        .expect("Failed to sign UCAN");
+
+    ucan.encode().expect("Failed to encode UCAN")
+}
+
+/// Full test account: user row (+ optional verified_minor), personal key,
+/// OAuth authorization, and a Bearer token routing through the OAuth handler.
+struct TestAccount {
+    keys: Keys,
+    pubkey: String,
+    token: String,
+}
+
+async fn setup_account(
+    pool: &PgPool,
+    tenant_id: i64,
+    key_manager: &dyn KeyManager,
+    verified_minor: bool,
+) -> TestAccount {
+    let keys = Keys::generate();
+    let pubkey = keys.public_key().to_hex();
+    insert_user(pool, tenant_id, &pubkey, verified_minor).await;
+    create_personal_key(pool, tenant_id, &pubkey, &keys, key_manager).await;
+    let redirect_origin = format!("https://minor-dm-{}.example.com", Uuid::new_v4());
+    let bunker_pubkey = create_oauth_authorization(pool, tenant_id, &pubkey, &redirect_origin).await;
+    let token = build_self_signed_ucan(&keys, tenant_id, &redirect_origin, Some(&bunker_pubkey)).await;
+    TestAccount { keys, pubkey, token }
+}
+
+async fn invoke_rpc(
+    tenant_id: i64,
+    auth_state: AuthState,
+    token: &str,
+    method: &str,
+    params: Vec<Value>,
+) -> Result<NostrRpcResponse, RpcError> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Authorization",
+        format!("Bearer {}", token).parse().expect("valid header"),
+    );
+    headers.insert("host", "login.divine.video".parse().expect("valid host"));
+    headers.insert("x-forwarded-proto", "https".parse().expect("valid proto"));
+
+    let Json(response) = nostr_rpc(
+        tenant_extractor(tenant_id),
+        State(auth_state),
+        headers,
+        Json(NostrRpcRequest {
+            method: method.to_string(),
+            params,
+        }),
+    )
+    .await?;
+    Ok(response)
+}
+
+fn hq_pubkey() -> PublicKey {
+    PublicKey::from_hex(PINNED_MINOR_CONTACTABLE_PUBKEYS[0]).unwrap()
+}
+
+fn unsigned_dm_json(kind: u16, author: &Keys, recipients: &[PublicKey]) -> Value {
+    let tags: Vec<Tag> = recipients.iter().map(|pk| Tag::public_key(*pk)).collect();
+    let unsigned = EventBuilder::new(Kind::from(kind), "gate test message")
+        .tags(tags)
+        .build(author.public_key());
+    serde_json::to_value(&unsigned).expect("serialize unsigned event")
+}
+
+/// The uniform, non-specific message every minor-gate refusal surfaces.
+const DENIED_MSG: &str = "Operation denied by policy";
+
+fn assert_rpc_denied(err: RpcError) {
+    match err {
+        RpcError::Auth(AuthError::Forbidden(msg)) => {
+            assert_eq!(msg, DENIED_MSG, "denial must use the uniform policy message");
+        }
+        other => panic!("expected Forbidden({DENIED_MSG}), got: {other:?}"),
+    }
+}
+
+// ============================================================================
+// HTTP RPC (/api/nostr) — sign_event
+// ============================================================================
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_sign_rumor_to_arbitrary_recipient_refused() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+
+    let err = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "sign_event",
+        vec![unsigned_dm_json(14, &minor.keys, &[mallory.public_key()])],
+    )
+    .await
+    .expect_err("minor DM rumor to arbitrary recipient must be refused");
+    assert_rpc_denied(err);
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_sign_rumor_to_pinned_official_allowed() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+
+    let response = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "sign_event",
+        vec![unsigned_dm_json(14, &minor.keys, &[hq_pubkey()])],
+    )
+    .await
+    .expect("minor DM rumor to pinned official must sign");
+    let signed: Event =
+        serde_json::from_value(response.result.expect("result present")).expect("valid event");
+    signed.verify().expect("valid signature");
+    assert_eq!(signed.kind.as_u16(), 14);
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_sign_public_note_unaffected() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+
+    // Kind 1 with a mention p-tag: public posting is not DM-shaped.
+    let response = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "sign_event",
+        vec![unsigned_dm_json(1, &minor.keys, &[mallory.public_key()])],
+    )
+    .await
+    .expect("minor public note must sign normally");
+    assert!(response.result.is_some());
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_sign_gift_wrap_to_arbitrary_recipient_refused() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+
+    let err = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "sign_event",
+        vec![unsigned_dm_json(1059, &minor.keys, &[mallory.public_key()])],
+    )
+    .await
+    .expect_err("minor gift wrap to arbitrary recipient must be refused");
+    assert_rpc_denied(err);
+}
+
+// ============================================================================
+// HTTP RPC (/api/nostr) — encrypt primitives
+// ============================================================================
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_nip44_encrypt_to_arbitrary_recipient_refused() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+
+    let err = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "nip44_encrypt",
+        vec![json!(mallory.public_key().to_hex()), json!("hello")],
+    )
+    .await
+    .expect_err("minor nip44_encrypt to arbitrary recipient must be refused");
+    assert_rpc_denied(err);
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_nip44_encrypt_to_official_and_self_allowed() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+
+    let to_official = invoke_rpc(
+        tenant_id,
+        auth_state.clone(),
+        &minor.token,
+        "nip44_encrypt",
+        vec![json!(hq_pubkey().to_hex()), json!("hello hq")],
+    )
+    .await
+    .expect("minor nip44_encrypt to pinned official must succeed");
+    assert!(to_official.result.is_some());
+
+    let to_self = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "nip44_encrypt",
+        vec![json!(minor.pubkey), json!("note to self")],
+    )
+    .await
+    .expect("minor nip44_encrypt to self must succeed");
+    assert!(to_self.result.is_some());
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_nip04_encrypt_to_arbitrary_recipient_refused() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+
+    let err = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "nip04_encrypt",
+        vec![json!(mallory.public_key().to_hex()), json!("hello")],
+    )
+    .await
+    .expect_err("minor nip04_encrypt to arbitrary recipient must be refused");
+    assert_rpc_denied(err);
+}
+
+// ============================================================================
+// HTTP RPC (/api/nostr) — kind-13 seal
+// ============================================================================
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_seal_flow_to_official_allowed_end_to_end() {
+    // The real custodial client flow: nip44_encrypt the rumor to the official
+    // via RPC, then sign the kind-13 seal via RPC. Both legs must pass.
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+
+    let rumor = json!({
+        "id": "0000000000000000000000000000000000000000000000000000000000000000",
+        "pubkey": minor.pubkey,
+        "created_at": 1_700_000_000,
+        "kind": 14,
+        "tags": [["p", hq_pubkey().to_hex()]],
+        "content": "hello hq, sealed",
+    })
+    .to_string();
+
+    let encrypted = invoke_rpc(
+        tenant_id,
+        auth_state.clone(),
+        &minor.token,
+        "nip44_encrypt",
+        vec![json!(hq_pubkey().to_hex()), json!(rumor)],
+    )
+    .await
+    .expect("sealing rumor to official must encrypt");
+    let ciphertext = encrypted
+        .result
+        .expect("ciphertext present")
+        .as_str()
+        .expect("ciphertext is string")
+        .to_string();
+
+    let seal = EventBuilder::new(Kind::from(13u16), ciphertext).build(minor.keys.public_key());
+    let response = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "sign_event",
+        vec![serde_json::to_value(&seal).expect("serialize seal")],
+    )
+    .await
+    .expect("seal to pinned official must sign");
+    assert!(response.result.is_some());
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_seal_to_arbitrary_recipient_refused() {
+    // Seal ciphertext produced OUTSIDE the gated encrypt primitive, under the
+    // user<->mallory conversation key (derivable by mallory alone). Keycast
+    // must refuse to sign it: it does not decrypt under any approved key.
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+
+    let rumor = json!({
+        "id": "0000000000000000000000000000000000000000000000000000000000000000",
+        "pubkey": minor.pubkey,
+        "created_at": 1_700_000_000,
+        "kind": 14,
+        "tags": [["p", mallory.public_key().to_hex()]],
+        "content": "smuggled",
+    })
+    .to_string();
+    let ciphertext = nip44::encrypt(
+        mallory.secret_key(),
+        &minor.keys.public_key(),
+        &rumor,
+        nip44::Version::V2,
+    )
+    .expect("mallory-side encryption");
+
+    let seal = EventBuilder::new(Kind::from(13u16), ciphertext).build(minor.keys.public_key());
+    let err = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "sign_event",
+        vec![serde_json::to_value(&seal).expect("serialize seal")],
+    )
+    .await
+    .expect_err("seal to arbitrary recipient must be refused");
+    assert_rpc_denied(err);
+}
+
+// ============================================================================
+// HTTP RPC (/api/nostr) — ingress (decrypt) stays open, non-minors unaffected
+// ============================================================================
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_decrypt_from_arbitrary_sender_still_allowed() {
+    // #183 scopes containment to egress; decrypt (ingress) is out of scope.
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+    let ciphertext = nip44::encrypt(
+        mallory.secret_key(),
+        &minor.keys.public_key(),
+        "inbound message",
+        nip44::Version::V2,
+    )
+    .expect("mallory encrypts to minor");
+
+    let response = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "nip44_decrypt",
+        vec![json!(mallory.public_key().to_hex()), json!(ciphertext)],
+    )
+    .await
+    .expect("minor decrypt of inbound message stays allowed (egress-only gate)");
+    assert_eq!(
+        response.result.expect("plaintext present").as_str(),
+        Some("inbound message")
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn non_minor_rpc_dm_signing_and_encryption_unaffected() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let adult = setup_account(&pool, tenant_id, &key_manager, false).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+
+    let signed = invoke_rpc(
+        tenant_id,
+        auth_state.clone(),
+        &adult.token,
+        "sign_event",
+        vec![unsigned_dm_json(14, &adult.keys, &[mallory.public_key()])],
+    )
+    .await
+    .expect("non-minor DM rumor to anyone must sign");
+    assert!(signed.result.is_some());
+
+    let encrypted = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &adult.token,
+        "nip44_encrypt",
+        vec![json!(mallory.public_key().to_hex()), json!("hello")],
+    )
+    .await
+    .expect("non-minor nip44_encrypt to anyone must succeed");
+    assert!(encrypted.result.is_some());
+}
+
+#[tokio::test]
+#[serial]
+async fn rpc_sign_refused_when_user_row_missing_fail_closed() {
+    // Handler cached, then the user row disappears: minor status (and account
+    // status) are unresolvable, so signing must refuse rather than pass.
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+
+    // Warm the handler cache with an allowed call.
+    invoke_rpc(
+        tenant_id,
+        auth_state.clone(),
+        &minor.token,
+        "get_public_key",
+        vec![],
+    )
+    .await
+    .expect("get_public_key warms the handler cache");
+
+    sqlx::query("DELETE FROM users WHERE pubkey = $1 AND tenant_id = $2")
+        .bind(&minor.pubkey)
+        .bind(tenant_id)
+        .execute(&pool)
+        .await
+        .expect("delete user row");
+
+    let err = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "sign_event",
+        vec![unsigned_dm_json(14, &minor.keys, &[hq_pubkey()])],
+    )
+    .await
+    .expect_err("unresolvable account must refuse signing");
+    assert!(
+        matches!(err, RpcError::Auth(_)),
+        "expected auth refusal, got: {err:?}"
+    );
+}
+
+// ============================================================================
+// /api/user/sign (slow path — signer_handlers: None)
+// ============================================================================
+
+async fn invoke_user_sign(
+    tenant_id: i64,
+    auth_state: AuthState,
+    token: &str,
+    event_json: Value,
+) -> Result<Value, AuthError> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Authorization",
+        format!("Bearer {}", token).parse().expect("valid header"),
+    );
+    headers.insert("host", "login.divine.video".parse().expect("valid host"));
+    headers.insert("x-forwarded-proto", "https".parse().expect("valid proto"));
+
+    let Json(response) = sign_event(
+        tenant_extractor(tenant_id),
+        State(auth_state),
+        headers,
+        Json(SignEventRequest { event: event_json }),
+    )
+    .await?;
+    Ok(response.signed_event)
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_user_sign_endpoint_refuses_dm_to_arbitrary_recipient() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+
+    let err = invoke_user_sign(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        unsigned_dm_json(14, &minor.keys, &[mallory.public_key()]),
+    )
+    .await
+    .expect_err("minor DM via /user/sign must be refused");
+    match err {
+        AuthError::Forbidden(msg) => assert_eq!(msg, DENIED_MSG),
+        other => panic!("expected Forbidden({DENIED_MSG}), got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_user_sign_endpoint_allows_dm_to_pinned_official() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+
+    let signed = invoke_user_sign(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        unsigned_dm_json(14, &minor.keys, &[hq_pubkey()]),
+    )
+    .await
+    .expect("minor DM to pinned official via /user/sign must sign");
+    let signed: Event = serde_json::from_value(signed).expect("valid event");
+    signed.verify().expect("valid signature");
+}
+
+#[tokio::test]
+#[serial]
+async fn non_minor_user_sign_endpoint_dm_unaffected() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let adult = setup_account(&pool, tenant_id, &key_manager, false).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+
+    let signed = invoke_user_sign(
+        tenant_id,
+        auth_state,
+        &adult.token,
+        unsigned_dm_json(14, &adult.keys, &[mallory.public_key()]),
+    )
+    .await
+    .expect("non-minor DM via /user/sign must sign");
+    assert!(signed.is_object());
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,3 +14,4 @@ pub mod signing_session;
 pub mod tenant_query;
 pub mod traits;
 pub mod types;
+pub mod verified_minor_dm;

--- a/core/src/verified_minor_dm.rs
+++ b/core/src/verified_minor_dm.rs
@@ -1,0 +1,56 @@
+// ABOUTME: Server-side DM containment gate for verified_minor accounts (support-trust-safety#183).
+// ABOUTME: Refuses to sign/encrypt DM-shaped events destined outside the pinned official set.
+
+//! Protected-minor (13-15) DM containment for custodial accounts.
+//!
+//! Keycast holds the signing key for custodial minors, and its signing API is
+//! reachable with just the account's credentials — so client-side DM
+//! restrictions (divine-mobile#5754 / divine-web#474) are friction, not
+//! containment, for these accounts. This module is the server-side backstop:
+//! for a `verified_minor` user, Keycast refuses to sign or encrypt DM-shaped
+//! payloads whose recipients fall outside the pinned official set.
+//!
+//! # Trust model (pin-only, deliberately)
+//!
+//! The clients approve a recipient via "pinned pubkey AND live NIP-05
+//! re-resolution" (divine-mobile#4948): the pin blocks attacker *addition*,
+//! the NIP-05 leg is a *revocation* lever. Server-side we enforce the pin
+//! only. A live NIP-05 lookup inside the signing hot path would add a network
+//! dependency to every DM sign and force a fail-open-vs-fail-closed call on
+//! every resolver hiccup; revocation server-side is handled by shipping an
+//! updated pin (and, for compromise, by the account-status lifecycle). The
+//! pinned values are mirrored by hand from the clients' shipped sets
+//! (`officialAccounts.ts` / `official_accounts.dart`) and must stay identical.
+//!
+//! # What is gated (egress only)
+//!
+//! * `nip04_encrypt` / `nip44_encrypt`: recipient must be the user or pinned.
+//! * `sign_event` kind 4 (NIP-04 DM), kinds 14/15 (NIP-17 rumors), kind 1059
+//!   (gift wrap): every `p` tag must resolve to the user or a pinned account,
+//!   and at least one `p` tag must be present.
+//! * `sign_event` kind 13 (NIP-59 seal): the seal names no recipient — its
+//!   content is NIP-44 ciphertext under the conversation key of the *unstated*
+//!   receiver. The recipient is recovered by trial-decrypting against the
+//!   user's conversation keys with each approved pubkey (NIP-44 v2 is
+//!   authenticated, so this is deterministic); the inner rumor's `p` tags must
+//!   also all be approved. Anything that does not decrypt is refused.
+//!
+//! Decrypt/unwrap (ingress) is intentionally untouched — #183 scopes
+//! containment to egress.
+//!
+//! Fail closed: an unresolvable recipient, an unparseable `p` tag, or a seal
+//! that decrypts to nothing is a refusal, never a pass-through.
+
+/// The pinned official accounts a protected minor may exchange DMs with.
+/// Mirrored by hand from the clients' shipped sets — keep the values identical
+/// to divine-web `officialAccounts.ts` and divine-mobile
+/// `official_accounts.dart` (verified 2026-07-09). Additions are
+/// deploy-gated by design: this is a child-contact list, and requiring a
+/// release to widen it is the accepted friction that makes the pin an
+/// attacker-addition barrier (no env override on purpose).
+pub const PINNED_MINOR_CONTACTABLE_PUBKEYS: [&str; 2] = [
+    // Divine HQ (_@divinehq.divine.video)
+    "c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e",
+    // Divine Moderation (moderation@divine.video)
+    "8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e",
+];

--- a/core/src/verified_minor_dm.rs
+++ b/core/src/verified_minor_dm.rs
@@ -24,22 +24,50 @@
 //!
 //! # What is gated (egress only)
 //!
+//! The recipient of a DM is bound by whoever can *decrypt* it, not by the
+//! attacker-controlled `p` tag: the NIP-44 / NIP-04 conversation key is
+//! *symmetric* ECDH, so a colluding non-approved party can compute the
+//! minor↔them key from their own secret and the minor's public key and forge
+//! minor-keyed ciphertext without ever calling Keycast. Binding on the `p` tag
+//! alone is therefore spoofable. Each shape is gated at the point its true
+//! recipient is actually determinable:
+//!
 //! * `nip04_encrypt` / `nip44_encrypt`: recipient must be the user or pinned.
-//! * `sign_event` kind 4 (NIP-04 DM), kinds 14/15 (NIP-17 rumors), kind 1059
-//!   (gift wrap): every `p` tag must resolve to the user or a pinned account,
-//!   and at least one `p` tag must be present.
+//!   This is the primitive that produces DM ciphertext, so it blocks a
+//!   non-colluding minor from encrypting to a stranger at all.
 //! * `sign_event` kind 13 (NIP-59 seal): the seal names no recipient — its
 //!   content is NIP-44 ciphertext under the conversation key of the *unstated*
 //!   receiver. The recipient is recovered by trial-decrypting against the
 //!   user's conversation keys with each approved pubkey (NIP-44 v2 is
-//!   authenticated, so this is deterministic); the inner rumor's `p` tags must
-//!   also all be approved. Anything that does not decrypt is refused.
+//!   authenticated, so this is deterministic); the inner rumor's `p` tags and
+//!   the seal's own `p` tags must also all be approved. This is the real NIP-17
+//!   containment point.
+//! * `sign_event` kind 4 (NIP-04 DM): a complete, normal-client-rendered DM
+//!   whose recipient IS the `p` tag (NIP-04 content is unauthenticated, so the
+//!   reader cannot be verified by decryption). Every `p` tag must be approved,
+//!   which keeps a minor-signed kind-4 facially addressed to an approved party.
+//! * `sign_event` kinds 14/15 (NIP-17 rumor) and 1059 (gift wrap): **refused
+//!   outright.** A conformant client never asks a remote signer to sign these
+//!   with the user's key (rumors are unsigned; wraps use a one-time ephemeral
+//!   key), so a `p`-tag check there is pure false confidence. The legitimate
+//!   NIP-17 DM to an approved official flows through `nip44_encrypt` (gated) +
+//!   the kind-13 seal (gated).
 //!
 //! Decrypt/unwrap (ingress) is intentionally untouched — #183 scopes
 //! containment to egress.
 //!
-//! Fail closed: an unresolvable recipient, an unparseable `p` tag, or a seal
-//! that decrypts to nothing is a refusal, never a pass-through.
+//! Fail closed: an unresolvable recipient, an unparseable `p` tag, a seal that
+//! decrypts to nothing, or an unverifiable DM-carrier kind is a refusal, never
+//! a pass-through.
+//!
+//! # Accepted ceiling
+//!
+//! A minor can freely sign public posts (e.g. kind 1), whose content is
+//! arbitrary — so a minor + a colluding recipient can always steganographically
+//! encode a payload the recipient extracts out-of-band. No server-side gate can
+//! close that (it is not a DM shape any normal client renders as a DM). This
+//! gate's job is narrower and achievable: Keycast will not produce a DM-shaped,
+//! normal-client-deliverable artifact addressed to a non-approved recipient.
 
 use nostr_sdk::nips::nip44;
 use nostr_sdk::{Keys, Kind, PublicKey, Tag, UnsignedEvent};
@@ -76,6 +104,10 @@ pub enum MinorDmDenied {
     /// A kind-13 seal decrypted, but the inner rumor is not a well-formed
     /// event JSON we can extract recipients from. Fail closed.
     SealRumorInvalid,
+    /// A DM-carrier kind (NIP-17 rumor 14/15, gift wrap 1059) whose recipient
+    /// cannot be verified at signing time and which a conformant client never
+    /// asks a remote signer to sign — refused outright. See [`validate_minor_sign`].
+    UnverifiableDmKind,
 }
 
 impl std::fmt::Display for MinorDmDenied {
@@ -85,6 +117,7 @@ impl std::fmt::Display for MinorDmDenied {
             MinorDmDenied::RecipientUnresolvable => "recipient unresolvable",
             MinorDmDenied::SealNotDecryptable => "seal not decryptable to an approved recipient",
             MinorDmDenied::SealRumorInvalid => "sealed rumor malformed",
+            MinorDmDenied::UnverifiableDmKind => "DM-carrier kind not signable by a minor",
         };
         write!(f, "verified_minor DM gate: {}", reason)
     }
@@ -134,12 +167,37 @@ pub fn validate_minor_encrypt(
 /// Takes the user's [`Keys`] (not just the pubkey) because a kind-13 seal
 /// names no recipient — recovering it requires trial-decrypting the content
 /// under the user's conversation keys with each approved pubkey.
+///
+/// Recipient binding differs by shape, because binding the *spoofable `p` tag*
+/// alone is not containment (the NIP-44 / NIP-04 conversation key is symmetric
+/// ECDH, so a colluding non-approved party can forge minor-keyed ciphertext and
+/// hide it behind a decoy approved `p` tag):
+///
+/// - **kind 4 (NIP-04 DM)** is a complete, normal-client-rendered DM whose
+///   recipient IS the `p` tag; NIP-04 content is unauthenticated AES-CBC, so we
+///   cannot verify the true reader by decryption. We require the `p` tag(s)
+///   approved, which keeps a minor-signed kind-4 facially addressed to an
+///   approved party; the gated `nip04_encrypt` primitive blocks producing the
+///   ciphertext for a non-colluding stranger. Residual: a colluding recipient
+///   can still read a decoy-`p`-tagged payload — the public-post steganography
+///   ceiling, reachable via any signable kind (e.g. a plain kind-1 note) and
+///   not closable server-side.
+/// - **kind 13 (NIP-59 seal)** names no recipient; we recover it by
+///   trial-decrypting the content against the approved conversation keys
+///   (authenticated NIP-44 v2 makes this deterministic). This is the real
+///   NIP-17 containment point.
+/// - **kinds 14/15 (NIP-17 rumor) and 1059 (gift wrap)** are refused outright.
+///   A conformant client NEVER asks a remote signer to sign these with the
+///   user's key: rumors are unsigned (NIP-59), and gift wraps are signed by a
+///   one-time ephemeral key, not the sender's. Signing one with the minor's key
+///   only serves a covert channel, and a `p`-tag check there is pure false
+///   confidence (see above). The legitimate NIP-17 DM to an approved official
+///   flows entirely through `nip44_encrypt` (gated) + the kind-13 seal (gated).
 pub fn validate_minor_sign(user_keys: &Keys, event: &UnsignedEvent) -> Result<(), MinorDmDenied> {
     match event.kind.as_u16() {
-        4 | 14 | 15 | 1059 => {
-            validate_p_tag_recipients(&user_keys.public_key(), event.tags.as_slice())
-        }
-        13 => validate_seal(user_keys, &event.content),
+        4 => validate_p_tag_recipients(&user_keys.public_key(), event.tags.as_slice()),
+        13 => validate_seal(user_keys, event),
+        14 | 15 | 1059 => Err(MinorDmDenied::UnverifiableDmKind),
         _ => Ok(()),
     }
 }
@@ -148,13 +206,46 @@ pub fn validate_minor_sign(user_keys: &Keys, event: &UnsignedEvent) -> Result<()
 /// `p` tag must be present — a DM shape with no recipient is unresolvable and
 /// therefore refused.
 fn validate_p_tag_recipients(user_pubkey: &PublicKey, tags: &[Tag]) -> Result<(), MinorDmDenied> {
-    let mut found_recipient = false;
+    let has_p_tag = tags
+        .iter()
+        .any(|tag| tag.as_slice().first().map(String::as_str) == Some("p"));
+    if !has_p_tag {
+        return Err(MinorDmDenied::RecipientUnresolvable);
+    }
+    validate_p_tags_approved(user_pubkey, tags)
+}
+
+/// A kind-13 seal's true recipient is whoever holds the other half of the
+/// NIP-44 conversation key its content was encrypted under. NIP-44 v2 is
+/// authenticated (HMAC), so trial decryption against the small approved set
+/// deterministically recovers the recipient — or proves it is not approved.
+///
+/// Per NIP-59 a seal carries no tags, but any `p` tags a client does attach
+/// would become relay-routable metadata, so they must be approved too (a
+/// near-free defense-in-depth check; content stays bound by decryption). The
+/// crypto here (≤3 ECDH + HKDF + a bounded NIP-44 decrypt) runs inline: it is
+/// sub-millisecond and bounded, unlike the unwrap-batch path that fans out.
+fn validate_seal(user_keys: &Keys, event: &UnsignedEvent) -> Result<(), MinorDmDenied> {
+    let user_pubkey = user_keys.public_key();
+    validate_p_tags_approved(&user_pubkey, event.tags.as_slice())?;
+    let candidates = [user_pubkey, PINNED_KEYS[0], PINNED_KEYS[1]];
+    for candidate in &candidates {
+        if let Ok(plaintext) = nip44::decrypt(user_keys.secret_key(), candidate, &event.content) {
+            return validate_sealed_rumor(&user_pubkey, &plaintext);
+        }
+    }
+    Err(MinorDmDenied::SealNotDecryptable)
+}
+
+/// Reject any `p` tag that is not a parseable, approved pubkey. Unlike
+/// [`validate_p_tag_recipients`], zero `p` tags is fine here — used where the
+/// recipient is established by other means (the seal's decryption target).
+fn validate_p_tags_approved(user_pubkey: &PublicKey, tags: &[Tag]) -> Result<(), MinorDmDenied> {
     for tag in tags {
         let slice = tag.as_slice();
         if slice.first().map(String::as_str) != Some("p") {
             continue;
         }
-        found_recipient = true;
         let recipient = slice
             .get(1)
             .and_then(|hex| PublicKey::from_hex(hex).ok())
@@ -163,26 +254,7 @@ fn validate_p_tag_recipients(user_pubkey: &PublicKey, tags: &[Tag]) -> Result<()
             return Err(MinorDmDenied::RecipientNotApproved);
         }
     }
-    if found_recipient {
-        Ok(())
-    } else {
-        Err(MinorDmDenied::RecipientUnresolvable)
-    }
-}
-
-/// A kind-13 seal's true recipient is whoever holds the other half of the
-/// NIP-44 conversation key its content was encrypted under. NIP-44 v2 is
-/// authenticated (HMAC), so trial decryption against the small approved set
-/// deterministically recovers the recipient — or proves it is not approved.
-fn validate_seal(user_keys: &Keys, content: &str) -> Result<(), MinorDmDenied> {
-    let user_pubkey = user_keys.public_key();
-    let candidates = [user_pubkey, PINNED_KEYS[0], PINNED_KEYS[1]];
-    for candidate in &candidates {
-        if let Ok(plaintext) = nip44::decrypt(user_keys.secret_key(), candidate, content) {
-            return validate_sealed_rumor(&user_pubkey, &plaintext);
-        }
-    }
-    Err(MinorDmDenied::SealNotDecryptable)
+    Ok(())
 }
 
 /// The decrypted seal payload must be an event-shaped JSON object whose `p`
@@ -314,72 +386,56 @@ mod tests {
         );
     }
 
-    // -- sign gate: non-DM kinds untouched --------------------------------------
+    // -- sign gate: rumor/wrap kinds (14 / 15 / 1059) refused outright ----------
+    //
+    // A conformant client never asks a remote signer to sign these with the
+    // user's key (rumors are unsigned; wraps use a one-time ephemeral key), and
+    // a `p`-tag check on them is spoofable (symmetric ECDH). So they are refused
+    // regardless of recipient — closing the decoy-`p`-tag covert channel.
 
     #[test]
-    fn non_dm_kinds_sign_normally_even_with_arbitrary_p_tags() {
-        let user = Keys::generate();
-        let mallory = Keys::generate();
-        // Kind 1 note mentioning an arbitrary pubkey: public posting, not a DM.
-        let event = dm_shaped_event(1, &user, &[mallory.public_key()]);
-        assert_eq!(validate_minor_sign(&user, &event), Ok(()));
-    }
-
-    // -- sign gate: p-tag kinds (4 / 14 / 15 / 1059) ----------------------------
-
-    #[test]
-    fn rumor_to_pinned_official_is_allowed() {
+    fn rumor_kind_14_refused_outright_even_to_pinned_official() {
         let user = Keys::generate();
         let event = dm_shaped_event(14, &user, &[hq_pubkey()]);
-        assert_eq!(validate_minor_sign(&user, &event), Ok(()));
-    }
-
-    #[test]
-    fn rumor_to_arbitrary_recipient_is_refused() {
-        let user = Keys::generate();
-        let mallory = Keys::generate();
-        let event = dm_shaped_event(14, &user, &[mallory.public_key()]);
         assert_eq!(
             validate_minor_sign(&user, &event),
-            Err(MinorDmDenied::RecipientNotApproved)
+            Err(MinorDmDenied::UnverifiableDmKind)
         );
     }
 
     #[test]
-    fn group_rumor_including_one_unapproved_recipient_is_refused() {
-        // All-or-nothing, matching the clients' group send semantics.
+    fn file_message_kind_15_refused_outright() {
         let user = Keys::generate();
-        let mallory = Keys::generate();
-        let event = dm_shaped_event(14, &user, &[hq_pubkey(), mallory.public_key()]);
-        assert_eq!(
-            validate_minor_sign(&user, &event),
-            Err(MinorDmDenied::RecipientNotApproved)
-        );
-    }
-
-    #[test]
-    fn rumor_without_p_tags_is_refused_fail_closed() {
-        let user = Keys::generate();
-        let event = dm_shaped_event(14, &user, &[]);
-        assert_eq!(
-            validate_minor_sign(&user, &event),
-            Err(MinorDmDenied::RecipientUnresolvable)
-        );
-    }
-
-    #[test]
-    fn file_message_rumor_kind_15_is_gated_like_kind_14() {
-        let user = Keys::generate();
-        let mallory = Keys::generate();
         assert_eq!(
             validate_minor_sign(&user, &dm_shaped_event(15, &user, &[hq_pubkey()])),
-            Ok(())
-        );
-        assert_eq!(
-            validate_minor_sign(&user, &dm_shaped_event(15, &user, &[mallory.public_key()])),
-            Err(MinorDmDenied::RecipientNotApproved)
+            Err(MinorDmDenied::UnverifiableDmKind)
         );
     }
+
+    #[test]
+    fn gift_wrap_kind_1059_refused_outright() {
+        let user = Keys::generate();
+        assert_eq!(
+            validate_minor_sign(&user, &dm_shaped_event(1059, &user, &[hq_pubkey()])),
+            Err(MinorDmDenied::UnverifiableDmKind)
+        );
+    }
+
+    #[test]
+    fn gift_wrap_with_decoy_approved_p_tag_is_refused_bypass_closed() {
+        // The bypass the adversarial review found: a 1059 whose content is
+        // ciphertext readable by a colluding non-approved party, hidden behind a
+        // decoy approved `p` tag. Refusing 1059 outright closes it — a p-tag
+        // check would have PASSED this and signed a covert channel.
+        let user = Keys::generate();
+        let event = dm_shaped_event(1059, &user, &[hq_pubkey()]);
+        assert_eq!(
+            validate_minor_sign(&user, &event),
+            Err(MinorDmDenied::UnverifiableDmKind)
+        );
+    }
+
+    // -- sign gate: NIP-04 DM (kind 4) stays p-tag-gated ------------------------
 
     #[test]
     fn nip04_dm_kind_4_is_gated_by_p_tags() {
@@ -400,31 +456,22 @@ mod tests {
     }
 
     #[test]
-    fn gift_wrap_kind_1059_is_gated_by_p_tags() {
+    fn nip04_group_including_one_unapproved_recipient_is_refused() {
+        // All-or-nothing across p tags.
         let user = Keys::generate();
         let mallory = Keys::generate();
+        let event = dm_shaped_event(4, &user, &[hq_pubkey(), mallory.public_key()]);
         assert_eq!(
-            validate_minor_sign(&user, &dm_shaped_event(1059, &user, &[hq_pubkey()])),
-            Ok(())
-        );
-        assert_eq!(
-            validate_minor_sign(
-                &user,
-                &dm_shaped_event(1059, &user, &[mallory.public_key()])
-            ),
+            validate_minor_sign(&user, &event),
             Err(MinorDmDenied::RecipientNotApproved)
-        );
-        assert_eq!(
-            validate_minor_sign(&user, &dm_shaped_event(1059, &user, &[])),
-            Err(MinorDmDenied::RecipientUnresolvable)
         );
     }
 
     #[test]
-    fn dm_with_malformed_p_tag_is_refused_fail_closed() {
+    fn nip04_with_malformed_p_tag_is_refused_fail_closed() {
         let user = Keys::generate();
         let tag = Tag::custom(TagKind::custom("p"), ["not-a-valid-pubkey"]);
-        let event = EventBuilder::new(Kind::from(14u16), "hi")
+        let event = EventBuilder::new(Kind::from(4u16), "hi")
             .tags([tag])
             .build(user.public_key());
         assert_eq!(
@@ -434,7 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn dm_p_tag_with_relay_hint_extra_elements_still_validates() {
+    fn nip04_p_tag_with_relay_hint_extra_elements_still_validates() {
         // ["p", "<hex>", "<relay-url>"] is a legal NIP-10-style tag form.
         let user = Keys::generate();
         let tag = Tag::parse([
@@ -443,10 +490,45 @@ mod tests {
             "wss://relay.example.com".to_string(),
         ])
         .unwrap();
-        let event = EventBuilder::new(Kind::from(14u16), "hi")
+        let event = EventBuilder::new(Kind::from(4u16), "hi")
             .tags([tag])
             .build(user.public_key());
         assert_eq!(validate_minor_sign(&user, &event), Ok(()));
+    }
+
+    #[test]
+    fn non_dm_kind_1_ignores_content_and_p_tags() {
+        // Public posting is out of scope: a kind-1 note may carry any content
+        // (including arbitrary ciphertext) and any p tags — the steganography
+        // ceiling lives here and is not closable server-side.
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        let event = dm_shaped_event(1, &user, &[mallory.public_key()]);
+        assert_eq!(validate_minor_sign(&user, &event), Ok(()));
+    }
+
+    #[test]
+    fn gated_kind_set_matches_validator_arms() {
+        // Anti-drift (M2): every kind is_minor_gated_kind marks must be actively
+        // handled by validate_minor_sign (never fall to the permissive `_` arm),
+        // and every non-gated kind must pass even when DM-shaped. Uses a garbage
+        // seal for 13 (fails closed) and an unapproved p tag for 4.
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        for kind in 0u16..=1100 {
+            let gated = is_minor_gated_kind(Kind::from(kind));
+            let event = if kind == 13 {
+                EventBuilder::new(Kind::from(13u16), "not-ciphertext").build(user.public_key())
+            } else {
+                dm_shaped_event(kind, &user, &[mallory.public_key()])
+            };
+            let result = validate_minor_sign(&user, &event);
+            assert_eq!(
+                result.is_err(),
+                gated,
+                "kind {kind}: gated={gated} but validator result={result:?}"
+            );
+        }
     }
 
     // -- sign gate: kind-13 seal (trial decryption) ------------------------------
@@ -550,5 +632,38 @@ mod tests {
             validate_minor_sign(&user, &event),
             Err(MinorDmDenied::SealRumorInvalid)
         );
+    }
+
+    #[test]
+    fn seal_with_unapproved_outer_p_tag_is_refused() {
+        // M1: a seal decrypting to an approved recipient but carrying an
+        // unapproved `p` tag on the seal EVENT itself (relay-routable metadata)
+        // is refused before any decryption.
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        let rumor = rumor_json(&user, &[hq_pubkey()]);
+        let content =
+            nip44::encrypt(user.secret_key(), &hq_pubkey(), &rumor, nip44::Version::V2).unwrap();
+        let event = EventBuilder::new(Kind::from(13u16), content)
+            .tags([Tag::public_key(mallory.public_key())])
+            .build(user.public_key());
+        assert_eq!(
+            validate_minor_sign(&user, &event),
+            Err(MinorDmDenied::RecipientNotApproved)
+        );
+    }
+
+    #[test]
+    fn seal_with_approved_outer_p_tag_is_allowed() {
+        // The benign case of the M1 check: an outer `p` tag naming the approved
+        // recipient (as some clients do for routing) does not trip the gate.
+        let user = Keys::generate();
+        let rumor = rumor_json(&user, &[hq_pubkey()]);
+        let content =
+            nip44::encrypt(user.secret_key(), &hq_pubkey(), &rumor, nip44::Version::V2).unwrap();
+        let event = EventBuilder::new(Kind::from(13u16), content)
+            .tags([Tag::public_key(hq_pubkey())])
+            .build(user.public_key());
+        assert_eq!(validate_minor_sign(&user, &event), Ok(()));
     }
 }

--- a/core/src/verified_minor_dm.rs
+++ b/core/src/verified_minor_dm.rs
@@ -147,10 +147,7 @@ pub fn validate_minor_sign(user_keys: &Keys, event: &UnsignedEvent) -> Result<()
 /// Every `p` tag must carry a parseable, approved pubkey, and at least one
 /// `p` tag must be present — a DM shape with no recipient is unresolvable and
 /// therefore refused.
-fn validate_p_tag_recipients(
-    user_pubkey: &PublicKey,
-    tags: &[Tag],
-) -> Result<(), MinorDmDenied> {
+fn validate_p_tag_recipients(user_pubkey: &PublicKey, tags: &[Tag]) -> Result<(), MinorDmDenied> {
     let mut found_recipient = false;
     for tag in tags {
         let slice = tag.as_slice();
@@ -192,10 +189,7 @@ fn validate_seal(user_keys: &Keys, content: &str) -> Result<(), MinorDmDenied> {
 /// tags (the rumor's stated recipients, possibly a group) are all approved.
 /// No `p` tags is fine: the actual recipient is already proven by which
 /// conversation key decrypted the seal.
-fn validate_sealed_rumor(
-    user_pubkey: &PublicKey,
-    plaintext: &str,
-) -> Result<(), MinorDmDenied> {
+fn validate_sealed_rumor(user_pubkey: &PublicKey, plaintext: &str) -> Result<(), MinorDmDenied> {
     let rumor: serde_json::Value =
         serde_json::from_str(plaintext).map_err(|_| MinorDmDenied::SealRumorInvalid)?;
     let tags = rumor
@@ -414,7 +408,10 @@ mod tests {
             Ok(())
         );
         assert_eq!(
-            validate_minor_sign(&user, &dm_shaped_event(1059, &user, &[mallory.public_key()])),
+            validate_minor_sign(
+                &user,
+                &dm_shaped_event(1059, &user, &[mallory.public_key()])
+            ),
             Err(MinorDmDenied::RecipientNotApproved)
         );
         assert_eq!(

--- a/core/src/verified_minor_dm.rs
+++ b/core/src/verified_minor_dm.rs
@@ -41,6 +41,10 @@
 //! Fail closed: an unresolvable recipient, an unparseable `p` tag, or a seal
 //! that decrypts to nothing is a refusal, never a pass-through.
 
+use nostr_sdk::nips::nip44;
+use nostr_sdk::{Keys, Kind, PublicKey, Tag, UnsignedEvent};
+use once_cell::sync::Lazy;
+
 /// The pinned official accounts a protected minor may exchange DMs with.
 /// Mirrored by hand from the clients' shipped sets — keep the values identical
 /// to divine-web `officialAccounts.ts` and divine-mobile
@@ -54,3 +58,500 @@ pub const PINNED_MINOR_CONTACTABLE_PUBKEYS: [&str; 2] = [
     // Divine Moderation (moderation@divine.video)
     "8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e",
 ];
+
+/// Why a verified_minor sign/encrypt request was refused. The variants exist
+/// for server-side logging; callers surface one uniform, non-specific error to
+/// the client (matching the policy-denial message) so account state is not
+/// leaked through error text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MinorDmDenied {
+    /// A recipient (encrypt target or `p` tag) is outside the approved set.
+    RecipientNotApproved,
+    /// The recipient cannot be determined (no `p` tags, or a `p` tag that is
+    /// not a valid pubkey). Fail closed.
+    RecipientUnresolvable,
+    /// A kind-13 seal whose content does not decrypt under any approved
+    /// conversation key — its recipient is unknowable to us. Fail closed.
+    SealNotDecryptable,
+    /// A kind-13 seal decrypted, but the inner rumor is not a well-formed
+    /// event JSON we can extract recipients from. Fail closed.
+    SealRumorInvalid,
+}
+
+impl std::fmt::Display for MinorDmDenied {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let reason = match self {
+            MinorDmDenied::RecipientNotApproved => "recipient not in approved set",
+            MinorDmDenied::RecipientUnresolvable => "recipient unresolvable",
+            MinorDmDenied::SealNotDecryptable => "seal not decryptable to an approved recipient",
+            MinorDmDenied::SealRumorInvalid => "sealed rumor malformed",
+        };
+        write!(f, "verified_minor DM gate: {}", reason)
+    }
+}
+
+/// Parsed pinned pubkeys. The constants are compile-time-fixed valid hex, so
+/// the expects cannot fire at runtime (pinned by the unit tests).
+static PINNED_KEYS: Lazy<[PublicKey; 2]> = Lazy::new(|| {
+    [
+        PublicKey::from_hex(PINNED_MINOR_CONTACTABLE_PUBKEYS[0])
+            .expect("pinned official pubkey 0 must be valid hex"),
+        PublicKey::from_hex(PINNED_MINOR_CONTACTABLE_PUBKEYS[1])
+            .expect("pinned official pubkey 1 must be valid hex"),
+    ]
+});
+
+/// A recipient is approved iff it is the user themselves (self-DMs cannot
+/// exfiltrate: only the user can decrypt them, and NIP-17 requires a
+/// self-addressed copy of every send) or one of the pinned officials.
+fn is_approved(user_pubkey: &PublicKey, candidate: &PublicKey) -> bool {
+    candidate == user_pubkey || PINNED_KEYS.contains(candidate)
+}
+
+/// Whether signing `kind` is subject to the verified_minor DM gate at all.
+/// Kinds outside this set sign normally for minors (public posting is
+/// relay-moderated and out of #183's scope).
+pub fn is_minor_gated_kind(kind: Kind) -> bool {
+    matches!(kind.as_u16(), 4 | 13 | 14 | 15 | 1059)
+}
+
+/// Gate for the encryption primitives (`nip04_encrypt` / `nip44_encrypt`):
+/// a verified_minor may encrypt only to themselves or a pinned official.
+pub fn validate_minor_encrypt(
+    user_pubkey: &PublicKey,
+    recipient: &PublicKey,
+) -> Result<(), MinorDmDenied> {
+    if is_approved(user_pubkey, recipient) {
+        Ok(())
+    } else {
+        Err(MinorDmDenied::RecipientNotApproved)
+    }
+}
+
+/// Gate for `sign_event`: refuse DM-shaped events whose recipients fall
+/// outside the approved set. Non-DM kinds pass through untouched.
+///
+/// Takes the user's [`Keys`] (not just the pubkey) because a kind-13 seal
+/// names no recipient — recovering it requires trial-decrypting the content
+/// under the user's conversation keys with each approved pubkey.
+pub fn validate_minor_sign(user_keys: &Keys, event: &UnsignedEvent) -> Result<(), MinorDmDenied> {
+    match event.kind.as_u16() {
+        4 | 14 | 15 | 1059 => {
+            validate_p_tag_recipients(&user_keys.public_key(), event.tags.as_slice())
+        }
+        13 => validate_seal(user_keys, &event.content),
+        _ => Ok(()),
+    }
+}
+
+/// Every `p` tag must carry a parseable, approved pubkey, and at least one
+/// `p` tag must be present — a DM shape with no recipient is unresolvable and
+/// therefore refused.
+fn validate_p_tag_recipients(
+    user_pubkey: &PublicKey,
+    tags: &[Tag],
+) -> Result<(), MinorDmDenied> {
+    let mut found_recipient = false;
+    for tag in tags {
+        let slice = tag.as_slice();
+        if slice.first().map(String::as_str) != Some("p") {
+            continue;
+        }
+        found_recipient = true;
+        let recipient = slice
+            .get(1)
+            .and_then(|hex| PublicKey::from_hex(hex).ok())
+            .ok_or(MinorDmDenied::RecipientUnresolvable)?;
+        if !is_approved(user_pubkey, &recipient) {
+            return Err(MinorDmDenied::RecipientNotApproved);
+        }
+    }
+    if found_recipient {
+        Ok(())
+    } else {
+        Err(MinorDmDenied::RecipientUnresolvable)
+    }
+}
+
+/// A kind-13 seal's true recipient is whoever holds the other half of the
+/// NIP-44 conversation key its content was encrypted under. NIP-44 v2 is
+/// authenticated (HMAC), so trial decryption against the small approved set
+/// deterministically recovers the recipient — or proves it is not approved.
+fn validate_seal(user_keys: &Keys, content: &str) -> Result<(), MinorDmDenied> {
+    let user_pubkey = user_keys.public_key();
+    let candidates = [user_pubkey, PINNED_KEYS[0], PINNED_KEYS[1]];
+    for candidate in &candidates {
+        if let Ok(plaintext) = nip44::decrypt(user_keys.secret_key(), candidate, content) {
+            return validate_sealed_rumor(&user_pubkey, &plaintext);
+        }
+    }
+    Err(MinorDmDenied::SealNotDecryptable)
+}
+
+/// The decrypted seal payload must be an event-shaped JSON object whose `p`
+/// tags (the rumor's stated recipients, possibly a group) are all approved.
+/// No `p` tags is fine: the actual recipient is already proven by which
+/// conversation key decrypted the seal.
+fn validate_sealed_rumor(
+    user_pubkey: &PublicKey,
+    plaintext: &str,
+) -> Result<(), MinorDmDenied> {
+    let rumor: serde_json::Value =
+        serde_json::from_str(plaintext).map_err(|_| MinorDmDenied::SealRumorInvalid)?;
+    let tags = rumor
+        .get("tags")
+        .and_then(|tags| tags.as_array())
+        .ok_or(MinorDmDenied::SealRumorInvalid)?;
+    for tag in tags {
+        let tag = tag.as_array().ok_or(MinorDmDenied::SealRumorInvalid)?;
+        if tag.first().and_then(|name| name.as_str()) != Some("p") {
+            continue;
+        }
+        let recipient = tag
+            .get(1)
+            .and_then(|hex| hex.as_str())
+            .and_then(|hex| PublicKey::from_hex(hex).ok())
+            .ok_or(MinorDmDenied::SealRumorInvalid)?;
+        if !is_approved(user_pubkey, &recipient) {
+            return Err(MinorDmDenied::RecipientNotApproved);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr_sdk::nips::nip44;
+    use nostr_sdk::{EventBuilder, Kind, Tag, TagKind};
+    use serde_json::json;
+
+    fn hq_pubkey() -> PublicKey {
+        PublicKey::from_hex(PINNED_MINOR_CONTACTABLE_PUBKEYS[0]).unwrap()
+    }
+
+    fn moderation_pubkey() -> PublicKey {
+        PublicKey::from_hex(PINNED_MINOR_CONTACTABLE_PUBKEYS[1]).unwrap()
+    }
+
+    /// Build an unsigned event of `kind` authored by `author` with one `p` tag
+    /// per recipient.
+    fn dm_shaped_event(kind: u16, author: &Keys, recipients: &[PublicKey]) -> UnsignedEvent {
+        let tags: Vec<Tag> = recipients.iter().map(|pk| Tag::public_key(*pk)).collect();
+        EventBuilder::new(Kind::from(kind), "test message")
+            .tags(tags)
+            .build(author.public_key())
+    }
+
+    /// Serialized kind-14 rumor JSON from `author` to `recipients`, the way a
+    /// client serializes the unsigned rumor before sealing it.
+    fn rumor_json(author: &Keys, recipients: &[PublicKey]) -> String {
+        let tags: Vec<Vec<String>> = recipients
+            .iter()
+            .map(|pk| vec!["p".to_string(), pk.to_hex()])
+            .collect();
+        json!({
+            "id": "0000000000000000000000000000000000000000000000000000000000000000",
+            "pubkey": author.public_key().to_hex(),
+            "created_at": 1_700_000_000,
+            "kind": 14,
+            "tags": tags,
+            "content": "sealed message",
+        })
+        .to_string()
+    }
+
+    /// Build a kind-13 seal event for `user` whose content is `plaintext`
+    /// NIP-44-encrypted under the conversation key (encrypt_secret, encrypt_to).
+    fn seal_event(
+        user: &Keys,
+        encrypt_secret: &nostr_sdk::SecretKey,
+        encrypt_to: &PublicKey,
+        plaintext: &str,
+    ) -> UnsignedEvent {
+        let content =
+            nip44::encrypt(encrypt_secret, encrypt_to, plaintext, nip44::Version::V2).unwrap();
+        EventBuilder::new(Kind::from(13u16), content).build(user.public_key())
+    }
+
+    // -- gated-kind classification --------------------------------------------
+
+    #[test]
+    fn gated_kinds_are_dm_shapes_only() {
+        for kind in [4u16, 13, 14, 15, 1059] {
+            assert!(is_minor_gated_kind(Kind::from(kind)), "kind {kind}");
+        }
+        for kind in [0u16, 1, 3, 6, 7, 30023, 10050, 24133] {
+            assert!(!is_minor_gated_kind(Kind::from(kind)), "kind {kind}");
+        }
+    }
+
+    // -- encrypt gate ----------------------------------------------------------
+
+    #[test]
+    fn minor_may_encrypt_to_pinned_officials() {
+        let user = Keys::generate();
+        assert_eq!(
+            validate_minor_encrypt(&user.public_key(), &hq_pubkey()),
+            Ok(())
+        );
+        assert_eq!(
+            validate_minor_encrypt(&user.public_key(), &moderation_pubkey()),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn minor_may_encrypt_to_self() {
+        let user = Keys::generate();
+        assert_eq!(
+            validate_minor_encrypt(&user.public_key(), &user.public_key()),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn minor_may_not_encrypt_to_arbitrary_recipient() {
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        assert_eq!(
+            validate_minor_encrypt(&user.public_key(), &mallory.public_key()),
+            Err(MinorDmDenied::RecipientNotApproved)
+        );
+    }
+
+    // -- sign gate: non-DM kinds untouched --------------------------------------
+
+    #[test]
+    fn non_dm_kinds_sign_normally_even_with_arbitrary_p_tags() {
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        // Kind 1 note mentioning an arbitrary pubkey: public posting, not a DM.
+        let event = dm_shaped_event(1, &user, &[mallory.public_key()]);
+        assert_eq!(validate_minor_sign(&user, &event), Ok(()));
+    }
+
+    // -- sign gate: p-tag kinds (4 / 14 / 15 / 1059) ----------------------------
+
+    #[test]
+    fn rumor_to_pinned_official_is_allowed() {
+        let user = Keys::generate();
+        let event = dm_shaped_event(14, &user, &[hq_pubkey()]);
+        assert_eq!(validate_minor_sign(&user, &event), Ok(()));
+    }
+
+    #[test]
+    fn rumor_to_arbitrary_recipient_is_refused() {
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        let event = dm_shaped_event(14, &user, &[mallory.public_key()]);
+        assert_eq!(
+            validate_minor_sign(&user, &event),
+            Err(MinorDmDenied::RecipientNotApproved)
+        );
+    }
+
+    #[test]
+    fn group_rumor_including_one_unapproved_recipient_is_refused() {
+        // All-or-nothing, matching the clients' group send semantics.
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        let event = dm_shaped_event(14, &user, &[hq_pubkey(), mallory.public_key()]);
+        assert_eq!(
+            validate_minor_sign(&user, &event),
+            Err(MinorDmDenied::RecipientNotApproved)
+        );
+    }
+
+    #[test]
+    fn rumor_without_p_tags_is_refused_fail_closed() {
+        let user = Keys::generate();
+        let event = dm_shaped_event(14, &user, &[]);
+        assert_eq!(
+            validate_minor_sign(&user, &event),
+            Err(MinorDmDenied::RecipientUnresolvable)
+        );
+    }
+
+    #[test]
+    fn file_message_rumor_kind_15_is_gated_like_kind_14() {
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        assert_eq!(
+            validate_minor_sign(&user, &dm_shaped_event(15, &user, &[hq_pubkey()])),
+            Ok(())
+        );
+        assert_eq!(
+            validate_minor_sign(&user, &dm_shaped_event(15, &user, &[mallory.public_key()])),
+            Err(MinorDmDenied::RecipientNotApproved)
+        );
+    }
+
+    #[test]
+    fn nip04_dm_kind_4_is_gated_by_p_tags() {
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        assert_eq!(
+            validate_minor_sign(&user, &dm_shaped_event(4, &user, &[moderation_pubkey()])),
+            Ok(())
+        );
+        assert_eq!(
+            validate_minor_sign(&user, &dm_shaped_event(4, &user, &[mallory.public_key()])),
+            Err(MinorDmDenied::RecipientNotApproved)
+        );
+        assert_eq!(
+            validate_minor_sign(&user, &dm_shaped_event(4, &user, &[])),
+            Err(MinorDmDenied::RecipientUnresolvable)
+        );
+    }
+
+    #[test]
+    fn gift_wrap_kind_1059_is_gated_by_p_tags() {
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        assert_eq!(
+            validate_minor_sign(&user, &dm_shaped_event(1059, &user, &[hq_pubkey()])),
+            Ok(())
+        );
+        assert_eq!(
+            validate_minor_sign(&user, &dm_shaped_event(1059, &user, &[mallory.public_key()])),
+            Err(MinorDmDenied::RecipientNotApproved)
+        );
+        assert_eq!(
+            validate_minor_sign(&user, &dm_shaped_event(1059, &user, &[])),
+            Err(MinorDmDenied::RecipientUnresolvable)
+        );
+    }
+
+    #[test]
+    fn dm_with_malformed_p_tag_is_refused_fail_closed() {
+        let user = Keys::generate();
+        let tag = Tag::custom(TagKind::custom("p"), ["not-a-valid-pubkey"]);
+        let event = EventBuilder::new(Kind::from(14u16), "hi")
+            .tags([tag])
+            .build(user.public_key());
+        assert_eq!(
+            validate_minor_sign(&user, &event),
+            Err(MinorDmDenied::RecipientUnresolvable)
+        );
+    }
+
+    #[test]
+    fn dm_p_tag_with_relay_hint_extra_elements_still_validates() {
+        // ["p", "<hex>", "<relay-url>"] is a legal NIP-10-style tag form.
+        let user = Keys::generate();
+        let tag = Tag::parse([
+            "p".to_string(),
+            hq_pubkey().to_hex(),
+            "wss://relay.example.com".to_string(),
+        ])
+        .unwrap();
+        let event = EventBuilder::new(Kind::from(14u16), "hi")
+            .tags([tag])
+            .build(user.public_key());
+        assert_eq!(validate_minor_sign(&user, &event), Ok(()));
+    }
+
+    // -- sign gate: kind-13 seal (trial decryption) ------------------------------
+
+    #[test]
+    fn seal_to_pinned_official_is_allowed() {
+        // The legit custodial flow: rumor NIP-44-encrypted to HQ via the
+        // (gated) encrypt primitive, then the seal is signed.
+        let user = Keys::generate();
+        let rumor = rumor_json(&user, &[hq_pubkey()]);
+        let event = seal_event(&user, user.secret_key(), &hq_pubkey(), &rumor);
+        assert_eq!(validate_minor_sign(&user, &event), Ok(()));
+    }
+
+    #[test]
+    fn seal_to_self_is_allowed_for_own_history_copy() {
+        // NIP-17 wraps every message to the sender as well (own history copy).
+        let user = Keys::generate();
+        let rumor = rumor_json(&user, &[hq_pubkey()]);
+        let event = seal_event(&user, user.secret_key(), &user.public_key(), &rumor);
+        assert_eq!(validate_minor_sign(&user, &event), Ok(()));
+    }
+
+    #[test]
+    fn seal_encrypted_to_arbitrary_recipient_is_refused() {
+        // Seal produced for a non-approved conversation key (e.g. the client
+        // colluding with the counterparty who derived the conversation key
+        // out-of-band): must not be signable.
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        let rumor = rumor_json(&user, &[mallory.public_key()]);
+        // K(mallory_sk, user_pk) == K(user_sk, mallory_pk): ciphertext readable
+        // by mallory, produced without ever calling our encrypt primitive.
+        let event = seal_event(&user, mallory.secret_key(), &user.public_key(), &rumor);
+        assert_eq!(
+            validate_minor_sign(&user, &event),
+            Err(MinorDmDenied::SealNotDecryptable)
+        );
+    }
+
+    #[test]
+    fn seal_with_garbage_content_is_refused_fail_closed() {
+        let user = Keys::generate();
+        let event =
+            EventBuilder::new(Kind::from(13u16), "not-nip44-ciphertext").build(user.public_key());
+        assert_eq!(
+            validate_minor_sign(&user, &event),
+            Err(MinorDmDenied::SealNotDecryptable)
+        );
+    }
+
+    #[test]
+    fn seal_to_official_whose_rumor_names_unapproved_recipient_is_refused() {
+        // Group all-or-nothing at the seal layer: decrypts under the HQ
+        // conversation key but the inner rumor also names mallory.
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        let rumor = rumor_json(&user, &[hq_pubkey(), mallory.public_key()]);
+        let event = seal_event(&user, user.secret_key(), &hq_pubkey(), &rumor);
+        assert_eq!(
+            validate_minor_sign(&user, &event),
+            Err(MinorDmDenied::RecipientNotApproved)
+        );
+    }
+
+    #[test]
+    fn seal_whose_plaintext_is_not_event_json_is_refused() {
+        let user = Keys::generate();
+        let event = seal_event(&user, user.secret_key(), &hq_pubkey(), "not json at all");
+        assert_eq!(
+            validate_minor_sign(&user, &event),
+            Err(MinorDmDenied::SealRumorInvalid)
+        );
+    }
+
+    #[test]
+    fn seal_whose_rumor_has_no_p_tags_is_allowed() {
+        // The recipient is already proven by which conversation key decrypted
+        // the content; an inner rumor without p tags (e.g. a self-addressed
+        // application-data rumor) adds no additional recipients.
+        let user = Keys::generate();
+        let rumor = rumor_json(&user, &[]);
+        let event = seal_event(&user, user.secret_key(), &hq_pubkey(), &rumor);
+        assert_eq!(validate_minor_sign(&user, &event), Ok(()));
+    }
+
+    #[test]
+    fn seal_rumor_with_malformed_p_tag_is_refused_fail_closed() {
+        let user = Keys::generate();
+        let rumor = json!({
+            "id": "0000000000000000000000000000000000000000000000000000000000000000",
+            "pubkey": user.public_key().to_hex(),
+            "created_at": 1_700_000_000,
+            "kind": 14,
+            "tags": [["p", "zzz-not-a-pubkey"]],
+            "content": "sealed message",
+        })
+        .to_string();
+        let event = seal_event(&user, user.secret_key(), &hq_pubkey(), &rumor);
+        assert_eq!(
+            validate_minor_sign(&user, &event),
+            Err(MinorDmDenied::SealRumorInvalid)
+        );
+    }
+}

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -121,7 +121,50 @@ impl SignerError {
     pub fn internal(msg: impl Into<String>) -> Self {
         Self::Internal(msg.into())
     }
+
+    /// Whether this error is an EXPECTED per-request denial that the client
+    /// caused (or a policy denies), as opposed to an internal server failure.
+    ///
+    /// On the NIP-46 relay path these are converted into a JSON-RPC
+    /// `{id, error}` reply so the client gets a clean refusal instead of a
+    /// silent relay timeout; internal failures still propagate to be logged.
+    /// The denial message is safe to surface (uniform policy text / the bad
+    /// parameter name), whereas internal errors must not leak server detail.
+    pub fn is_expected_client_denial(&self) -> bool {
+        matches!(
+            self,
+            Self::PermissionDenied(_)
+                | Self::MissingParameter(_)
+                | Self::InvalidKey(_)
+                | Self::InvalidRequest(_)
+        )
+    }
 }
 
 /// Result type for signer operations
 pub type SignerResult<T> = Result<T, SignerError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expected_client_denials_are_classified() {
+        assert!(SignerError::permission_denied("Operation denied by policy")
+            .is_expected_client_denial());
+        assert!(SignerError::MissingParameter("pubkey").is_expected_client_denial());
+        assert!(SignerError::invalid_key("bad hex").is_expected_client_denial());
+        assert!(SignerError::invalid_request("malformed").is_expected_client_denial());
+    }
+
+    #[test]
+    fn internal_errors_are_not_client_denials() {
+        // These must propagate (and be logged), never surface to the client as
+        // a JSON-RPC error with server detail.
+        assert!(!SignerError::internal("boom").is_expected_client_denial());
+        assert!(!SignerError::encryption("crypto failed").is_expected_client_denial());
+        assert!(!SignerError::data_corruption("bad row").is_expected_client_denial());
+        assert!(!SignerError::relay("relay down").is_expected_client_denial());
+        assert!(!SignerError::invalid_permission("bad policy").is_expected_client_denial());
+    }
+}

--- a/signer/src/signer_daemon.rs
+++ b/signer/src/signer_daemon.rs
@@ -87,6 +87,287 @@ impl Nip46Handler {
         }
     }
 
+    /// The bunker (wire) public key for this handler. Test-only accessor so the
+    /// relay-reply tests can decrypt the response event addressed to the client.
+    #[doc(hidden)]
+    pub fn bunker_public_key(&self) -> PublicKey {
+        self.bunker_keys.public_key()
+    }
+
+    /// Build the encrypted NIP-46 wire response event for a request.
+    ///
+    /// Dispatches `method`, converts an EXPECTED per-request denial (see
+    /// [`SignerError::is_expected_client_denial`]) into a JSON-RPC `{id, error}`
+    /// reply, and builds+signs the encrypted `NostrConnect` response event
+    /// addressed to the client. Returns `Err` ONLY for internal failures (the
+    /// caller logs those); every expected denial yields an `{id, error}`
+    /// response event so the client gets a clean refusal, never a relay timeout.
+    ///
+    /// Extracted from `handle_nip46_request` so the relay reply path is testable
+    /// without a live relay/coordinator (keeps the handler thin per the layering
+    /// guideline). `request_event_pubkey` / `request_event_id` are the client's
+    /// request event pubkey (response encryption target + `p` tag) and id
+    /// (`e` tag); `use_nip44` mirrors how the request itself was decrypted.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn build_nip46_response_event(
+        &self,
+        method: &str,
+        request: &serde_json::Value,
+        request_id: &serde_json::Value,
+        client_pubkey: &str,
+        request_event_pubkey: PublicKey,
+        request_event_id: EventId,
+        use_nip44: bool,
+    ) -> SignerResult<Event> {
+        // Dispatch the method; convert an EXPECTED per-request denial into a
+        // JSON-RPC {id, error} reply so the client gets a clean refusal instead
+        // of a relay timeout. Internal failures propagate to be logged.
+        let response = match self
+            .dispatch_nip46_method(method, request, request_id, client_pubkey)
+            .await
+        {
+            Ok(value) => value,
+            Err(e) if e.is_expected_client_denial() => {
+                tracing::info!(
+                    event = "nip46.denial_response",
+                    method = %method,
+                    reason = %e,
+                    "returning JSON-RPC error for expected per-request denial"
+                );
+                serde_json::json!({ "id": request_id, "error": e.to_string() })
+            }
+            Err(e) => return Err(e),
+        };
+
+        // Encrypt the response to the client with the same scheme the request
+        // arrived under (CPU-bound, spawn_blocking).
+        let response_str = response.to_string();
+        let encrypted_response = {
+            let secret = self.bunker_keys.secret_key().clone();
+            let pubkey = request_event_pubkey;
+            let text = response_str;
+            tokio::task::spawn_blocking(move || {
+                if use_nip44 {
+                    nip44::encrypt(&secret, &pubkey, &text, nip44::Version::V2)
+                        .map_err(SignerError::from)
+                } else {
+                    nip04::encrypt(&secret, &pubkey, &text).map_err(SignerError::from)
+                }
+            })
+            .await
+            .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
+        };
+
+        // Build + sign the NostrConnect response event addressed to the client.
+        let response_event = {
+            let keys = self.bunker_keys.clone();
+            let content = encrypted_response;
+            let sender = request_event_pubkey;
+            let event_id = request_event_id.to_hex();
+            tokio::task::spawn_blocking(move || {
+                EventBuilder::new(Kind::NostrConnect, content)
+                    .tags(vec![
+                        Tag::public_key(sender),
+                        Tag::parse(vec!["e".to_string(), event_id]).unwrap(),
+                    ])
+                    .sign_with_keys(&keys)
+            })
+            .await
+            .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
+        };
+
+        Ok(response_event)
+    }
+
+    /// Dispatch a decrypted NIP-46 method to its JSON-RPC result value, or a
+    /// `SignerError`. Split out of `handle_nip46_request` so the reply path is
+    /// testable and the wire handler stays thin. `?` here surfaces denials as
+    /// `Err`, which the caller ([`Nip46Handler::build_nip46_response_event`])
+    /// converts into a JSON-RPC `{id, error}` reply for expected denials.
+    async fn dispatch_nip46_method(
+        &self,
+        method: &str,
+        request: &serde_json::Value,
+        request_id: &serde_json::Value,
+        client_pubkey: &str,
+    ) -> SignerResult<serde_json::Value> {
+        Ok(match method {
+            "sign_event" => {
+                // handle_sign_event already returns a full response with id
+                self.handle_sign_event(request).await?
+            }
+            "get_public_key" => serde_json::json!({
+                "id": request_id,
+                "result": self.user_keys.public_key().to_hex()
+            }),
+            "connect" => {
+                // Process connect with client pubkey tracking (NIP-46 security)
+                if let Some(provided_secret) = request["params"][1].as_str() {
+                    match self.process_connect(client_pubkey, provided_secret).await {
+                        Ok(result) => serde_json::json!({"id": request_id, "result": result}),
+                        Err(e) => serde_json::json!({"id": request_id, "error": e.to_string()}),
+                    }
+                } else {
+                    // No secret provided - still track client pubkey for future validation
+                    serde_json::json!({"id": request_id, "result": "ack"})
+                }
+            }
+            "nip44_encrypt" => {
+                // params: [third_party_pubkey, plaintext]
+                let third_party_hex = request["params"][0]
+                    .as_str()
+                    .ok_or(SignerError::MissingParameter("pubkey"))?;
+                let plaintext = request["params"][1]
+                    .as_str()
+                    .ok_or(SignerError::MissingParameter("plaintext"))?;
+
+                let third_party_pubkey = PublicKey::from_hex(third_party_hex)
+                    .map_err(|e| SignerError::invalid_key(e.to_string()))?;
+
+                // Validate policy before encryption
+                self.validate_permissions_for_encrypt(plaintext, &third_party_pubkey)
+                    .await?;
+
+                // CPU-bound crypto wrapped in spawn_blocking
+                let ciphertext = {
+                    let secret = self.user_keys.secret_key().clone();
+                    let pubkey = third_party_pubkey;
+                    let text = plaintext.to_string();
+                    tokio::task::spawn_blocking(move || {
+                        nip44::encrypt(&secret, &pubkey, &text, nip44::Version::V2)
+                    })
+                    .await
+                    .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
+                };
+
+                // Log activity in background (non-blocking)
+                self.spawn_update_activity();
+
+                serde_json::json!({
+                    "id": request_id,
+                    "result": ciphertext
+                })
+            }
+            "nip44_decrypt" => {
+                // params: [third_party_pubkey, ciphertext]
+                let third_party_hex = request["params"][0]
+                    .as_str()
+                    .ok_or(SignerError::MissingParameter("pubkey"))?;
+                let ciphertext = request["params"][1]
+                    .as_str()
+                    .ok_or(SignerError::MissingParameter("ciphertext"))?;
+
+                let third_party_pubkey = PublicKey::from_hex(third_party_hex)
+                    .map_err(|e| SignerError::invalid_key(e.to_string()))?;
+
+                // Validate policy before decryption
+                self.validate_permissions_for_decrypt(ciphertext, &third_party_pubkey)
+                    .await?;
+
+                // CPU-bound crypto wrapped in spawn_blocking
+                // Returns SecretString for automatic memory zeroization on drop
+                let plaintext: SecretString = {
+                    let secret = self.user_keys.secret_key().clone();
+                    let pubkey = third_party_pubkey;
+                    let text = ciphertext.to_string();
+                    tokio::task::spawn_blocking(move || {
+                        nip44::decrypt(&secret, &pubkey, &text).map(SecretString::from)
+                    })
+                    .await
+                    .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
+                };
+
+                // Log activity in background (non-blocking)
+                self.spawn_update_activity();
+
+                // Expose secret only at serialization boundary
+                serde_json::json!({
+                    "id": request_id,
+                    "result": plaintext.expose_secret()
+                })
+            }
+            "nip04_encrypt" => {
+                // params: [third_party_pubkey, plaintext]
+                let third_party_hex = request["params"][0]
+                    .as_str()
+                    .ok_or(SignerError::MissingParameter("pubkey"))?;
+                let plaintext = request["params"][1]
+                    .as_str()
+                    .ok_or(SignerError::MissingParameter("plaintext"))?;
+
+                let third_party_pubkey = PublicKey::from_hex(third_party_hex)
+                    .map_err(|e| SignerError::invalid_key(e.to_string()))?;
+
+                // Validate policy before encryption
+                self.validate_permissions_for_encrypt(plaintext, &third_party_pubkey)
+                    .await?;
+
+                // CPU-bound crypto wrapped in spawn_blocking
+                let ciphertext = {
+                    let secret = self.user_keys.secret_key().clone();
+                    let pubkey = third_party_pubkey;
+                    let text = plaintext.to_string();
+                    tokio::task::spawn_blocking(move || nip04::encrypt(&secret, &pubkey, &text))
+                        .await
+                        .map_err(|e| {
+                            SignerError::internal(format!("spawn_blocking failed: {}", e))
+                        })??
+                };
+
+                // Log activity in background (non-blocking)
+                self.spawn_update_activity();
+
+                serde_json::json!({
+                    "id": request_id,
+                    "result": ciphertext
+                })
+            }
+            "nip04_decrypt" => {
+                // params: [third_party_pubkey, ciphertext]
+                let third_party_hex = request["params"][0]
+                    .as_str()
+                    .ok_or(SignerError::MissingParameter("pubkey"))?;
+                let ciphertext = request["params"][1]
+                    .as_str()
+                    .ok_or(SignerError::MissingParameter("ciphertext"))?;
+
+                let third_party_pubkey = PublicKey::from_hex(third_party_hex)
+                    .map_err(|e| SignerError::invalid_key(e.to_string()))?;
+
+                // Validate policy before decryption
+                self.validate_permissions_for_decrypt(ciphertext, &third_party_pubkey)
+                    .await?;
+
+                // CPU-bound crypto wrapped in spawn_blocking
+                // Returns SecretString for automatic memory zeroization on drop
+                let plaintext: SecretString = {
+                    let secret = self.user_keys.secret_key().clone();
+                    let pubkey = third_party_pubkey;
+                    let text = ciphertext.to_string();
+                    tokio::task::spawn_blocking(move || {
+                        nip04::decrypt(&secret, &pubkey, &text).map(SecretString::from)
+                    })
+                    .await
+                    .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
+                };
+
+                // Log activity in background (non-blocking)
+                self.spawn_update_activity();
+
+                // Expose secret only at serialization boundary
+                serde_json::json!({
+                    "id": request_id,
+                    "result": plaintext.expose_secret()
+                })
+            }
+            _ => {
+                tracing::warn!("Unsupported NIP-46 method: {}", method);
+                serde_json::json!({"id": request_id, "error": format!("Unsupported method: {}", method)})
+            }
+        })
+    }
+
     /// Check if this handler is a tombstone (revoked or expired)
     pub fn is_tombstone(&self) -> bool {
         self.status != HandlerStatus::Active
@@ -1477,235 +1758,22 @@ impl UnifiedSigner {
             }
         }
 
-        // Handle different NIP-46 methods
-        let result = match method {
-            "sign_event" => {
-                let signed = handler.handle_sign_event(&request).await?;
-                // handle_sign_event already returns full response with id
-                signed
-            }
-            "get_public_key" => {
-                serde_json::json!({
-                    "id": request_id,
-                    "result": handler.user_keys.public_key().to_hex()
-                })
-            }
-            "connect" => {
-                // Process connect with client pubkey tracking (NIP-46 security)
-                // client_pubkey already extracted above from event.pubkey
-                if let Some(provided_secret) = request["params"][1].as_str() {
-                    match handler
-                        .process_connect(&client_pubkey, provided_secret)
-                        .await
-                    {
-                        Ok(result) => serde_json::json!({"id": request_id, "result": result}),
-                        Err(e) => serde_json::json!({"id": request_id, "error": e.to_string()}),
-                    }
-                } else {
-                    // No secret provided - still track client pubkey for future validation
-                    serde_json::json!({"id": request_id, "result": "ack"})
-                }
-            }
-            "nip44_encrypt" => {
-                // params: [third_party_pubkey, plaintext]
-                let third_party_hex = request["params"][0]
-                    .as_str()
-                    .ok_or(SignerError::MissingParameter("pubkey"))?;
-                let plaintext = request["params"][1]
-                    .as_str()
-                    .ok_or(SignerError::MissingParameter("plaintext"))?;
-
-                let third_party_pubkey = PublicKey::from_hex(third_party_hex)
-                    .map_err(|e| SignerError::invalid_key(e.to_string()))?;
-
-                // Validate policy before encryption
-                handler
-                    .validate_permissions_for_encrypt(plaintext, &third_party_pubkey)
-                    .await?;
-
-                // CPU-bound crypto wrapped in spawn_blocking
-                let ciphertext = {
-                    let secret = handler.user_keys.secret_key().clone();
-                    let pubkey = third_party_pubkey;
-                    let text = plaintext.to_string();
-                    tokio::task::spawn_blocking(move || {
-                        nip44::encrypt(&secret, &pubkey, &text, nip44::Version::V2)
-                    })
-                    .await
-                    .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
-                };
-
-                // Log activity in background (non-blocking)
-                handler.spawn_update_activity();
-
-                serde_json::json!({
-                    "id": request_id,
-                    "result": ciphertext
-                })
-            }
-            "nip44_decrypt" => {
-                // params: [third_party_pubkey, ciphertext]
-                let third_party_hex = request["params"][0]
-                    .as_str()
-                    .ok_or(SignerError::MissingParameter("pubkey"))?;
-                let ciphertext = request["params"][1]
-                    .as_str()
-                    .ok_or(SignerError::MissingParameter("ciphertext"))?;
-
-                let third_party_pubkey = PublicKey::from_hex(third_party_hex)
-                    .map_err(|e| SignerError::invalid_key(e.to_string()))?;
-
-                // Validate policy before decryption
-                handler
-                    .validate_permissions_for_decrypt(ciphertext, &third_party_pubkey)
-                    .await?;
-
-                // CPU-bound crypto wrapped in spawn_blocking
-                // Returns SecretString for automatic memory zeroization on drop
-                let plaintext: SecretString = {
-                    let secret = handler.user_keys.secret_key().clone();
-                    let pubkey = third_party_pubkey;
-                    let text = ciphertext.to_string();
-                    tokio::task::spawn_blocking(move || {
-                        nip44::decrypt(&secret, &pubkey, &text).map(SecretString::from)
-                    })
-                    .await
-                    .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
-                };
-
-                // Log activity in background (non-blocking)
-                handler.spawn_update_activity();
-
-                // Expose secret only at serialization boundary
-                serde_json::json!({
-                    "id": request_id,
-                    "result": plaintext.expose_secret()
-                })
-            }
-            "nip04_encrypt" => {
-                // params: [third_party_pubkey, plaintext]
-                let third_party_hex = request["params"][0]
-                    .as_str()
-                    .ok_or(SignerError::MissingParameter("pubkey"))?;
-                let plaintext = request["params"][1]
-                    .as_str()
-                    .ok_or(SignerError::MissingParameter("plaintext"))?;
-
-                let third_party_pubkey = PublicKey::from_hex(third_party_hex)
-                    .map_err(|e| SignerError::invalid_key(e.to_string()))?;
-
-                // Validate policy before encryption
-                handler
-                    .validate_permissions_for_encrypt(plaintext, &third_party_pubkey)
-                    .await?;
-
-                // CPU-bound crypto wrapped in spawn_blocking
-                let ciphertext = {
-                    let secret = handler.user_keys.secret_key().clone();
-                    let pubkey = third_party_pubkey;
-                    let text = plaintext.to_string();
-                    tokio::task::spawn_blocking(move || nip04::encrypt(&secret, &pubkey, &text))
-                        .await
-                        .map_err(|e| {
-                            SignerError::internal(format!("spawn_blocking failed: {}", e))
-                        })??
-                };
-
-                // Log activity in background (non-blocking)
-                handler.spawn_update_activity();
-
-                serde_json::json!({
-                    "id": request_id,
-                    "result": ciphertext
-                })
-            }
-            "nip04_decrypt" => {
-                // params: [third_party_pubkey, ciphertext]
-                let third_party_hex = request["params"][0]
-                    .as_str()
-                    .ok_or(SignerError::MissingParameter("pubkey"))?;
-                let ciphertext = request["params"][1]
-                    .as_str()
-                    .ok_or(SignerError::MissingParameter("ciphertext"))?;
-
-                let third_party_pubkey = PublicKey::from_hex(third_party_hex)
-                    .map_err(|e| SignerError::invalid_key(e.to_string()))?;
-
-                // Validate policy before decryption
-                handler
-                    .validate_permissions_for_decrypt(ciphertext, &third_party_pubkey)
-                    .await?;
-
-                // CPU-bound crypto wrapped in spawn_blocking
-                // Returns SecretString for automatic memory zeroization on drop
-                let plaintext: SecretString = {
-                    let secret = handler.user_keys.secret_key().clone();
-                    let pubkey = third_party_pubkey;
-                    let text = ciphertext.to_string();
-                    tokio::task::spawn_blocking(move || {
-                        nip04::decrypt(&secret, &pubkey, &text).map(SecretString::from)
-                    })
-                    .await
-                    .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
-                };
-
-                // Log activity in background (non-blocking)
-                handler.spawn_update_activity();
-
-                // Expose secret only at serialization boundary
-                serde_json::json!({
-                    "id": request_id,
-                    "result": plaintext.expose_secret()
-                })
-            }
-            _ => {
-                tracing::warn!("Unsupported NIP-46 method: {}", method);
-                serde_json::json!({"id": request_id, "error": format!("Unsupported method: {}", method)})
-            }
-        };
-
-        let response = result;
-
-        // Encrypt response using the same method as the request (CPU-bound, use spawn_blocking)
-        let response_str = response.to_string();
-        let encrypted_response = {
-            let secret = bunker_secret.clone();
-            let pubkey = event.pubkey;
-            let text = response_str.clone();
-            let use_44 = use_nip44;
-            tokio::task::spawn_blocking(move || {
-                if use_44 {
-                    tracing::debug!("Encrypting response with NIP-44");
-                    nip44::encrypt(&secret, &pubkey, &text, nip44::Version::V2)
-                        .map_err(SignerError::from)
-                } else {
-                    tracing::debug!("Encrypting response with NIP-04");
-                    nip04::encrypt(&secret, &pubkey, &text).map_err(SignerError::from)
-                }
-            })
-            .await
-            .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
-        };
-
-        // Build and publish response event (signing is CPU-bound, use spawn_blocking)
-        tracing::debug!("Sending NIP-46 response to {}", event.pubkey);
-
-        let response_event = {
-            let keys = handler.bunker_keys.clone();
-            let content = encrypted_response;
-            let sender = event.pubkey;
-            let event_id = event.id.to_hex();
-            tokio::task::spawn_blocking(move || {
-                EventBuilder::new(Kind::NostrConnect, content)
-                    .tags(vec![
-                        Tag::public_key(sender),
-                        Tag::parse(vec!["e".to_string(), event_id]).unwrap(),
-                    ])
-                    .sign_with_keys(&keys)
-            })
-            .await
-            .map_err(|e| SignerError::internal(format!("spawn_blocking failed: {}", e)))??
-        };
+        // Dispatch the method and build the encrypted response event. Expected
+        // per-request denials (permission denied, bad params/key) become a clean
+        // JSON-RPC {id, error} reply here instead of ?-propagating out of this
+        // handler and leaving the client to time out; only internal failures
+        // still propagate to be logged. See build_nip46_response_event.
+        let response_event = handler
+            .build_nip46_response_event(
+                method,
+                &request,
+                &request_id,
+                &client_pubkey,
+                event.pubkey,
+                event.id,
+                use_nip44,
+            )
+            .await?;
 
         tracing::debug!(
             "Sending response event {} (size: {} bytes)",

--- a/signer/src/signer_daemon.rs
+++ b/signer/src/signer_daemon.rs
@@ -122,24 +122,51 @@ impl Nip46Handler {
 
     /// Check that the user's account is active (not suspended or banned).
     /// Only applies to OAuth authorizations (personal keys tied to a user account).
-    /// Team authorizations don't have user rows — they're managed through team admin.
-    async fn check_user_active(&self) -> SignerResult<()> {
+    /// Team authorizations don't have user rows — they're managed through team
+    /// admin, are not minor accounts, and return `false` for the flag.
+    ///
+    /// Returns the account's `verified_minor` flag (same row, no extra query)
+    /// so callers can apply the DM containment gate (support-trust-safety#183).
+    async fn check_user_active(&self) -> SignerResult<bool> {
         if !self.is_oauth {
-            return Ok(());
+            return Ok(false);
         }
         let user_pubkey = self.user_keys.public_key().to_hex();
-        let status: Option<(String,)> =
-            sqlx::query_as("SELECT status FROM users WHERE pubkey = $1 AND tenant_id = $2")
-                .bind(&user_pubkey)
-                .bind(self.tenant_id)
-                .fetch_optional(&self.pool)
-                .await?;
+        let status: Option<(String, bool)> = sqlx::query_as(
+            "SELECT status, verified_minor FROM users WHERE pubkey = $1 AND tenant_id = $2",
+        )
+        .bind(&user_pubkey)
+        .bind(self.tenant_id)
+        .fetch_optional(&self.pool)
+        .await?;
 
         match status {
-            Some((s,)) if s == "active" => Ok(()),
+            Some((s, verified_minor)) if s == "active" => Ok(verified_minor),
             Some(_) => Err(SignerError::permission_denied("Account restricted")),
             None => Err(SignerError::permission_denied("User not found")),
         }
+    }
+
+    /// Account-level gates that must run before any signing: active status and
+    /// the verified_minor DM containment gate (support-trust-safety#183).
+    /// Both relay-dispatched (`handle_sign_event`) and direct
+    /// (`sign_event_direct`) signing must pass through here.
+    async fn check_user_sign_gates(&self, unsigned_event: &UnsignedEvent) -> SignerResult<()> {
+        let verified_minor = self.check_user_active().await?;
+        if verified_minor {
+            keycast_core::verified_minor_dm::validate_minor_sign(&self.user_keys, unsigned_event)
+                .map_err(|denied| {
+                tracing::warn!(
+                    event = "minor_dm_gate.sign_denied",
+                    user_pubkey = %self.user_keys.public_key().to_hex(),
+                    kind = unsigned_event.kind.as_u16(),
+                    reason = %denied,
+                    "verified_minor DM sign refused (NIP-46 signer)"
+                );
+                SignerError::permission_denied("Operation denied by policy")
+            })?;
+        }
+        Ok(())
     }
 
     /// Validate permissions before signing an event.
@@ -194,7 +221,26 @@ impl Nip46Handler {
         plaintext: &str,
         recipient_pubkey: &PublicKey,
     ) -> SignerResult<()> {
-        self.check_user_active().await?;
+        let verified_minor = self.check_user_active().await?;
+        // verified_minor DM containment (support-trust-safety#183): the
+        // encryption primitive is where a NIP-17 seal's recipient is in the
+        // clear, so this is the containment point for DM egress.
+        if verified_minor {
+            keycast_core::verified_minor_dm::validate_minor_encrypt(
+                &self.user_keys.public_key(),
+                recipient_pubkey,
+            )
+            .map_err(|denied| {
+                tracing::warn!(
+                    event = "minor_dm_gate.encrypt_denied",
+                    user_pubkey = %self.user_keys.public_key().to_hex(),
+                    recipient = %recipient_pubkey.to_hex(),
+                    reason = %denied,
+                    "verified_minor DM encrypt refused (NIP-46 signer)"
+                );
+                SignerError::permission_denied("Operation denied by policy")
+            })?;
+        }
         // Load permissions based on authorization type
         let permissions = if self.is_oauth {
             let oauth_auth =
@@ -241,6 +287,8 @@ impl Nip46Handler {
         ciphertext: &str,
         sender_pubkey: &PublicKey,
     ) -> SignerResult<()> {
+        // Status gate only: decrypt is ingress, out of the DM containment
+        // gate's egress-only scope (support-trust-safety#183).
         self.check_user_active().await?;
         // Load permissions based on authorization type
         let permissions = if self.is_oauth {
@@ -1698,8 +1746,8 @@ impl SigningHandler for Nip46Handler {
             self.authorization_id
         );
 
-        // Check account status and policy permissions before signing
-        self.check_user_active().await?;
+        // Check account status, minor DM gate, and policy permissions before signing
+        self.check_user_sign_gates(&unsigned_event).await?;
         self.validate_permissions_for_sign(&unsigned_event).await?;
 
         // Canonicalize the pubkey to match the signer keys, matching SigningSession::sign_event behavior.
@@ -1798,8 +1846,8 @@ impl Nip46Handler {
             content,
         );
 
-        // Check account status and policy permissions before signing
-        self.check_user_active().await?;
+        // Check account status, minor DM gate, and policy permissions before signing
+        self.check_user_sign_gates(&unsigned_event).await?;
         self.validate_permissions_for_sign(&unsigned_event).await?;
 
         // Sign the event with user keys (CPU-bound, use spawn_blocking)

--- a/signer/tests/verified_minor_dm_daemon_test.rs
+++ b/signer/tests/verified_minor_dm_daemon_test.rs
@@ -298,3 +298,152 @@ async fn daemon_non_minor_encrypt_unaffected() {
         .await
         .expect("non-minor encrypt to anyone must be allowed");
 }
+
+// ============================================================================
+// relay reply path (build_nip46_response_event) — a denial must PRODUCE an
+// encrypted {id, error} response event, not ?-propagate (which timed the client
+// out). support-trust-safety#183 review (dcadenas).
+// ============================================================================
+
+/// Decrypt a bunker→client NIP-44 wire response and parse its JSON-RPC body.
+fn decrypt_response(
+    client: &Keys,
+    bunker_pubkey: &PublicKey,
+    response: &Event,
+) -> serde_json::Value {
+    assert_eq!(
+        response.kind,
+        Kind::NostrConnect,
+        "response must be a NIP-46 wire event"
+    );
+    let content = nip44::decrypt(client.secret_key(), bunker_pubkey, &response.content)
+        .expect("client must be able to decrypt the bunker's response");
+    serde_json::from_str(&content).expect("response body must be valid JSON-RPC")
+}
+
+#[tokio::test]
+async fn daemon_relay_denied_minor_sign_produces_error_response_event() {
+    let pool = setup_test_db().await;
+    let km = FileKeyManager::new().expect("key manager");
+    let (handler, user_keys) = create_oauth_handler(&pool, &km, true).await; // verified_minor
+    let client = Keys::generate();
+    let mallory = Keys::generate();
+
+    // sign_event request for a kind-14 DM to a non-approved recipient (denied).
+    let unsigned = dm_rumor(14, &user_keys, &[mallory.public_key()]);
+    let request = serde_json::json!({
+        "id": "req-sign",
+        "method": "sign_event",
+        "params": [serde_json::to_string(&unsigned).unwrap()],
+    });
+
+    let response = handler
+        .build_nip46_response_event(
+            "sign_event",
+            &request,
+            &serde_json::json!("req-sign"),
+            &client.public_key().to_hex(),
+            client.public_key(),
+            EventId::all_zeros(),
+            true,
+        )
+        .await
+        .expect("a denial must PRODUCE a response event, not propagate an error");
+
+    let body = decrypt_response(&client, &handler.bunker_public_key(), &response);
+    assert_eq!(body["id"], "req-sign");
+    assert!(
+        body["error"]
+            .as_str()
+            .expect("error is a string")
+            .contains("Operation denied by policy"),
+        "denial must carry the uniform policy message, got: {}",
+        body["error"]
+    );
+    assert!(
+        body.get("result").is_none(),
+        "a denial must not carry a result"
+    );
+}
+
+#[tokio::test]
+async fn daemon_relay_denied_minor_encrypt_produces_error_response_event() {
+    let pool = setup_test_db().await;
+    let km = FileKeyManager::new().expect("key manager");
+    let (handler, _user_keys) = create_oauth_handler(&pool, &km, true).await; // verified_minor
+    let client = Keys::generate();
+    let mallory = Keys::generate();
+
+    let request = serde_json::json!({
+        "id": "req-enc",
+        "method": "nip44_encrypt",
+        "params": [mallory.public_key().to_hex(), "secret text"],
+    });
+
+    let response = handler
+        .build_nip46_response_event(
+            "nip44_encrypt",
+            &request,
+            &serde_json::json!("req-enc"),
+            &client.public_key().to_hex(),
+            client.public_key(),
+            EventId::all_zeros(),
+            true,
+        )
+        .await
+        .expect("an encrypt denial must produce a response event, not propagate");
+
+    let body = decrypt_response(&client, &handler.bunker_public_key(), &response);
+    assert_eq!(body["id"], "req-enc");
+    assert!(
+        body["error"]
+            .as_str()
+            .expect("error is a string")
+            .contains("Operation denied by policy"),
+        "denial must carry the uniform policy message, got: {}",
+        body["error"]
+    );
+    assert!(body.get("result").is_none());
+}
+
+#[tokio::test]
+async fn daemon_relay_non_minor_sign_produces_result_response_event() {
+    let pool = setup_test_db().await;
+    let km = FileKeyManager::new().expect("key manager");
+    let (handler, user_keys) = create_oauth_handler(&pool, &km, false).await; // non-minor
+    let client = Keys::generate();
+    let mallory = Keys::generate();
+
+    // A non-minor may sign a DM to anyone: the happy path must still build a
+    // {id, result} response event.
+    let unsigned = dm_rumor(14, &user_keys, &[mallory.public_key()]);
+    let request = serde_json::json!({
+        "id": "req-ok",
+        "method": "sign_event",
+        "params": [serde_json::to_string(&unsigned).unwrap()],
+    });
+
+    let response = handler
+        .build_nip46_response_event(
+            "sign_event",
+            &request,
+            &serde_json::json!("req-ok"),
+            &client.public_key().to_hex(),
+            client.public_key(),
+            EventId::all_zeros(),
+            true,
+        )
+        .await
+        .expect("non-minor sign must produce a response event");
+
+    let body = decrypt_response(&client, &handler.bunker_public_key(), &response);
+    assert_eq!(body["id"], "req-ok");
+    assert!(
+        body.get("error").is_none(),
+        "the happy path carries no error"
+    );
+    assert!(
+        body.get("result").is_some(),
+        "the happy path carries the signed result"
+    );
+}

--- a/signer/tests/verified_minor_dm_daemon_test.rs
+++ b/signer/tests/verified_minor_dm_daemon_test.rs
@@ -134,16 +134,32 @@ async fn daemon_minor_sign_rumor_to_arbitrary_recipient_refused() {
 }
 
 #[tokio::test]
-async fn daemon_minor_sign_rumor_to_pinned_official_allowed() {
+async fn daemon_minor_sign_rumor_kind_14_refused_outright() {
+    // Conformant NIP-17 never signs a rumor via a remote signer; refused
+    // regardless of recipient.
     let pool = setup_test_db().await;
     let key_manager = FileKeyManager::new().expect("key manager");
     let (handler, user_keys) = create_oauth_handler(&pool, &key_manager, true).await;
 
     let unsigned = dm_rumor(14, &user_keys, &[hq_pubkey()]);
+    let err = handler
+        .sign_event_direct(unsigned)
+        .await
+        .expect_err("minor kind-14 rumor must be refused even to an official");
+    assert_denied(err);
+}
+
+#[tokio::test]
+async fn daemon_minor_sign_nip04_kind_4_to_official_allowed() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let (handler, user_keys) = create_oauth_handler(&pool, &key_manager, true).await;
+
+    let unsigned = dm_rumor(4, &user_keys, &[hq_pubkey()]);
     let signed = handler
         .sign_event_direct(unsigned)
         .await
-        .expect("minor DM rumor to pinned official must sign");
+        .expect("minor NIP-04 DM to a pinned official must sign");
     signed.verify().expect("valid signature");
 }
 

--- a/signer/tests/verified_minor_dm_daemon_test.rs
+++ b/signer/tests/verified_minor_dm_daemon_test.rs
@@ -1,0 +1,284 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Verified_minor DM containment gate tests for the NIP-46 signer daemon
+// ABOUTME: path (support-trust-safety#183) — the relay-based signing surface.
+
+use keycast_core::encryption::{file_key_manager::FileKeyManager, KeyManager};
+use keycast_core::signing_handler::SigningHandler;
+use keycast_core::verified_minor_dm::PINNED_MINOR_CONTACTABLE_PUBKEYS;
+use keycast_signer::Nip46Handler;
+use nostr_sdk::nips::nip44;
+use nostr_sdk::prelude::*;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn setup_test_db() -> PgPool {
+    let database_url =
+        std::env::var("DATABASE_URL").expect("DATABASE_URL must be set to run database tests");
+
+    PgPool::connect(&database_url).await.expect(
+        "Failed to connect to database. Make sure PostgreSQL is running and DATABASE_URL is set.",
+    )
+}
+
+fn hq_pubkey() -> PublicKey {
+    PublicKey::from_hex(PINNED_MINOR_CONTACTABLE_PUBKEYS[0]).unwrap()
+}
+
+/// Create a user (optionally verified_minor) with a personal key and an OAuth
+/// authorization row, and return an OAuth-mode Nip46Handler for it.
+async fn create_oauth_handler(
+    pool: &PgPool,
+    key_manager: &dyn KeyManager,
+    verified_minor: bool,
+) -> (Nip46Handler, Keys) {
+    let user_keys = Keys::generate();
+    let bunker_keys = Keys::generate();
+
+    if verified_minor {
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, verified_minor, verified_minor_at, created_at, updated_at)
+             VALUES ($1, 1, TRUE, NOW(), NOW(), NOW())",
+        )
+        .bind(user_keys.public_key().to_hex())
+        .execute(pool)
+        .await
+        .expect("Failed to create verified_minor user");
+    } else {
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+             VALUES ($1, 1, NOW(), NOW())",
+        )
+        .bind(user_keys.public_key().to_hex())
+        .execute(pool)
+        .await
+        .expect("Failed to create user");
+    }
+
+    let user_secret = user_keys.secret_key().secret_bytes();
+    let encrypted_secret = key_manager
+        .encrypt(&user_secret)
+        .await
+        .expect("Failed to encrypt user secret");
+    sqlx::query(
+        "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id)
+         VALUES ($1, $2, 1)",
+    )
+    .bind(user_keys.public_key().to_hex())
+    .bind(&encrypted_secret)
+    .execute(pool)
+    .await
+    .expect("Failed to create personal key");
+
+    let secret_hash = bcrypt::hash(format!("secret_{}", Uuid::new_v4()), 4).expect("hash");
+    let oauth_id: i32 = sqlx::query_scalar(
+        "INSERT INTO oauth_authorizations
+         (user_pubkey, redirect_origin, client_id, bunker_public_key, secret_hash, relays, policy_id, tenant_id, handle_expires_at, created_at, updated_at)
+         VALUES ($1, $2, 'Minor Gate Test App', $3, $4, $5, NULL, 1, NOW() + INTERVAL '30 days', NOW(), NOW())
+         RETURNING id",
+    )
+    .bind(user_keys.public_key().to_hex())
+    .bind(format!("https://minor-daemon-{}.example.com", Uuid::new_v4()))
+    .bind(bunker_keys.public_key().to_hex())
+    .bind(&secret_hash)
+    .bind(serde_json::json!(["wss://relay.example.com"]))
+    .fetch_one(pool)
+    .await
+    .expect("Failed to create OAuth authorization");
+
+    let handler = Nip46Handler::new_for_test(
+        bunker_keys,
+        user_keys.clone(),
+        secret_hash,
+        oauth_id,
+        1,
+        true, // OAuth: user-account-backed, subject to status + minor gates
+        pool.clone(),
+    );
+
+    (handler, user_keys)
+}
+
+fn dm_rumor(kind: u16, author: &Keys, recipients: &[PublicKey]) -> UnsignedEvent {
+    let tags: Vec<Tag> = recipients.iter().map(|pk| Tag::public_key(*pk)).collect();
+    EventBuilder::new(Kind::from(kind), "daemon gate test")
+        .tags(tags)
+        .build(author.public_key())
+}
+
+fn assert_denied(err: impl std::fmt::Display) {
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Operation denied by policy"),
+        "expected the uniform policy-denial message, got: {msg}"
+    );
+}
+
+// ============================================================================
+// sign path (sign_event_direct — shared gate with the relay dispatch)
+// ============================================================================
+
+#[tokio::test]
+async fn daemon_minor_sign_rumor_to_arbitrary_recipient_refused() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let (handler, user_keys) = create_oauth_handler(&pool, &key_manager, true).await;
+    let mallory = Keys::generate();
+
+    let unsigned = dm_rumor(14, &user_keys, &[mallory.public_key()]);
+    let err = handler
+        .sign_event_direct(unsigned)
+        .await
+        .expect_err("minor DM rumor to arbitrary recipient must be refused");
+    assert_denied(err);
+}
+
+#[tokio::test]
+async fn daemon_minor_sign_rumor_to_pinned_official_allowed() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let (handler, user_keys) = create_oauth_handler(&pool, &key_manager, true).await;
+
+    let unsigned = dm_rumor(14, &user_keys, &[hq_pubkey()]);
+    let signed = handler
+        .sign_event_direct(unsigned)
+        .await
+        .expect("minor DM rumor to pinned official must sign");
+    signed.verify().expect("valid signature");
+}
+
+#[tokio::test]
+async fn daemon_minor_sign_public_note_unaffected() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let (handler, user_keys) = create_oauth_handler(&pool, &key_manager, true).await;
+    let mallory = Keys::generate();
+
+    let unsigned = dm_rumor(1, &user_keys, &[mallory.public_key()]);
+    handler
+        .sign_event_direct(unsigned)
+        .await
+        .expect("minor public note must sign normally");
+}
+
+#[tokio::test]
+async fn daemon_minor_seal_gate_enforced() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let (handler, user_keys) = create_oauth_handler(&pool, &key_manager, true).await;
+    let mallory = Keys::generate();
+
+    let rumor = serde_json::json!({
+        "id": "0000000000000000000000000000000000000000000000000000000000000000",
+        "pubkey": user_keys.public_key().to_hex(),
+        "created_at": 1_700_000_000,
+        "kind": 14,
+        "tags": [["p", hq_pubkey().to_hex()]],
+        "content": "sealed",
+    })
+    .to_string();
+
+    // Legit: sealed to the official under the user's conversation key.
+    let official_content = nip44::encrypt(
+        user_keys.secret_key(),
+        &hq_pubkey(),
+        &rumor,
+        nip44::Version::V2,
+    )
+    .expect("encrypt to official");
+    let seal = EventBuilder::new(Kind::from(13u16), official_content).build(user_keys.public_key());
+    handler
+        .sign_event_direct(seal)
+        .await
+        .expect("seal to pinned official must sign");
+
+    // Smuggled: sealed under the user<->mallory conversation key.
+    let mallory_content = nip44::encrypt(
+        mallory.secret_key(),
+        &user_keys.public_key(),
+        &rumor,
+        nip44::Version::V2,
+    )
+    .expect("mallory-side encrypt");
+    let seal = EventBuilder::new(Kind::from(13u16), mallory_content).build(user_keys.public_key());
+    let err = handler
+        .sign_event_direct(seal)
+        .await
+        .expect_err("seal to arbitrary recipient must be refused");
+    assert_denied(err);
+}
+
+#[tokio::test]
+async fn daemon_non_minor_sign_unaffected() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let (handler, user_keys) = create_oauth_handler(&pool, &key_manager, false).await;
+    let mallory = Keys::generate();
+
+    let unsigned = dm_rumor(14, &user_keys, &[mallory.public_key()]);
+    handler
+        .sign_event_direct(unsigned)
+        .await
+        .expect("non-minor DM rumor to anyone must sign");
+}
+
+// ============================================================================
+// encrypt / decrypt validation path (relay nip04/nip44 dispatch)
+// ============================================================================
+
+#[tokio::test]
+async fn daemon_minor_encrypt_to_arbitrary_recipient_refused() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let (handler, _user_keys) = create_oauth_handler(&pool, &key_manager, true).await;
+    let mallory = Keys::generate();
+
+    let err = handler
+        .validate_permissions_for_encrypt("hello", &mallory.public_key())
+        .await
+        .expect_err("minor encrypt to arbitrary recipient must be refused");
+    assert_denied(err);
+}
+
+#[tokio::test]
+async fn daemon_minor_encrypt_to_official_and_self_allowed() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let (handler, user_keys) = create_oauth_handler(&pool, &key_manager, true).await;
+
+    handler
+        .validate_permissions_for_encrypt("hello hq", &hq_pubkey())
+        .await
+        .expect("minor encrypt to pinned official must be allowed");
+    handler
+        .validate_permissions_for_encrypt("note to self", &user_keys.public_key())
+        .await
+        .expect("minor encrypt to self must be allowed");
+}
+
+#[tokio::test]
+async fn daemon_minor_decrypt_from_arbitrary_sender_still_allowed() {
+    // #183 scopes containment to egress; decrypt (ingress) is out of scope.
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let (handler, _user_keys) = create_oauth_handler(&pool, &key_manager, true).await;
+    let mallory = Keys::generate();
+
+    handler
+        .validate_permissions_for_decrypt("ciphertext", &mallory.public_key())
+        .await
+        .expect("minor decrypt from arbitrary sender stays allowed (egress-only gate)");
+}
+
+#[tokio::test]
+async fn daemon_non_minor_encrypt_unaffected() {
+    let pool = setup_test_db().await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let (handler, _user_keys) = create_oauth_handler(&pool, &key_manager, false).await;
+    let mallory = Keys::generate();
+
+    handler
+        .validate_permissions_for_encrypt("hello", &mallory.public_key())
+        .await
+        .expect("non-minor encrypt to anyone must be allowed");
+}


### PR DESCRIPTION
## Summary

Server-side DM containment for `verified_minor` accounts (divinevideo/support-trust-safety#183). For a verified_minor account, Keycast refuses to sign or encrypt DM-shaped events whose recipients fall outside the approved official set, across every signing surface. A non-minor account is unaffected.

**Why this is the real lever:** Keycast's headless signing API is reachable with just the account's own email/password (public CORS), so for a custodial minor the shipped app-side DM restriction (#176, mobile #5754 / web #474) is friction, not containment. The paired app-side change (#182) removes the raw-key escape; this PR closes the headless-signer path. Together they gate the epic's custodial-containment claim (#173).

## The binding insight (why not just check the `p` tag)

A DM's recipient is bound by whoever can *decrypt* it, not by the attacker-controlled `p` tag. The NIP-44 / NIP-04 conversation key is **symmetric ECDH**, so a colluding non-approved party can compute the minor↔them key from their own secret key plus the minor's public key, and forge minor-keyed ciphertext without ever calling Keycast. So a naive "every `p` tag must be approved" check is spoofable: hide the real payload behind a decoy approved `p` tag. Each shape is therefore gated at the point its true recipient is actually determinable.

## Enforcement points and DM shapes covered

- **`nip04_encrypt` / `nip44_encrypt`** — recipient must be the user or a pinned official. This is the primitive that produces DM ciphertext, so it blocks a non-colluding minor from encrypting to a stranger at all.
- **kind 13 (NIP-59 seal)** — the seal names no recipient in its tags; its content is NIP-44 ciphertext under the conversation key of the unstated receiver. The recipient is recovered by trial-decrypting the content against the user's conversation keys with each approved pubkey. NIP-44 v2 is authenticated (HMAC), so this is deterministic: decrypts under an approved key ⇒ the recipient is that approved party (cryptographically bound); decrypts under none ⇒ refused. The inner rumor's `p` tags and the seal's own `p` tags must also all be approved. This is the real NIP-17 containment point — the one kind a conformant client actually asks the signer to sign.
- **kind 4 (NIP-04 DM)** — a complete, normal-client-rendered DM whose recipient *is* the `p` tag (NIP-04 content is unauthenticated AES-CBC, so the reader cannot be verified by decryption). Every `p` tag must be approved, keeping a minor-signed kind-4 facially addressed to an approved party; the gated encrypt primitive blocks producing the ciphertext for a non-colluding stranger. This is a live divine send path (video-share-via-DM, NIP-04 fallback).
- **kinds 14/15 (NIP-17 rumor) and 1059 (gift wrap)** — **refused outright.** A conformant client never asks a remote signer to sign these with the user's key: rumors are unsigned (NIP-59), and gift wraps are signed by a one-time ephemeral key, not the sender's. Signing one with the minor's key only serves a covert channel, and a `p`-tag check there is pure false confidence. The legitimate NIP-17 DM to an approved official flows entirely through `nip44_encrypt` (gated) + the kind-13 seal (gated).

**Ingress (decrypt / gift-wrap unwrap) is deliberately untouched** — #183 scopes containment to egress. `nip04_decrypt`, `nip44_decrypt`, and `nip17_unwrap_batch` still work for a minor (reading inbound DMs is not egress).

The approved set is `{ the user themselves, Divine HQ, Divine Moderation }`. Self is included because NIP-17 wraps a copy of every message to the sender, and a self-DM can only be read by the user.

## Accepted ceiling (documented, not closable server-side)

A minor can freely sign public posts (kind 1), whose content is arbitrary. So a minor + a colluding recipient can always steganographically encode a payload the recipient extracts out-of-band, through a public post — no server-side gate can close that, and it is not a DM shape any normal client renders as a DM. This gate's achievable job is narrower: Keycast will not produce a DM-shaped, normal-client-deliverable artifact addressed to a non-approved recipient.

## Approved set: pin-only server-side (design decision)

The clients approve a recipient via **pin ∩ live NIP-05** (#4948): the pin blocks attacker addition, the live NIP-05 leg is a revocation lever. Server-side I enforce the **pin only**, deliberately:

- A live NIP-05 lookup in the signing hot path adds latency and a hard network dependency to a critical op, and a resolver failure would force a fail-open-vs-fail-closed decision on every single DM sign.
- The pin is what actually answers "is this recipient approved" — that needs only the pubkey set.
- Server-side revocation is handled by shipping an updated pinned set on key rotation, plus the existing account-status lifecycle for compromise — not by live-resolving NIP-05 mid-sign.

This mirrors the pinned set into a **third** location (mobile `official_accounts.dart`, web `officialAccounts.ts`, and now keycast `core/src/verified_minor_dm.rs`), maintained by hand. A shared source is a future cleanup, not in scope here; the values are kept identical (verified 2026-07-09).

## Fail-closed behavior

This is a child-safety gate, so every ambiguous case refuses: no `p` tags on a kind-4, a malformed/unparseable `p` tag, a seal whose content decrypts under no approved key, a seal whose plaintext is not event-shaped JSON, an unverifiable DM-carrier kind (14/15/1059), an unresolvable minor status, or a missing user row. Refusals surface a uniform `Operation denied by policy` message (identical to a policy denial, so account state is not leaked through error text); the specific reason is logged server-side only.

## Where it is wired

The `verified_minor` flag is read from the same per-request row as the existing account-status check on every surface, so a protection flip applies immediately despite handler caching (the BLAKE3 HTTP handler cache still runs a fresh status query per request).

- **HTTP RPC `POST /api/nostr`** (`api/src/api/http/nostr_rpc.rs`) — the primary open headless path. `sign_event`, `nip04_encrypt`, `nip44_encrypt` gated.
- **`POST /api/user/sign`** (`api/src/api/http/auth.rs`) — the minor flag is resolved once and both the fast path (cached signer handler) and the slow path (DB + decrypt) gate through a shared helper, each returning a clean 403.
- **NIP-46 relay signer** (`signer/src/signer_daemon.rs`) — a shared `check_user_sign_gates` runs on both relay-dispatched (`handle_sign_event`) and direct (`sign_event_direct`) signing; the encrypt gate lives in `validate_permissions_for_encrypt`, which every `nip04`/`nip44` encrypt dispatch already passes through.

## Review

Reviewed by two adversarial subagents (a senior code review and a bypass-hunt scoped to the acceptance criteria, fail-closed, recipient-identifiability at each shape, and any signing path that skips the gate). Two findings were confirmed against source and fixed in this branch:

1. **Spoofable `p`-tag binding for kinds 14/15/1059 (high):** the symmetric-ECDH property let a colluding recipient hide a minor-readable payload behind a decoy approved `p` tag. Fixed by refusing those kinds outright (they are never legitimately signed via a remote signer) and keeping the real binding on the seal (trial-decrypt) and the encrypt primitives.
2. **Fast-path error surface (important):** on the hot `/user/sign` fast path, a minor-gate denial mapped through the signer handler to a 503 with a retry message instead of a 403. Fixed by gating both paths in the handler before signing, with a fast-path (`signer_handlers: Some`) test asserting the clean 403.

Also folded in: kind-13 seal `p` tags are now validated (defense-in-depth), and the gated-kind list is pinned to the validator by an anti-drift test.

## Out of scope (noted per #183)

The headless client-identity weakness (self-reported `client_id` / `redirect_uri`) is separate hardening called out in #183; this PR does not expand into it. I did trace whether it's currently exploitable: the two capability decisions that consume client identity are each gated behind a stronger factor, so the weakness is latent, not live. Account deletion (`auth.rs`) requires either a user-signed UCAN or the `first_party` fact, and `first_party` is set only for headless-flow tokens, which require the account's email/password — a claimed `client_id` grants nothing without the credentials. The preloaded-user signing path (`nostr_rpc.rs`) additionally requires a server-signed UCAN, which a caller cannot forge. It would only become exploitable if a future control trusted `client_id` on its own. It also does not touch this gate: the minor DM check reads `verified_minor` from the account row per request and never consults the caller's claimed client identity, so it holds against any client, official or forged.

The `verified_minor` gate contains DM *egress via the signer*. It does not by itself close raw-key *egress*: `POST /user/export-key` (returns the nsec) and `POST /user/change-key` (swaps to a caller-supplied key) are password-authenticated with no `verified_minor` gate today, so a custodial minor could export their key via the headless API and then bypass this gate entirely from any client. That is the server-side complement to #182's app-side affordance removal and is tracked separately — this PR does not address it.

## Testing

TDD across three cycles (core unit, API integration, signer daemon), each written red-first and watched fail before implementing:

- `core/src/verified_minor_dm.rs` — 24 unit tests (kind classification + anti-drift, encrypt gate, kind-4 p-tag gating, kind-13 seal trial-decrypt + outer/inner p-tags, 14/15/1059 refused, the decoy-p-tag bypass proven closed, every fail-closed refusal).
- `api/tests/verified_minor_dm_gate_test.rs` — 18 integration tests over `/api/nostr` and `/user/sign` (refusals, allow to officials + self, non-minor unaffected, seal end-to-end, ingress-still-open, fail-closed on missing user row, and the fast-path 403).
- `signer/tests/verified_minor_dm_daemon_test.rs` — 10 tests over the NIP-46 signer.

Full workspace suite, `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`, and `cargo fmt --all -- --check` all clean.

- [x] `cargo test --workspace` (+ integration-feature suites for core/api/signer)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`

## Visuals

- [x] No visual change (backend only)

## Related Issue

- Closes divinevideo/support-trust-safety#183
