### PR TITLE
refactor(user-repo): consolidate account-status tuple queries onto a FromRow struct

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -15,8 +15,8 @@ use crate::api::error::{ApiError, ApiResult};
 use crate::api::extractors::UcanAuth;
 use keycast_core::repositories::{
     test_redirect_pattern, AdminAuditEventRecord, AdminAuditEventRepository, AuthEventRepository,
-    ClaimTokenRepository, OAuthAuthorizationRepository, RegisteredClient,
-    RegisteredClientRepository, RepositoryError, UserRepository,
+    ClaimTokenRepository, FullAdminStatusRow, OAuthAuthorizationRepository, RegisteredClient,
+    RegisteredClientRepository, RepositoryError, UserRepository, VerifiedMinorRow,
 };
 use keycast_core::types::claim_token::generate_claim_token;
 use keycast_core::types::user::UserStatus;
@@ -1860,7 +1860,13 @@ pub async fn get_user_status_admin(
     let tenant_id = tenant.0.id;
     let user_repo = UserRepository::new(auth_state.state.db.clone());
 
-    let (status, suspended_reason, suspended_at, verified_minor, verified_minor_at) = user_repo
+    let FullAdminStatusRow {
+        status,
+        suspended_reason,
+        suspended_at,
+        verified_minor,
+        verified_minor_at,
+    } = user_repo
         .get_full_admin_status(&pubkey, tenant_id)
         .await?
         .ok_or_else(|| ApiError::not_found("User not found"))?;
@@ -1929,10 +1935,16 @@ pub async fn set_user_status_admin(
 
     // set_user_status doesn't return verified_minor, so fetch it separately.
     // This is the write path (infrequent), so the extra query is acceptable.
-    let (verified_minor, verified_minor_at) = user_repo
+    let VerifiedMinorRow {
+        verified_minor,
+        verified_minor_at,
+    } = user_repo
         .get_verified_minor(&pubkey, tenant_id)
         .await?
-        .unwrap_or((false, None));
+        .unwrap_or(VerifiedMinorRow {
+            verified_minor: false,
+            verified_minor_at: None,
+        });
 
     Ok(Json(UserStatusResponse {
         pubkey,
@@ -2092,7 +2104,13 @@ pub async fn clear_verified_minor_admin(
         );
     }
 
-    let (status, suspended_reason, suspended_at, verified_minor, verified_minor_at) = user_repo
+    let FullAdminStatusRow {
+        status,
+        suspended_reason,
+        suspended_at,
+        verified_minor,
+        verified_minor_at,
+    } = user_repo
         .get_full_admin_status(&pubkey, tenant_id)
         .await?
         .ok_or_else(|| ApiError::not_found("User not found"))?;

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -18,8 +18,9 @@ use crate::brand::BRAND_NAME;
 use crate::nip98;
 use keycast_core::metrics::METRICS;
 use keycast_core::repositories::{
-    CreateOAuthAuthorizationParams, OAuthAuthorizationRepository, OAuthCodeRepository,
-    PersonalKeysRepository, PolicyRepository, UserRepository,
+    AccountStatusWithMinorRow, CreateOAuthAuthorizationParams, OAuthAuthorizationRepository,
+    OAuthCodeRepository, PersonalKeysRepository, PolicyRepository, UserRepository,
+    VerifiedMinorRow,
 };
 use keycast_core::traits::CustomPermission;
 use nostr_sdk::{Keys, PublicKey, ToBech32, UnsignedEvent};
@@ -2426,14 +2427,14 @@ pub async fn get_account_status(
         .await?;
 
     match user {
-        Some((
+        Some(AccountStatusWithMinorRow {
             email,
             email_verified,
             status,
             suspended_reason,
             verified_minor,
             verified_minor_at,
-        )) => Ok(Json(AccountStatusResponse::from_account_row(
+        }) => Ok(Json(AccountStatusResponse::from_account_row(
             user_pubkey,
             email,
             email_verified,
@@ -3276,7 +3277,7 @@ pub async fn sign_event(
                 .get_verified_minor(&user_pubkey, tenant_id)
                 .await?
                 .ok_or_else(|| AuthError::Forbidden("Operation denied by policy".to_string()))?
-                .0
+                .verified_minor
         } else {
             false
         };
@@ -3914,7 +3915,10 @@ async fn refuse_key_egress_for_verified_minor(
 ) -> Result<(), AuthError> {
     let is_non_minor = matches!(
         user_repo.get_verified_minor(user_pubkey, tenant_id).await?,
-        Some((false, _))
+        Some(VerifiedMinorRow {
+            verified_minor: false,
+            ..
+        })
     );
     if !is_non_minor {
         tracing::warn!(

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -531,12 +531,12 @@ pub async fn auth_status(
 
         // Return authenticated with pubkey, optionally with email info if user exists in DB
         // NIP-07 admins may not have a user record, but their UCAN session is still valid
-        if let Some((email, email_verified, _status, _reason)) = user_info {
+        if let Some(account) = user_info {
             Ok(Json(AuthStatusResponse {
                 authenticated: true,
                 pubkey: Some(user_pubkey),
-                email,
-                email_verified,
+                email: account.email,
+                email_verified: account.email_verified,
             }))
         } else {
             // User not in DB (NIP-07 admin) - still authenticated via UCAN
@@ -625,7 +625,7 @@ pub async fn authorize_get(
                     tracing::warn!("UCAN cookie has pubkey {} but user doesn't exist in tenant {}, clearing stale cookie", pubkey, tenant_id);
                     (None, true, None) // User was deleted, clear the cookie
                 }
-                Some((email, _verified, _status, _reason)) => (user_pubkey, false, email),
+                Some(account) => (user_pubkey, false, account.email),
             }
         }
     } else {

--- a/api/tests/account_status_minor_test.rs
+++ b/api/tests/account_status_minor_test.rs
@@ -5,7 +5,7 @@
 
 mod common;
 
-use keycast_core::repositories::UserRepository;
+use keycast_core::repositories::{AccountStatusWithMinorRow, UserRepository};
 use nostr_sdk::Keys;
 use sqlx::PgPool;
 
@@ -43,11 +43,16 @@ async fn approved_minor_surfaces_flag_while_active() {
     let repo = UserRepository::new(pool.clone());
     let pubkey = insert_user(&pool, true).await;
 
-    let (_email, _email_verified, status, _suspended_reason, verified_minor, verified_minor_at) =
-        repo.get_account_status_with_minor(&pubkey, TENANT_ID)
-            .await
-            .expect("query ok")
-            .expect("user exists");
+    let AccountStatusWithMinorRow {
+        status,
+        verified_minor,
+        verified_minor_at,
+        ..
+    } = repo
+        .get_account_status_with_minor(&pubkey, TENANT_ID)
+        .await
+        .expect("query ok")
+        .expect("user exists");
 
     // The whole point of keycast#263: an approved minor is `active`, yet the flag must
     // still come through so clients can detect the protected-minor state.
@@ -69,7 +74,11 @@ async fn regular_user_reports_not_a_minor() {
     let repo = UserRepository::new(pool.clone());
     let pubkey = insert_user(&pool, false).await;
 
-    let (.., verified_minor, verified_minor_at) = repo
+    let AccountStatusWithMinorRow {
+        verified_minor,
+        verified_minor_at,
+        ..
+    } = repo
         .get_account_status_with_minor(&pubkey, TENANT_ID)
         .await
         .expect("query ok")

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -39,6 +39,7 @@ pub use registered_client::{
 pub use stored_key::StoredKeyRepository;
 pub use team::TeamRepository;
 pub use user::{
-    AdminUserDetails, ClaimConsumeOutcome, DeleteAccountResult, FinalizeEmailOutcome,
-    PendingEmailChange, PendingEmailSide, UserRepository, VerificationTokenData,
+    AccountStatusRow, AccountStatusWithMinorRow, AdminUserDetails, ClaimConsumeOutcome,
+    DeleteAccountResult, FinalizeEmailOutcome, FullAdminStatusRow, PendingEmailChange,
+    PendingEmailSide, UserRepository, VerificationTokenData, VerifiedMinorRow,
 };

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -71,6 +71,51 @@ pub struct AdminUserDetails {
     pub updated_at: DateTime<Utc>,
 }
 
+// Row structs backing the account-status / verified_minor safeguard queries below.
+// `FromRow` maps by column name, so callers read named fields and the six-column
+// shape can no longer be mis-ordered the way a positional tuple can. These are
+// per-method rather than one over-selecting struct so every query's `SELECT` list
+// stays byte-for-byte identical, including the oauth hot-path `get_account_status`.
+
+/// Email + status for `get_account_status` (oauth login/session path).
+#[derive(Debug, FromRow)]
+pub struct AccountStatusRow {
+    pub email: Option<String>,
+    pub email_verified: Option<bool>,
+    pub status: UserStatus,
+    pub suspended_reason: Option<String>,
+}
+
+/// `AccountStatusRow` plus the approved-minor flag/timestamp for
+/// `get_account_status_with_minor` (backs `GET /user/account`).
+#[derive(Debug, FromRow)]
+pub struct AccountStatusWithMinorRow {
+    pub email: Option<String>,
+    pub email_verified: Option<bool>,
+    pub status: UserStatus,
+    pub suspended_reason: Option<String>,
+    pub verified_minor: bool,
+    pub verified_minor_at: Option<DateTime<Utc>>,
+}
+
+/// Verified-minor flag + timestamp for `get_verified_minor`.
+#[derive(Debug, FromRow)]
+pub struct VerifiedMinorRow {
+    pub verified_minor: bool,
+    pub verified_minor_at: Option<DateTime<Utc>>,
+}
+
+/// Status + suspension + verified-minor fields for `get_full_admin_status`
+/// (admin status endpoints).
+#[derive(Debug, FromRow)]
+pub struct FullAdminStatusRow {
+    pub status: UserStatus,
+    pub suspended_reason: Option<String>,
+    pub suspended_at: Option<DateTime<Utc>>,
+    pub verified_minor: bool,
+    pub verified_minor_at: Option<DateTime<Utc>>,
+}
+
 /// Outcome of atomically consuming a claim token and claiming the account.
 /// Only `Claimed` mutates anything; the other outcomes guarantee both the
 /// token and the user row are untouched (see
@@ -936,8 +981,7 @@ impl UserRepository {
         &self,
         pubkey: &str,
         tenant_id: i64,
-    ) -> Result<Option<(Option<String>, Option<bool>, UserStatus, Option<String>)>, RepositoryError>
-    {
+    ) -> Result<Option<AccountStatusRow>, RepositoryError> {
         sqlx::query_as(
             "SELECT email, email_verified, status, suspended_reason FROM users WHERE pubkey = $1 AND tenant_id = $2",
         )
@@ -948,26 +992,16 @@ impl UserRepository {
         .map_err(Into::into)
     }
 
-    /// Like `get_account_status`, but also returns the approved-minor flag and timestamp.
+    /// Like `get_account_status`, but also returns the approved-minor flag and timestamp
+    /// (see [`AccountStatusWithMinorRow`]).
     /// Backs `GET /user/account` so clients can detect the protected-minor (13-15) state
     /// directly from Keycast. Kept separate from `get_account_status` so the oauth
     /// login/session paths that share that method are untouched.
-    /// Returns (email, email_verified, status, suspended_reason, verified_minor, verified_minor_at).
     pub async fn get_account_status_with_minor(
         &self,
         pubkey: &str,
         tenant_id: i64,
-    ) -> Result<
-        Option<(
-            Option<String>,
-            Option<bool>,
-            UserStatus,
-            Option<String>,
-            bool,
-            Option<DateTime<Utc>>,
-        )>,
-        RepositoryError,
-    > {
+    ) -> Result<Option<AccountStatusWithMinorRow>, RepositoryError> {
         sqlx::query_as(
             "SELECT email, email_verified, status, suspended_reason, verified_minor, verified_minor_at \
              FROM users WHERE pubkey = $1 AND tenant_id = $2",
@@ -1409,7 +1443,7 @@ impl UserRepository {
         &self,
         pubkey: &str,
         tenant_id: i64,
-    ) -> Result<Option<(bool, Option<DateTime<Utc>>)>, RepositoryError> {
+    ) -> Result<Option<VerifiedMinorRow>, RepositoryError> {
         sqlx::query_as(
             "SELECT verified_minor, verified_minor_at FROM users WHERE pubkey = $1 AND tenant_id = $2",
         )
@@ -1467,16 +1501,7 @@ impl UserRepository {
         &self,
         pubkey: &str,
         tenant_id: i64,
-    ) -> Result<
-        Option<(
-            UserStatus,
-            Option<String>,
-            Option<DateTime<Utc>>,
-            bool,
-            Option<DateTime<Utc>>,
-        )>,
-        RepositoryError,
-    > {
+    ) -> Result<Option<FullAdminStatusRow>, RepositoryError> {
         sqlx::query_as(
             "SELECT status, suspended_reason, suspended_at, verified_minor, verified_minor_at \
              FROM users WHERE pubkey = $1 AND tenant_id = $2",
@@ -2404,8 +2429,10 @@ mod tests {
         let transitioned = repo.clear_verified_minor(&pubkey, 1).await.unwrap();
         assert!(transitioned, "clearing a set flag is a real transition");
 
-        let (verified_minor, verified_minor_at) =
-            repo.get_verified_minor(&pubkey, 1).await.unwrap().unwrap();
+        let VerifiedMinorRow {
+            verified_minor,
+            verified_minor_at,
+        } = repo.get_verified_minor(&pubkey, 1).await.unwrap().unwrap();
         assert!(!verified_minor);
         assert!(verified_minor_at.is_none());
 
@@ -2492,8 +2519,10 @@ mod tests {
         assert!(matches!(result, Err(RepositoryError::NotFound(_))));
 
         // Tenant-1 flag is untouched.
-        let (verified_minor, verified_minor_at) =
-            repo.get_verified_minor(&pubkey, 1).await.unwrap().unwrap();
+        let VerifiedMinorRow {
+            verified_minor,
+            verified_minor_at,
+        } = repo.get_verified_minor(&pubkey, 1).await.unwrap().unwrap();
         assert!(
             verified_minor,
             "tenant-1 flag must survive a tenant-2 clear attempt"
@@ -2530,7 +2559,13 @@ mod tests {
 
         assert!(repo.clear_verified_minor(&pubkey, 1).await.unwrap());
 
-        let (status, suspended_reason, suspended_at, verified_minor, _) = repo
+        let FullAdminStatusRow {
+            status,
+            suspended_reason,
+            suspended_at,
+            verified_minor,
+            ..
+        } = repo
             .get_full_admin_status(&pubkey, 1)
             .await
             .unwrap()


### PR DESCRIPTION
## Summary

- Replace the four positional-tuple `SELECT ... FROM users` methods in `core/src/repositories/user.rs` (`get_account_status`, `get_account_status_with_minor`, `get_verified_minor`, `get_full_admin_status`) with per-method `#[derive(sqlx::FromRow)]` row structs, so every call site reads named fields instead of `.0`/`.1` or a six-element destructure.

## Motivation

- The six-element positional tuple from `get_account_status_with_minor` is easy to mis-order, which surfaced during the keycast#263 review (#266). These are the protected-minor / account-status safeguard paths, so a silent field swap here is a correctness-and-safety hazard. `FromRow` maps by column name, so the shape can no longer be destructured in the wrong order.
- Design tradeoff: I used four per-method structs rather than one struct that always selects the full column set. The single-struct option is a bit less boilerplate, but it would rewrite the `SELECT` list of all four queries (including the oauth login/session hot-path `get_account_status`, which is deliberately kept minimal) and would need `#[sqlx(default)]` on absent columns, silently fabricating defaults. Per-method structs keep every query byte-for-byte identical and never carry a column the query didn't select. The cost is four small structs with some overlapping fields, which stays local to `user.rs`.
- Pure refactor: no query text, binds, or returned values change, only the shape callers read.

## Related Issue

- Closes #267
- Part of divinevideo/support-trust-safety#173

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] Full core + api integration suites (CI parity, Postgres+Redis via `docker-compose.deps.yml`): core `151` tests, api `~330` across ~40 binaries, `0` failures. Directly covers `account_status_minor_test`, `verified_minor_dm_gate_test`, `verified_minor_key_egress_test`, the oauth/session paths, and the `core::repositories::user` tests exercising `get_verified_minor` / `get_full_admin_status`.
- [x] Compiler backstop: retargeting the return types makes any unconverted call site fail to build, so a clean `--workspace` build proves all call sites were migrated.

## Visuals

- [x] No visual change
