### PR TITLE
fix(auth): complete OAuth verify_email row-state retries

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1581,13 +1581,79 @@ pub async fn verify_email(
 
         // Create user with email_verified=true (they just verified!)
         let user_repo = UserRepository::new(pool.clone());
-        let user_already_exists = user_repo.exists(&oauth_data.user_pubkey, tenant_id).await?;
+        let existing_user = user_repo
+            .oauth_registration_state(&oauth_data.user_pubkey, tenant_id)
+            .await?;
 
-        if user_already_exists {
-            tracing::info!(
-                "Retrying OAuth email verification for existing user: {}",
-                oauth_data.user_pubkey
-            );
+        if let Some(existing) = existing_user {
+            match existing.email.as_deref() {
+                Some(existing_email) if existing_email == email => {
+                    // Genuine retry: a prior attempt already applied the pending
+                    // credentials. Backfill the personal key if that attempt (or
+                    // another creation path) left it missing.
+                    tracing::info!(
+                        "Retrying OAuth email verification for existing user: {}",
+                        oauth_data.user_pubkey
+                    );
+                    if oauth_data.pending_encrypted_secret.is_some() && !existing.has_personal_key {
+                        user_repo
+                            .complete_pending_oauth_registration(
+                                &oauth_data.user_pubkey,
+                                tenant_id,
+                                email,
+                                password_hash,
+                                &req.token,
+                                oauth_data.pending_encrypted_secret.as_deref(),
+                            )
+                            .await?;
+                        tracing::info!(
+                            "Backfilled missing personal key during OAuth verification retry: {}",
+                            oauth_data.user_pubkey
+                        );
+                    }
+                }
+                Some(_) => {
+                    // The pubkey is already bound to a different email. Never
+                    // overwrite an existing account's credentials from an
+                    // unauthenticated verification link.
+                    tracing::warn!(
+                        "OAuth email verification for pubkey {} conflicts with an existing account email",
+                        oauth_data.user_pubkey
+                    );
+                    oauth_code_repo
+                        .delete_by_verification_token(&req.token, tenant_id)
+                        .await?;
+                    return Err(AuthError::DuplicateKey);
+                }
+                None => {
+                    // Bare row pre-created by another path (team membership,
+                    // authorization pre-creation): apply the pending registration
+                    // instead of silently dropping it.
+                    if let Err(err) = user_repo
+                        .complete_pending_oauth_registration(
+                            &oauth_data.user_pubkey,
+                            tenant_id,
+                            email,
+                            password_hash,
+                            &req.token,
+                            oauth_data.pending_encrypted_secret.as_deref(),
+                        )
+                        .await
+                    {
+                        if matches!(err, keycast_core::repositories::RepositoryError::Duplicate) {
+                            oauth_code_repo
+                                .delete_by_verification_token(&req.token, tenant_id)
+                                .await?;
+                            return Err(AuthError::EmailAlreadyExists);
+                        }
+                        return Err(err.into());
+                    }
+                    tracing::info!(
+                        "Applied pending OAuth registration to pre-existing user row: {}",
+                        oauth_data.user_pubkey
+                    );
+                }
+            }
         } else if let Some(ref encrypted_secret) = oauth_data.pending_encrypted_secret {
             // Auto-generated or direct nsec: create user + personal_keys
             // Use a transaction to ensure atomicity
@@ -4807,6 +4873,129 @@ mod tests {
 
         cleanup_verify_email_test_data(&pool, &existing_pubkey, &verification_token).await;
         cleanup_verify_email_test_data(&pool, &pending_pubkey, &verification_token).await;
+    }
+
+    #[cfg(feature = "integration-tests")]
+    async fn insert_pending_oauth_registration(
+        pool: &PgPool,
+        pubkey: &str,
+        email: &str,
+        verification_token: &str,
+        password_hash: &str,
+        encrypted_secret: Option<&[u8]>,
+    ) {
+        let placeholder_code = format!("placeholder_{}", Uuid::new_v4());
+        sqlx::query(
+            "INSERT INTO oauth_codes (
+                tenant_id, code, user_pubkey, client_id, redirect_uri, scope,
+                expires_at, created_at, pending_email, pending_password_hash,
+                pending_email_verification_token, pending_encrypted_secret
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), $8, $9, $10, $11)",
+        )
+        .bind(1_i64)
+        .bind(&placeholder_code)
+        .bind(pubkey)
+        .bind("TestApp")
+        .bind("https://test.example.com/callback")
+        .bind("policy:social")
+        .bind(Utc::now() + Duration::hours(24))
+        .bind(email)
+        .bind(password_hash)
+        .bind(verification_token)
+        .bind(encrypted_secret)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_applies_pending_registration_to_bare_user_row() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+        let pending_keys = Keys::generate();
+        let pubkey = pending_keys.public_key().to_hex();
+        let email = format!("verify-bare-row-{}@example.com", Uuid::new_v4());
+        let verification_token = format!("verify_{}", Uuid::new_v4());
+        let password_hash = bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap();
+        let encrypted_secret = pending_keys.secret_key().to_secret_bytes().to_vec();
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &verification_token).await;
+
+        // Bare row pre-created by another path (team add, authorization pre-create)
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+             VALUES ($1, 1, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        insert_pending_oauth_registration(
+            &pool,
+            &pubkey,
+            &email,
+            &verification_token,
+            &password_hash,
+            Some(&encrypted_secret),
+        )
+        .await;
+
+        let response = match verify_email(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            Json(VerifyEmailRequest {
+                token: verification_token.clone(),
+            }),
+        )
+        .await
+        {
+            Ok(response) => response.into_response(),
+            Err(err) => err.into_response(),
+        };
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let row: (Option<String>, Option<String>, bool) = sqlx::query_as(
+            "SELECT email, password_hash, email_verified FROM users
+             WHERE pubkey = $1 AND tenant_id = 1",
+        )
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            row.0.as_deref(),
+            Some(email.as_str()),
+            "pending email must be applied to the pre-existing bare row"
+        );
+        assert_eq!(
+            row.1.as_deref(),
+            Some(password_hash.as_str()),
+            "pending password must be applied to the pre-existing bare row"
+        );
+        assert!(row.2, "email must be marked verified");
+
+        let key_count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM personal_keys WHERE user_pubkey = $1")
+                .bind(&pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(key_count.0, 1, "personal key must be created");
+
+        let usable_code_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE tenant_id = 1 AND user_pubkey = $1 AND pending_email IS NULL",
+        )
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(usable_code_count.0, 1, "OAuth code should be minted");
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &verification_token).await;
     }
 
     #[cfg(feature = "integration-tests")]

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -5000,6 +5000,253 @@ mod tests {
 
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
+    async fn test_verify_email_retry_backfills_missing_personal_key() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+        let pending_keys = Keys::generate();
+        let pubkey = pending_keys.public_key().to_hex();
+        let email = format!("verify-backfill-{}@example.com", Uuid::new_v4());
+        let verification_token = format!("verify_{}", Uuid::new_v4());
+        let password_hash = bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap();
+        let encrypted_secret = pending_keys.secret_key().to_secret_bytes().to_vec();
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &verification_token).await;
+
+        // Row already carries the pending email (prior retry applied it) but the
+        // personal key is missing — e.g. a registration dropped by the old
+        // idempotency-by-existence bug.
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+             VALUES ($1, 1, $2, $3, true, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(&email)
+        .bind(&password_hash)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        insert_pending_oauth_registration(
+            &pool,
+            &pubkey,
+            &email,
+            &verification_token,
+            &password_hash,
+            Some(&encrypted_secret),
+        )
+        .await;
+
+        let response = match verify_email(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            Json(VerifyEmailRequest {
+                token: verification_token.clone(),
+            }),
+        )
+        .await
+        {
+            Ok(response) => response.into_response(),
+            Err(err) => err.into_response(),
+        };
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let stored_secrets: Vec<(Vec<u8>,)> =
+            sqlx::query_as("SELECT encrypted_secret_key FROM personal_keys WHERE user_pubkey = $1")
+                .bind(&pubkey)
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            stored_secrets.len(),
+            1,
+            "retry must backfill exactly one personal key"
+        );
+        assert_eq!(
+            stored_secrets[0].0, encrypted_secret,
+            "backfilled key must hold the pending secret"
+        );
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &verification_token).await;
+    }
+
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_conflicting_account_email_returns_conflict_without_minting() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+        let pending_keys = Keys::generate();
+        let pubkey = pending_keys.public_key().to_hex();
+        let existing_email = format!("verify-existing-{}@example.com", Uuid::new_v4());
+        let pending_email = format!("verify-pending-{}@example.com", Uuid::new_v4());
+        let verification_token = format!("verify_{}", Uuid::new_v4());
+        let password_hash = bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap();
+        let encrypted_secret = pending_keys.secret_key().to_secret_bytes().to_vec();
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &verification_token).await;
+
+        // The pubkey is already bound to a different email.
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+             VALUES ($1, 1, $2, $3, true, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(&existing_email)
+        .bind(&password_hash)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        insert_pending_oauth_registration(
+            &pool,
+            &pubkey,
+            &pending_email,
+            &verification_token,
+            &password_hash,
+            Some(&encrypted_secret),
+        )
+        .await;
+
+        let response = match verify_email(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            Json(VerifyEmailRequest {
+                token: verification_token.clone(),
+            }),
+        )
+        .await
+        {
+            Ok(response) => response.into_response(),
+            Err(err) => err.into_response(),
+        };
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+
+        let row: (Option<String>,) =
+            sqlx::query_as("SELECT email FROM users WHERE pubkey = $1 AND tenant_id = 1")
+                .bind(&pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            row.0.as_deref(),
+            Some(existing_email.as_str()),
+            "existing account email must not be overwritten"
+        );
+
+        let minted_code_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE tenant_id = 1 AND user_pubkey = $1 AND pending_email IS NULL",
+        )
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(minted_code_count.0, 0, "no OAuth code may be minted");
+
+        let pending_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE tenant_id = 1 AND pending_email_verification_token = $1",
+        )
+        .bind(&verification_token)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            pending_count.0, 0,
+            "unresolvable pending registration should be cleaned up"
+        );
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &verification_token).await;
+    }
+
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_bare_row_with_taken_email_returns_email_conflict() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+        let owner_pubkey = Keys::generate().public_key().to_hex();
+        let pending_keys = Keys::generate();
+        let pending_pubkey = pending_keys.public_key().to_hex();
+        let email = format!("verify-taken-{}@example.com", Uuid::new_v4());
+        let verification_token = format!("verify_{}", Uuid::new_v4());
+        let password_hash = bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap();
+        let encrypted_secret = pending_keys.secret_key().to_secret_bytes().to_vec();
+
+        cleanup_verify_email_test_data(&pool, &owner_pubkey, &verification_token).await;
+        cleanup_verify_email_test_data(&pool, &pending_pubkey, &verification_token).await;
+
+        // Another user owns the pending email; the pending pubkey has a bare row.
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+             VALUES ($1, 1, $2, $3, true, NOW(), NOW())",
+        )
+        .bind(&owner_pubkey)
+        .bind(&email)
+        .bind(&password_hash)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+             VALUES ($1, 1, NOW(), NOW())",
+        )
+        .bind(&pending_pubkey)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        insert_pending_oauth_registration(
+            &pool,
+            &pending_pubkey,
+            &email,
+            &verification_token,
+            &password_hash,
+            Some(&encrypted_secret),
+        )
+        .await;
+
+        let response = match verify_email(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            Json(VerifyEmailRequest {
+                token: verification_token.clone(),
+            }),
+        )
+        .await
+        {
+            Ok(response) => response.into_response(),
+            Err(err) => err.into_response(),
+        };
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["code"], super::EMAIL_ALREADY_EXISTS_CODE);
+
+        let row: (Option<String>,) =
+            sqlx::query_as("SELECT email FROM users WHERE pubkey = $1 AND tenant_id = 1")
+                .bind(&pending_pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0, None, "bare row must stay untouched on conflict");
+
+        let minted_code_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE tenant_id = 1 AND user_pubkey = $1 AND pending_email IS NULL",
+        )
+        .bind(&pending_pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(minted_code_count.0, 0, "no OAuth code may be minted");
+
+        cleanup_verify_email_test_data(&pool, &owner_pubkey, &verification_token).await;
+        cleanup_verify_email_test_data(&pool, &pending_pubkey, &verification_token).await;
+    }
+
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
     async fn test_update_profile_username_taken_returns_conflict() {
         let pool = create_test_db().await;
         let auth_state = create_test_auth_state(pool.clone());

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1595,15 +1595,15 @@ pub async fn verify_email(
                         "Retrying OAuth email verification for existing user: {}",
                         oauth_data.user_pubkey
                     );
-                    if oauth_data.pending_encrypted_secret.is_some() && !existing.has_personal_key {
+                    if let (Some(encrypted_secret), false) = (
+                        oauth_data.pending_encrypted_secret.as_deref(),
+                        existing.has_personal_key,
+                    ) {
                         user_repo
-                            .complete_pending_oauth_registration(
+                            .backfill_personal_key(
                                 &oauth_data.user_pubkey,
                                 tenant_id,
-                                email,
-                                password_hash,
-                                &req.token,
-                                oauth_data.pending_encrypted_secret.as_deref(),
+                                encrypted_secret,
                             )
                             .await?;
                         tracing::info!(
@@ -5008,6 +5008,8 @@ mod tests {
         let email = format!("verify-backfill-{}@example.com", Uuid::new_v4());
         let verification_token = format!("verify_{}", Uuid::new_v4());
         let password_hash = bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap();
+        let changed_password_hash =
+            bcrypt::hash("changedpassword123", bcrypt::DEFAULT_COST).unwrap();
         let encrypted_secret = pending_keys.secret_key().to_secret_bytes().to_vec();
 
         cleanup_verify_email_test_data(&pool, &pubkey, &verification_token).await;
@@ -5021,7 +5023,7 @@ mod tests {
         )
         .bind(&pubkey)
         .bind(&email)
-        .bind(&password_hash)
+        .bind(&changed_password_hash)
         .execute(&pool)
         .await
         .unwrap();
@@ -5065,6 +5067,17 @@ mod tests {
         assert_eq!(
             stored_secrets[0].0, encrypted_secret,
             "backfilled key must hold the pending secret"
+        );
+
+        let stored_password_hash: (String,) =
+            sqlx::query_as("SELECT password_hash FROM users WHERE pubkey = $1 AND tenant_id = 1")
+                .bind(&pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            stored_password_hash.0, changed_password_hash,
+            "retry key backfill must not rewrite existing credentials"
         );
 
         cleanup_verify_email_test_data(&pool, &pubkey, &verification_token).await;

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1588,26 +1588,56 @@ pub async fn verify_email(
         if let Some(existing) = existing_user {
             match existing.email.as_deref() {
                 Some(existing_email) if existing_email == email => {
-                    // Genuine retry: a prior attempt already applied the pending
-                    // credentials. Backfill the personal key if that attempt (or
-                    // another creation path) left it missing.
-                    tracing::info!(
-                        "Retrying OAuth email verification for existing user: {}",
-                        oauth_data.user_pubkey
-                    );
-                    if let (Some(encrypted_secret), false) = (
-                        oauth_data.pending_encrypted_secret.as_deref(),
-                        existing.has_personal_key,
-                    ) {
-                        user_repo
-                            .backfill_personal_key(
+                    if existing.email_verified && existing.has_password_hash {
+                        // Genuine retry: a prior attempt already applied the pending
+                        // credentials. Backfill the personal key if that attempt (or
+                        // another creation path) left it missing.
+                        tracing::info!(
+                            "Retrying OAuth email verification for existing user: {}",
+                            oauth_data.user_pubkey
+                        );
+                        if let (Some(encrypted_secret), false) = (
+                            oauth_data.pending_encrypted_secret.as_deref(),
+                            existing.has_personal_key,
+                        ) {
+                            user_repo
+                                .backfill_personal_key(
+                                    &oauth_data.user_pubkey,
+                                    tenant_id,
+                                    encrypted_secret,
+                                )
+                                .await?;
+                            tracing::info!(
+                                "Backfilled missing personal key during OAuth verification retry: {}",
+                                oauth_data.user_pubkey
+                            );
+                        }
+                    } else {
+                        // A same-email row can come from standard registration before
+                        // verification or before bcrypt finishes. Complete it before
+                        // minting an OAuth code.
+                        if let Err(err) = user_repo
+                            .complete_pending_oauth_registration(
                                 &oauth_data.user_pubkey,
                                 tenant_id,
-                                encrypted_secret,
+                                email,
+                                password_hash,
+                                &req.token,
+                                oauth_data.pending_encrypted_secret.as_deref(),
                             )
-                            .await?;
+                            .await
+                        {
+                            if matches!(err, keycast_core::repositories::RepositoryError::Duplicate)
+                            {
+                                oauth_code_repo
+                                    .delete_by_verification_token(&req.token, tenant_id)
+                                    .await?;
+                                return Err(AuthError::EmailAlreadyExists);
+                            }
+                            return Err(err.into());
+                        }
                         tracing::info!(
-                            "Backfilled missing personal key during OAuth verification retry: {}",
+                            "Completed incomplete same-email OAuth registration row: {}",
                             oauth_data.user_pubkey
                         );
                     }
@@ -5079,6 +5109,94 @@ mod tests {
             stored_password_hash.0, changed_password_hash,
             "retry key backfill must not rewrite existing credentials"
         );
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &verification_token).await;
+    }
+
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_verify_email_completes_same_email_unverified_row_before_minting() {
+        let pool = create_test_db().await;
+        let auth_state = create_test_auth_state(pool.clone());
+        let pending_keys = Keys::generate();
+        let pubkey = pending_keys.public_key().to_hex();
+        let email = format!("verify-incomplete-{}@example.com", Uuid::new_v4());
+        let verification_token = format!("verify_{}", Uuid::new_v4());
+        let password_hash = bcrypt::hash("testpassword123", bcrypt::DEFAULT_COST).unwrap();
+        let encrypted_secret = pending_keys.secret_key().to_secret_bytes().to_vec();
+
+        cleanup_verify_email_test_data(&pool, &pubkey, &verification_token).await;
+
+        // Standard registration can leave the same pubkey/email row incomplete
+        // until this verification link is clicked.
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+             VALUES ($1, 1, $2, NULL, false, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(&email)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        insert_pending_oauth_registration(
+            &pool,
+            &pubkey,
+            &email,
+            &verification_token,
+            &password_hash,
+            Some(&encrypted_secret),
+        )
+        .await;
+
+        let response = match verify_email(
+            create_test_tenant(),
+            State(auth_state),
+            HeaderMap::new(),
+            Json(VerifyEmailRequest {
+                token: verification_token.clone(),
+            }),
+        )
+        .await
+        {
+            Ok(response) => response.into_response(),
+            Err(err) => err.into_response(),
+        };
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let row: (Option<String>, Option<String>, bool) = sqlx::query_as(
+            "SELECT email, password_hash, email_verified FROM users
+             WHERE pubkey = $1 AND tenant_id = 1",
+        )
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0.as_deref(), Some(email.as_str()));
+        assert_eq!(
+            row.1.as_deref(),
+            Some(password_hash.as_str()),
+            "pending password must complete the incomplete same-email row"
+        );
+        assert!(row.2, "OAuth verification must mark the row verified");
+
+        let usable_code_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM oauth_codes
+             WHERE tenant_id = 1 AND user_pubkey = $1 AND pending_email IS NULL",
+        )
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(usable_code_count.0, 1, "OAuth code should be minted");
+
+        let key_count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM personal_keys WHERE user_pubkey = $1")
+                .bind(&pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(key_count.0, 1, "personal key must be created once");
 
         cleanup_verify_email_test_data(&pool, &pubkey, &verification_token).await;
     }

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1414,11 +1414,15 @@ impl UserRepository {
     ///
     /// Sets email/password/verified state on the row and inserts the personal
     /// key if one is pending and none exists yet, all in one transaction.
+    /// If the row already carries the pending email (a concurrent request won
+    /// the completion race), this is success: existing credentials are never
+    /// rewritten and only a missing personal key is backfilled.
     ///
     /// # Errors
     ///
     /// Returns [`RepositoryError::NotFound`] if no row exists for this pubkey.
-    /// Returns [`RepositoryError::Duplicate`] if the email is owned by another user.
+    /// Returns [`RepositoryError::Duplicate`] if the email is owned by another
+    /// user or the row is already bound to a different email.
     pub async fn complete_pending_oauth_registration(
         &self,
         pubkey: &str,
@@ -1448,22 +1452,26 @@ impl UserRepository {
         .rows_affected();
 
         if updated == 0 {
-            let exists = sqlx::query_scalar::<_, bool>(
-                "SELECT EXISTS(SELECT 1 FROM users WHERE pubkey = $1 AND tenant_id = $2)",
+            let existing_email = sqlx::query_scalar::<_, Option<String>>(
+                "SELECT email FROM users WHERE pubkey = $1 AND tenant_id = $2",
             )
             .bind(pubkey)
             .bind(tenant_id)
-            .fetch_one(&mut *tx)
+            .fetch_optional(&mut *tx)
             .await?;
 
-            if exists {
-                return Err(RepositoryError::Duplicate);
+            match existing_email {
+                // A concurrent request already applied this exact registration;
+                // fall through so a missing personal key can still be backfilled.
+                Some(Some(existing)) if existing == email => {}
+                Some(_) => return Err(RepositoryError::Duplicate),
+                None => {
+                    return Err(RepositoryError::NotFound(format!(
+                        "no users row for pubkey {} in tenant {}",
+                        pubkey, tenant_id
+                    )));
+                }
             }
-
-            return Err(RepositoryError::NotFound(format!(
-                "no users row for pubkey {} in tenant {}",
-                pubkey, tenant_id
-            )));
         }
 
         if let Some(secret) = encrypted_secret {
@@ -2960,6 +2968,65 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(key_count.0, 0, "failed completion must not insert a key");
+
+        cleanup_user(&pool, &pubkey).await;
+    }
+
+    #[tokio::test]
+    async fn test_complete_pending_oauth_registration_already_applied_email_is_idempotent() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let suffix = test_suffix();
+        let pubkey = Keys::generate().public_key().to_hex();
+        let email = format!("oauth-applied-{}@example.com", suffix);
+        let secret = vec![5_u8; 32];
+
+        // Simulate losing the completion race: a concurrent request already
+        // bound the row to the pending email, but the personal key is missing.
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+             VALUES ($1, 1, $2, 'existing-hash', true, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(&email)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        repo.complete_pending_oauth_registration(
+            &pubkey,
+            1,
+            &email,
+            "pending-hash",
+            "token",
+            Some(&secret),
+        )
+        .await
+        .expect("row already bound to the pending email must be treated as success");
+
+        let row: (Option<String>,) =
+            sqlx::query_as("SELECT password_hash FROM users WHERE pubkey = $1 AND tenant_id = 1")
+                .bind(&pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            row.0.as_deref(),
+            Some("existing-hash"),
+            "idempotent completion must not rewrite existing credentials"
+        );
+
+        let keys: Vec<(Vec<u8>,)> =
+            sqlx::query_as("SELECT encrypted_secret_key FROM personal_keys WHERE user_pubkey = $1")
+                .bind(&pubkey)
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(keys.len(), 1, "missing personal key must be backfilled");
+        assert_eq!(
+            keys[0].0, secret,
+            "backfilled key must hold the pending secret"
+        );
 
         cleanup_user(&pool, &pubkey).await;
     }

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -2553,6 +2553,7 @@ mod tests {
         cleanup_user(&pool, &h2).await;
         cleanup_user(&pool, &h3).await;
     }
+
     #[tokio::test]
     async fn test_clear_verified_minor_clears_flag_and_timestamp() {
         let pool = setup_pool().await;

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1382,6 +1382,34 @@ impl UserRepository {
         .map_err(Into::into)
     }
 
+    /// Insert a missing personal key for an existing OAuth user.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RepositoryError::Database`] if the insert query fails.
+    pub async fn backfill_personal_key(
+        &self,
+        pubkey: &str,
+        tenant_id: i64,
+        encrypted_secret: &[u8],
+    ) -> Result<(), RepositoryError> {
+        let now = Utc::now();
+
+        sqlx::query(
+            "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
+             SELECT $1, $2, $3, $4, $4
+             WHERE NOT EXISTS (SELECT 1 FROM personal_keys WHERE user_pubkey = $1)",
+        )
+        .bind(pubkey)
+        .bind(encrypted_secret)
+        .bind(tenant_id)
+        .bind(now)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
     /// Apply a pending OAuth registration to an existing users row.
     ///
     /// Sets email/password/verified state on the row and inserts the personal
@@ -1407,7 +1435,7 @@ impl UserRepository {
             "UPDATE users
              SET email = $1, password_hash = $2, email_verified = true,
                  email_verification_token = $3, updated_at = $4
-             WHERE pubkey = $5 AND tenant_id = $6",
+             WHERE pubkey = $5 AND tenant_id = $6 AND email IS NULL",
         )
         .bind(email)
         .bind(password_hash)
@@ -1420,6 +1448,18 @@ impl UserRepository {
         .rows_affected();
 
         if updated == 0 {
+            let exists = sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS(SELECT 1 FROM users WHERE pubkey = $1 AND tenant_id = $2)",
+            )
+            .bind(pubkey)
+            .bind(tenant_id)
+            .fetch_one(&mut *tx)
+            .await?;
+
+            if exists {
+                return Err(RepositoryError::Duplicate);
+            }
+
             return Err(RepositoryError::NotFound(format!(
                 "no users row for pubkey {} in tenant {}",
                 pubkey, tenant_id
@@ -2866,6 +2906,61 @@ mod tests {
         assert!(!row.1, "failed completion must roll back email_verified");
 
         cleanup_user(&pool, &owner_pubkey).await;
+        cleanup_user(&pool, &pubkey).await;
+    }
+
+    #[tokio::test]
+    async fn test_complete_pending_oauth_registration_bound_row_returns_duplicate() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let suffix = test_suffix();
+        let pubkey = Keys::generate().public_key().to_hex();
+        let existing_email = format!("oauth-bound-existing-{}@example.com", suffix);
+        let pending_email = format!("oauth-bound-pending-{}@example.com", suffix);
+
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+             VALUES ($1, 1, $2, 'existing-hash', true, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(&existing_email)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let result = repo
+            .complete_pending_oauth_registration(
+                &pubkey,
+                1,
+                &pending_email,
+                "pending-hash",
+                "token",
+                Some(&[1_u8; 32]),
+            )
+            .await;
+        assert!(
+            matches!(result, Err(RepositoryError::Duplicate)),
+            "completing a row already bound to an email must fail with Duplicate, got: {result:?}"
+        );
+
+        let row: (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT email, password_hash FROM users WHERE pubkey = $1 AND tenant_id = 1",
+        )
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0.as_deref(), Some(existing_email.as_str()));
+        assert_eq!(row.1.as_deref(), Some("existing-hash"));
+
+        let key_count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM personal_keys WHERE user_pubkey = $1")
+                .bind(&pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(key_count.0, 0, "failed completion must not insert a key");
+
         cleanup_user(&pool, &pubkey).await;
     }
 

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -34,6 +34,10 @@ pub struct VerificationTokenData {
 pub struct OAuthRegistrationState {
     /// Email currently on the row, if any.
     pub email: Option<String>,
+    /// Whether the row has completed email verification.
+    pub email_verified: bool,
+    /// Whether the row has a password hash ready for password login.
+    pub has_password_hash: bool,
     /// Whether a personal_keys row exists for this pubkey.
     pub has_personal_key: bool,
 }
@@ -1372,6 +1376,8 @@ impl UserRepository {
     ) -> Result<Option<OAuthRegistrationState>, RepositoryError> {
         sqlx::query_as(
             "SELECT u.email,
+                    u.email_verified,
+                    u.password_hash IS NOT NULL AS has_password_hash,
                     EXISTS(SELECT 1 FROM personal_keys pk WHERE pk.user_pubkey = u.pubkey) AS has_personal_key
              FROM users u WHERE u.pubkey = $1 AND u.tenant_id = $2",
         )
@@ -1397,8 +1403,8 @@ impl UserRepository {
 
         sqlx::query(
             "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
-             SELECT $1, $2, $3, $4, $4
-             WHERE NOT EXISTS (SELECT 1 FROM personal_keys WHERE user_pubkey = $1)",
+             VALUES ($1, $2, $3, $4, $4)
+             ON CONFLICT (user_pubkey) DO NOTHING",
         )
         .bind(pubkey)
         .bind(encrypted_secret)
@@ -1437,9 +1443,14 @@ impl UserRepository {
 
         let updated = sqlx::query(
             "UPDATE users
-             SET email = $1, password_hash = $2, email_verified = true,
+             SET email = $1, password_hash = COALESCE(password_hash, $2), email_verified = true,
                  email_verification_token = $3, updated_at = $4
-             WHERE pubkey = $5 AND tenant_id = $6 AND email IS NULL",
+             WHERE pubkey = $5
+               AND tenant_id = $6
+               AND (
+                   email IS NULL
+                   OR (email = $1 AND (email_verified = false OR password_hash IS NULL))
+               )",
         )
         .bind(email)
         .bind(password_hash)
@@ -1452,18 +1463,19 @@ impl UserRepository {
         .rows_affected();
 
         if updated == 0 {
-            let existing_email = sqlx::query_scalar::<_, Option<String>>(
-                "SELECT email FROM users WHERE pubkey = $1 AND tenant_id = $2",
+            let existing_state = sqlx::query_as::<_, (Option<String>, bool, bool)>(
+                "SELECT email, email_verified, password_hash IS NOT NULL AS has_password_hash
+                 FROM users WHERE pubkey = $1 AND tenant_id = $2",
             )
             .bind(pubkey)
             .bind(tenant_id)
             .fetch_optional(&mut *tx)
             .await?;
 
-            match existing_email {
+            match existing_state {
                 // A concurrent request already applied this exact registration;
                 // fall through so a missing personal key can still be backfilled.
-                Some(Some(existing)) if existing == email => {}
+                Some((Some(existing), true, true)) if existing == email => {}
                 Some(_) => return Err(RepositoryError::Duplicate),
                 None => {
                     return Err(RepositoryError::NotFound(format!(
@@ -1477,8 +1489,8 @@ impl UserRepository {
         if let Some(secret) = encrypted_secret {
             sqlx::query(
                 "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
-                 SELECT $1, $2, $3, $4, $4
-                 WHERE NOT EXISTS (SELECT 1 FROM personal_keys WHERE user_pubkey = $1)",
+                 VALUES ($1, $2, $3, $4, $4)
+                 ON CONFLICT (user_pubkey) DO NOTHING",
             )
             .bind(pubkey)
             .bind(secret)
@@ -2778,6 +2790,8 @@ mod tests {
             .unwrap()
             .expect("bare row should have state");
         assert_eq!(bare_state.email, None);
+        assert!(!bare_state.email_verified);
+        assert!(!bare_state.has_password_hash);
         assert!(!bare_state.has_personal_key);
 
         let full_state = repo
@@ -2786,6 +2800,8 @@ mod tests {
             .unwrap()
             .expect("full row should have state");
         assert_eq!(full_state.email.as_deref(), Some(email.as_str()));
+        assert!(full_state.email_verified);
+        assert!(full_state.has_password_hash);
         assert!(full_state.has_personal_key);
 
         cleanup_user(&pool, &bare_pubkey).await;
@@ -2871,6 +2887,33 @@ mod tests {
                 .unwrap();
         assert_eq!(keys.len(), 1, "existing key must not be duplicated");
         assert_eq!(keys[0].0, existing_secret, "existing key must be preserved");
+
+        cleanup_user(&pool, &pubkey).await;
+    }
+
+    #[tokio::test]
+    async fn test_backfill_personal_key_is_idempotent() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let pubkey = Keys::generate().public_key().to_hex();
+
+        create_bare_user(&pool, &pubkey).await;
+
+        repo.backfill_personal_key(&pubkey, 1, &[1_u8; 32])
+            .await
+            .unwrap();
+        repo.backfill_personal_key(&pubkey, 1, &[2_u8; 32])
+            .await
+            .unwrap();
+
+        let keys: Vec<(Vec<u8>,)> =
+            sqlx::query_as("SELECT encrypted_secret_key FROM personal_keys WHERE user_pubkey = $1")
+                .bind(&pubkey)
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(keys.len(), 1, "backfill must not duplicate personal keys");
+        assert_eq!(keys[0].0, vec![1_u8; 32], "first key must be preserved");
 
         cleanup_user(&pool, &pubkey).await;
     }
@@ -3028,6 +3071,61 @@ mod tests {
             keys[0].0, secret,
             "backfilled key must hold the pending secret"
         );
+
+        cleanup_user(&pool, &pubkey).await;
+    }
+
+    #[tokio::test]
+    async fn test_complete_pending_oauth_registration_completes_same_email_incomplete_row() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let suffix = test_suffix();
+        let pubkey = Keys::generate().public_key().to_hex();
+        let email = format!("oauth-incomplete-{}@example.com", suffix);
+        let secret = vec![6_u8; 32];
+
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+             VALUES ($1, 1, $2, NULL, false, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(&email)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        repo.complete_pending_oauth_registration(
+            &pubkey,
+            1,
+            &email,
+            "pending-hash",
+            "token",
+            Some(&secret),
+        )
+        .await
+        .expect("same-email incomplete row should be completed");
+
+        let row: (Option<String>, Option<String>, bool, Option<String>) = sqlx::query_as(
+            "SELECT email, password_hash, email_verified, email_verification_token
+             FROM users WHERE pubkey = $1 AND tenant_id = 1",
+        )
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0.as_deref(), Some(email.as_str()));
+        assert_eq!(row.1.as_deref(), Some("pending-hash"));
+        assert!(row.2, "same-email row must be marked verified");
+        assert_eq!(row.3.as_deref(), Some("token"));
+
+        let keys: Vec<(Vec<u8>,)> =
+            sqlx::query_as("SELECT encrypted_secret_key FROM personal_keys WHERE user_pubkey = $1")
+                .bind(&pubkey)
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(keys.len(), 1, "missing personal key must be backfilled");
+        assert_eq!(keys[0].0, secret);
 
         cleanup_user(&pool, &pubkey).await;
     }

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -25,6 +25,19 @@ pub struct VerificationTokenData {
     pub email_verified: bool,
 }
 
+/// Snapshot of an existing users row used to gate OAuth registration finalization.
+///
+/// Distinguishes a genuine registration retry (row already carries the pending
+/// email) from a bare row created by another path (team membership, authorization
+/// pre-creation) that still needs the pending credentials applied.
+#[derive(Debug, FromRow)]
+pub struct OAuthRegistrationState {
+    /// Email currently on the row, if any.
+    pub email: Option<String>,
+    /// Whether a personal_keys row exists for this pubkey.
+    pub has_personal_key: bool,
+}
+
 /// Which side of a pending email change a token belongs to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PendingEmailSide {
@@ -1349,6 +1362,88 @@ impl UserRepository {
         Ok(())
     }
 
+    /// Fetch the registration-relevant state of an existing users row.
+    ///
+    /// Returns `None` when no row exists for this pubkey in the tenant.
+    pub async fn oauth_registration_state(
+        &self,
+        pubkey: &str,
+        tenant_id: i64,
+    ) -> Result<Option<OAuthRegistrationState>, RepositoryError> {
+        sqlx::query_as(
+            "SELECT u.email,
+                    EXISTS(SELECT 1 FROM personal_keys pk WHERE pk.user_pubkey = u.pubkey) AS has_personal_key
+             FROM users u WHERE u.pubkey = $1 AND u.tenant_id = $2",
+        )
+        .bind(pubkey)
+        .bind(tenant_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    /// Apply a pending OAuth registration to an existing users row.
+    ///
+    /// Sets email/password/verified state on the row and inserts the personal
+    /// key if one is pending and none exists yet, all in one transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RepositoryError::NotFound`] if no row exists for this pubkey.
+    /// Returns [`RepositoryError::Duplicate`] if the email is owned by another user.
+    pub async fn complete_pending_oauth_registration(
+        &self,
+        pubkey: &str,
+        tenant_id: i64,
+        email: &str,
+        password_hash: &str,
+        verification_token: &str,
+        encrypted_secret: Option<&[u8]>,
+    ) -> Result<(), RepositoryError> {
+        let mut tx = self.pool.begin().await?;
+        let now = Utc::now();
+
+        let updated = sqlx::query(
+            "UPDATE users
+             SET email = $1, password_hash = $2, email_verified = true,
+                 email_verification_token = $3, updated_at = $4
+             WHERE pubkey = $5 AND tenant_id = $6",
+        )
+        .bind(email)
+        .bind(password_hash)
+        .bind(verification_token)
+        .bind(now)
+        .bind(pubkey)
+        .bind(tenant_id)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+
+        if updated == 0 {
+            return Err(RepositoryError::NotFound(format!(
+                "no users row for pubkey {} in tenant {}",
+                pubkey, tenant_id
+            )));
+        }
+
+        if let Some(secret) = encrypted_secret {
+            sqlx::query(
+                "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
+                 SELECT $1, $2, $3, $4, $4
+                 WHERE NOT EXISTS (SELECT 1 FROM personal_keys WHERE user_pubkey = $1)",
+            )
+            .bind(pubkey)
+            .bind(secret)
+            .bind(tenant_id)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
     /// Change user's key in a single transaction.
     ///
     /// Performs a complete key rotation:
@@ -2410,7 +2505,6 @@ mod tests {
         cleanup_user(&pool, &h2).await;
         cleanup_user(&pool, &h3).await;
     }
-
     #[tokio::test]
     async fn test_clear_verified_minor_clears_flag_and_timestamp() {
         let pool = setup_pool().await;
@@ -2576,5 +2670,224 @@ mod tests {
         assert!(!verified_minor);
 
         cleanup_user(&pool, &pubkey).await;
+    }
+
+    async fn create_bare_user(pool: &PgPool, pubkey: &str) {
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+             VALUES ($1, 1, NOW(), NOW())",
+        )
+        .bind(pubkey)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_oauth_registration_state_none_for_unknown_user() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool);
+        let pubkey = Keys::generate().public_key().to_hex();
+
+        let state = repo.oauth_registration_state(&pubkey, 1).await.unwrap();
+        assert!(state.is_none(), "Unknown pubkey should have no state");
+    }
+
+    #[tokio::test]
+    async fn test_oauth_registration_state_reports_email_and_key_presence() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let suffix = test_suffix();
+
+        let bare_pubkey = Keys::generate().public_key().to_hex();
+        create_bare_user(&pool, &bare_pubkey).await;
+
+        let full_pubkey = Keys::generate().public_key().to_hex();
+        let email = format!("oauth-state-{}@example.com", suffix);
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, created_at, updated_at)
+             VALUES ($1, 1, $2, 'hash', true, NOW(), NOW())",
+        )
+        .bind(&full_pubkey)
+        .bind(&email)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
+             VALUES ($1, $2, 1, NOW(), NOW())",
+        )
+        .bind(&full_pubkey)
+        .bind(vec![1_u8, 2, 3])
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let bare_state = repo
+            .oauth_registration_state(&bare_pubkey, 1)
+            .await
+            .unwrap()
+            .expect("bare row should have state");
+        assert_eq!(bare_state.email, None);
+        assert!(!bare_state.has_personal_key);
+
+        let full_state = repo
+            .oauth_registration_state(&full_pubkey, 1)
+            .await
+            .unwrap()
+            .expect("full row should have state");
+        assert_eq!(full_state.email.as_deref(), Some(email.as_str()));
+        assert!(full_state.has_personal_key);
+
+        cleanup_user(&pool, &bare_pubkey).await;
+        cleanup_user(&pool, &full_pubkey).await;
+    }
+
+    #[tokio::test]
+    async fn test_complete_pending_oauth_registration_applies_pending_to_bare_row() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let suffix = test_suffix();
+        let pubkey = Keys::generate().public_key().to_hex();
+        let email = format!("oauth-complete-{}@example.com", suffix);
+        let token = format!("token-{}", suffix);
+        let secret = vec![7_u8; 32];
+
+        create_bare_user(&pool, &pubkey).await;
+
+        repo.complete_pending_oauth_registration(&pubkey, 1, &email, "hash", &token, Some(&secret))
+            .await
+            .unwrap();
+
+        let row: (Option<String>, Option<String>, bool, Option<String>) = sqlx::query_as(
+            "SELECT email, password_hash, email_verified, email_verification_token
+             FROM users WHERE pubkey = $1 AND tenant_id = 1",
+        )
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0.as_deref(), Some(email.as_str()));
+        assert_eq!(row.1.as_deref(), Some("hash"));
+        assert!(row.2, "email_verified should be set");
+        assert_eq!(row.3.as_deref(), Some(token.as_str()));
+
+        let stored_secret: (Vec<u8>,) =
+            sqlx::query_as("SELECT encrypted_secret_key FROM personal_keys WHERE user_pubkey = $1")
+                .bind(&pubkey)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(stored_secret.0, secret);
+
+        cleanup_user(&pool, &pubkey).await;
+    }
+
+    #[tokio::test]
+    async fn test_complete_pending_oauth_registration_keeps_existing_personal_key() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let suffix = test_suffix();
+        let pubkey = Keys::generate().public_key().to_hex();
+        let email = format!("oauth-keep-key-{}@example.com", suffix);
+        let existing_secret = vec![9_u8; 32];
+
+        create_bare_user(&pool, &pubkey).await;
+        sqlx::query(
+            "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
+             VALUES ($1, $2, 1, NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(&existing_secret)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        repo.complete_pending_oauth_registration(
+            &pubkey,
+            1,
+            &email,
+            "hash",
+            "token",
+            Some(&[1_u8; 32]),
+        )
+        .await
+        .unwrap();
+
+        let keys: Vec<(Vec<u8>,)> =
+            sqlx::query_as("SELECT encrypted_secret_key FROM personal_keys WHERE user_pubkey = $1")
+                .bind(&pubkey)
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(keys.len(), 1, "existing key must not be duplicated");
+        assert_eq!(keys[0].0, existing_secret, "existing key must be preserved");
+
+        cleanup_user(&pool, &pubkey).await;
+    }
+
+    #[tokio::test]
+    async fn test_complete_pending_oauth_registration_duplicate_email_rolls_back() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let suffix = test_suffix();
+        let email = format!("oauth-dup-{}@example.com", suffix);
+
+        let owner_pubkey = Keys::generate().public_key().to_hex();
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, email, created_at, updated_at)
+             VALUES ($1, 1, $2, NOW(), NOW())",
+        )
+        .bind(&owner_pubkey)
+        .bind(&email)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let pubkey = Keys::generate().public_key().to_hex();
+        create_bare_user(&pool, &pubkey).await;
+
+        let result = repo
+            .complete_pending_oauth_registration(&pubkey, 1, &email, "hash", "token", None)
+            .await;
+        assert!(
+            matches!(result, Err(RepositoryError::Duplicate)),
+            "claiming an owned email must fail with Duplicate, got: {result:?}"
+        );
+
+        let row: (Option<String>, bool) = sqlx::query_as(
+            "SELECT email, email_verified FROM users WHERE pubkey = $1 AND tenant_id = 1",
+        )
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, None, "failed completion must roll back the email");
+        assert!(!row.1, "failed completion must roll back email_verified");
+
+        cleanup_user(&pool, &owner_pubkey).await;
+        cleanup_user(&pool, &pubkey).await;
+    }
+
+    #[tokio::test]
+    async fn test_complete_pending_oauth_registration_unknown_user_not_found() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool);
+        let pubkey = Keys::generate().public_key().to_hex();
+
+        let result = repo
+            .complete_pending_oauth_registration(
+                &pubkey,
+                1,
+                "oauth-missing@example.com",
+                "hash",
+                "token",
+                None,
+            )
+            .await;
+        assert!(
+            matches!(result, Err(RepositoryError::NotFound(_))),
+            "completing a missing row must fail with NotFound, got: {result:?}"
+        );
     }
 }

--- a/database/migrations/20260720120000_unique_personal_keys_user_pubkey.sql
+++ b/database/migrations/20260720120000_unique_personal_keys_user_pubkey.sql
@@ -1,0 +1,16 @@
+WITH ranked_personal_keys AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY user_pubkey
+            ORDER BY updated_at DESC NULLS LAST, created_at DESC NULLS LAST, id DESC
+        ) AS row_number
+    FROM personal_keys
+)
+DELETE FROM personal_keys pk
+USING ranked_personal_keys ranked
+WHERE pk.id = ranked.id
+  AND ranked.row_number > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_personal_keys_user_pubkey_unique
+    ON personal_keys (user_pubkey);


### PR DESCRIPTION
## Summary

OAuth email verification now distinguishes a completed retry from an incomplete same-email users row.
Same-email rows that are still unverified or missing a password hash are completed before an OAuth code is minted.
Personal-key repair inserts are backed by a unique `personal_keys(user_pubkey)` index and use `ON CONFLICT DO NOTHING`, so concurrent retries cannot create duplicate key rows.

## Motivation

Some server paths create bare or incomplete `users` rows before OAuth email verification finishes.
The old idempotency check treated any matching email as completed registration, which could report success while leaving the row unverified or incomplete.
The personal-key repair path also relied on a non-atomic `NOT EXISTS` guard without a database uniqueness constraint.

## Related Issue

- Closes #264

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo test --workspace`
- [x] `cargo test -p keycast_core --features integration-tests oauth_registration_state`
- [x] `cargo test -p keycast_core --features integration-tests complete_pending_oauth_registration`
- [x] `cargo test -p keycast_core --features integration-tests backfill_personal_key_is_idempotent`
- [x] `cargo test -p keycast_api --features integration-tests verify_email_completes_same_email_unverified_row_before_minting`
- [x] `DATABASE_URL=postgres://postgres:password@127.0.0.1:5432/keycast_test REDIS_URL=redis://127.0.0.1:16379 TEST_REDIS_URL=redis://127.0.0.1:16379 cargo test -p keycast_core --features integration-tests --lib -- --test-threads=1`
- [x] `DATABASE_URL=postgres://postgres:password@127.0.0.1:5432/keycast_test REDIS_URL=redis://127.0.0.1:16379 TEST_REDIS_URL=redis://127.0.0.1:16379 cargo test -p keycast_api --features integration-tests --lib --tests -- --test-threads=1`
- [ ] Manual verification completed (no UI change; covered by integration tests)

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
