### PR TITLE
feat(minor-safety): server-side verified_minor gate on key export + change-key

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -3841,6 +3841,45 @@ pub struct ChangeKeyResponse {
     pub message: String,
 }
 
+/// Refuse a raw-key egress operation (export-key / change-key) for a
+/// `verified_minor` account (support-trust-safety#188).
+///
+/// This is the server-side complement to the app-side affordance removal
+/// (#182): Keycast holds the key for a custodial minor, so an ungated
+/// export/change-key over the headless API would let the minor extract or swap
+/// their key with just their password and bypass every other guardrail. Called
+/// at the top of the handler, before the password check and before any key
+/// material is touched, so the least code runs between authentication and the
+/// refusal. The block lifts automatically when `verified_minor` is cleared
+/// (age-up / revocation) — the same flag that drives the DM gate.
+///
+/// Fail closed: only an explicit non-minor status proceeds; `verified_minor` OR
+/// an unresolvable account (no row) is refused. The uniform policy-denial
+/// message leaks no account state; the specific reason is logged server-side.
+async fn refuse_key_egress_for_verified_minor(
+    user_repo: &UserRepository,
+    tenant_id: i64,
+    user_pubkey: &str,
+    operation: &str,
+) -> Result<(), AuthError> {
+    let is_non_minor = matches!(
+        user_repo.get_verified_minor(user_pubkey, tenant_id).await?,
+        Some((false, _))
+    );
+    if !is_non_minor {
+        tracing::warn!(
+            event = "minor_key_egress_denied",
+            user_pubkey = %user_pubkey,
+            operation = %operation,
+            "verified_minor raw-key egress refused"
+        );
+        return Err(AuthError::Forbidden(
+            "Operation denied by policy".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Export user's private key (requires password and verified email)
 pub async fn export_key(
     tenant: crate::api::tenant::TenantExtractor,
@@ -3852,6 +3891,10 @@ pub async fn export_key(
     let user_pubkey = extract_user_from_token(&headers, tenant_id).await?;
     let pool = &auth_state.state.db;
     let key_manager = auth_state.state.key_manager.as_ref();
+    let user_repo = UserRepository::new(pool.clone());
+
+    // verified_minor accounts cannot export their raw key (support-trust-safety#188).
+    refuse_key_egress_for_verified_minor(&user_repo, tenant_id, &user_pubkey, "export_key").await?;
 
     // Extract password and format from request
     let password = req
@@ -3862,7 +3905,6 @@ pub async fn export_key(
     let format = req.get("format").and_then(|v| v.as_str()).unwrap_or("nsec");
 
     // Verify password and email verification status
-    let user_repo = UserRepository::new(pool.clone());
     let result = user_repo
         .find_with_password_and_verified(&user_pubkey, tenant_id)
         .await?;
@@ -3926,9 +3968,12 @@ pub async fn change_key(
     let old_pubkey = extract_user_from_token(&headers, tenant_id).await?;
     let pool = &auth_state.state.db;
     let key_manager = auth_state.state.key_manager.as_ref();
+    let user_repo = UserRepository::new(pool.clone());
+
+    // verified_minor accounts cannot swap to a self-held key (support-trust-safety#188).
+    refuse_key_egress_for_verified_minor(&user_repo, tenant_id, &old_pubkey, "change_key").await?;
 
     // Get user's email and verify password
-    let user_repo = UserRepository::new(pool.clone());
     let (email, password_hash) = user_repo
         .get_credentials(&old_pubkey, tenant_id)
         .await?

--- a/api/tests/verified_minor_key_egress_test.rs
+++ b/api/tests/verified_minor_key_egress_test.rs
@@ -1,0 +1,396 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration tests for the verified_minor raw-key egress gate (support-trust-safety#188)
+// ABOUTME: over POST /user/export-key and POST /user/change-key.
+
+mod common;
+
+use axum::{extract::State, http::HeaderMap, Json};
+use chrono::Utc;
+use keycast_api::api::{
+    http::{
+        auth::{change_key, export_key, AuthError, ChangeKeyRequest},
+        routes::AuthState,
+    },
+    tenant::{Tenant, TenantExtractor},
+};
+use keycast_api::bcrypt_queue::BcryptQueue;
+use keycast_api::handlers::http_rpc_handler::new_http_handler_cache;
+use keycast_api::state::KeycastState;
+use keycast_api::ucan_auth::{nostr_pubkey_to_did, NostrKeyMaterial};
+use keycast_core::encryption::file_key_manager::FileKeyManager;
+use keycast_core::encryption::KeyManager;
+use keycast_core::secret_pool::SecretPool;
+use moka::future::Cache;
+use nostr_sdk::prelude::*;
+use serde_json::json;
+use serial_test::serial;
+use sqlx::PgPool;
+use std::sync::Arc;
+use ucan::builder::UcanBuilder;
+use uuid::Uuid;
+
+const TENANT_ID: i64 = 1;
+
+/// The uniform, non-specific message every minor-egress refusal surfaces.
+const DENIED_MSG: &str = "Operation denied by policy";
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+    pool
+}
+
+fn create_test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: TENANT_ID,
+        domain: "login.divine.video".to_string(),
+        name: "Key Egress Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+fn create_test_auth_state(pool: PgPool, key_manager: Arc<Box<dyn KeyManager>>) -> AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+/// Insert a user (optionally verified_minor) with an email + bcrypt password
+/// hash and email verified, so both export-key and change-key can authenticate.
+async fn insert_user(
+    pool: &PgPool,
+    pubkey: &str,
+    email: &str,
+    password: &str,
+    verified_minor: bool,
+) {
+    let password_hash = bcrypt::hash(password, 4).expect("hash password");
+    sqlx::query(
+        "INSERT INTO users
+            (pubkey, tenant_id, email, password_hash, email_verified, verified_minor, verified_minor_at, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, true, $5, CASE WHEN $5 THEN NOW() ELSE NULL END, NOW(), NOW())",
+    )
+    .bind(pubkey)
+    .bind(TENANT_ID)
+    .bind(email)
+    .bind(&password_hash)
+    .bind(verified_minor)
+    .execute(pool)
+    .await
+    .expect("insert user");
+}
+
+async fn create_personal_key(
+    pool: &PgPool,
+    user_pubkey: &str,
+    user_keys: &Keys,
+    km: &dyn KeyManager,
+) {
+    let encrypted = km
+        .encrypt(&user_keys.secret_key().secret_bytes())
+        .await
+        .expect("encrypt user secret");
+    sqlx::query(
+        "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id) VALUES ($1, $2, $3)",
+    )
+    .bind(user_pubkey)
+    .bind(&encrypted)
+    .bind(TENANT_ID)
+    .execute(pool)
+    .await
+    .expect("create personal key");
+}
+
+async fn bearer_for(keys: &Keys) -> String {
+    let key_material = NostrKeyMaterial::from_keys(keys.clone());
+    let user_did = nostr_pubkey_to_did(&keys.public_key());
+    let ucan = UcanBuilder::default()
+        .issued_by(&key_material)
+        .for_audience(&user_did)
+        .with_lifetime(3600)
+        .with_fact(json!({
+            "tenant_id": TENANT_ID,
+            "email": "key-egress-test@example.com",
+            "redirect_origin": "https://login.divine.video",
+        }))
+        .build()
+        .expect("build UCAN")
+        .sign()
+        .await
+        .expect("sign UCAN");
+    format!("Bearer {}", ucan.encode().expect("encode UCAN"))
+}
+
+fn auth_headers(bearer: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert("Authorization", bearer.parse().expect("valid header"));
+    headers.insert("host", "login.divine.video".parse().expect("valid host"));
+    headers.insert("x-forwarded-proto", "https".parse().expect("valid proto"));
+    // change-key requires a first-party (HTTPS) Origin header; export-key ignores it.
+    headers.insert(
+        "origin",
+        "https://login.divine.video".parse().expect("valid origin"),
+    );
+    headers
+}
+
+async fn user_exists(pool: &PgPool, pubkey: &str) -> bool {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM users WHERE pubkey = $1 AND tenant_id = $2")
+        .bind(pubkey)
+        .bind(TENANT_ID)
+        .fetch_one(pool)
+        .await
+        .expect("count users")
+        > 0
+}
+
+fn unique_email() -> String {
+    format!("ke-{}@example.com", Uuid::new_v4())
+}
+
+fn km_arc(km: FileKeyManager) -> Arc<Box<dyn KeyManager>> {
+    Arc::new(Box::new(km) as Box<dyn KeyManager>)
+}
+
+// ============================================================================
+// export-key
+// ============================================================================
+
+#[tokio::test]
+#[serial]
+async fn minor_export_key_refused() {
+    let pool = setup_pool().await;
+    let km = FileKeyManager::new().expect("key manager");
+    let keys = Keys::generate();
+    let pubkey = keys.public_key().to_hex();
+    insert_user(&pool, &pubkey, &unique_email(), "correct-horse", true).await;
+    create_personal_key(&pool, &pubkey, &keys, &km).await;
+    let auth_state = create_test_auth_state(pool.clone(), km_arc(km));
+
+    let err = export_key(
+        create_test_tenant(),
+        State(auth_state),
+        auth_headers(&bearer_for(&keys).await),
+        Json(json!({ "password": "correct-horse", "format": "nsec" })),
+    )
+    .await
+    .expect_err("verified_minor export-key must be refused");
+
+    match err {
+        AuthError::Forbidden(msg) => assert_eq!(msg, DENIED_MSG),
+        other => panic!("expected Forbidden({DENIED_MSG}), got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_export_key_refused_before_password_check() {
+    // Placement: the gate precedes the password check, so a verified_minor is
+    // refused with the uniform message even on a WRONG password (never reaching
+    // InvalidCredentials). This keeps the least code between auth and refusal.
+    let pool = setup_pool().await;
+    let km = FileKeyManager::new().expect("key manager");
+    let keys = Keys::generate();
+    let pubkey = keys.public_key().to_hex();
+    insert_user(&pool, &pubkey, &unique_email(), "correct-horse", true).await;
+    create_personal_key(&pool, &pubkey, &keys, &km).await;
+    let auth_state = create_test_auth_state(pool.clone(), km_arc(km));
+
+    let err = export_key(
+        create_test_tenant(),
+        State(auth_state),
+        auth_headers(&bearer_for(&keys).await),
+        Json(json!({ "password": "WRONG-password", "format": "nsec" })),
+    )
+    .await
+    .expect_err("verified_minor export-key must be refused regardless of password");
+
+    match err {
+        AuthError::Forbidden(msg) => assert_eq!(msg, DENIED_MSG),
+        other => panic!("expected Forbidden({DENIED_MSG}) before password check, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn non_minor_export_key_returns_nsec() {
+    let pool = setup_pool().await;
+    let km = FileKeyManager::new().expect("key manager");
+    let keys = Keys::generate();
+    let pubkey = keys.public_key().to_hex();
+    insert_user(&pool, &pubkey, &unique_email(), "correct-horse", false).await;
+    create_personal_key(&pool, &pubkey, &keys, &km).await;
+    let auth_state = create_test_auth_state(pool.clone(), km_arc(km));
+
+    let Json(resp) = export_key(
+        create_test_tenant(),
+        State(auth_state),
+        auth_headers(&bearer_for(&keys).await),
+        Json(json!({ "password": "correct-horse", "format": "nsec" })),
+    )
+    .await
+    .expect("non-minor export-key must succeed");
+
+    assert!(
+        resp.key.starts_with("nsec1"),
+        "expected an nsec, got: {}",
+        resp.key
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn export_key_missing_user_row_fails_closed() {
+    // Fail closed: a valid token whose account row cannot be resolved (so minor
+    // status is unknown) must be refused, not fall through.
+    let pool = setup_pool().await;
+    let km = FileKeyManager::new().expect("key manager");
+    let keys = Keys::generate(); // no user row inserted
+    let auth_state = create_test_auth_state(pool.clone(), km_arc(km));
+
+    let err = export_key(
+        create_test_tenant(),
+        State(auth_state),
+        auth_headers(&bearer_for(&keys).await),
+        Json(json!({ "password": "whatever", "format": "nsec" })),
+    )
+    .await
+    .expect_err("unresolvable account must fail closed");
+
+    match err {
+        AuthError::Forbidden(msg) => assert_eq!(msg, DENIED_MSG),
+        other => panic!("expected Forbidden({DENIED_MSG}) fail-closed, got: {other:?}"),
+    }
+}
+
+// ============================================================================
+// change-key
+// ============================================================================
+
+#[tokio::test]
+#[serial]
+async fn minor_change_key_refused_and_key_unchanged() {
+    let pool = setup_pool().await;
+    let km = FileKeyManager::new().expect("key manager");
+    let keys = Keys::generate();
+    let pubkey = keys.public_key().to_hex();
+    insert_user(&pool, &pubkey, &unique_email(), "correct-horse", true).await;
+    create_personal_key(&pool, &pubkey, &keys, &km).await;
+    let auth_state = create_test_auth_state(pool.clone(), km_arc(km));
+
+    let new_keys = Keys::generate();
+    let new_pubkey = new_keys.public_key().to_hex();
+
+    let err = change_key(
+        create_test_tenant(),
+        State(auth_state),
+        auth_headers(&bearer_for(&keys).await),
+        Json(ChangeKeyRequest {
+            password: "correct-horse".to_string(),
+            nsec: Some(new_keys.secret_key().to_bech32().expect("nsec")),
+        }),
+    )
+    .await
+    .expect_err("verified_minor change-key must be refused");
+
+    match err {
+        AuthError::Forbidden(msg) => assert_eq!(msg, DENIED_MSG),
+        other => panic!("expected Forbidden({DENIED_MSG}), got: {other:?}"),
+    }
+    // No key swap happened: the original identity still exists, the new one was
+    // never created.
+    assert!(
+        user_exists(&pool, &pubkey).await,
+        "old identity must survive a refused change-key"
+    );
+    assert!(
+        !user_exists(&pool, &new_pubkey).await,
+        "refused change-key must not create the new identity"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn non_minor_change_key_succeeds() {
+    let pool = setup_pool().await;
+    let km = FileKeyManager::new().expect("key manager");
+    let keys = Keys::generate();
+    let pubkey = keys.public_key().to_hex();
+    insert_user(&pool, &pubkey, &unique_email(), "correct-horse", false).await;
+    create_personal_key(&pool, &pubkey, &keys, &km).await;
+    let auth_state = create_test_auth_state(pool.clone(), km_arc(km));
+
+    let new_keys = Keys::generate();
+    let new_pubkey = new_keys.public_key().to_hex();
+
+    change_key(
+        create_test_tenant(),
+        State(auth_state),
+        auth_headers(&bearer_for(&keys).await),
+        Json(ChangeKeyRequest {
+            password: "correct-horse".to_string(),
+            nsec: Some(new_keys.secret_key().to_bech32().expect("nsec")),
+        }),
+    )
+    .await
+    .expect("non-minor change-key must succeed");
+
+    assert!(
+        user_exists(&pool, &new_pubkey).await,
+        "non-minor change-key must migrate to the new identity"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn change_key_missing_user_row_fails_closed() {
+    // Symmetric to export_key_missing_user_row_fails_closed: an unresolvable
+    // account (valid token, no row) must be refused, not fall through.
+    let pool = setup_pool().await;
+    let km = FileKeyManager::new().expect("key manager");
+    let keys = Keys::generate(); // no user row inserted
+    let auth_state = create_test_auth_state(pool.clone(), km_arc(km));
+
+    let new_keys = Keys::generate();
+    let err = change_key(
+        create_test_tenant(),
+        State(auth_state),
+        auth_headers(&bearer_for(&keys).await),
+        Json(ChangeKeyRequest {
+            password: "whatever".to_string(),
+            nsec: Some(new_keys.secret_key().to_bech32().expect("nsec")),
+        }),
+    )
+    .await
+    .expect_err("unresolvable account must fail closed");
+
+    match err {
+        AuthError::Forbidden(msg) => assert_eq!(msg, DENIED_MSG),
+        other => panic!("expected Forbidden({DENIED_MSG}) fail-closed, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

- Server-side `verified_minor` gate on `POST /user/export-key` and `POST /user/change-key`, closing the raw-key egress path for custodial minors.
- The server-side complement to the app-side affordance removal (#182), and the key-egress twin of the DM containment (#183, keycast#284): #182 hides the export/change-key affordances in the apps; this refuses them at Keycast so the key can't be extracted over the headless API.

## Motivation

Keycast holds the signing key for a custodial minor. Both endpoints are password-authenticated with no minor gate today: `export_key` decrypts and returns the raw nsec, `change_key` swaps the account to a caller-supplied key. They sit on first-party CORS, but CORS is a browser control only, so a script with the account's own Keycast password can call either directly over the headless API. A custodial minor knows their password (they log in with it), so they could export their nsec, load it into any client, and bypass every other guardrail — including the #183/#284 DM containment. That collapses the epic's custodial-containment premise into the accepted self-custody ceiling. This PR removes that escape hatch.

## What it does

- Both handlers call a shared `refuse_key_egress_for_verified_minor` helper at the top, **before the password check and before any key material is touched**, so the least code runs between authentication and the refusal.
- **Fail closed:** only an explicit non-minor status proceeds; `verified_minor` OR an unresolvable account (no user row) is refused.
- **Uniform refusal:** `AuthError::Forbidden("Operation denied by policy")` — identical to a policy denial, so it leaks no account state; the specific reason is logged server-side only.
- **Auto-lifts:** the block clears the moment `verified_minor` is cleared (age-up / revocation via the existing lifecycle), the same flag that drives the DM gate. No special handoff path; a guardian/admin key handoff for a still-minor account, if ever needed, is future admin/service-token work.
- Non-minor accounts are unaffected.

## Design note

Gated at the top of each handler rather than after password verification, deliberately: for a child-safety key-egress gate, fail-fast (refuse before any password work or key decrypt/swap) minimizes the code path to the key material, and it makes the fail-closed-on-unresolvable case real and testable. The tradeoff is that a caller holding a valid token but not the password could infer minor status from the uniform refusal; that's low-sensitivity (they already hold account-level auth) and not a bypass.

## Testing

TDD, red-first. New `api/tests/verified_minor_key_egress_test.rs` (6 integration tests): verified_minor refused on export-key (including before the password check, on a wrong password), non-minor export returns an nsec, fail-closed on a missing user row, verified_minor refused on change-key with the original identity left intact, non-minor change-key succeeds. Existing `change_key_test` and `email_change_test` suites still green (no regression).

- [x] `cargo test -p keycast_api --features integration-tests --test verified_minor_key_egress_test` (6 pass) + change_key/email_change regression
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`

## Related Issue

- Closes divinevideo/support-trust-safety#188

## Visuals

- [x] No visual change (backend only)
