### PR TITLE
feat(minor-safety): durable admin_audit_events for user status changes (#279)

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -1885,6 +1885,11 @@ pub async fn get_user_status_admin(
 pub struct SetUserStatusRequest {
     pub status: String,
     pub reason: Option<String>,
+    /// Moderator's hex pubkey. Optional; when present and the status actually
+    /// changes it drives the durable admin_audit_events row. That table's
+    /// actor_pubkey is NOT NULL, so an absent actor falls back to log-only
+    /// (same contract as clear_verified_minor_admin).
+    pub actor: Option<String>,
 }
 
 pub async fn set_user_status_admin(
@@ -1909,16 +1914,33 @@ pub async fn set_user_status_admin(
         }
     };
 
-    if !status.is_active() && req.reason.as_ref().is_none_or(|r| r.trim().is_empty()) {
+    // Validate the optional actor as a 64-char hex pubkey so a T&S action never
+    // silently loses its audit trail to a malformed actor (mirrors
+    // clear_verified_minor_admin).
+    if let Some(actor) = req.actor.as_deref() {
+        if actor.len() != 64 || !actor.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(ApiError::bad_request(
+                "actor must be a 64-character hex pubkey",
+            ));
+        }
+    }
+
+    // Sanitize the caller-supplied reason (strip control/bidi/zero-width, bound to
+    // 500) before it is logged OR persisted -- to the suspended_reason column and
+    // the audit metadata alike. A suspend/ban whose reason is empty after cleaning
+    // is rejected as missing, same as an absent reason.
+    let reason_clean = sanitize_reason(req.reason.clone());
+    if !status.is_active() && reason_clean.is_none() {
         return Err(ApiError::bad_request(
             "reason is required when status is suspended or banned",
         ));
     }
 
+    // active clears the reason; suspended/banned carry the sanitized reason.
     let reason = if status.is_active() {
         None
     } else {
-        req.reason.as_deref().map(str::trim)
+        reason_clean.as_deref()
     };
     let (old_status, updated_status, suspended_reason, suspended_at) = user_repo
         .set_user_status(&pubkey, tenant_id, &status, reason)
@@ -1929,9 +1951,44 @@ pub async fn set_user_status_admin(
         pubkey = %pubkey,
         old_status = %old_status.as_str(),
         new_status = %updated_status.as_str(),
-        reason = ?req.reason,
+        actor = ?req.actor,
+        reason = ?reason,
         "Admin changed user status"
     );
+
+    // Durable audit row (best-effort) only for a real status transition and only
+    // when an actor is supplied -- the same bar clear_verified_minor sets. Gating
+    // on the status actually changing keeps a relay-manager retry after a lost
+    // response from appending a second event asserting a change that never
+    // happened. The table's actor_pubkey is NOT NULL, so no actor -> log-only. A
+    // failed insert logs and the status change still succeeds. (keycast#279)
+    if old_status.as_str() != updated_status.as_str() {
+        if let Some(actor) = req.actor.as_deref() {
+            let audit_repo = AdminAuditEventRepository::new(auth_state.state.db.clone());
+            if let Err(error) = audit_repo
+                .record(AdminAuditEventRecord {
+                    tenant_id,
+                    actor_pubkey: actor.to_string(),
+                    action: "set_user_status".to_string(),
+                    target_resource_type: "user".to_string(),
+                    target_resource_id: Some(pubkey.clone()),
+                    target_client_id: None,
+                    metadata_json: serde_json::json!({
+                        "old_status": old_status.as_str(),
+                        "new_status": updated_status.as_str(),
+                        "reason": reason,
+                    }),
+                })
+                .await
+            {
+                tracing::error!(
+                    pubkey = %pubkey,
+                    error = %error,
+                    "Failed to write admin_audit_events row for user status change"
+                );
+            }
+        }
+    }
 
     // set_user_status doesn't return verified_minor, so fetch it separately.
     // This is the write path (infrequent), so the extra query is acceptable.

--- a/api/tests/user_status_admin_test.rs
+++ b/api/tests/user_status_admin_test.rs
@@ -590,3 +590,319 @@ async fn test_reactivate_from_banned_clears_suspended_at() {
     assert!(status.suspended_reason.is_none());
     assert!(status.suspended_at.is_none());
 }
+
+// --- Durable admin_audit_events for status changes (keycast#279) ---
+
+#[derive(sqlx::FromRow)]
+struct AuditRow {
+    actor_pubkey: String,
+    action: String,
+    target_resource_type: String,
+    target_resource_id: Option<String>,
+    metadata_json: serde_json::Value,
+}
+
+/// Reads the `set_user_status` audit rows for one target user. Scoping by the
+/// (random) target pubkey keeps the read isolated from other tests sharing the DB.
+async fn read_status_audit_rows(pool: &PgPool, target_pubkey: &str) -> Vec<AuditRow> {
+    sqlx::query_as::<_, AuditRow>(
+        "SELECT actor_pubkey, action, target_resource_type, target_resource_id, metadata_json \
+         FROM admin_audit_events \
+         WHERE tenant_id = $1 AND target_resource_id = $2 AND action = 'set_user_status' \
+         ORDER BY id",
+    )
+    .bind(TENANT_ID)
+    .bind(target_pubkey)
+    .fetch_all(pool)
+    .await
+    .unwrap()
+}
+
+/// Suspend with an actor writes exactly one durable audit row carrying the
+/// old/new status and reason, consistent with clear-verified_minor.
+#[tokio::test]
+async fn test_set_user_status_with_actor_writes_audit_row() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_test_user(&pool).await;
+    let actor = Keys::generate().public_key().to_hex();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/admin/users/{}/status", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({
+                        "status": "suspended",
+                        "reason": "age_review",
+                        "actor": actor,
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let rows = read_status_audit_rows(&pool, &pubkey).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].action, "set_user_status");
+    assert_eq!(rows[0].actor_pubkey, actor);
+    assert_eq!(rows[0].target_resource_type, "user");
+    assert_eq!(rows[0].target_resource_id.as_deref(), Some(pubkey.as_str()));
+    assert_eq!(rows[0].metadata_json["old_status"], "active");
+    assert_eq!(rows[0].metadata_json["new_status"], "suspended");
+    assert_eq!(rows[0].metadata_json["reason"], "age_review");
+}
+
+/// No actor -> log-only (actor_pubkey is NOT NULL), so no audit row.
+#[tokio::test]
+async fn test_set_user_status_without_actor_writes_no_audit_row() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_test_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/admin/users/{}/status", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({
+                        "status": "suspended",
+                        "reason": "age_review"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(read_status_audit_rows(&pool, &pubkey).await.is_empty());
+}
+
+/// A no-op call (status unchanged) with an actor writes no row: gating on a real
+/// transition keeps a relay-manager retry from appending a phantom state change.
+#[tokio::test]
+async fn test_set_user_status_noop_writes_no_audit_row() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let pubkey = create_test_user(&pool).await;
+    let actor = Keys::generate().public_key().to_hex();
+
+    // Pre-suspend directly (no audit row) so the HTTP call is a same-status no-op.
+    let user_repo = UserRepository::new(pool.clone());
+    user_repo
+        .set_user_status(
+            &pubkey,
+            TENANT_ID,
+            &keycast_core::types::user::UserStatus::Suspended,
+            Some("age_review"),
+        )
+        .await
+        .unwrap();
+
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/admin/users/{}/status", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({
+                        "status": "suspended",
+                        "reason": "age_review",
+                        "actor": actor,
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(read_status_audit_rows(&pool, &pubkey).await.is_empty());
+}
+
+/// A malformed actor 400s (the T&S action never silently loses its audit trail)
+/// and leaves the account status untouched.
+#[tokio::test]
+async fn test_set_user_status_malformed_actor_rejected() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_test_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/admin/users/{}/status", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({
+                        "status": "suspended",
+                        "reason": "age_review",
+                        "actor": "not-a-hex-pubkey",
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let row: (String,) = sqlx::query_as("SELECT status FROM users WHERE pubkey = $1")
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.0, "active");
+    assert!(read_status_audit_rows(&pool, &pubkey).await.is_empty());
+}
+
+/// The reason is sanitized (control/bidi/zero-width stripped) before it reaches
+/// BOTH the persisted `suspended_reason` column and the audit metadata.
+#[tokio::test]
+async fn test_set_user_status_reason_sanitized_in_audit_and_column() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_test_user(&pool).await;
+    let actor = Keys::generate().public_key().to_hex();
+
+    // Bidi override (U+202E) + zero-width space (U+200B) embedded in the reason.
+    let dirty_reason = "ban\u{202E}\u{200B}ned";
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/admin/users/{}/status", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({
+                        "status": "banned",
+                        "reason": dirty_reason,
+                        "actor": actor,
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let status: UserStatusResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(status.suspended_reason.as_deref(), Some("banned"));
+
+    let rows = read_status_audit_rows(&pool, &pubkey).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].metadata_json["reason"], "banned");
+}
+
+/// A reason that is entirely control/bidi/zero-width characters sanitizes to
+/// nothing, so a suspend/ban with it is rejected as a missing reason.
+#[tokio::test]
+async fn test_set_user_status_control_only_reason_rejected() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let pubkey = create_test_user(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/admin/users/{}/status", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({
+                        "status": "suspended",
+                        "reason": "\u{202E}\u{200B}\u{0007}",
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+/// Unsuspend (suspended -> active) with an actor is a real transition and writes
+/// an audit row; the cleared reason is recorded as null.
+#[tokio::test]
+async fn test_set_user_status_unsuspend_with_actor_writes_audit_row() {
+    common::assert_test_database_url();
+    unsafe { std::env::set_var("KEYCAST_SERVICE_TOKEN", SERVICE_TOKEN) };
+    let pool = common::setup_test_db().await;
+    let pubkey = create_test_user(&pool).await;
+    let actor = Keys::generate().public_key().to_hex();
+
+    // Pre-suspend directly so the HTTP call is a suspended -> active transition.
+    let user_repo = UserRepository::new(pool.clone());
+    user_repo
+        .set_user_status(
+            &pubkey,
+            TENANT_ID,
+            &keycast_core::types::user::UserStatus::Suspended,
+            Some("age_review"),
+        )
+        .await
+        .unwrap();
+
+    let app = build_app(create_test_auth_state(pool.clone()));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/admin/users/{}/status", pubkey))
+                .header("authorization", format!("Bearer {}", SERVICE_TOKEN))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({
+                        "status": "active",
+                        "actor": actor,
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let rows = read_status_audit_rows(&pool, &pubkey).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].actor_pubkey, actor);
+    assert_eq!(rows[0].metadata_json["old_status"], "suspended");
+    assert_eq!(rows[0].metadata_json["new_status"], "active");
+    assert!(rows[0].metadata_json["reason"].is_null());
+}


### PR DESCRIPTION
## Summary

- set_user_status_admin (suspend/ban/unsuspend) now writes a durable, queryable
  admin_audit_events row, closing the gap where it only emitted an ephemeral
  tracing line that ages out of log retention. Its sibling clear_verified_minor
  already had this; this raises the status-change path to the same forensic bar.
- An optional `actor` (moderator hex pubkey) in the request body drives the row.
  Absent actor falls back to log-only (actor_pubkey is NOT NULL); a malformed
  actor 400s. The write is best-effort (a failed insert logs and the status
  change still succeeds) and fires only on a real status transition, so a
  relay-manager retry after a lost response can't append a phantom change.
- The caller-supplied reason is now sanitized (strip control/bidi/zero-width/
  line-separator chars, bound to 500) before it is logged or persisted, feeding
  both the suspended_reason column and the audit metadata. A reason empty after
  cleaning is rejected as missing.

Mirrors clear_verified_minor_admin throughout.

## Motivation

Part of the protected-minor epic. #265/#280 gave clear-verified_minor a durable
audit trail; its sibling enforcement action (suspend/ban/unsuspend) was still
log-only. For minor-safety forensics both need to be durably queryable. The
reason-sanitization scope was added on the issue by the T&S review, matching the
#280 pattern.

## Related Issue

- Closes #279
- Part of the protected-minor epic (support-trust-safety#173)

## Testing

Scoped to one handler in the api crate, so targeted verification:
- [x] cargo test -p keycast_api --features integration-tests --test user_status_admin_test (19 pass: 14 existing + 5 new)
- [x] cargo test -p keycast_api --features integration-tests --test clear_verified_minor_test --test registered_clients_audit_test (15 pass, no regression)
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated
- [x] cargo fmt --all -- --check

## Visuals

- [x] No visual change

## Notes for reviewers

- Auth: unchanged. The endpoint keeps service-token auth; the new `actor` is an
  audit attribution field, not an auth principal.
- Deliberate choice: on unsuspend (-> active) the reason is cleared, so the row
  records reason: null. If capturing an unsuspend rationale is wanted, that is a
  small scope extension.
- Follow-on (separate repo): relay-manager's suspend/ban/unsuspend need to pass
  `actor` for the row to populate in prod. Same shared-admin-pubkey caveat as
  clear-verified_minor; keycast's log-only fallback covers the gap until then.
