### PR TITLE
fix(deploy): guard Cloud Build source context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -45,6 +45,19 @@ docs/
 test-results/
 .private-journal/
 coverage/
+.playwright-mcp/
+e2e/playwright-report/
+web/test-results/
+
+# Local development tooling
+.claude/
+.cursor/
+.kamal/
+.repo-cache/
+.specify/
+.superpowers/
+.worktrees/
+k8s_local_tests/
 
 # IDE and editor files
 .vscode/
@@ -56,7 +69,18 @@ coverage/
 
 # Build outputs not needed in final image
 web/build/
+web/.netlify/
+web/.output/
+web/.svelte-kit/
+web/.vercel/
+web/.wrangler/
 api/oauth-ui/dist/
+
+# Load testing artifacts
+tools/loadtest/*.json
+tools/loadtest/**/*.json
+tools/loadtest/*.cfg
+tools/loadtest/pgbouncer/
 
 # Temporary files
 *.log

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,6 +1,8 @@
 # Version control
+.gcloudignore
 .git
 .gitignore
+#!include:.gitignore
 
 # Rust build artifacts
 target/
@@ -37,6 +39,19 @@ docs/
 test-results/
 .private-journal/
 coverage/
+.playwright-mcp/
+e2e/playwright-report/
+web/test-results/
+
+# Local development tooling
+.claude/
+.cursor/
+.kamal/
+.repo-cache/
+.specify/
+.superpowers/
+.worktrees/
+k8s_local_tests/
 
 # IDE and editor files
 .vscode/
@@ -48,7 +63,18 @@ coverage/
 
 # Build outputs not needed in final image
 web/build/
+web/.netlify/
+web/.output/
+web/.svelte-kit/
+web/.vercel/
+web/.wrangler/
 api/oauth-ui/dist/
+
+# Load testing artifacts
+tools/loadtest/*.json
+tools/loadtest/**/*.json
+tools/loadtest/*.cfg
+tools/loadtest/pgbouncer/
 
 # Temporary files
 *.log

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
 		"dev:web": "cd web && VITE_ALLOWED_PUBKEYS=89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5 bun run dev",
 		"build": "cargo build --release --bin keycast",
 		"build:web": "cd web && bun run build",
-		"deploy:gcp": "gcloud builds submit --config=cloudbuild.yaml --project=openvine-co",
-		"deploy": "gcloud builds submit --config=cloudbuild.yaml --project=openvine-co",
+		"deploy:preflight": "./scripts/check-cloudbuild-context.sh",
+		"deploy:gcp": "bun run deploy:preflight && gcloud builds submit --config=cloudbuild.yaml --project=openvine-co",
+		"deploy": "bun run deploy:preflight && gcloud builds submit --config=cloudbuild.yaml --project=openvine-co",
 		"logs": "./scripts/view-logs.sh",
 		"logs:watch": "./scripts/logs-watch.sh",
 		"db:reset": "bun run deps:up && sqlx database reset -y --database-url postgres://postgres:password@localhost/keycast --source ./database/migrations",
@@ -28,7 +29,8 @@
 		"setup:hooks": "cp scripts/hooks/pre-push .git/hooks/ && chmod +x .git/hooks/pre-push",
 		"test": "(test -f master.key || ./scripts/generate_key.sh) && bun run deps:up && (docker exec keycast-postgres psql -U postgres -tc \"SELECT 1 FROM pg_database WHERE datname = 'keycast_test'\" | grep -q 1 || docker exec keycast-postgres createdb -U postgres keycast_test) && DATABASE_URL=${DATABASE_URL:-postgres://postgres:password@localhost:5432/keycast_test} cargo run --bin keycast -- --migrate && DATABASE_URL=${DATABASE_URL:-postgres://postgres:password@localhost:5432/keycast_test} REDIS_URL=${REDIS_URL:-redis://localhost:16379} TEST_REDIS_URL=${TEST_REDIS_URL:-redis://localhost:16379} cargo nextest run --workspace && DATABASE_URL=${DATABASE_URL:-postgres://postgres:password@localhost:5432/keycast_test} REDIS_URL=${REDIS_URL:-redis://localhost:16379} TEST_REDIS_URL=${TEST_REDIS_URL:-redis://localhost:16379} cargo test -p keycast_core --features integration-tests --lib && DATABASE_URL=${DATABASE_URL:-postgres://postgres:password@localhost:5432/keycast_test} REDIS_URL=${REDIS_URL:-redis://localhost:16379} TEST_REDIS_URL=${TEST_REDIS_URL:-redis://localhost:16379} cargo test -p keycast_api --features integration-tests --lib --tests && DATABASE_URL=${DATABASE_URL:-postgres://postgres:password@localhost:5432/keycast_test} REDIS_URL=${REDIS_URL:-redis://localhost:16379} TEST_REDIS_URL=${TEST_REDIS_URL:-redis://localhost:16379} cargo test -p keycast_signer --features integration-tests --lib --tests && TEST_REDIS_URL=${TEST_REDIS_URL:-redis://localhost:16379} cargo test -p cluster-hashring --lib -- --ignored",
 		"test:ci": "DATABASE_URL=${DATABASE_URL:-postgres://postgres:password@localhost:5432/keycast_test} REDIS_URL=${REDIS_URL:-redis://localhost:16379} TEST_REDIS_URL=${TEST_REDIS_URL:-redis://localhost:16379} cargo nextest run --workspace && DATABASE_URL=${DATABASE_URL:-postgres://postgres:password@localhost:5432/keycast_test} REDIS_URL=${REDIS_URL:-redis://localhost:16379} TEST_REDIS_URL=${TEST_REDIS_URL:-redis://localhost:16379} cargo test -p keycast_core --features integration-tests --lib && DATABASE_URL=${DATABASE_URL:-postgres://postgres:password@localhost:5432/keycast_test} REDIS_URL=${REDIS_URL:-redis://localhost:16379} TEST_REDIS_URL=${TEST_REDIS_URL:-redis://localhost:16379} cargo test -p keycast_api --features integration-tests --lib --tests && DATABASE_URL=${DATABASE_URL:-postgres://postgres:password@localhost:5432/keycast_test} REDIS_URL=${REDIS_URL:-redis://localhost:16379} TEST_REDIS_URL=${TEST_REDIS_URL:-redis://localhost:16379} cargo test -p keycast_signer --features integration-tests --lib --tests && TEST_REDIS_URL=${TEST_REDIS_URL:-redis://localhost:16379} cargo test -p cluster-hashring --lib -- --ignored",
-		"check": "cargo fmt --all -- --check && cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated && cargo test --workspace"
+		"test:deploy-preflight": "bash tests/scripts/check-cloudbuild-context-test.sh",
+		"check": "bun run test:deploy-preflight && cargo fmt --all -- --check && cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated && cargo test --workspace"
 	},
 	"devDependencies": {
 		"concurrently": "^9.1.2",

--- a/scripts/check-cloudbuild-context.sh
+++ b/scripts/check-cloudbuild-context.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v git >/dev/null 2>&1; then
+	printf 'Cloud Build context check requires git.\n' >&2
+	exit 1
+fi
+
+if ! command -v gcloud >/dev/null 2>&1; then
+	printf 'Cloud Build context check requires gcloud.\n' >&2
+	exit 1
+fi
+
+if ! repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+	printf 'Cloud Build context check must run inside a Git worktree.\n' >&2
+	exit 1
+fi
+
+cd "$repo_root"
+
+upload_list=$(mktemp)
+trap 'rm -f "$upload_list"' EXIT
+
+if ! gcloud meta list-files-for-upload . >"$upload_list"; then
+	printf 'Could not determine Cloud Build upload files. Refusing to deploy.\n' >&2
+	exit 1
+fi
+
+uploaded_count=0
+untracked_paths=()
+
+while IFS= read -r path; do
+	[[ -z "$path" ]] && continue
+	uploaded_count=$((uploaded_count + 1))
+
+	if ! git ls-files --error-unmatch -- "$path" >/dev/null 2>&1; then
+		untracked_paths+=("$path")
+	fi
+done <"$upload_list"
+
+if ((${#untracked_paths[@]} > 0)); then
+	printf 'Cloud Build would upload files that are not tracked by Git:\n' >&2
+	printf '  %s\n' "${untracked_paths[@]}" >&2
+	printf 'Refusing to deploy. Update ignore rules or remove these files.\n' >&2
+	exit 1
+fi
+
+printf 'Cloud Build context is clean: %d tracked files.\n' "$uploaded_count"

--- a/tests/fixtures/bin/gcloud
+++ b/tests/fixtures/bin/gcloud
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" != "meta list-files-for-upload ." ]]; then
+	printf 'unexpected gcloud arguments: %s\n' "$*" >&2
+	exit 64
+fi
+
+printf '%s' "${FAKE_GCLOUD_OUTPUT:-}"
+exit "${FAKE_GCLOUD_STATUS:-0}"

--- a/tests/scripts/check-cloudbuild-context-test.sh
+++ b/tests/scripts/check-cloudbuild-context-test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+guard="$repo_root/scripts/check-cloudbuild-context.sh"
+fake_bin="$repo_root/tests/fixtures/bin"
+result_file=$(mktemp)
+trap 'rm -f "$result_file"' EXIT
+
+if [[ ! -x "$guard" ]]; then
+	printf 'FAIL: expected executable guard at %s\n' "$guard" >&2
+	exit 1
+fi
+
+run_guard() {
+	local output=$1
+	local status=$2
+
+	PATH="$fake_bin:$PATH" \
+		FAKE_GCLOUD_OUTPUT="$output" \
+		FAKE_GCLOUD_STATUS="$status" \
+		"$guard" >"$result_file" 2>&1
+}
+
+if ! run_guard $'.gcloudignore\npackage.json\n' 0; then
+	printf 'FAIL: tracked upload paths should pass\n' >&2
+	cat "$result_file" >&2
+	exit 1
+fi
+
+if run_guard $'.gcloudignore\nuntracked-cloudbuild-context-file\n' 0; then
+	printf 'FAIL: an untracked upload path should fail\n' >&2
+	exit 1
+fi
+
+if ! grep -Fq 'untracked-cloudbuild-context-file' "$result_file"; then
+	printf 'FAIL: rejection should name the untracked path\n' >&2
+	cat "$result_file" >&2
+	exit 1
+fi
+
+if run_guard '' 23; then
+	printf 'FAIL: a gcloud listing error should fail closed\n' >&2
+	exit 1
+fi
+
+if ! grep -Fq 'Could not determine Cloud Build upload files.' "$result_file"; then
+	printf 'FAIL: gcloud failure should explain why the guard stopped\n' >&2
+	cat "$result_file" >&2
+	exit 1
+fi
+
+printf 'Cloud Build context guard tests passed.\n'


### PR DESCRIPTION
## Summary

Cloud Build could upload local files that Git intentionally ignored, including generated frontend output, test artifacts, load-test data, and nested worktrees.
This change aligns the Cloud Build and Docker source filters with the repository's local-file rules.
Deploy commands now stop before starting Cloud Build if any upload path is not tracked by Git.

## Motivation

The production image did not retain most of these files because the Dockerfile uses multiple stages, but they still entered private Cloud Build source archives.
Excluding them reduces unnecessary data exposure and makes deployments more reproducible.

## What Changed

The source filters now cover the local files that previously escaped them, and the deploy path has a fail-closed safety check.

- Included the root `.gitignore` from `.gcloudignore` and added explicit exclusions for nested generated and load-test artifacts.
- Mirrored the relevant workspace and generated-file exclusions in `.dockerignore`.
- Added a deploy preflight that compares gcloud's exact upload list with Git's index without reading file contents.
- Added regression coverage for tracked files, untracked files, and gcloud listing failures.
- Wired the guard into both Bun deploy commands and the repository check command.

## Related Issue

- No linked issue.

## Testing

The regression test was observed failing before the guard existed and passing after implementation.
The actual gcloud upload manifest contains 430 files, all tracked by Git.
No deployment was started.

- [x] `bun run check`
- [x] `bun run deploy:preflight`
- [x] `cargo build --release --workspace`
- [x] `cargo test --workspace --verbose` (baseline before changes)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] Manual verification completed with ignored and non-ignored sentinel paths

## Risks

Runtime behavior and Cloud Run configuration are unchanged.
The operational risk is limited to source packaging: a required build input that is newly ignored would cause a build failure rather than changing a running service.

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
