### PR TITLE
chore: Run web unit tests in pull-request CI

### DIFF
--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -94,9 +94,28 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  web-test:
+    name: Web Tests
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test
+
   docker:
     name: Build & Push
-    needs: test
+    needs: [test, web-test]
     runs-on: ubuntu-24.04
     if: github.event_name != 'pull_request'
     permissions:

--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -110,8 +110,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Check types
+        run: bun run check
+
       - name: Run tests
-        run: bun test
+        run: bun run test
 
   docker:
     name: Build & Push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,9 @@ Run the smallest relevant verification first, then broaden if the change is cros
   - `cargo test --workspace --verbose` for a quick pass.
   - `bun run test` to spin up Postgres + Redis via `docker-compose.deps.yml`, set up the test database, and run the full workspace + integration-feature test suite (matches what CI runs via `bun run test:ci`).
   - Targeted test commands (e.g. `cd api && cargo test --test oauth_integration_test`) when a change is scoped to a single crate or path. Record that scope in the PR.
+- Web checks:
+  - `cd web && bun run check` for Svelte/TypeScript validation.
+  - `cd web && bun run test` for frontend unit tests.
 - Combined gate: `bun run check` runs fmt, clippy, and `cargo test --workspace` together.
 - Optional pre-push parity with CI: `bun run setup:hooks` installs `scripts/hooks/pre-push`.
 - For `web/` changes, manually verify the affected path in the browser and document the manual checks in the PR.

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -84,6 +84,8 @@ else
     # Now build web app
     cd web
     bun install
+    echo "  → Running web unit tests..."
+    bun run test
     bun run build
     cd ..
 fi

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
+		"test": "bun test",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},


### PR DESCRIPTION
## Summary

Pull requests previously ran Rust tests but did not run the existing web unit tests. This change adds a parallel Web Tests job so frontend regressions appear before merge, includes the web Svelte/TypeScript check in that job, and blocks image publishing when those checks fail.

## Motivation

The web app already had Bun tests, but the pull request workflow and pre-push hook never invoked them. The web suite runs separately because it does not need Rust, Postgres, or Redis, which keeps feedback fast.

## Related Issue

- Closes #305

## Testing

- `cargo check --workspace --all-targets --all-features`
- `cd web && bun run check` (0 errors, 0 warnings)
- `cd web && bun run test` (31 passed)
- Temporary failing `web/` test probe made `cd web && bun run test` fail with exit code 1, then was removed and the suite was rerun cleanly
- `actionlint` with the repository custom runner label excluded
- `git diff --check`

## Risks

This only changes CI, local pre-push behavior, and contributor verification docs, so application runtime risk is low. If branch protection later enumerates required checks, a maintainer can add Web Tests to the main branch ruleset.

## Visuals

No visual change.
