### PR TITLE
fix(oauth): register Crossposter client

### DIFF
--- a/api/tests/registered_clients_migration_test.rs
+++ b/api/tests/registered_clients_migration_test.rs
@@ -37,6 +37,36 @@ async fn migrations_register_divine_invite_admin_oauth_client() {
 }
 
 #[tokio::test]
+async fn migrations_register_divine_crossposter_oauth_client() {
+    let pool = common::setup_test_db().await;
+    let repo = RegisteredClientRepository::new(pool);
+
+    let allowed_redirects = repo
+        .get_allowed_redirect_uris("Divine Crossposter", 1)
+        .await
+        .unwrap()
+        .expect("Divine Crossposter should be seeded as a registered OAuth client");
+
+    assert_eq!(
+        allowed_redirects,
+        vec!["https://crossposter.divine.video/".to_string()]
+    );
+
+    repo.validate_redirect_uri("Divine Crossposter", "https://crossposter.divine.video/", 1)
+        .await
+        .unwrap();
+
+    assert!(repo
+        .validate_redirect_uri(
+            "Divine Crossposter",
+            "https://crossposter.divine.video/callback",
+            1,
+        )
+        .await
+        .is_err());
+}
+
+#[tokio::test]
 async fn registered_clients_tenant_id_is_bigint() {
     // Every other tenant_id column in this schema is BIGINT (tenants.id,
     // users.tenant_id, oauth_authorizations.tenant_id, etc.). 0008 originally

--- a/database/migrations/20260710150000_seed_divine_crossposter_client.sql
+++ b/database/migrations/20260710150000_seed_divine_crossposter_client.sql
@@ -1,0 +1,18 @@
+-- Register Divine Crossposter as a first-party OAuth client.
+INSERT INTO public.registered_clients (
+    tenant_id,
+    client_id,
+    name,
+    allowed_redirect_uris
+)
+VALUES (
+    1,
+    'Divine Crossposter',
+    'Divine Crossposter',
+    ARRAY['https://crossposter.divine.video/']::TEXT[]
+)
+ON CONFLICT (tenant_id, client_id) DO UPDATE
+SET
+    name = EXCLUDED.name,
+    allowed_redirect_uris = EXCLUDED.allowed_redirect_uris,
+    updated_at = NOW();


### PR DESCRIPTION
## Summary
- seed `Divine Crossposter` as a tenant-1 OAuth client
- restrict it to the exact `https://crossposter.divine.video/` callback
- cover exact-match acceptance and alternate-path rejection in migration tests

## Motivation
Crossposter was reusing the registered `Divine Identity Verification` client ID, so Keycast correctly rejected the Crossposter callback before login. A dedicated registration gives the app a truthful client identity and binds it to its production redirect.

## Companion change
- Crossposter client identity: https://github.com/divinevideo/divine-crosposter/pull/8

## Test plan
- [x] `cargo test -p keycast_api --test registered_clients_migration_test` — 3 passed
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## Deployment note
The migration is idempotent and can deploy before or after the companion Crossposter client-ID change. Keycast open OAuth makes either order safe.