### PR TITLE
feat(support-admin): surface minor/age-review terminal status in user lookup

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -915,6 +915,11 @@ pub struct UserLookupDetails {
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suspended_reason: Option<String>,
+    /// Approved protected-minor (13-15) flag. Terminal age-review signal; the in-review
+    /// state lives in relay-manager, not keycast.
+    pub verified_minor: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verified_minor_at: Option<String>,
     pub active_sessions: i64,
     pub created_at: String,
     pub last_active: Option<String>,
@@ -947,6 +952,8 @@ async fn enrich_user_lookup_details(
         has_personal_key: details.has_personal_key,
         status: details.status.as_str().to_string(),
         suspended_reason: details.suspended_reason,
+        verified_minor: details.verified_minor,
+        verified_minor_at: details.verified_minor_at.map(|at| at.to_rfc3339()),
         active_sessions: sessions.len() as i64,
         created_at: details.created_at.to_rfc3339(),
         last_active,
@@ -996,6 +1003,8 @@ mod user_lookup_response_tests {
             has_personal_key: false,
             status: UserStatus::Active,
             suspended_reason: None,
+            verified_minor: false,
+            verified_minor_at: None,
             created_at: now,
             updated_at: now,
         }
@@ -1044,6 +1053,8 @@ mod user_lookup_response_tests {
             has_personal_key: false,
             status: "active".to_string(),
             suspended_reason: None,
+            verified_minor: false,
+            verified_minor_at: None,
             active_sessions: 0,
             created_at: "2026-07-17T12:00:00+00:00".to_string(),
             last_active: None,

--- a/api/tests/user_lookup_test.rs
+++ b/api/tests/user_lookup_test.rs
@@ -1,0 +1,280 @@
+// ABOUTME: HTTP-handler tests for the support-admin user-lookup endpoint (get_user_lookup)
+// ABOUTME: Locks the response contract for minor/age-review terminal status + the auth gate (#309)
+
+#![cfg(feature = "integration-tests")]
+
+mod common;
+
+use axum::extract::{Query, State};
+use chrono::Utc;
+use keycast_api::{
+    api::{
+        extractors::UcanAuth,
+        http::{
+            admin::{get_user_lookup, UserLookupQuery},
+            routes::AuthState,
+        },
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use std::sync::Arc;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+const TENANT_ID: i64 = 1;
+
+// -----------------------------------------------------------------------------
+// Fixtures (mirror registered_clients_admin_http_test: inject tenant + UcanAuth
+// directly instead of resolving them from request headers + global state).
+// -----------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct AuthConfig {
+    pubkey: String,
+    admin_role: Option<String>,
+}
+
+impl AuthConfig {
+    fn full_admin() -> Self {
+        Self {
+            pubkey: Keys::generate().public_key().to_hex(),
+            admin_role: Some("full".to_string()),
+        }
+    }
+
+    fn non_admin() -> Self {
+        Self {
+            pubkey: Keys::generate().public_key().to_hex(),
+            admin_role: None,
+        }
+    }
+
+    fn into_auth(self) -> UcanAuth {
+        UcanAuth {
+            pubkey: self.pubkey,
+            admin_role: self.admin_role,
+        }
+    }
+}
+
+fn create_test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: TENANT_ID,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn create_test_auth_state(pool: PgPool) -> AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+async fn cleanup_user(pool: &PgPool, pubkey: &str) {
+    sqlx::query("DELETE FROM users WHERE pubkey = $1")
+        .bind(pubkey)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn lookup_surfaces_verified_minor() {
+    let pool = common::setup_test_db().await;
+    let pubkey = Keys::generate().public_key().to_hex();
+    let username = format!("minoruser{}", Uuid::new_v4().simple());
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, verified_minor, verified_minor_at, created_at, updated_at) \
+         VALUES ($1, $2, $3, TRUE, NOW(), NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .bind(TENANT_ID)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let resp = get_user_lookup(
+        create_test_tenant(),
+        State(create_test_auth_state(pool.clone())),
+        AuthConfig::full_admin().into_auth(),
+        Query(UserLookupQuery {
+            q: username.clone(),
+        }),
+    )
+    .await
+    .expect("full admin lookup should succeed")
+    .0;
+
+    assert_eq!(
+        resp.results.len(),
+        1,
+        "should find the seeded minor account"
+    );
+    let user = &resp.results[0];
+    assert_eq!(user.pubkey, pubkey);
+    assert!(
+        user.verified_minor,
+        "verified_minor must be surfaced in the lookup response (#309)"
+    );
+    assert!(user.verified_minor_at.is_some());
+    assert_eq!(user.status, "active");
+
+    cleanup_user(&pool, &pubkey).await;
+}
+
+#[tokio::test]
+async fn lookup_surfaces_suspended_status_and_reason() {
+    let pool = common::setup_test_db().await;
+    let pubkey = Keys::generate().public_key().to_hex();
+    let username = format!("suspended{}", Uuid::new_v4().simple());
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, status, suspended_reason, suspended_at, created_at, updated_at) \
+         VALUES ($1, $2, $3, 'suspended', 'age_review', NOW(), NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .bind(TENANT_ID)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let resp = get_user_lookup(
+        create_test_tenant(),
+        State(create_test_auth_state(pool.clone())),
+        AuthConfig::full_admin().into_auth(),
+        Query(UserLookupQuery {
+            q: username.clone(),
+        }),
+    )
+    .await
+    .expect("full admin lookup should succeed")
+    .0;
+
+    assert_eq!(resp.results.len(), 1);
+    let user = &resp.results[0];
+    assert_eq!(user.status, "suspended");
+    assert_eq!(user.suspended_reason.as_deref(), Some("age_review"));
+    assert!(!user.verified_minor);
+
+    cleanup_user(&pool, &pubkey).await;
+}
+
+#[tokio::test]
+async fn lookup_suggestions_carry_verified_minor() {
+    // verified_minor must ride the shared enrich helper onto the "did you mean" suggestion
+    // path too, not only exact results. Relies on pg_trgm (created by the email-trgm migration).
+    let pool = common::setup_test_db().await;
+    let pubkey = Keys::generate().public_key().to_hex();
+    let unique = Uuid::new_v4().simple().to_string();
+    let email = format!("verifiedminor-{}@example.com", unique);
+    // A one-char typo (.com -> .con): no exact/substring match, but trigram-close, so the
+    // account can only come back through the suggestion path.
+    let typo = format!("verifiedminor-{}@example.con", unique);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, email_verified, verified_minor, verified_minor_at, created_at, updated_at) \
+         VALUES ($1, $2, $3, TRUE, TRUE, NOW(), NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .bind(TENANT_ID)
+    .bind(&email)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let resp = get_user_lookup(
+        create_test_tenant(),
+        State(create_test_auth_state(pool.clone())),
+        AuthConfig::full_admin().into_auth(),
+        Query(UserLookupQuery { q: typo }),
+    )
+    .await
+    .expect("full admin lookup should succeed")
+    .0;
+
+    assert!(
+        resp.results.iter().all(|u| u.pubkey != pubkey),
+        "the typo email should not be an exact/substring result"
+    );
+    let suggestion = resp
+        .suggestions
+        .iter()
+        .find(|u| u.pubkey == pubkey)
+        .expect("verified-minor account should surface as a did-you-mean suggestion");
+    assert!(
+        suggestion.verified_minor,
+        "verified_minor must be carried on the suggestion path, not only exact results"
+    );
+
+    cleanup_user(&pool, &pubkey).await;
+}
+
+#[tokio::test]
+async fn lookup_rejects_non_admin() {
+    let pool = common::setup_test_db().await;
+
+    let result = get_user_lookup(
+        create_test_tenant(),
+        State(create_test_auth_state(pool.clone())),
+        AuthConfig::non_admin().into_auth(),
+        Query(UserLookupQuery {
+            q: "anyone".to_string(),
+        }),
+    )
+    .await;
+
+    assert!(result.is_err(), "non-admin must be denied the user lookup");
+}

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -2951,6 +2951,8 @@ mod tests {
                 tenant_id BIGINT NOT NULL,
                 status TEXT NOT NULL DEFAULT 'active',
                 suspended_reason TEXT,
+                verified_minor BOOLEAN NOT NULL DEFAULT FALSE,
+                verified_minor_at TIMESTAMPTZ,
                 created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
             )",

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -69,6 +69,11 @@ pub struct AdminUserDetails {
     pub has_personal_key: bool,
     pub status: UserStatus,
     pub suspended_reason: Option<String>,
+    // Selected by every admin-lookup query (deliberately no `#[sqlx(default)]`, unlike
+    // `authoritative` which is computed post-fetch): a query that forgets these columns
+    // must fail loudly rather than silently report a minor as non-minor.
+    pub verified_minor: bool,
+    pub verified_minor_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -106,6 +111,8 @@ const ADMIN_EMAIL_SUGGESTION_QUERY: &str = "SELECT
         (pk.user_pubkey IS NOT NULL) as \"has_personal_key\",
         u.status,
         u.suspended_reason,
+        u.verified_minor,
+        u.verified_minor_at,
         u.created_at,
         u.updated_at
      FROM users u
@@ -2077,6 +2084,8 @@ impl UserRepository {
                 (pk.user_pubkey IS NOT NULL) as \"has_personal_key\",
                 u.status,
                 u.suspended_reason,
+                u.verified_minor,
+                u.verified_minor_at,
                 u.created_at,
                 u.updated_at
              FROM users u
@@ -2172,6 +2181,8 @@ impl UserRepository {
                 (pk.user_pubkey IS NOT NULL) as \"has_personal_key\",
                 u.status,
                 u.suspended_reason,
+                u.verified_minor,
+                u.verified_minor_at,
                 u.created_at,
                 u.updated_at
              FROM users u
@@ -2571,6 +2582,38 @@ mod tests {
         cleanup_user(&pool, &h1).await;
         cleanup_user(&pool, &h2).await;
         cleanup_user(&pool, &h3).await;
+    }
+
+    #[tokio::test]
+    async fn test_find_users_for_admin_surfaces_verified_minor() {
+        let pool = setup_pool().await;
+        let repo = UserRepository::new(pool.clone());
+        let suffix = test_suffix();
+
+        let pubkey = Keys::generate().public_key().to_hex();
+        let username = format!("minoruser-{}", suffix);
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, username, verified_minor, verified_minor_at, created_at, updated_at) \
+             VALUES ($1, 1, $2, TRUE, NOW(), NOW(), NOW())",
+        )
+        .bind(&pubkey)
+        .bind(&username)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let results = repo.find_users_for_admin(&username, 1).await.unwrap().users;
+        assert_eq!(results.len(), 1, "should find the verified-minor user");
+        assert!(
+            results[0].verified_minor,
+            "admin lookup must surface verified_minor so support sees the terminal age-review state"
+        );
+        assert!(
+            results[0].verified_minor_at.is_some(),
+            "verified_minor_at should accompany a set flag"
+        );
+
+        cleanup_user(&pool, &pubkey).await;
     }
 
     #[tokio::test]

--- a/web/src/routes/support-admin/+page.svelte
+++ b/web/src/routes/support-admin/+page.svelte
@@ -72,6 +72,10 @@
 		display_name: string | null;
 		vine_id: string | null;
 		has_personal_key: boolean;
+		status: string;
+		suspended_reason?: string | null;
+		verified_minor: boolean;
+		verified_minor_at?: string | null;
 		active_sessions: number;
 		created_at: string;
 		last_active: string | null;
@@ -131,6 +135,11 @@
 		} finally {
 			isSearching = false;
 		}
+	}
+
+	function accountStatusLabel(u: UserDetails): string {
+		const base = u.status.charAt(0).toUpperCase() + u.status.slice(1);
+		return u.suspended_reason ? `${base} (${u.suspended_reason})` : base;
 	}
 
 	function formatDate(iso: string): string {
@@ -370,6 +379,12 @@
 									{#if isSuggestedUser(u)}
 										<span class="suggested-badge">Suggested</span>
 									{/if}
+									{#if u.verified_minor}
+										<span class="flag-badge flag-minor">Minor</span>
+									{/if}
+									{#if u.status !== 'active'}
+										<span class="flag-badge" class:flag-suspended={u.status === 'suspended'} class:flag-banned={u.status === 'banned'}>{u.status}</span>
+									{/if}
 									<span class="list-sessions">{u.active_sessions} {u.active_sessions === 1 ? 'session' : 'sessions'}</span>
 								</button>
 
@@ -416,6 +431,14 @@
 											<div class="status-item" class:status-ok={u.active_sessions > 0} class:status-none={u.active_sessions === 0}>
 												<span>{u.active_sessions} active {u.active_sessions === 1 ? 'session' : 'sessions'}</span>
 											</div>
+											<div class="status-item" class:status-ok={u.status === 'active'} class:status-warn={u.status === 'suspended'} class:status-error={u.status === 'banned'}>
+												<span>{accountStatusLabel(u)}</span>
+											</div>
+											{#if u.verified_minor}
+												<div class="status-item status-warn">
+													<span>Protected minor{u.verified_minor_at ? ` (since ${formatDate(u.verified_minor_at)})` : ''}</span>
+												</div>
+											{/if}
 										</div>
 
 										<div class="user-fields">
@@ -867,6 +890,28 @@
 		flex-shrink: 0;
 	}
 
+	.flag-badge {
+		padding: 0.125rem 0.375rem;
+		border-radius: 9999px;
+		font-size: 0.65rem;
+		font-weight: 600;
+		line-height: 1.2;
+		text-transform: uppercase;
+		letter-spacing: 0.025em;
+		flex-shrink: 0;
+	}
+
+	.flag-minor,
+	.flag-suspended {
+		background: color-mix(in srgb, var(--color-divine-warning) 20%, transparent);
+		color: var(--color-divine-warning);
+	}
+
+	.flag-banned {
+		background: color-mix(in srgb, var(--color-divine-error) 20%, transparent);
+		color: var(--color-divine-error);
+	}
+
 	.email-match {
 		background: color-mix(in srgb, var(--color-divine-green) 20%, transparent);
 		color: var(--color-divine-green);
@@ -968,6 +1013,10 @@
 
 	.status-item.status-none {
 		color: var(--color-divine-text-tertiary);
+	}
+
+	.status-item.status-error {
+		color: var(--color-divine-error);
 	}
 
 	.status-neutral {


### PR DESCRIPTION
## Summary

- Surfaces an account's terminal age-review status in the support-admin user lookup: `verified_minor` + `verified_minor_at` (approved protected minor, 13-15), plus the account `status` / `suspended_reason` that the API already returned but the UI dropped.
- Backend: adds the two `verified_minor` columns to `AdminUserDetails` and all three admin-lookup SELECTs (`find_users_for_admin`, the email-suggestion query, and the batch/email lookup), threaded through the shared `enrich_user_lookup_details` helper so both results and "did you mean" suggestions carry them.
- Frontend: renders account status (active / suspended / banned + reason) and a protected-minor badge on the existing lookup rows and status strip.
- Builds on the lookup rework in #301 (merged); no changes to its search/authoritative logic.

## Motivation

- From a support check-in: when a user says "I can't post / features don't work," support had no way to tell from the lookup tool whether the account went through age review or where it landed, so they guessed or escalated ("it's an opaque process to me"). This gives them the terminal outcome at a glance.
- Sibling of #263 (which exposed `verified_minor` on the client-facing `/user/account`); this does the equivalent for the human support tool.

## Related Issue

- Closes #309
- Out of scope by design: the reported / in-review (non-terminal) age-review state, which lives in divine-relay-manager (`age_review_cases`), not keycast. Divine-username search is tracked separately in #49.

## Testing

Targeted (scope recorded per AGENTS.md; the full `bun run test` suite runs in CI):
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated` - clean
- `cargo test -p keycast_core --features integration-tests --lib find_users_for_admin` - 8 pass, incl. `test_find_users_for_admin_surfaces_verified_minor` (mutation-verified: flipping the fixture to `FALSE` makes it fail)
- `cargo test -p keycast_api --features integration-tests --test user_lookup_test` - 4 pass: `verified_minor` on exact results, `verified_minor` on the "did you mean" suggestion path, suspended `status`/`suspended_reason`, and the non-admin auth gate
- `cargo test -p keycast_api --features integration-tests --test batch_lookup_test` - 12 pass (regression guard for the shared `AdminUserDetails` SELECT)
- #301's `user_lookup_response_tests` still green (field additions didn't break serialization/tier tests)
- `npm run check` (svelte-check): `support-admin/+page.svelte` clean

## Visuals

- UI/web change. A browser screenshot was not captured locally (no bun dev server in this environment); svelte-check passes on the page. The change adds, to each lookup result row and the expanded status strip: an account-status label (active / suspended / banned + reason) and a "Minor" badge for approved protected minors. Recommend capturing a screenshot before merge.
- No sensitive external brand/partner names.
