### PR TITLE
feat: nip17_wrap_batch RPC (send-side gift-wrap batch) — mirror of #254, cut 4 RPCs/DM to 1

### DIFF
--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -15,7 +15,7 @@ use keycast_core::repositories::{
 };
 use keycast_core::signing_session::{parse_cache_key, CacheKey, SigningSession};
 use keycast_core::traits::CustomPermission;
-use nostr_sdk::{Event, Keys, PublicKey, UnsignedEvent};
+use nostr_sdk::{Event, JsonUtil, Keys, PublicKey, UnsignedEvent};
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -950,40 +950,42 @@ fn parse_nip17_wrap_batch_params(params: &[JsonValue]) -> Result<Nip17WrapBatchP
     Ok(Nip17WrapBatchParams { rumor, recipients })
 }
 
-fn wrap_error_slot(code: &str) -> JsonValue {
+fn error_slot(code: &str) -> JsonValue {
     serde_json::json!({ "error": code })
 }
 
 /// Build ordered, index-aligned gift wraps for one shared rumor.
 ///
 /// Construction is deliberately sequential: a request can contain at most
-/// [`MAX_WRAP_BATCH`] recipients, and one in-flight recipient at a time avoids
-/// crowding Tokio's shared blocking pool while preserving duplicate slots.
+/// [`MAX_WRAP_BATCH`] recipients, and one in-flight recipient at a time keeps
+/// per-request work bounded while preserving duplicate slots.
 async fn wrap_gift_wrap_batch(
     handler: &Arc<HttpRpcHandler>,
     rumor: &UnsignedEvent,
     recipients: &[Result<PublicKey, ()>],
 ) -> Vec<JsonValue> {
+    let mut rumor = rumor.clone();
+    rumor.ensure_id();
+    let plaintext = rumor.as_json();
+
     let mut results = Vec::with_capacity(recipients.len());
     for recipient in recipients {
         let slot = match recipient {
-            Err(()) => wrap_error_slot("invalid_recipient"),
-            Ok(recipient) => match handler.nip17_wrap(rumor.clone(), recipient).await {
+            Err(()) => error_slot("invalid_recipient"),
+            Ok(recipient) => match handler
+                .nip17_wrap_prevalidated_plaintext(&plaintext, recipient)
+                .await
+            {
                 Ok(gift_wrap) => match serde_json::to_value(gift_wrap) {
                     Ok(event) => serde_json::json!({ "gift_wrap": event }),
-                    Err(_) => wrap_error_slot("internal"),
+                    Err(_) => error_slot("internal"),
                 },
-                Err(error) => wrap_error_slot(error.code()),
+                Err(error) => error_slot(error.code()),
             },
         };
         results.push(slot);
     }
     results
-}
-
-/// Build the per-item error slot for the unwrap batch response.
-fn unwrap_error_slot(code: &str) -> JsonValue {
-    serde_json::json!({ "error": code })
 }
 
 /// Unwrap a batch of NIP-59 gift wraps into ordered, index-aligned result slots.
@@ -1014,7 +1016,7 @@ async fn unwrap_gift_wrap_batch(
         set.spawn(async move {
             let event: Event = match serde_json::from_value(item) {
                 Ok(e) => e,
-                Err(_) => return (idx, unwrap_error_slot("invalid_event")),
+                Err(_) => return (idx, error_slot("invalid_event")),
             };
             let slot = match handler.nip17_unwrap(event).await {
                 Ok(unwrapped) => match serde_json::to_value(&unwrapped.rumor) {
@@ -1022,9 +1024,9 @@ async fn unwrap_gift_wrap_batch(
                         "rumor": rumor,
                         "sender": unwrapped.sender.to_hex(),
                     }),
-                    Err(_) => unwrap_error_slot("internal"),
+                    Err(_) => error_slot("internal"),
                 },
-                Err(e) => unwrap_error_slot(e.code()),
+                Err(e) => error_slot(e.code()),
             };
             (idx, slot)
         });
@@ -1033,7 +1035,7 @@ async fn unwrap_gift_wrap_batch(
     // Pre-fill with internal-error slots so a task that fails to report a result
     // (e.g. a JoinError from a panicked task) still yields a valid, index-aligned
     // slot rather than a hole in the ordered response.
-    let mut results = vec![unwrap_error_slot("internal"); items.len()];
+    let mut results = vec![error_slot("internal"); items.len()];
     while let Some(joined) = set.join_next().await {
         if let Ok((idx, slot)) = joined {
             results[idx] = slot;
@@ -1206,6 +1208,23 @@ mod tests {
         let rumor =
             nostr_sdk::EventBuilder::private_msg_rumor(recipient, "batch send").build(author);
         serde_json::to_value(rumor).expect("serialize rumor")
+    }
+
+    fn assert_gift_wrap_has_recipient_p_tag(slot: &JsonValue, recipient: &PublicKey) {
+        let recipient_hex = recipient.to_hex();
+        let tags = slot["gift_wrap"]["tags"]
+            .as_array()
+            .expect("gift wrap has tags");
+        assert!(
+            tags.iter().any(|tag| {
+                let Some(parts) = tag.as_array() else {
+                    return false;
+                };
+                parts.first().and_then(JsonValue::as_str) == Some("p")
+                    && parts.get(1).and_then(JsonValue::as_str) == Some(recipient_hex.as_str())
+            }),
+            "gift wrap must include recipient p tag"
+        );
     }
 
     #[test]
@@ -1424,6 +1443,7 @@ mod tests {
             (2usize, &receiver_b),
             (3usize, &receiver_a),
         ] {
+            assert_gift_wrap_has_recipient_p_tag(&results[idx], &receiver.public_key());
             let wrap: Event = serde_json::from_value(results[idx]["gift_wrap"].clone())
                 .expect("successful slot contains an event");
             let unwrapped = nostr_sdk::nips::nip59::UnwrappedGift::from_gift_wrap(receiver, &wrap)

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -30,6 +30,11 @@ use super::routes::AuthState;
 /// limit (gift wraps are ~1-2 KB each). Mirrors the `batch_lookup_users` cap.
 const MAX_UNWRAP_BATCH: usize = 100;
 
+/// Maximum recipients accepted in one `nip17_wrap_batch` request.
+/// The shared rumor is processed sequentially so this is also a hard bound on
+/// per-request seal and gift-wrap crypto.
+const MAX_WRAP_BATCH: usize = 100;
+
 /// RPC request format (mirrors NIP-46)
 #[derive(Debug, Deserialize)]
 pub struct NostrRpcRequest {
@@ -126,6 +131,9 @@ impl From<HandlerError> for RpcError {
 /// - nip17_unwrap_batch: Unwraps a batch of NIP-59 gift wraps (1059→seal→rumor),
 ///   returning ordered per-item `{rumor, sender}` / `{error}` slots. Amortizes the
 ///   per-request auth/status overhead and collapses the client's 2 RPCs-per-DM.
+/// - nip17_wrap_batch: Wraps one shared NIP-17 rumor for an ordered recipient
+///   list, returning per-recipient `{gift_wrap}` / `{error}` slots. Preserves
+///   the existing NIP-44 encryption and kind-13 signing policy checks.
 ///
 /// Uses BLAKE3 token cache - on cache hit, skips UCAN verification entirely.
 /// All operations use cached handler with in-memory permission validation (no DB hits).
@@ -260,6 +268,51 @@ pub async fn nostr_rpc(
             JsonValue::Array(results)
         }
 
+        "nip17_wrap_batch" => {
+            let batch = parse_nip17_wrap_batch_params(&req.params)?;
+
+            // Common rumor failures invalidate every possible recipient slot,
+            // so reject them once at request level before any crypto.
+            if batch.rumor.pubkey != handler.public_key() {
+                return Err(RpcError::InvalidParams(
+                    "Rumor author must match signer".into(),
+                ));
+            }
+            batch
+                .rumor
+                .verify_id()
+                .map_err(|_| RpcError::InvalidParams("Invalid rumor id".into()))?;
+
+            // Whole-batch validity gate, matching nip17_unwrap_batch. The
+            // handler primitives still recheck validity at each operation.
+            if !handler.is_valid() {
+                return Err(RpcError::Auth(AuthError::InvalidToken));
+            }
+
+            if verified_minor {
+                enforce_minor_dm_rumor(&handler, &batch.rumor)?;
+                // Validate every parseable encryption target before building
+                // any slot. Malformed targets cannot receive a wrap and remain
+                // isolated as `invalid_recipient` slots.
+                for recipient in batch
+                    .recipients
+                    .iter()
+                    .filter_map(|recipient| recipient.as_ref().ok())
+                {
+                    enforce_minor_dm_encrypt(&handler, recipient)?;
+                }
+            }
+
+            // Sequential construction bounds blocking crypto and naturally
+            // preserves duplicate and positional recipient semantics.
+            let results = wrap_gift_wrap_batch(&handler, &batch.rumor, &batch.recipients).await;
+
+            // One coalesced activity update for the whole RPC request.
+            spawn_log_activity(pool.clone(), handler.is_oauth(), handler.authorization_id());
+
+            JsonValue::Array(results)
+        }
+
         "nip04_encrypt" => {
             let (recipient_pubkey, plaintext) = parse_encrypt_params(&req.params)?;
 
@@ -365,6 +418,25 @@ fn enforce_minor_dm_encrypt(
                 recipient = %recipient.to_hex(),
                 reason = %denied,
                 "verified_minor DM encrypt refused"
+            );
+            RpcError::Auth(AuthError::Forbidden(MINOR_DM_DENIED_MSG.into()))
+        })
+}
+
+/// Apply the verified_minor containment gate to an already-parsed raw rumor
+/// before Keycast composes any per-recipient seals.
+fn enforce_minor_dm_rumor(
+    handler: &Arc<HttpRpcHandler>,
+    rumor: &UnsignedEvent,
+) -> Result<(), RpcError> {
+    keycast_core::verified_minor_dm::validate_minor_rumor_recipients(&handler.public_key(), rumor)
+        .map_err(|denied| {
+            tracing::warn!(
+                event = "minor_dm_gate.rumor_denied",
+                user_pubkey = %handler.user_pubkey_hex(),
+                kind = rumor.kind.as_u16(),
+                reason = %denied,
+                "verified_minor NIP-17 rumor refused"
             );
             RpcError::Auth(AuthError::Forbidden(MINOR_DM_DENIED_MSG.into()))
         })
@@ -822,6 +894,93 @@ fn parse_decrypt_params(params: &[JsonValue]) -> Result<(PublicKey, String), Rpc
     Ok((pubkey, ciphertext.to_string()))
 }
 
+struct Nip17WrapBatchParams {
+    rumor: UnsignedEvent,
+    recipients: Vec<Result<PublicKey, ()>>,
+}
+
+/// Parse `[rumor_object, [recipient_pubkey_hex...]]`.
+///
+/// The shared rumor and recipient-list shape are request-level concerns.
+/// Individual malformed recipient entries remain positional per-item errors so
+/// valid siblings can still be wrapped without reindexing the response.
+fn parse_nip17_wrap_batch_params(params: &[JsonValue]) -> Result<Nip17WrapBatchParams, RpcError> {
+    if params.len() != 2 {
+        return Err(RpcError::InvalidParams(
+            "Expected rumor and recipient list parameters".into(),
+        ));
+    }
+
+    let rumor_value = params
+        .first()
+        .filter(|value| value.is_object())
+        .ok_or_else(|| RpcError::InvalidParams("Missing rumor object".into()))?;
+    let rumor: UnsignedEvent = serde_json::from_value(rumor_value.clone())
+        .map_err(|e| RpcError::InvalidParams(format!("Invalid rumor format: {}", e)))?;
+    if !matches!(rumor.kind.as_u16(), 14 | 15) {
+        return Err(RpcError::InvalidParams(
+            "Rumor kind must be 14 or 15".into(),
+        ));
+    }
+
+    let recipient_values = params
+        .get(1)
+        .and_then(JsonValue::as_array)
+        .ok_or_else(|| RpcError::InvalidParams("Missing recipient list".into()))?;
+    if recipient_values.is_empty() {
+        return Err(RpcError::InvalidParams("Empty recipient list".into()));
+    }
+    if recipient_values.len() > MAX_WRAP_BATCH {
+        return Err(RpcError::InvalidParams(format!(
+            "Maximum {} recipients per batch",
+            MAX_WRAP_BATCH
+        )));
+    }
+
+    let recipients = recipient_values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or(())
+                .and_then(|hex| PublicKey::from_hex(hex).map_err(|_| ()))
+        })
+        .collect();
+
+    Ok(Nip17WrapBatchParams { rumor, recipients })
+}
+
+fn wrap_error_slot(code: &str) -> JsonValue {
+    serde_json::json!({ "error": code })
+}
+
+/// Build ordered, index-aligned gift wraps for one shared rumor.
+///
+/// Construction is deliberately sequential: a request can contain at most
+/// [`MAX_WRAP_BATCH`] recipients, and one in-flight recipient at a time avoids
+/// crowding Tokio's shared blocking pool while preserving duplicate slots.
+async fn wrap_gift_wrap_batch(
+    handler: &Arc<HttpRpcHandler>,
+    rumor: &UnsignedEvent,
+    recipients: &[Result<PublicKey, ()>],
+) -> Vec<JsonValue> {
+    let mut results = Vec::with_capacity(recipients.len());
+    for recipient in recipients {
+        let slot = match recipient {
+            Err(()) => wrap_error_slot("invalid_recipient"),
+            Ok(recipient) => match handler.nip17_wrap(rumor.clone(), recipient).await {
+                Ok(gift_wrap) => match serde_json::to_value(gift_wrap) {
+                    Ok(event) => serde_json::json!({ "gift_wrap": event }),
+                    Err(_) => wrap_error_slot("internal"),
+                },
+                Err(error) => wrap_error_slot(error.code()),
+            },
+        };
+        results.push(slot);
+    }
+    results
+}
+
 /// Build the per-item error slot for the unwrap batch response.
 fn unwrap_error_slot(code: &str) -> JsonValue {
     serde_json::json!({ "error": code })
@@ -1043,6 +1202,70 @@ mod tests {
         assert!(result.is_err());
     }
 
+    fn wrap_rumor_value(author: PublicKey, recipient: PublicKey) -> JsonValue {
+        let rumor =
+            nostr_sdk::EventBuilder::private_msg_rumor(recipient, "batch send").build(author);
+        serde_json::to_value(rumor).expect("serialize rumor")
+    }
+
+    #[test]
+    fn parse_wrap_batch_accepts_shared_rumor_and_preserves_recipient_slots() {
+        let sender = Keys::generate();
+        let receiver = Keys::generate();
+        let receiver_hex = receiver.public_key().to_hex();
+        let params = vec![
+            wrap_rumor_value(sender.public_key(), receiver.public_key()),
+            serde_json::json!([receiver_hex, "not-a-pubkey", receiver.public_key().to_hex()]),
+        ];
+
+        let parsed = parse_nip17_wrap_batch_params(&params).expect("valid batch shape");
+
+        assert_eq!(parsed.rumor.pubkey, sender.public_key());
+        assert_eq!(parsed.recipients.len(), 3);
+        assert_eq!(
+            parsed.recipients[0].as_ref().expect("valid recipient"),
+            &receiver.public_key()
+        );
+        assert!(parsed.recipients[1].is_err());
+        assert_eq!(
+            parsed.recipients[2].as_ref().expect("duplicate recipient"),
+            &receiver.public_key()
+        );
+    }
+
+    #[test]
+    fn parse_wrap_batch_rejects_empty_and_over_cap_recipient_lists() {
+        let sender = Keys::generate();
+        let receiver = Keys::generate();
+        let rumor = wrap_rumor_value(sender.public_key(), receiver.public_key());
+
+        let empty = parse_nip17_wrap_batch_params(&[rumor.clone(), serde_json::json!([])]);
+        assert!(matches!(empty, Err(RpcError::InvalidParams(_))));
+
+        let recipients = vec![receiver.public_key().to_hex(); MAX_WRAP_BATCH + 1];
+        let over_cap =
+            parse_nip17_wrap_batch_params(&[rumor, serde_json::to_value(recipients).unwrap()]);
+        assert!(matches!(over_cap, Err(RpcError::InvalidParams(_))));
+    }
+
+    #[test]
+    fn parse_wrap_batch_rejects_malformed_or_non_nip17_rumor() {
+        let malformed = parse_nip17_wrap_batch_params(&[
+            serde_json::json!({ "kind": 14 }),
+            serde_json::json!(["not-a-pubkey"]),
+        ]);
+        assert!(matches!(malformed, Err(RpcError::InvalidParams(_))));
+
+        let sender = Keys::generate();
+        let receiver = Keys::generate();
+        let note = nostr_sdk::EventBuilder::text_note("not a rumor").build(sender.public_key());
+        let wrong_kind = parse_nip17_wrap_batch_params(&[
+            serde_json::to_value(note).unwrap(),
+            serde_json::json!([receiver.public_key().to_hex()]),
+        ]);
+        assert!(matches!(wrong_kind, Err(RpcError::InvalidParams(_))));
+    }
+
     #[test]
     fn test_rpc_response_success() {
         let response = NostrRpcResponse::success(JsonValue::String("test".to_string()));
@@ -1173,5 +1396,45 @@ mod tests {
                 "authenticated sender out of order at slot {i}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn wrap_gift_wrap_batch_preserves_order_duplicates_and_partial_errors() {
+        let handler = Arc::new(create_test_handler_with_dpop(None));
+        let receiver_a = Keys::generate();
+        let receiver_b = Keys::generate();
+        let rumor = nostr_sdk::EventBuilder::private_msg_rumor(
+            receiver_a.public_key(),
+            "ordered batch send",
+        )
+        .build(handler.public_key());
+        let recipients = vec![
+            Ok(receiver_a.public_key()),
+            Err(()),
+            Ok(receiver_b.public_key()),
+            Ok(receiver_a.public_key()),
+        ];
+
+        let results = wrap_gift_wrap_batch(&handler, &rumor, &recipients).await;
+
+        assert_eq!(results.len(), recipients.len());
+        assert_eq!(results[1]["error"].as_str(), Some("invalid_recipient"));
+        for (idx, receiver) in [
+            (0usize, &receiver_a),
+            (2usize, &receiver_b),
+            (3usize, &receiver_a),
+        ] {
+            let wrap: Event = serde_json::from_value(results[idx]["gift_wrap"].clone())
+                .expect("successful slot contains an event");
+            let unwrapped = nostr_sdk::nips::nip59::UnwrappedGift::from_gift_wrap(receiver, &wrap)
+                .await
+                .expect("intended recipient unwraps");
+            assert_eq!(unwrapped.sender, handler.public_key());
+            assert_eq!(unwrapped.rumor.content, "ordered batch send");
+        }
+        assert_ne!(
+            results[0]["gift_wrap"]["id"], results[3]["gift_wrap"]["id"],
+            "duplicate recipients get distinct ephemeral outer wraps"
+        );
     }
 }

--- a/api/src/handlers/http_rpc_handler.rs
+++ b/api/src/handlers/http_rpc_handler.rs
@@ -70,9 +70,12 @@ impl UnwrapError {
 
 /// Per-recipient failure reason for NIP-17 gift-wrap creation.
 ///
-/// The HTTP batch response exposes these as stable `{"error": "<code>"}`
-/// slots, allowing one recipient failure to remain isolated without weakening
-/// authorization or permission checks for the rest of the batch.
+/// The HTTP batch response exposes recipient-scoped failures as stable
+/// `{"error": "<code>"}` slots, allowing one recipient failure to remain
+/// isolated without weakening authorization or permission checks for the rest of
+/// the batch. Common rumor failures such as [`Self::InvalidRumorAuthor`] and
+/// [`Self::InvalidRumorId`] are rejected by the RPC layer as request-level
+/// invalid params before any per-recipient slots are built.
 #[derive(Debug, Error)]
 pub enum WrapError {
     #[error("authorization expired or revoked")]
@@ -416,14 +419,34 @@ impl HttpRpcHandler {
         rumor.ensure_id();
 
         let plaintext = rumor.as_json();
-        let ciphertext = self
-            .nip44_encrypt(recipient, &plaintext)
+        self.nip17_wrap_prevalidated_plaintext(&plaintext, recipient)
             .await
-            .map_err(|error| match error {
-                HandlerError::AuthorizationInvalid => WrapError::AuthorizationInvalid,
-                HandlerError::PermissionDenied => WrapError::PermissionDenied,
-                HandlerError::Encryption(_) | HandlerError::Signing(_) => WrapError::EncryptFailed,
-            })?;
+    }
+
+    /// Build one NIP-59 gift wrap from a prevalidated, serialized rumor.
+    ///
+    /// The caller must verify the rumor author and id before passing plaintext.
+    /// This keeps batch wrapping from rehashing and reserializing the same rumor
+    /// for every recipient while preserving the encrypt and sign policy gates.
+    pub(crate) async fn nip17_wrap_prevalidated_plaintext(
+        &self,
+        plaintext: &str,
+        recipient: &PublicKey,
+    ) -> Result<Event, WrapError> {
+        if !self.is_valid() {
+            return Err(WrapError::AuthorizationInvalid);
+        }
+
+        let ciphertext =
+            self.nip44_encrypt(recipient, plaintext)
+                .await
+                .map_err(|error| match error {
+                    HandlerError::AuthorizationInvalid => WrapError::AuthorizationInvalid,
+                    HandlerError::PermissionDenied => WrapError::PermissionDenied,
+                    HandlerError::Encryption(_) | HandlerError::Signing(_) => {
+                        WrapError::EncryptFailed
+                    }
+                })?;
 
         let seal = EventBuilder::new(Kind::Seal, ciphertext)
             .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))

--- a/api/src/handlers/http_rpc_handler.rs
+++ b/api/src/handlers/http_rpc_handler.rs
@@ -8,7 +8,9 @@ use keycast_core::traits::CustomPermission;
 use moka::future::Cache;
 use nostr_sdk::nips::nip04;
 use nostr_sdk::nips::nip59::{self, UnwrappedGift};
-use nostr_sdk::{Event, Keys, Kind, PublicKey, UnsignedEvent};
+use nostr_sdk::{
+    Event, EventBuilder, JsonUtil, Keys, Kind, PublicKey, Tag, Timestamp, UnsignedEvent,
+};
 use once_cell::sync::Lazy;
 use secrecy::SecretString;
 use std::sync::Arc;
@@ -62,6 +64,44 @@ impl UnwrapError {
             UnwrapError::SenderMismatch => "sender_mismatch",
             UnwrapError::PermissionDenied => "permission_denied",
             UnwrapError::Internal => "internal",
+        }
+    }
+}
+
+/// Per-recipient failure reason for NIP-17 gift-wrap creation.
+///
+/// The HTTP batch response exposes these as stable `{"error": "<code>"}`
+/// slots, allowing one recipient failure to remain isolated without weakening
+/// authorization or permission checks for the rest of the batch.
+#[derive(Debug, Error)]
+pub enum WrapError {
+    #[error("authorization expired or revoked")]
+    AuthorizationInvalid,
+    #[error("rumor author does not match signer")]
+    InvalidRumorAuthor,
+    #[error("rumor id does not match its contents")]
+    InvalidRumorId,
+    #[error("permission denied")]
+    PermissionDenied,
+    #[error("rumor encryption failed")]
+    EncryptFailed,
+    #[error("seal signing failed")]
+    SignFailed,
+    #[error("gift wrap construction failed")]
+    WrapFailed,
+}
+
+impl WrapError {
+    /// Stable wire code for a per-recipient wrap result slot.
+    pub fn code(&self) -> &'static str {
+        match self {
+            WrapError::AuthorizationInvalid => "authorization_invalid",
+            WrapError::InvalidRumorAuthor => "invalid_rumor_author",
+            WrapError::InvalidRumorId => "invalid_rumor_id",
+            WrapError::PermissionDenied => "permission_denied",
+            WrapError::EncryptFailed => "encrypt_failed",
+            WrapError::SignFailed => "sign_failed",
+            WrapError::WrapFailed => "wrap_failed",
         }
     }
 }
@@ -354,6 +394,55 @@ impl HttpRpcHandler {
             .map_err(|e| HandlerError::Encryption(e.to_string()))
     }
 
+    /// Build one NIP-59 gift wrap while preserving the cached HTTP
+    /// authorization and custom-permission checks.
+    ///
+    /// The rumor is encrypted through [`Self::nip44_encrypt`] and the kind-13
+    /// seal is signed through [`Self::sign_event`]. Only the ephemeral outer
+    /// kind-1059 wrap is delegated directly to nostr-sdk, so the user's secret
+    /// key never bypasses the existing encrypt/sign policy surfaces.
+    pub async fn nip17_wrap(
+        &self,
+        mut rumor: UnsignedEvent,
+        recipient: &PublicKey,
+    ) -> Result<Event, WrapError> {
+        if !self.is_valid() {
+            return Err(WrapError::AuthorizationInvalid);
+        }
+        if rumor.pubkey != self.user_pubkey {
+            return Err(WrapError::InvalidRumorAuthor);
+        }
+        rumor.verify_id().map_err(|_| WrapError::InvalidRumorId)?;
+        rumor.ensure_id();
+
+        let plaintext = rumor.as_json();
+        let ciphertext = self
+            .nip44_encrypt(recipient, &plaintext)
+            .await
+            .map_err(|error| match error {
+                HandlerError::AuthorizationInvalid => WrapError::AuthorizationInvalid,
+                HandlerError::PermissionDenied => WrapError::PermissionDenied,
+                HandlerError::Encryption(_) | HandlerError::Signing(_) => WrapError::EncryptFailed,
+            })?;
+
+        let seal = EventBuilder::new(Kind::Seal, ciphertext)
+            .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))
+            .build(self.user_pubkey);
+        let signed_seal = self.sign_event(seal).await.map_err(|error| match error {
+            HandlerError::AuthorizationInvalid => WrapError::AuthorizationInvalid,
+            HandlerError::PermissionDenied => WrapError::PermissionDenied,
+            HandlerError::Signing(_) | HandlerError::Encryption(_) => WrapError::SignFailed,
+        })?;
+
+        let recipient = *recipient;
+        tokio::task::spawn_blocking(move || {
+            EventBuilder::gift_wrap_from_seal(&recipient, &signed_seal, Vec::<Tag>::new())
+        })
+        .await
+        .map_err(|_| WrapError::WrapFailed)?
+        .map_err(|_| WrapError::WrapFailed)
+    }
+
     /// Unwrap a single NIP-59 gift wrap (kind 1059) → seal (kind 13) → rumor.
     ///
     /// This is the per-item primitive behind the `nip17_unwrap_batch` RPC. It
@@ -562,6 +651,21 @@ mod tests {
         )
     }
 
+    fn allowed_kinds_permission(kinds: &[u16]) -> Box<dyn CustomPermission> {
+        use keycast_core::types::permission::{JsonConfig, Permission};
+
+        let now = Utc::now();
+        Permission {
+            id: 1,
+            identifier: "allowed_kinds".to_string(),
+            config: JsonConfig(serde_json::json!({ "allowed_kinds": kinds })),
+            created_at: now,
+            updated_at: now,
+        }
+        .to_custom_permission()
+        .expect("allowed_kinds test permission")
+    }
+
     #[test]
     fn test_is_valid_no_expiration() {
         let handler = create_test_handler(None, None);
@@ -669,6 +773,134 @@ mod tests {
         );
 
         assert_eq!(handler.expected_dpop_jkt(), Some("thumbprint-123"));
+    }
+
+    // -- nip17_wrap (NIP-59 gift-wrap creation) ------------------------------
+
+    fn build_rumor(author: PublicKey, receiver: PublicKey, text: &str) -> UnsignedEvent {
+        nostr_sdk::EventBuilder::private_msg_rumor(receiver, text).build(author)
+    }
+
+    #[tokio::test]
+    async fn nip17_wrap_round_trips_for_recipient() {
+        let handler = create_test_handler(None, None);
+        let receiver = Keys::generate();
+        let rumor = build_rumor(
+            handler.public_key(),
+            receiver.public_key(),
+            "hello from keycast",
+        );
+
+        let gift_wrap = handler
+            .nip17_wrap(rumor.clone(), &receiver.public_key())
+            .await
+            .expect("wrap should succeed");
+
+        gift_wrap.verify().expect("outer wrap must verify");
+        assert_eq!(gift_wrap.kind, Kind::GiftWrap);
+
+        let unwrapped = UnwrappedGift::from_gift_wrap(&receiver, &gift_wrap)
+            .await
+            .expect("recipient should unwrap");
+        assert_eq!(unwrapped.sender, handler.public_key());
+        assert_eq!(unwrapped.rumor.content, rumor.content);
+        assert_eq!(unwrapped.rumor.pubkey, handler.public_key());
+        assert!(unwrapped.rumor.id.is_some());
+    }
+
+    #[tokio::test]
+    async fn nip17_wrap_denied_when_authorization_expired() {
+        let expires = Utc::now() - chrono::Duration::hours(1);
+        let handler = create_test_handler(Some(expires), None);
+        let receiver = Keys::generate();
+        let rumor = build_rumor(handler.public_key(), receiver.public_key(), "expired");
+
+        let err = handler
+            .nip17_wrap(rumor, &receiver.public_key())
+            .await
+            .expect_err("expired authorization must be denied");
+
+        assert_eq!(err.code(), "authorization_invalid");
+    }
+
+    #[tokio::test]
+    async fn nip17_wrap_rejects_mismatched_rumor_author() {
+        let handler = create_test_handler(None, None);
+        let receiver = Keys::generate();
+        let impersonated = Keys::generate();
+        let rumor = build_rumor(impersonated.public_key(), receiver.public_key(), "spoofed");
+
+        let err = handler
+            .nip17_wrap(rumor, &receiver.public_key())
+            .await
+            .expect_err("rumor author must equal the signer");
+
+        assert_eq!(err.code(), "invalid_rumor_author");
+    }
+
+    #[tokio::test]
+    async fn nip17_wrap_rejects_inconsistent_supplied_rumor_id() {
+        let handler = create_test_handler(None, None);
+        let receiver = Keys::generate();
+        let mut rumor = build_rumor(handler.public_key(), receiver.public_key(), "bad id");
+        rumor.id = Some(nostr_sdk::EventId::all_zeros());
+
+        let err = handler
+            .nip17_wrap(rumor, &receiver.public_key())
+            .await
+            .expect_err("inconsistent supplied rumor id must be rejected");
+
+        assert_eq!(err.code(), "invalid_rumor_id");
+    }
+
+    #[tokio::test]
+    async fn nip17_wrap_preserves_encrypt_permission() {
+        use keycast_core::custom_permissions::encrypt_to_self::EncryptToSelf;
+
+        let handler =
+            create_test_handler_with_permissions(None, None, vec![Box::new(EncryptToSelf {})]);
+        let receiver = Keys::generate();
+        let rumor = build_rumor(handler.public_key(), receiver.public_key(), "not to self");
+
+        let err = handler
+            .nip17_wrap(rumor, &receiver.public_key())
+            .await
+            .expect_err("encrypt_to_self must deny wrapping to another recipient");
+
+        assert_eq!(err.code(), "permission_denied");
+    }
+
+    #[tokio::test]
+    async fn nip17_wrap_preserves_kind_13_sign_permission() {
+        let handler =
+            create_test_handler_with_permissions(None, None, vec![allowed_kinds_permission(&[1])]);
+        let receiver = Keys::generate();
+        let rumor = build_rumor(
+            handler.public_key(),
+            receiver.public_key(),
+            "seal sign denied",
+        );
+
+        let err = handler
+            .nip17_wrap(rumor, &receiver.public_key())
+            .await
+            .expect_err("kind policy must deny signing the seal");
+
+        assert_eq!(err.code(), "permission_denied");
+    }
+
+    #[test]
+    fn wrap_error_codes_are_stable() {
+        assert_eq!(
+            WrapError::AuthorizationInvalid.code(),
+            "authorization_invalid"
+        );
+        assert_eq!(WrapError::InvalidRumorAuthor.code(), "invalid_rumor_author");
+        assert_eq!(WrapError::InvalidRumorId.code(), "invalid_rumor_id");
+        assert_eq!(WrapError::PermissionDenied.code(), "permission_denied");
+        assert_eq!(WrapError::EncryptFailed.code(), "encrypt_failed");
+        assert_eq!(WrapError::SignFailed.code(), "sign_failed");
+        assert_eq!(WrapError::WrapFailed.code(), "wrap_failed");
     }
 
     // -- nip17_unwrap (NIP-59 gift-wrap unwrap) ------------------------------

--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -1413,6 +1413,62 @@ async fn gift_wrap_param(sender: &Keys, receiver: &PublicKey, text: &str) -> Val
     serde_json::to_value(&wrap).expect("serialize gift wrap")
 }
 
+fn wrap_rumor_param(sender: &Keys, receiver: &PublicKey, text: &str) -> Value {
+    let rumor = EventBuilder::private_msg_rumor(*receiver, text).build(sender.public_key());
+    serde_json::to_value(rumor).expect("serialize rumor")
+}
+
+struct WrapRpcAccount {
+    user_keys: Keys,
+    pubkey: String,
+    auth_id: i32,
+    token: String,
+    auth_state: AuthState,
+}
+
+async fn setup_wrap_rpc_account(
+    pool: &PgPool,
+    tenant_id: i64,
+    expires_at: Option<chrono::DateTime<Utc>>,
+    revoked_at: Option<chrono::DateTime<Utc>>,
+) -> WrapRpcAccount {
+    let (user_keys, pubkey) = create_test_user();
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+    insert_user(pool, tenant_id, &pubkey).await;
+    create_personal_key(pool, tenant_id, &pubkey, &user_keys, &key_manager).await;
+
+    let redirect_origin = format!("https://wrap-{}.example.com", Uuid::new_v4());
+    let (auth_id, bunker_pubkey) = create_test_oauth_authorization(
+        pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        None,
+        expires_at,
+        revoked_at,
+    )
+    .await;
+    let token = build_self_signed_ucan(
+        &user_keys,
+        tenant_id,
+        &redirect_origin,
+        Some(&bunker_pubkey),
+    )
+    .await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+
+    WrapRpcAccount {
+        user_keys,
+        pubkey,
+        auth_id,
+        token,
+        auth_state,
+    }
+}
+
 /// Happy path + partial failure: a batch with one decryptable wrap, one
 /// non-gift-wrap event, one wrap for a different recipient, and one unparseable
 /// item returns four ordered, index-aligned slots (success / per-item errors).
@@ -1624,4 +1680,231 @@ async fn test_suspended_user_denied_nip17_unwrap_batch() {
         RpcError::AccountSuspended(msg) => assert_eq!(msg, "Account restricted"),
         other => panic!("expected AccountSuspended, got: {:?}", other),
     }
+}
+
+// ============================================================================
+// nip17_wrap_batch (NIP-59 gift-wrap creation)
+// ============================================================================
+
+#[tokio::test]
+#[serial]
+async fn test_nip17_wrap_batch_happy_path_order_duplicates_partial_failure_and_activity() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let account = setup_wrap_rpc_account(&pool, tenant_id, None, None).await;
+    let recipient = Keys::generate();
+    let rumor = wrap_rumor_param(
+        &account.user_keys,
+        &recipient.public_key(),
+        "one shared rumor",
+    );
+
+    let response = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        account.auth_state,
+        &format!("Bearer {}", account.token),
+        None,
+        NostrRpcRequest {
+            method: "nip17_wrap_batch".to_string(),
+            params: vec![
+                rumor,
+                json!([
+                    recipient.public_key().to_hex(),
+                    "not-a-recipient",
+                    account.pubkey,
+                    recipient.public_key().to_hex()
+                ]),
+            ],
+        },
+    )
+    .await
+    .expect("batch wrap should return ordered slots");
+
+    let results = response
+        .result
+        .as_ref()
+        .and_then(Value::as_array)
+        .expect("result array");
+    assert_eq!(results.len(), 4);
+    assert_eq!(results[1]["error"].as_str(), Some("invalid_recipient"));
+
+    let mut rumor_ids = Vec::new();
+    for (idx, receiver) in [
+        (0usize, &recipient),
+        (2usize, &account.user_keys),
+        (3usize, &recipient),
+    ] {
+        let gift_wrap: Event = serde_json::from_value(results[idx]["gift_wrap"].clone())
+            .expect("successful slot contains gift wrap");
+        let unwrapped = UnwrappedGift::from_gift_wrap(receiver, &gift_wrap)
+            .await
+            .expect("intended recipient unwraps");
+        assert_eq!(unwrapped.sender, account.user_keys.public_key());
+        assert_eq!(unwrapped.rumor.content, "one shared rumor");
+        rumor_ids.push(unwrapped.rumor.id.expect("server ensures rumor id"));
+    }
+    assert!(
+        rumor_ids.windows(2).all(|pair| pair[0] == pair[1]),
+        "every slot must carry the same durable rumor id"
+    );
+    assert_ne!(
+        results[0]["gift_wrap"]["id"], results[3]["gift_wrap"]["id"],
+        "duplicate recipients retain separate ephemeral gift wraps"
+    );
+
+    let mut activity_count = 0;
+    for _ in 0..100 {
+        activity_count = sqlx::query_scalar::<_, i32>(
+            "SELECT activity_count FROM oauth_authorizations WHERE id = $1",
+        )
+        .bind(account.auth_id)
+        .fetch_one(&pool)
+        .await
+        .expect("read activity count");
+        if activity_count == 1 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert_eq!(
+        activity_count, 1,
+        "the whole batch records exactly one coalesced activity update"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_nip17_wrap_batch_rejects_malformed_common_shape_empty_and_cap() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let account = setup_wrap_rpc_account(&pool, tenant_id, None, None).await;
+    let recipient = Keys::generate();
+    let valid_rumor = wrap_rumor_param(&account.user_keys, &recipient.public_key(), "valid shape");
+
+    let malformed = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        account.auth_state.clone(),
+        &format!("Bearer {}", account.token),
+        None,
+        NostrRpcRequest {
+            method: "nip17_wrap_batch".to_string(),
+            params: vec![
+                json!({ "kind": 14 }),
+                json!([recipient.public_key().to_hex()]),
+            ],
+        },
+    )
+    .await
+    .expect_err("malformed shared rumor is request-level invalid params");
+    assert!(matches!(malformed, RpcError::InvalidParams(_)));
+
+    let wrong_author = Keys::generate();
+    let wrong_author_rumor =
+        wrap_rumor_param(&wrong_author, &recipient.public_key(), "wrong author");
+    let wrong_author_err = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        account.auth_state.clone(),
+        &format!("Bearer {}", account.token),
+        None,
+        NostrRpcRequest {
+            method: "nip17_wrap_batch".to_string(),
+            params: vec![wrong_author_rumor, json!([recipient.public_key().to_hex()])],
+        },
+    )
+    .await
+    .expect_err("shared rumor author mismatch is request-level invalid params");
+    assert!(matches!(wrong_author_err, RpcError::InvalidParams(_)));
+
+    let empty = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        account.auth_state.clone(),
+        &format!("Bearer {}", account.token),
+        None,
+        NostrRpcRequest {
+            method: "nip17_wrap_batch".to_string(),
+            params: vec![valid_rumor.clone(), json!([])],
+        },
+    )
+    .await
+    .expect_err("empty recipient list is rejected");
+    assert!(matches!(empty, RpcError::InvalidParams(_)));
+
+    let recipients = vec![recipient.public_key().to_hex(); 101];
+    let over_cap = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        account.auth_state,
+        &format!("Bearer {}", account.token),
+        None,
+        NostrRpcRequest {
+            method: "nip17_wrap_batch".to_string(),
+            params: vec![valid_rumor, serde_json::to_value(recipients).unwrap()],
+        },
+    )
+    .await
+    .expect_err("over-cap recipient list is rejected");
+    assert!(matches!(over_cap, RpcError::InvalidParams(_)));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_suspended_user_denied_nip17_wrap_batch() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let account = setup_wrap_rpc_account(&pool, tenant_id, None, None).await;
+    suspend_user(&pool, &account.pubkey, tenant_id).await;
+    let recipient = Keys::generate();
+
+    let err = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        account.auth_state,
+        &format!("Bearer {}", account.token),
+        None,
+        NostrRpcRequest {
+            method: "nip17_wrap_batch".to_string(),
+            params: vec![
+                wrap_rumor_param(&account.user_keys, &recipient.public_key(), "restricted"),
+                json!([recipient.public_key().to_hex()]),
+            ],
+        },
+    )
+    .await
+    .expect_err("suspended user cannot wrap a batch");
+
+    match err {
+        RpcError::AccountSuspended(msg) => assert_eq!(msg, "Account restricted"),
+        other => panic!("expected AccountSuspended, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_revoked_authorization_denied_nip17_wrap_batch() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let account = setup_wrap_rpc_account(
+        &pool,
+        tenant_id,
+        None,
+        Some(Utc::now() - Duration::minutes(1)),
+    )
+    .await;
+    let recipient = Keys::generate();
+
+    let err = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        account.auth_state,
+        &format!("Bearer {}", account.token),
+        None,
+        NostrRpcRequest {
+            method: "nip17_wrap_batch".to_string(),
+            params: vec![
+                wrap_rumor_param(&account.user_keys, &recipient.public_key(), "revoked"),
+                json!([recipient.public_key().to_hex()]),
+            ],
+        },
+    )
+    .await
+    .expect_err("revoked authorization cannot wrap a batch");
+
+    assert!(matches!(err, RpcError::Auth(AuthError::InvalidToken)));
 }

--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -1418,6 +1418,23 @@ fn wrap_rumor_param(sender: &Keys, receiver: &PublicKey, text: &str) -> Value {
     serde_json::to_value(rumor).expect("serialize rumor")
 }
 
+fn assert_gift_wrap_has_recipient_p_tag(slot: &Value, recipient: &PublicKey) {
+    let recipient_hex = recipient.to_hex();
+    let tags = slot["gift_wrap"]["tags"]
+        .as_array()
+        .expect("gift wrap has tags");
+    assert!(
+        tags.iter().any(|tag| {
+            let Some(parts) = tag.as_array() else {
+                return false;
+            };
+            parts.first().and_then(Value::as_str) == Some("p")
+                && parts.get(1).and_then(Value::as_str) == Some(recipient_hex.as_str())
+        }),
+        "gift wrap must include recipient p tag"
+    );
+}
+
 struct WrapRpcAccount {
     user_keys: Keys,
     pubkey: String,
@@ -1734,6 +1751,7 @@ async fn test_nip17_wrap_batch_happy_path_order_duplicates_partial_failure_and_a
         (2usize, &account.user_keys),
         (3usize, &recipient),
     ] {
+        assert_gift_wrap_has_recipient_p_tag(&results[idx], &receiver.public_key());
         let gift_wrap: Event = serde_json::from_value(results[idx]["gift_wrap"].clone())
             .expect("successful slot contains gift wrap");
         let unwrapped = UnwrappedGift::from_gift_wrap(receiver, &gift_wrap)

--- a/api/tests/verified_minor_dm_gate_test.rs
+++ b/api/tests/verified_minor_dm_gate_test.rs
@@ -537,6 +537,107 @@ async fn minor_rpc_nip44_encrypt_to_official_and_self_allowed() {
     assert!(to_self.result.is_some());
 }
 
+// ============================================================================
+// HTTP RPC (/api/nostr) — nip17_wrap_batch
+// ============================================================================
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_nip17_wrap_batch_to_official_and_self_allowed() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let rumor = unsigned_dm_json(14, &minor.keys, &[hq_pubkey()]);
+
+    let response = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "nip17_wrap_batch",
+        vec![
+            rumor,
+            json!([hq_pubkey().to_hex(), minor.keys.public_key().to_hex()]),
+        ],
+    )
+    .await
+    .expect("minor may wrap the same approved rumor to official and self");
+
+    let slots = response
+        .result
+        .as_ref()
+        .and_then(Value::as_array)
+        .expect("ordered result slots");
+    assert_eq!(slots.len(), 2);
+    assert_eq!(slots[0]["gift_wrap"]["kind"].as_u64(), Some(1059));
+
+    let self_wrap: Event = serde_json::from_value(slots[1]["gift_wrap"].clone())
+        .expect("self slot contains gift wrap");
+    let unwrapped = UnwrappedGift::from_gift_wrap(&minor.keys, &self_wrap)
+        .await
+        .expect("minor can unwrap own history copy");
+    assert_eq!(unwrapped.sender, minor.keys.public_key());
+    assert_eq!(unwrapped.rumor.content, "gate test message");
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_nip17_wrap_batch_to_arbitrary_slot_refused() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+    let rumor = unsigned_dm_json(14, &minor.keys, &[hq_pubkey()]);
+
+    let err = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "nip17_wrap_batch",
+        vec![rumor, json!([mallory.public_key().to_hex()])],
+    )
+    .await
+    .expect_err("minor may not add an arbitrary encryption recipient slot");
+
+    assert_rpc_denied(err);
+}
+
+#[tokio::test]
+#[serial]
+async fn minor_rpc_nip17_wrap_batch_embedded_arbitrary_recipient_refused() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let key_manager = FileKeyManager::new().expect("key manager");
+    let minor = setup_account(&pool, tenant_id, &key_manager, true).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let mallory = Keys::generate();
+    let rumor = unsigned_dm_json(14, &minor.keys, &[hq_pubkey(), mallory.public_key()]);
+
+    let err = invoke_rpc(
+        tenant_id,
+        auth_state,
+        &minor.token,
+        "nip17_wrap_batch",
+        vec![rumor, json!([minor.keys.public_key().to_hex()])],
+    )
+    .await
+    .expect_err("approved self slot cannot smuggle an arbitrary rumor p-tag");
+
+    assert_rpc_denied(err);
+}
+
 #[tokio::test]
 #[serial]
 async fn minor_rpc_nip04_encrypt_to_arbitrary_recipient_refused() {

--- a/core/src/verified_minor_dm.rs
+++ b/core/src/verified_minor_dm.rs
@@ -161,6 +161,20 @@ pub fn validate_minor_encrypt(
     }
 }
 
+/// Gate the recipient tags of an already-parsed NIP-17 rumor.
+///
+/// This is used when Keycast composes the kind-13 seal itself: the normal
+/// verified-minor sign gate learns the rumor recipients by decrypting the
+/// client-composed seal, while the server-composed path already has the raw
+/// rumor and can validate its tags directly. Zero `p` tags remains valid
+/// because the actual encryption recipient is checked separately.
+pub fn validate_minor_rumor_recipients(
+    user_pubkey: &PublicKey,
+    rumor: &UnsignedEvent,
+) -> Result<(), MinorDmDenied> {
+    validate_p_tags_approved(user_pubkey, rumor.tags.as_slice())
+}
+
 /// Gate for `sign_event`: refuse DM-shaped events whose recipients fall
 /// outside the approved set. Non-DM kinds pass through untouched.
 ///
@@ -383,6 +397,56 @@ mod tests {
         assert_eq!(
             validate_minor_encrypt(&user.public_key(), &mallory.public_key()),
             Err(MinorDmDenied::RecipientNotApproved)
+        );
+    }
+
+    // -- already-parsed NIP-17 rumor gate -------------------------------------
+
+    #[test]
+    fn raw_rumor_to_pinned_official_and_self_is_allowed() {
+        let user = Keys::generate();
+        let rumor = dm_shaped_event(14, &user, &[hq_pubkey(), user.public_key()]);
+
+        assert_eq!(
+            validate_minor_rumor_recipients(&user.public_key(), &rumor),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn raw_rumor_with_unapproved_recipient_is_refused() {
+        let user = Keys::generate();
+        let mallory = Keys::generate();
+        let rumor = dm_shaped_event(14, &user, &[hq_pubkey(), mallory.public_key()]);
+
+        assert_eq!(
+            validate_minor_rumor_recipients(&user.public_key(), &rumor),
+            Err(MinorDmDenied::RecipientNotApproved)
+        );
+    }
+
+    #[test]
+    fn raw_rumor_with_malformed_recipient_is_refused_fail_closed() {
+        let user = Keys::generate();
+        let malformed = Tag::custom(TagKind::custom("p"), ["not-a-valid-pubkey"]);
+        let rumor = EventBuilder::new(Kind::PrivateDirectMessage, "hello")
+            .tags([malformed])
+            .build(user.public_key());
+
+        assert_eq!(
+            validate_minor_rumor_recipients(&user.public_key(), &rumor),
+            Err(MinorDmDenied::RecipientUnresolvable)
+        );
+    }
+
+    #[test]
+    fn raw_rumor_without_p_tags_is_allowed() {
+        let user = Keys::generate();
+        let rumor = dm_shaped_event(14, &user, &[]);
+
+        assert_eq!(
+            validate_minor_rumor_recipients(&user.public_key(), &rumor),
+            Ok(())
         );
     }
 


### PR DESCRIPTION
## Summary

Sending one NIP-17 message through a remote signer currently takes four HTTP calls for the recipient and self copies.
The new `nip17_wrap_batch` method sends one shared rumor to up to 100 recipients in one authenticated call and returns one ordered result per recipient.
Duplicate recipients stay aligned, while malformed recipient keys get isolated error slots.

## Motivation

The server must not bypass the permissions and minor-account safeguards that protect the existing encrypt and sign methods.
The new builder reuses `nip44_encrypt` and `sign_event`, validates rumor authors and IDs, and checks both batch targets and embedded `p` tags for protected accounts.
Wrapping runs sequentially under the recipient cap to keep server work bounded.
This is HTTP-only and does not change NIP-46, the frontend, the database, or deployment settings.

## Related Issue

- Closes #292

## Testing

The full workspace gates passed, along with PostgreSQL round-trip tests for ordering, partial failures, account restrictions, revocation, activity logging, and protected-account containment.

- [x] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [ ] Manual verification completed

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved