### PR TITLE
docs: align README with Divine brand guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,3 +262,7 @@ See [docs/TEAMS.md](./docs/TEAMS.md) for team key management documentation.
 ## License
 
 [MIT](LICENSE)
+
+---
+
+Part of [Divine](https://divine.video) — your playground for human creativity · [Brand guidelines](https://github.com/divinevideo/brand-guidelines)


### PR DESCRIPTION
Branding/docs pass to align the README with the Divine brand guidelines.

## Changes
- Added the standard Divine footer at the end of README.md linking to divine.video and the brand guidelines repo.

## Intentionally left unchanged
- The README uses "Keycast" as its own product name throughout — correct, not a misuse of the Divine brand.
- The `FROM_NAME` row documents the default value `Divine`, which maps directly to the code constant `BRAND_NAME = "Divine"` in `api/src/brand.rs`. Left as-is to keep the docs technically accurate (machine-read config default, not brand prose).
- No other prose changes were needed; the README was already on-brand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)