### PR TITLE
Support-admin: deeplink user lookup via ?q= (one-click from support tools)

### DIFF
--- a/web/src/lib/utils/deeplink.test.ts
+++ b/web/src/lib/utils/deeplink.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { deeplinkQuery } from "./deeplink";
+
+describe("deeplinkQuery", () => {
+    test("returns the q value when present", () => {
+        expect(deeplinkQuery(new URLSearchParams("q=npub1abc"))).toBe(
+            "npub1abc",
+        );
+    });
+
+    test("trims surrounding whitespace", () => {
+        expect(deeplinkQuery(new URLSearchParams("q=%20%20kofi%20%20"))).toBe(
+            "kofi",
+        );
+    });
+
+    test("returns null when q is absent", () => {
+        expect(deeplinkQuery(new URLSearchParams(""))).toBeNull();
+    });
+
+    test("returns null when q is empty", () => {
+        expect(deeplinkQuery(new URLSearchParams("q="))).toBeNull();
+    });
+
+    test("returns null when q is whitespace only", () => {
+        expect(deeplinkQuery(new URLSearchParams("q=%20%20"))).toBeNull();
+    });
+});

--- a/web/src/lib/utils/deeplink.test.ts
+++ b/web/src/lib/utils/deeplink.test.ts
@@ -14,6 +14,12 @@ describe("deeplinkQuery", () => {
         );
     });
 
+    test("keeps internal whitespace, trimming only the ends", () => {
+        expect(deeplinkQuery(new URLSearchParams("q=%20foo%20bar%20"))).toBe(
+            "foo bar",
+        );
+    });
+
     test("returns null when q is absent", () => {
         expect(deeplinkQuery(new URLSearchParams(""))).toBeNull();
     });

--- a/web/src/lib/utils/deeplink.ts
+++ b/web/src/lib/utils/deeplink.ts
@@ -1,0 +1,11 @@
+/**
+ * Extract the auto-run search query from a page's URL params.
+ *
+ * Returns the trimmed `q` value, or null when it is absent or empty. This lets a
+ * deeplink like `/support-admin?q=<pubkey>` run the lookup on load, while a bare
+ * visit (or an empty `q`) does nothing.
+ */
+export function deeplinkQuery(params: URLSearchParams): string | null {
+    const q = params.get("q")?.trim();
+    return q ? q : null;
+}

--- a/web/src/routes/support-admin/+page.svelte
+++ b/web/src/routes/support-admin/+page.svelte
@@ -3,7 +3,9 @@
 	import { BRAND } from '$lib/brand';
 	import { KeycastApi } from '$lib/keycast_api.svelte';
 	import { redirectToLoginOnAuthError } from '$lib/utils/auth';
+	import { deeplinkQuery } from '$lib/utils/deeplink';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
 	import Loader from '$lib/components/Loader.svelte';
 	import InvalidateClaimTokenModal from '$lib/components/InvalidateClaimTokenModal.svelte';
 	import { ShieldCheck, Warning, MagnifyingGlass, User, Key, Calendar, Globe, Copy, Check, CheckCircle, XCircle, Link, CaretDown, CaretRight } from 'phosphor-svelte';
@@ -74,11 +76,22 @@
 			adminRole = response.role;
 		} catch (err) {
 			if (redirectToLoginOnAuthError(err)) return;
-			goto('/login?redirect=/support-admin', { replaceState: true });
+			// Preserve the deeplink (e.g. ?q=<pubkey>) across the login bounce; safeRedirectPath
+			// keeps the query on the login side. (The 401 path already does this via the helper.)
+			const dest = $page.url.pathname + $page.url.search;
+			goto(`/login?redirect=${encodeURIComponent(dest)}`, { replaceState: true });
 			return;
 		}
 
 		status = 'ready';
+
+		// Deeplink: /support-admin?q=<pubkey|npub|email|username> runs the lookup on load, so
+		// links from support tools (e.g. the Zendesk report note) resolve in one click.
+		const q = deeplinkQuery($page.url.searchParams);
+		if (q) {
+			searchQuery = q;
+			void searchUser();
+		}
 	});
 
 	async function searchUser() {


### PR DESCRIPTION
Closes #298.

## Why
The support-admin user lookup requires paste + click. The Zendesk content-report note (divine-relay-manager #187 / #188) links agents to look up a reported pubkey here, but the page ignored URL params, so it couldn't pre-run the search. This makes those links one-click.

## What
- `/support-admin?q=<hex|npub|email|username>` runs the lookup on load — reuses the existing search path and the `/admin/user-lookup?q=` API; no new param.
- Preserves the deeplink across the login bounce. The 401 path (the actual logged-out case) already preserved it, since `redirectToLoginOnAuthError` captures `pathname + search`. Only the non-401 fallback hardcoded `/support-admin` and dropped `?q=`; this fixes that for parity, and `safeRedirectPath` keeps the query on the login side.

## How
- Pure `deeplinkQuery(params)` helper (returns the trimmed `q`, or null when absent/empty), unit-tested with `bun:test`.
- `support-admin/+page.svelte` `onMount` reads `$page.url.searchParams` once the admin check resolves and, if `q` is present, sets `searchQuery` and runs the existing `searchUser()`.

## Scope / non-goals
- Read-only param: the URL is not rewritten on manual searches.
- No behavior change when landing on `/support-admin` without `?q=`.

## Relationship to divine-relay-manager #188
This lands the one-click behavior for the `support-admin?q=` link in that PR's Zendesk note. The note degrades gracefully without this change (blank search box + paste the hex/npub printed in the note), so the two can ship independently; deploying this to prod upgrades that link to one-click.

## Testing
- `bun test`: 15 pass (6 for `deeplinkQuery`, covering present / trim / internal-whitespace / absent / empty / whitespace-only).
- `svelte-check`: 0 new errors (8 pre-existing on `main` in `QRCode.svelte` and a `keys/[pubkey]` page, unrelated).
- `biome`: new `.ts` files clean.
- Manual: `/support-admin?q=<hex>` auto-runs the lookup; logged-out lands on login then returns to the deeplink.
