### PR TITLE
fix(atproto): advertise configured entryway origin

### DIFF
--- a/api/src/api/http/atproto_oauth_metadata.rs
+++ b/api/src/api/http/atproto_oauth_metadata.rs
@@ -21,8 +21,9 @@ pub struct AuthorizationServerMetadata {
 }
 
 pub fn authorization_server_origin() -> String {
-    std::env::var("APP_URL")
+    std::env::var("ATPROTO_ENTRYWAY_ORIGIN")
         .ok()
+        .or_else(|| std::env::var("APP_URL").ok())
         .or_else(|| std::env::var("VITE_DOMAIN").ok())
         .and_then(|raw| {
             Url::parse(&raw).ok().and_then(|url| {

--- a/api/tests/atproto_oauth_metadata_test.rs
+++ b/api/tests/atproto_oauth_metadata_test.rs
@@ -7,13 +7,44 @@ use axum::{
 use http_body_util::BodyExt;
 use keycast_api::api::http::atproto_oauth_metadata::authorization_server_metadata;
 use serde_json::Value;
+use serial_test::serial;
 use tower::ServiceExt;
 
-#[tokio::test]
-async fn metadata_endpoint_exposes_required_atproto_fields() {
-    unsafe {
-        std::env::set_var("APP_URL", "https://login.divine.video");
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
     }
+
+    fn remove(key: &'static str) -> Self {
+        let previous = std::env::var(key).ok();
+        unsafe { std::env::remove_var(key) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn metadata_endpoint_exposes_required_atproto_fields() {
+    let _entryway = EnvGuard::remove("ATPROTO_ENTRYWAY_ORIGIN");
+    let _app = EnvGuard::set("APP_URL", "https://login.divine.video");
 
     let app = Router::new().route(
         "/.well-known/oauth-authorization-server",
@@ -78,4 +109,44 @@ async fn metadata_endpoint_exposes_required_atproto_fields() {
         .as_array()
         .unwrap()
         .contains(&Value::String("ES256".to_string())));
+}
+
+#[tokio::test]
+#[serial]
+async fn metadata_prefers_configured_entryway_origin_over_human_login_origin() {
+    let _app = EnvGuard::set("APP_URL", "https://login.divine.video");
+    let _entryway = EnvGuard::set(
+        "ATPROTO_ENTRYWAY_ORIGIN",
+        "https://entryway.divine.video/ignored/path",
+    );
+
+    let app = Router::new().route(
+        "/.well-known/oauth-authorization-server",
+        get(authorization_server_metadata),
+    );
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/.well-known/oauth-authorization-server")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let payload: Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(payload["issuer"], "https://entryway.divine.video");
+    assert_eq!(
+        payload["authorization_endpoint"],
+        "https://entryway.divine.video/api/atproto/oauth/authorize"
+    );
+    assert_eq!(
+        payload["token_endpoint"],
+        "https://entryway.divine.video/api/atproto/oauth/token"
+    );
+    assert_eq!(
+        payload["pushed_authorization_request_endpoint"],
+        "https://entryway.divine.video/api/atproto/oauth/par"
+    );
 }


### PR DESCRIPTION
## Summary
- prefer `ATPROTO_ENTRYWAY_ORIGIN` over the human-console `APP_URL` for ATProto authorization-server metadata
- normalize the configured value to an origin before constructing issuer, authorize, token, and PAR URLs
- retain `APP_URL` as the fallback when entryway configuration is absent

## Production impact
`entryway.divine.video` currently reaches Keycast but advertises `login.divine.video`, breaking the ATProto discovery boundary. The production deployment already supplies `ATPROTO_ENTRYWAY_ORIGIN=https://entryway.divine.video`; this change makes the runtime honor it.

## Verification
- `cargo test -p keycast_api --test atproto_oauth_metadata_test -- --nocapture` (2 passed)
- `cargo check -p keycast_api`
- `cargo fmt --check`
- adversarial review: PASS

The full `cargo test -p keycast_api` run reaches 149 passing unit tests, then existing DB-backed `atproto_http_test` cases fail during setup with `VersionMissing(20260530000000)`; this change does not touch migrations or those tests.
