### PR TITLE
fix(atproto): reconcile app-claimed Divine usernames

### DIFF
--- a/api/src/api/http/atproto.rs
+++ b/api/src/api/http/atproto.rs
@@ -48,12 +48,21 @@ pub struct AtprotoStatusResponse {
     pub username: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UsernameResolution {
+    Resolved(String),
+    NotClaimed,
+    Unavailable,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum AtprotoControlError {
     #[error("user not found")]
     UserNotFound,
     #[error("username must be claimed before enabling atproto")]
     UsernameNotClaimed,
+    #[error("username resolution is temporarily unavailable")]
+    UsernameResolutionUnavailable,
     #[error("requested username does not match claimed username")]
     UsernameMismatch,
     #[error("{}", .0.public_message())]
@@ -89,7 +98,7 @@ pub async fn resolve_username_with_fallback<F, Fut>(
     tenant_id: i64,
     user_pubkey: &str,
     lookup: F,
-) -> Result<Option<String>, AtprotoControlError>
+) -> Result<UsernameResolution, AtprotoControlError>
 where
     F: FnOnce(String) -> Fut,
     Fut: Future<Output = Result<Option<PubkeyLookupResponse>, DivineNameError>>,
@@ -110,7 +119,7 @@ pub async fn resolve_username_with_fallback_enabled<F, Fut>(
     user_pubkey: &str,
     divine_names_enabled: bool,
     lookup: F,
-) -> Result<Option<String>, AtprotoControlError>
+) -> Result<UsernameResolution, AtprotoControlError>
 where
     F: FnOnce(String) -> Fut,
     Fut: Future<Output = Result<Option<PubkeyLookupResponse>, DivineNameError>>,
@@ -120,32 +129,42 @@ where
         .await?
         .ok_or(AtprotoControlError::UserNotFound)?;
 
-    if local_username.is_some() || !divine_names_enabled {
-        return Ok(local_username);
+    if let Some(username) = local_username {
+        return Ok(UsernameResolution::Resolved(username));
+    }
+
+    if !divine_names_enabled {
+        return Ok(UsernameResolution::NotClaimed);
     }
 
     let lookup_response = match lookup(user_pubkey.to_string()).await {
         Ok(Some(response)) => response,
-        Ok(None) => return Ok(None),
+        Ok(None) => return Ok(UsernameResolution::NotClaimed),
         Err(error) => {
             tracing::warn!(
                 "Failed to look up Divine username for ATProto fallback by pubkey {}: {}",
                 user_pubkey,
                 error
             );
-            return Ok(None);
+            return Ok(UsernameResolution::Unavailable);
         }
     };
 
-    if let Some(ref lookup_pubkey) = lookup_response.pubkey {
-        if !lookup_pubkey.eq_ignore_ascii_case(user_pubkey) {
-            tracing::warn!(
-                "Divine username lookup by pubkey returned mismatched owner: requested_pubkey={}, returned_pubkey={}",
-                user_pubkey,
-                lookup_pubkey
-            );
-            return Ok(None);
-        }
+    let Some(ref lookup_pubkey) = lookup_response.pubkey else {
+        tracing::warn!(
+            "Divine username lookup by pubkey returned no owner for requested_pubkey={}",
+            user_pubkey
+        );
+        return Ok(UsernameResolution::Unavailable);
+    };
+
+    if !lookup_pubkey.eq_ignore_ascii_case(user_pubkey) {
+        tracing::warn!(
+            "Divine username lookup by pubkey returned mismatched owner: requested_pubkey={}, returned_pubkey={}",
+            user_pubkey,
+            lookup_pubkey
+        );
+        return Ok(UsernameResolution::NotClaimed);
     }
 
     let Some(resolved_username) = lookup_response.canonical.or(lookup_response.name) else {
@@ -153,7 +172,7 @@ where
             "Divine username lookup by pubkey returned no username for pubkey {}",
             user_pubkey
         );
-        return Ok(None);
+        return Ok(UsernameResolution::NotClaimed);
     };
 
     let normalized_username = match super::auth::normalize_nip05_username(&resolved_username) {
@@ -165,7 +184,7 @@ where
                 user_pubkey,
                 error
             );
-            return Ok(None);
+            return Ok(UsernameResolution::NotClaimed);
         }
     };
 
@@ -184,14 +203,14 @@ where
             tenant_id,
             conflicting_pubkey
         );
-        return Ok(None);
+        return Ok(UsernameResolution::NotClaimed);
     }
 
     match repo
         .update_username(user_pubkey, &normalized_username, tenant_id)
         .await
     {
-        Ok(()) => Ok(Some(normalized_username)),
+        Ok(()) => Ok(UsernameResolution::Resolved(normalized_username)),
         Err(RepositoryError::Duplicate) => {
             tracing::warn!(
                 "Refusing to reconcile Divine username '{}' for pubkey {} because a duplicate local username appeared in tenant {}",
@@ -199,9 +218,19 @@ where
                 user_pubkey,
                 tenant_id
             );
-            Ok(None)
+            Ok(UsernameResolution::NotClaimed)
         }
         Err(error) => Err(error.into()),
+    }
+}
+
+fn require_resolved_username(
+    resolution: UsernameResolution,
+) -> Result<String, AtprotoControlError> {
+    match resolution {
+        UsernameResolution::Resolved(username) => Ok(username),
+        UsernameResolution::NotClaimed => Err(AtprotoControlError::UsernameNotClaimed),
+        UsernameResolution::Unavailable => Err(AtprotoControlError::UsernameResolutionUnavailable),
     }
 }
 
@@ -232,12 +261,12 @@ pub async fn enable_user_atproto(
     user_pubkey: &str,
     requested_username: &str,
 ) -> Result<AtprotoStatusResponse, AtprotoControlError> {
-    let claimed_username =
+    let claimed_username = require_resolved_username(
         resolve_username_with_fallback(repo, tenant_id, user_pubkey, |pubkey| async move {
             divine_names::lookup_by_pubkey(&pubkey).await
         })
-        .await?
-        .ok_or(AtprotoControlError::UsernameNotClaimed)?;
+        .await?,
+    )?;
 
     if claimed_username != requested_username {
         return Err(AtprotoControlError::UsernameMismatch);
@@ -293,12 +322,12 @@ pub async fn reenable_user_atproto(
     tenant_id: i64,
     user_pubkey: &str,
 ) -> Result<AtprotoStatusResponse, AtprotoControlError> {
-    let claimed_username =
+    let claimed_username = require_resolved_username(
         resolve_username_with_fallback(repo, tenant_id, user_pubkey, |pubkey| async move {
             divine_names::lookup_by_pubkey(&pubkey).await
         })
-        .await?
-        .ok_or(AtprotoControlError::UsernameNotClaimed)?;
+        .await?,
+    )?;
 
     repo.set_atproto_state(user_pubkey, tenant_id, true, Some("pending"), None, None)
         .await?;
@@ -345,18 +374,32 @@ pub async fn get_user_atproto_status(
     tenant_id: i64,
     user_pubkey: &str,
 ) -> Result<AtprotoStatusResponse, AtprotoControlError> {
-    let username =
+    let (response, _) =
+        get_user_atproto_status_with_resolution(repo, tenant_id, user_pubkey).await?;
+    Ok(response)
+}
+
+async fn get_user_atproto_status_with_resolution(
+    repo: &UserRepository,
+    tenant_id: i64,
+    user_pubkey: &str,
+) -> Result<(AtprotoStatusResponse, UsernameResolution), AtprotoControlError> {
+    let username_resolution =
         resolve_username_with_fallback(repo, tenant_id, user_pubkey, |pubkey| async move {
             divine_names::lookup_by_pubkey(&pubkey).await
         })
         .await?;
+    let username = match &username_resolution {
+        UsernameResolution::Resolved(username) => Some(username.clone()),
+        UsernameResolution::NotClaimed | UsernameResolution::Unavailable => None,
+    };
 
     let state = repo
         .get_atproto_state(user_pubkey, tenant_id)
         .await?
         .ok_or(AtprotoControlError::UserNotFound)?;
 
-    Ok(map_state_to_response(username, state))
+    Ok((map_state_to_response(username, state), username_resolution))
 }
 
 pub async fn sync_user_atproto_state_by_pubkey(
@@ -473,11 +516,18 @@ where
         ));
     }
 
-    let current = get_user_atproto_status(user_repo, tenant_id, authenticated_user_pubkey)
-        .await
-        .map_err(map_control_error)?;
+    let (current, username_resolution) =
+        get_user_atproto_status_with_resolution(user_repo, tenant_id, authenticated_user_pubkey)
+            .await
+            .map_err(map_control_error)?;
 
     if enabled {
+        if matches!(&username_resolution, UsernameResolution::Unavailable) {
+            return Err(map_control_error(
+                AtprotoControlError::UsernameResolutionUnavailable,
+            ));
+        }
+
         if current.enabled && matches!(current.state.as_deref(), Some("pending" | "ready")) {
             return Ok(current);
         }
@@ -493,11 +543,7 @@ where
             .map_err(map_control_error);
         }
 
-        let username = current
-            .username
-            .clone()
-            .ok_or(AtprotoControlError::UsernameNotClaimed)
-            .map_err(map_control_error)?;
+        let username = require_resolved_username(username_resolution).map_err(map_control_error)?;
 
         return enable_user_atproto_with_trigger(
             user_repo,
@@ -533,6 +579,12 @@ fn map_control_error(error: AtprotoControlError) -> AuthError {
         AtprotoControlError::UsernameNotClaimed => {
             AuthError::BadRequest("Username must be claimed before enabling ATProto".to_string())
         }
+        AtprotoControlError::UsernameResolutionUnavailable => AuthError::ServiceUnavailable {
+            message:
+                "ATProto username lookup is temporarily unavailable. Please try again shortly."
+                    .to_string(),
+            retry_after: Some(30),
+        },
         AtprotoControlError::UsernameMismatch => AuthError::BadRequest(
             "Requested username does not match the claimed username".to_string(),
         ),

--- a/api/src/api/http/atproto.rs
+++ b/api/src/api/http/atproto.rs
@@ -207,10 +207,21 @@ where
     }
 
     match repo
-        .update_username(user_pubkey, &normalized_username, tenant_id)
+        .update_username_if_missing(user_pubkey, &normalized_username, tenant_id)
         .await
     {
-        Ok(()) => Ok(UsernameResolution::Resolved(normalized_username)),
+        Ok(true) => Ok(UsernameResolution::Resolved(normalized_username)),
+        Ok(false) => {
+            let current_username = repo
+                .get_username(user_pubkey, tenant_id)
+                .await?
+                .ok_or(AtprotoControlError::UserNotFound)?;
+
+            Ok(current_username.map_or(
+                UsernameResolution::Unavailable,
+                UsernameResolution::Resolved,
+            ))
+        }
         Err(RepositoryError::Duplicate) => {
             tracing::warn!(
                 "Refusing to reconcile Divine username '{}' for pubkey {} because a duplicate local username appeared in tenant {}",

--- a/api/src/api/http/atproto.rs
+++ b/api/src/api/http/atproto.rs
@@ -1,3 +1,4 @@
+use crate::divine_names::{self, DivineNameError, PubkeyLookupResponse};
 use axum::{
     extract::{Path, State},
     http::{HeaderMap, StatusCode},
@@ -83,6 +84,127 @@ fn validate_atproto_state(state: Option<&str>) -> Result<(), AuthError> {
     }
 }
 
+pub async fn resolve_username_with_fallback<F, Fut>(
+    repo: &UserRepository,
+    tenant_id: i64,
+    user_pubkey: &str,
+    lookup: F,
+) -> Result<Option<String>, AtprotoControlError>
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = Result<Option<PubkeyLookupResponse>, DivineNameError>>,
+{
+    resolve_username_with_fallback_enabled(
+        repo,
+        tenant_id,
+        user_pubkey,
+        divine_names::is_enabled(),
+        lookup,
+    )
+    .await
+}
+
+pub async fn resolve_username_with_fallback_enabled<F, Fut>(
+    repo: &UserRepository,
+    tenant_id: i64,
+    user_pubkey: &str,
+    divine_names_enabled: bool,
+    lookup: F,
+) -> Result<Option<String>, AtprotoControlError>
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = Result<Option<PubkeyLookupResponse>, DivineNameError>>,
+{
+    let local_username = repo
+        .get_username(user_pubkey, tenant_id)
+        .await?
+        .ok_or(AtprotoControlError::UserNotFound)?;
+
+    if local_username.is_some() || !divine_names_enabled {
+        return Ok(local_username);
+    }
+
+    let lookup_response = match lookup(user_pubkey.to_string()).await {
+        Ok(Some(response)) => response,
+        Ok(None) => return Ok(None),
+        Err(error) => {
+            tracing::warn!(
+                "Failed to look up Divine username for ATProto fallback by pubkey {}: {}",
+                user_pubkey,
+                error
+            );
+            return Ok(None);
+        }
+    };
+
+    if let Some(ref lookup_pubkey) = lookup_response.pubkey {
+        if !lookup_pubkey.eq_ignore_ascii_case(user_pubkey) {
+            tracing::warn!(
+                "Divine username lookup by pubkey returned mismatched owner: requested_pubkey={}, returned_pubkey={}",
+                user_pubkey,
+                lookup_pubkey
+            );
+            return Ok(None);
+        }
+    }
+
+    let Some(resolved_username) = lookup_response.canonical.or(lookup_response.name) else {
+        tracing::warn!(
+            "Divine username lookup by pubkey returned no username for pubkey {}",
+            user_pubkey
+        );
+        return Ok(None);
+    };
+
+    let normalized_username = match super::auth::normalize_nip05_username(&resolved_username) {
+        Ok(username) => username,
+        Err(error) => {
+            tracing::warn!(
+                "Divine username lookup returned invalid username '{}' for pubkey {}: {:?}",
+                resolved_username,
+                user_pubkey,
+                error
+            );
+            return Ok(None);
+        }
+    };
+
+    if !repo
+        .check_username_available(&normalized_username, user_pubkey, tenant_id)
+        .await?
+    {
+        let conflicting_pubkey = repo
+            .find_pubkey_by_username(&normalized_username, tenant_id)
+            .await?
+            .unwrap_or_else(|| "<unknown>".to_string());
+        tracing::warn!(
+            "Refusing to reconcile Divine username '{}' for pubkey {} because tenant {} already assigns it to pubkey {}",
+            normalized_username,
+            user_pubkey,
+            tenant_id,
+            conflicting_pubkey
+        );
+        return Ok(None);
+    }
+
+    match repo
+        .update_username(user_pubkey, &normalized_username, tenant_id)
+        .await
+    {
+        Ok(()) => Ok(Some(normalized_username)),
+        Err(RepositoryError::Duplicate) => {
+            tracing::warn!(
+                "Refusing to reconcile Divine username '{}' for pubkey {} because a duplicate local username appeared in tenant {}",
+                normalized_username,
+                user_pubkey,
+                tenant_id
+            );
+            Ok(None)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
 fn authorize_internal_sync(headers: &HeaderMap) -> Result<(), AuthError> {
     let expected = std::env::var("KEYCAST_ATPROTO_TOKEN")
         .ok()
@@ -110,10 +232,11 @@ pub async fn enable_user_atproto(
     user_pubkey: &str,
     requested_username: &str,
 ) -> Result<AtprotoStatusResponse, AtprotoControlError> {
-    let claimed_username = repo
-        .get_username(user_pubkey, tenant_id)
+    let claimed_username =
+        resolve_username_with_fallback(repo, tenant_id, user_pubkey, |pubkey| async move {
+            divine_names::lookup_by_pubkey(&pubkey).await
+        })
         .await?
-        .ok_or(AtprotoControlError::UserNotFound)?
         .ok_or(AtprotoControlError::UsernameNotClaimed)?;
 
     if claimed_username != requested_username {
@@ -170,10 +293,11 @@ pub async fn reenable_user_atproto(
     tenant_id: i64,
     user_pubkey: &str,
 ) -> Result<AtprotoStatusResponse, AtprotoControlError> {
-    let claimed_username = repo
-        .get_username(user_pubkey, tenant_id)
+    let claimed_username =
+        resolve_username_with_fallback(repo, tenant_id, user_pubkey, |pubkey| async move {
+            divine_names::lookup_by_pubkey(&pubkey).await
+        })
         .await?
-        .ok_or(AtprotoControlError::UserNotFound)?
         .ok_or(AtprotoControlError::UsernameNotClaimed)?;
 
     repo.set_atproto_state(user_pubkey, tenant_id, true, Some("pending"), None, None)
@@ -221,10 +345,11 @@ pub async fn get_user_atproto_status(
     tenant_id: i64,
     user_pubkey: &str,
 ) -> Result<AtprotoStatusResponse, AtprotoControlError> {
-    let username = repo
-        .get_username(user_pubkey, tenant_id)
-        .await?
-        .ok_or(AtprotoControlError::UserNotFound)?;
+    let username =
+        resolve_username_with_fallback(repo, tenant_id, user_pubkey, |pubkey| async move {
+            divine_names::lookup_by_pubkey(&pubkey).await
+        })
+        .await?;
 
     let state = repo
         .get_atproto_state(user_pubkey, tenant_id)

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -93,7 +93,7 @@ pub(crate) fn public_handle_domain() -> String {
         .unwrap_or_else(|| DEFAULT_NIP05_DOMAIN.to_string())
 }
 
-fn normalize_nip05_username(raw_username: &str) -> Result<String, AuthError> {
+pub(crate) fn normalize_nip05_username(raw_username: &str) -> Result<String, AuthError> {
     let username = raw_username.trim().to_lowercase();
 
     if username.is_empty() {
@@ -2585,19 +2585,37 @@ pub async fn update_profile(
         // Check divine-name-server FIRST (if enabled) - this is the authoritative source
         if crate::divine_names::is_enabled() {
             match crate::divine_names::check_availability(&username).await {
-                Ok((available, reason)) => {
-                    if !available {
-                        let error_msg =
-                            reason.unwrap_or_else(|| "Username is not available".to_string());
+                Ok(response) => {
+                    if !response.available {
+                        let same_owner_active = response.status.as_deref() == Some("active")
+                            && response
+                                .pubkey
+                                .as_deref()
+                                .is_some_and(|pubkey| pubkey.eq_ignore_ascii_case(&user_pubkey));
+
+                        if !same_owner_active {
+                            let error_msg = response
+                                .reason
+                                .unwrap_or_else(|| "Username is not available".to_string());
+                            tracing::info!(
+                                "Username '{}' not available on divine-name-server: {}",
+                                username,
+                                error_msg
+                            );
+                            return Err(AuthError::Conflict(
+                                "Username is not available. Please choose another username."
+                                    .to_string(),
+                            ));
+                        }
+
+                        let error_msg = response
+                            .reason
+                            .unwrap_or_else(|| "already claimed".to_string());
                         tracing::info!(
-                            "Username '{}' not available on divine-name-server: {}",
+                            "Username '{}' is already active on divine-name-server for the authenticated user: {}",
                             username,
                             error_msg
                         );
-                        return Err(AuthError::Conflict(
-                            "Username is not available. Please choose another username."
-                                .to_string(),
-                        ));
                     }
                 }
                 Err(e) => {

--- a/api/src/divine_names.rs
+++ b/api/src/divine_names.rs
@@ -5,9 +5,10 @@ use nostr_sdk::prelude::*;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const DEFAULT_NAME_SERVER_URL: &str = "https://names.divine.video";
+const NAME_SERVER_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Serialize)]
 struct ClaimRequest {
@@ -48,6 +49,13 @@ pub enum DivineNameError {
     ClaimError(String),
     #[error("Invalid response: {0}")]
     ResponseError(String),
+}
+
+fn name_server_client() -> Result<Client, DivineNameError> {
+    Client::builder()
+        .timeout(NAME_SERVER_TIMEOUT)
+        .build()
+        .map_err(DivineNameError::RequestError)
 }
 
 /// Create a NIP-98 auth event for the claim endpoint
@@ -113,7 +121,7 @@ pub async fn claim_username(
     );
 
     // Make HTTP request
-    let client = Client::new();
+    let client = name_server_client()?;
     let response = client
         .post(&url)
         .header("Authorization", auth_header)
@@ -166,12 +174,15 @@ pub struct AvailabilityResponse {
     #[serde(default)]
     pub status: Option<String>,
     #[serde(default)]
+    pub pubkey: Option<String>,
+    #[serde(default)]
+    pub code: Option<String>,
+    #[serde(default)]
     pub error: Option<String>,
 }
 
 /// Check if a username is available on divine-name-server (no auth required)
-/// Returns (available, reason) - reason is set when not available
-pub async fn check_availability(username: &str) -> Result<(bool, Option<String>), DivineNameError> {
+pub async fn check_availability(username: &str) -> Result<AvailabilityResponse, DivineNameError> {
     let base_url = std::env::var("DIVINE_NAME_SERVER_URL")
         .unwrap_or_else(|_| DEFAULT_NAME_SERVER_URL.to_string());
     let url = format!(
@@ -180,7 +191,7 @@ pub async fn check_availability(username: &str) -> Result<(bool, Option<String>)
         username
     );
 
-    let client = Client::new();
+    let client = name_server_client()?;
     let response = client.get(&url).send().await?;
 
     let status = response.status();
@@ -202,7 +213,7 @@ pub async fn check_availability(username: &str) -> Result<(bool, Option<String>)
         ));
     }
 
-    Ok((check_response.available, check_response.reason))
+    Ok(check_response)
 }
 
 /// Look up a username via NIP-05 nostr.json on divine-name-server.
@@ -217,9 +228,7 @@ pub async fn lookup_by_name(username: &str) -> Result<Option<String>, DivineName
         encoded_name
     );
 
-    let client = Client::builder()
-        .timeout(std::time::Duration::from_secs(3))
-        .build()?;
+    let client = name_server_client()?;
     let response = client.get(&url).send().await?;
 
     let status = response.status();
@@ -284,7 +293,7 @@ pub async fn lookup_by_pubkey(
         pubkey
     );
 
-    let client = Client::new();
+    let client = name_server_client()?;
     let response = client.get(&url).send().await?;
 
     let status = response.status();

--- a/api/tests/atproto_http_test.rs
+++ b/api/tests/atproto_http_test.rs
@@ -390,6 +390,64 @@ async fn username_resolver_persists_app_claimed_name() {
 }
 
 #[tokio::test]
+async fn username_resolver_does_not_overwrite_concurrent_local_claim() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let user_pubkey = Keys::generate().public_key().to_hex();
+    let remote_username = format!("alice-stale-{}", &user_pubkey[..8]);
+    let concurrent_username = format!("alice-current-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let update_pool = pool.clone();
+    let update_pubkey = user_pubkey.clone();
+    let expected_current = concurrent_username.clone();
+    let resolved = resolve_username_with_fallback_enabled(
+        &repo,
+        tenant_id,
+        &user_pubkey,
+        true,
+        move |lookup_pubkey| async move {
+            sqlx::query(
+                "UPDATE users SET username = $1, updated_at = NOW()
+                 WHERE pubkey = $2 AND tenant_id = $3",
+            )
+            .bind(&expected_current)
+            .bind(&update_pubkey)
+            .bind(tenant_id)
+            .execute(&update_pool)
+            .await
+            .expect("concurrent username claim should succeed");
+
+            Ok(Some(lookup_response(&lookup_pubkey, &remote_username)))
+        },
+    )
+    .await
+    .expect("resolver should preserve the concurrent claim");
+
+    assert_eq!(
+        resolved,
+        UsernameResolution::Resolved(concurrent_username.clone())
+    );
+    let persisted = repo
+        .get_username(&user_pubkey, tenant_id)
+        .await
+        .expect("username query should succeed")
+        .expect("user should exist");
+    assert_eq!(persisted.as_deref(), Some(concurrent_username.as_str()));
+}
+
+#[tokio::test]
 async fn username_resolver_refuses_local_conflict() {
     let pool = common::setup_test_db().await;
     let repo = UserRepository::new(pool.clone());

--- a/api/tests/atproto_http_test.rs
+++ b/api/tests/atproto_http_test.rs
@@ -1,13 +1,19 @@
 mod common;
 
+use axum::{
+    extract::{Path, State},
+    routing::get,
+    Json, Router,
+};
 use chrono::{Duration, Utc};
 use keycast_api::api::http::atproto::{
     disable_user_atproto, disable_user_atproto_and_revoke_sessions,
     disable_user_atproto_with_trigger, enable_user_atproto, enable_user_atproto_with_trigger,
-    get_user_atproto_status, set_user_atproto_crosspost, sync_user_atproto_state_by_pubkey,
-    SetCrosspostContext,
+    get_user_atproto_status, resolve_username_with_fallback_enabled, set_user_atproto_crosspost,
+    sync_user_atproto_state_by_pubkey, SetCrosspostContext,
 };
 use keycast_api::api::http::auth::AuthError;
+use keycast_api::divine_names::{DivineNameError, PubkeyLookupResponse};
 use keycast_core::repositories::{
     AtprotoOAuthSessionRepository, CreateAtprotoOAuthSessionParams, IssueAtprotoTokensParams,
     UserRepository,
@@ -15,11 +21,96 @@ use keycast_core::repositories::{
 use keycast_core::types::refresh_token::hash_refresh_token;
 use nostr_sdk::Keys;
 use reqwest::StatusCode;
+use serial_test::serial;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
 use uuid::Uuid;
+
+#[derive(Clone)]
+struct NameLookupMock {
+    pubkey: String,
+    username: String,
+}
+
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(ref value) = self.previous {
+            std::env::set_var(self.key, value);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
+async fn mock_name_lookup(
+    State(mock): State<NameLookupMock>,
+    Path(pubkey): Path<String>,
+) -> Json<serde_json::Value> {
+    if pubkey == mock.pubkey {
+        Json(serde_json::json!({
+            "ok": true,
+            "found": true,
+            "name": mock.username,
+            "canonical": mock.username,
+            "pubkey": mock.pubkey,
+        }))
+    } else {
+        Json(serde_json::json!({
+            "ok": true,
+            "found": false,
+        }))
+    }
+}
+
+async fn start_name_lookup_server(
+    pubkey: String,
+    username: String,
+) -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new()
+        .route("/api/username/by-pubkey/:pubkey", get(mock_name_lookup))
+        .with_state(NameLookupMock { pubkey, username });
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve divine name lookup app");
+    });
+
+    (format!("http://{}", address), handle)
+}
+
+fn lookup_response(pubkey: &str, username: &str) -> PubkeyLookupResponse {
+    PubkeyLookupResponse {
+        ok: true,
+        found: true,
+        name: Some(username.to_string()),
+        canonical: Some(username.to_string()),
+        pubkey: Some(pubkey.to_string()),
+        profile_url: None,
+        nip05: None,
+        error: None,
+    }
+}
 
 #[tokio::test]
 async fn enable_sets_pending_and_returns_accepted() {
@@ -115,6 +206,222 @@ async fn status_returns_username_and_lifecycle_fields() {
     assert_eq!(response.state.as_deref(), Some("failed"));
     assert_eq!(response.did, None);
     assert_eq!(response.error.as_deref(), Some("provisioning failed"));
+}
+
+#[tokio::test]
+async fn username_resolver_keeps_local_username_without_lookup() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-local-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, created_at, updated_at)
+         VALUES ($1, $2, $3, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let lookup_calls = Arc::new(AtomicUsize::new(0));
+    let seen = lookup_calls.clone();
+
+    let resolved =
+        resolve_username_with_fallback_enabled(&repo, tenant_id, &user_pubkey, true, move |_| {
+            let seen = seen.clone();
+            async move {
+                seen.fetch_add(1, Ordering::SeqCst);
+                Ok::<Option<PubkeyLookupResponse>, DivineNameError>(None)
+            }
+        })
+        .await
+        .expect("resolver should succeed");
+
+    assert_eq!(resolved.as_deref(), Some(username.as_str()));
+    assert_eq!(lookup_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn username_resolver_persists_app_claimed_name() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-resolved-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let lookup_username = username.clone();
+    let resolved = resolve_username_with_fallback_enabled(
+        &repo,
+        tenant_id,
+        &user_pubkey,
+        true,
+        |pubkey| async move { Ok(Some(lookup_response(&pubkey, &lookup_username))) },
+    )
+    .await
+    .expect("resolver should succeed");
+
+    assert_eq!(resolved.as_deref(), Some(username.as_str()));
+    let persisted = repo
+        .get_username(&user_pubkey, tenant_id)
+        .await
+        .expect("username query should succeed")
+        .expect("user should exist");
+    assert_eq!(persisted.as_deref(), Some(username.as_str()));
+}
+
+#[tokio::test]
+async fn username_resolver_refuses_local_conflict() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let owner_pubkey = Keys::generate().public_key().to_hex();
+    let conflicting_pubkey = Keys::generate().public_key().to_hex();
+    let username = format!("alice-conflict-{}", &owner_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, created_at, updated_at)
+         VALUES ($1, $2, $3, NOW(), NOW()), ($4, $2, NULL, NOW(), NOW())",
+    )
+    .bind(&conflicting_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .bind(&owner_pubkey)
+    .execute(&pool)
+    .await
+    .expect("failed to insert users");
+
+    let lookup_username = username.clone();
+    let resolved = resolve_username_with_fallback_enabled(
+        &repo,
+        tenant_id,
+        &owner_pubkey,
+        true,
+        |pubkey| async move { Ok(Some(lookup_response(&pubkey, &lookup_username))) },
+    )
+    .await
+    .expect("resolver should not fail on conflicts");
+
+    assert_eq!(resolved, None);
+    let persisted = repo
+        .get_username(&owner_pubkey, tenant_id)
+        .await
+        .expect("username query should succeed")
+        .expect("user should exist");
+    assert_eq!(persisted, None);
+}
+
+#[tokio::test]
+async fn username_resolver_lookup_failure_returns_none() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let resolved =
+        resolve_username_with_fallback_enabled(&repo, tenant_id, &user_pubkey, true, |_| async {
+            Err(DivineNameError::ResponseError("lookup failed".to_string()))
+        })
+        .await
+        .expect("resolver should swallow lookup errors");
+
+    assert_eq!(resolved, None);
+}
+
+#[tokio::test]
+#[serial]
+async fn crosspost_enable_reconciles_app_claimed_username() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-app-claimed-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, atproto_enabled, atproto_state, created_at, updated_at)
+         VALUES ($1, $2, false, NULL, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let (base_url, server_handle) =
+        start_name_lookup_server(user_pubkey.clone(), username.clone()).await;
+    let _divine_name_server = EnvGuard::set("DIVINE_NAME_SERVER_URL", &base_url);
+
+    let expected_pubkey = user_pubkey.clone();
+    let expected_username = username.clone();
+    let response = set_user_atproto_crosspost(
+        SetCrosspostContext {
+            user_repo: &repo,
+            session_repo: &session_repo,
+            tenant_id,
+            authenticated_user_pubkey: &user_pubkey,
+            requested_pubkey: &user_pubkey,
+            enabled: true,
+        },
+        move |pubkey, requested_username, crosspost_enabled| {
+            let expected_pubkey = expected_pubkey.clone();
+            let expected_username = expected_username.clone();
+            async move {
+                assert_eq!(pubkey, expected_pubkey);
+                assert_eq!(requested_username, expected_username);
+                assert!(crosspost_enabled);
+                Ok(())
+            }
+        },
+        |_pubkey| async { Ok(()) },
+        |_pubkey| async { Ok(()) },
+    )
+    .await
+    .expect("crosspost enable should succeed with app-claimed username");
+
+    assert!(response.enabled);
+    assert_eq!(response.state.as_deref(), Some("pending"));
+    assert_eq!(response.username.as_deref(), Some(username.as_str()));
+    let persisted = repo
+        .get_username(&user_pubkey, tenant_id)
+        .await
+        .expect("username query should succeed")
+        .expect("user should exist");
+    assert_eq!(persisted.as_deref(), Some(username.as_str()));
+
+    server_handle.abort();
 }
 
 #[tokio::test]

--- a/api/tests/atproto_http_test.rs
+++ b/api/tests/atproto_http_test.rs
@@ -10,7 +10,7 @@ use keycast_api::api::http::atproto::{
     disable_user_atproto, disable_user_atproto_and_revoke_sessions,
     disable_user_atproto_with_trigger, enable_user_atproto, enable_user_atproto_with_trigger,
     get_user_atproto_status, resolve_username_with_fallback_enabled, set_user_atproto_crosspost,
-    sync_user_atproto_state_by_pubkey, SetCrosspostContext,
+    sync_user_atproto_state_by_pubkey, SetCrosspostContext, UsernameResolution,
 };
 use keycast_api::api::http::auth::AuthError;
 use keycast_api::divine_names::{DivineNameError, PubkeyLookupResponse};
@@ -32,6 +32,13 @@ use uuid::Uuid;
 struct NameLookupMock {
     pubkey: String,
     username: String,
+}
+
+#[derive(Clone)]
+struct FlakyNameLookupMock {
+    pubkey: String,
+    username: String,
+    calls: Arc<AtomicUsize>,
 }
 
 struct EnvGuard {
@@ -94,6 +101,101 @@ async fn start_name_lookup_server(
         axum::serve(listener, app)
             .await
             .expect("serve divine name lookup app");
+    });
+
+    (format!("http://{}", address), handle)
+}
+
+async fn mock_name_lookup_failure() -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "ok": false,
+        "found": false,
+        "name": null,
+        "canonical": null,
+        "pubkey": null,
+        "profile_url": null,
+        "nip05": null,
+        "error": "lookup failed",
+    }))
+}
+
+async fn mock_name_lookup_failure_then_success(
+    State(mock): State<FlakyNameLookupMock>,
+    Path(pubkey): Path<String>,
+) -> Json<serde_json::Value> {
+    if mock.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+        return mock_name_lookup_failure().await;
+    }
+
+    if pubkey == mock.pubkey {
+        Json(serde_json::json!({
+            "ok": true,
+            "found": true,
+            "name": mock.username,
+            "canonical": mock.username,
+            "pubkey": mock.pubkey,
+            "profile_url": null,
+            "nip05": null,
+            "error": null,
+        }))
+    } else {
+        Json(serde_json::json!({
+            "ok": true,
+            "found": false,
+            "name": null,
+            "canonical": null,
+            "pubkey": null,
+            "profile_url": null,
+            "nip05": null,
+            "error": null,
+        }))
+    }
+}
+
+async fn start_name_lookup_failure_server() -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route(
+        "/api/username/by-pubkey/:pubkey",
+        get(mock_name_lookup_failure),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve failing Divine name lookup app");
+    });
+
+    (format!("http://{}", address), handle)
+}
+
+async fn start_name_lookup_failure_then_success_server(
+    pubkey: String,
+    username: String,
+) -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new()
+        .route(
+            "/api/username/by-pubkey/:pubkey",
+            get(mock_name_lookup_failure_then_success),
+        )
+        .with_state(FlakyNameLookupMock {
+            pubkey,
+            username,
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve flaky Divine name lookup app");
     });
 
     (format!("http://{}", address), handle)
@@ -243,7 +345,7 @@ async fn username_resolver_keeps_local_username_without_lookup() {
         .await
         .expect("resolver should succeed");
 
-    assert_eq!(resolved.as_deref(), Some(username.as_str()));
+    assert_eq!(resolved, UsernameResolution::Resolved(username.clone()));
     assert_eq!(lookup_calls.load(Ordering::SeqCst), 0);
 }
 
@@ -278,7 +380,7 @@ async fn username_resolver_persists_app_claimed_name() {
     .await
     .expect("resolver should succeed");
 
-    assert_eq!(resolved.as_deref(), Some(username.as_str()));
+    assert_eq!(resolved, UsernameResolution::Resolved(username.clone()));
     let persisted = repo
         .get_username(&user_pubkey, tenant_id)
         .await
@@ -320,7 +422,7 @@ async fn username_resolver_refuses_local_conflict() {
     .await
     .expect("resolver should not fail on conflicts");
 
-    assert_eq!(resolved, None);
+    assert_eq!(resolved, UsernameResolution::NotClaimed);
     let persisted = repo
         .get_username(&owner_pubkey, tenant_id)
         .await
@@ -330,7 +432,7 @@ async fn username_resolver_refuses_local_conflict() {
 }
 
 #[tokio::test]
-async fn username_resolver_lookup_failure_returns_none() {
+async fn username_resolver_lookup_failure_returns_unavailable() {
     let pool = common::setup_test_db().await;
     let repo = UserRepository::new(pool.clone());
     let tenant_id = 1_i64;
@@ -355,7 +457,50 @@ async fn username_resolver_lookup_failure_returns_none() {
         .await
         .expect("resolver should swallow lookup errors");
 
-    assert_eq!(resolved, None);
+    assert_eq!(resolved, UsernameResolution::Unavailable);
+}
+
+#[tokio::test]
+async fn username_resolver_missing_owner_returns_unavailable_without_persisting() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let user_pubkey = Keys::generate().public_key().to_hex();
+    let username = format!("alice-unverified-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let lookup_username = username.clone();
+    let resolved = resolve_username_with_fallback_enabled(
+        &repo,
+        tenant_id,
+        &user_pubkey,
+        true,
+        |pubkey| async move {
+            let mut response = lookup_response(&pubkey, &lookup_username);
+            response.pubkey = None;
+            Ok(Some(response))
+        },
+    )
+    .await
+    .expect("resolver should classify an unverifiable owner");
+
+    assert_eq!(resolved, UsernameResolution::Unavailable);
+    let persisted = repo
+        .get_username(&user_pubkey, tenant_id)
+        .await
+        .expect("username query should succeed")
+        .expect("user should exist");
+    assert_eq!(persisted, None);
 }
 
 #[tokio::test]
@@ -780,6 +925,155 @@ async fn crosspost_enable_dependency_failure_returns_service_unavailable() {
             retry_after: Some(30),
         } if message == "ATProto enablement is temporarily unavailable. Please try again later."
     ));
+}
+
+#[tokio::test]
+#[serial]
+async fn crosspost_enable_lookup_failure_returns_service_unavailable() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let user_pubkey = Keys::generate().public_key().to_hex();
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, atproto_enabled, atproto_state, created_at, updated_at)
+         VALUES ($1, $2, false, NULL, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let (base_url, server_handle) = start_name_lookup_failure_server().await;
+    let _divine_name_server = EnvGuard::set("DIVINE_NAME_SERVER_URL", &base_url);
+
+    let error = set_user_atproto_crosspost(
+        SetCrosspostContext {
+            user_repo: &repo,
+            session_repo: &session_repo,
+            tenant_id,
+            authenticated_user_pubkey: &user_pubkey,
+            requested_pubkey: &user_pubkey,
+            enabled: true,
+        },
+        |_pubkey, _requested_username, _crosspost_enabled| async { Ok(()) },
+        |_pubkey| async { Ok(()) },
+        |_pubkey| async { Ok(()) },
+    )
+    .await
+    .expect_err("lookup failure should become service unavailable");
+
+    assert!(matches!(
+        error,
+        AuthError::ServiceUnavailable {
+            retry_after: Some(30),
+            ..
+        }
+    ));
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+#[serial]
+async fn crosspost_enable_lookup_failure_returns_service_unavailable_when_already_pending() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let user_pubkey = Keys::generate().public_key().to_hex();
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, atproto_enabled, atproto_state, created_at, updated_at)
+         VALUES ($1, $2, true, 'pending', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let (base_url, server_handle) = start_name_lookup_failure_server().await;
+    let _divine_name_server = EnvGuard::set("DIVINE_NAME_SERVER_URL", &base_url);
+
+    let error = set_user_atproto_crosspost(
+        SetCrosspostContext {
+            user_repo: &repo,
+            session_repo: &session_repo,
+            tenant_id,
+            authenticated_user_pubkey: &user_pubkey,
+            requested_pubkey: &user_pubkey,
+            enabled: true,
+        },
+        |_pubkey, _requested_username, _crosspost_enabled| async { Ok(()) },
+        |_pubkey| async { Ok(()) },
+        |_pubkey| async { Ok(()) },
+    )
+    .await
+    .expect_err("lookup failure should not be hidden by the pending state");
+
+    assert!(matches!(
+        error,
+        AuthError::ServiceUnavailable {
+            retry_after: Some(30),
+            ..
+        }
+    ));
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+#[serial]
+async fn crosspost_enable_uses_first_unavailable_resolution_when_disabled() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let user_pubkey = Keys::generate().public_key().to_hex();
+    let username = format!("alice-flaky-{}", &user_pubkey[..8]);
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, atproto_enabled, atproto_state, created_at, updated_at)
+         VALUES ($1, $2, false, 'disabled', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let (base_url, server_handle) =
+        start_name_lookup_failure_then_success_server(user_pubkey.clone(), username).await;
+    let _divine_name_server = EnvGuard::set("DIVINE_NAME_SERVER_URL", &base_url);
+
+    let error = set_user_atproto_crosspost(
+        SetCrosspostContext {
+            user_repo: &repo,
+            session_repo: &session_repo,
+            tenant_id,
+            authenticated_user_pubkey: &user_pubkey,
+            requested_pubkey: &user_pubkey,
+            enabled: true,
+        },
+        |_pubkey, _requested_username, _crosspost_enabled| async { Ok(()) },
+        |_pubkey| async { Ok(()) },
+        |_pubkey| async { Ok(()) },
+    )
+    .await
+    .expect_err("the first unavailable resolution should remain authoritative");
+
+    assert!(matches!(
+        error,
+        AuthError::ServiceUnavailable {
+            retry_after: Some(30),
+            ..
+        }
+    ));
+
+    server_handle.abort();
 }
 
 #[tokio::test]

--- a/api/tests/update_profile_divine_name_test.rs
+++ b/api/tests/update_profile_divine_name_test.rs
@@ -4,7 +4,7 @@ use axum::{
     extract::{Path, State},
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
-    routing::get,
+    routing::{get, post},
     Json, Router,
 };
 use http_body_util::BodyExt;
@@ -122,16 +122,44 @@ impl Drop for EnvGuard {
     }
 }
 
-async fn mock_name_check(Path(username): Path<String>) -> Json<serde_json::Value> {
+#[derive(Clone)]
+struct NameCheckMock {
+    owner_pubkey: Option<String>,
+}
+
+async fn mock_name_check(
+    State(mock): State<NameCheckMock>,
+    Path(username): Path<String>,
+) -> Json<serde_json::Value> {
+    if let Some(pubkey) = mock.owner_pubkey {
+        Json(json!({
+            "ok": true,
+            "available": false,
+            "reason": format!("{username} is already claimed"),
+            "status": "active",
+            "pubkey": pubkey,
+        }))
+    } else {
+        Json(json!({
+            "ok": true,
+            "available": false,
+            "reason": format!("{username} is reserved"),
+        }))
+    }
+}
+
+async fn mock_name_claim() -> Json<serde_json::Value> {
     Json(json!({
         "ok": true,
-        "available": false,
-        "reason": format!("{username} is reserved"),
+        "name": "claimed-name",
     }))
 }
 
-async fn start_name_check_server() -> (String, JoinHandle<()>) {
-    let app = Router::new().route("/api/username/check/:username", get(mock_name_check));
+async fn start_name_check_server(owner_pubkey: Option<String>) -> (String, JoinHandle<()>) {
+    let app = Router::new()
+        .route("/api/username/check/:username", get(mock_name_check))
+        .route("/api/username/claim", post(mock_name_claim))
+        .with_state(NameCheckMock { owner_pubkey });
 
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -327,7 +355,7 @@ async fn update_profile_divine_name_conflict_returns_conflict_status() {
             .expect("authorization header should parse"),
     );
 
-    let (base_url, server_handle) = start_name_check_server().await;
+    let (base_url, server_handle) = start_name_check_server(None).await;
     let _divine_name_server = EnvGuard::set("DIVINE_NAME_SERVER_URL", &base_url);
     let _enable_divine_names = EnvGuard::set("ENABLE_DIVINE_NAMES", "1");
 
@@ -357,6 +385,126 @@ async fn update_profile_divine_name_conflict_returns_conflict_status() {
         body["error"],
         "Username is not available. Please choose another username."
     );
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+#[serial]
+async fn update_profile_divine_name_same_owner_active_claim_succeeds() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+
+    let user_keys = Keys::generate();
+    let user_pubkey = user_keys.public_key().to_hex();
+    let tenant_id = 1_i64;
+    let username = format!("same-owner-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let token = build_test_ucan(&user_keys, tenant_id).await;
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::AUTHORIZATION,
+        format!("Bearer {token}")
+            .parse()
+            .expect("authorization header should parse"),
+    );
+
+    let (base_url, server_handle) = start_name_check_server(Some(user_pubkey.clone())).await;
+    let _divine_name_server = EnvGuard::set("DIVINE_NAME_SERVER_URL", &base_url);
+    let _enable_divine_names = EnvGuard::set("ENABLE_DIVINE_NAMES", "1");
+
+    let response = auth::update_profile(
+        create_test_tenant(tenant_id),
+        State(create_test_auth_state(pool)),
+        headers,
+        Json(auth::ProfileData {
+            username: Some(username.clone()),
+            name: None,
+            about: None,
+            picture: None,
+            banner: None,
+            nip05: None,
+            website: None,
+            lud16: None,
+        }),
+    )
+    .await
+    .into_response();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let persisted = repo
+        .get_username(&user_pubkey, tenant_id)
+        .await
+        .expect("username query should succeed")
+        .expect("user should exist");
+    assert_eq!(persisted.as_deref(), Some(username.as_str()));
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+#[serial]
+async fn update_profile_divine_name_different_owner_active_claim_conflicts() {
+    let pool = common::setup_test_db().await;
+
+    let user_keys = Keys::generate();
+    let user_pubkey = user_keys.public_key().to_hex();
+    let other_pubkey = Keys::generate().public_key().to_hex();
+    let tenant_id = 1_i64;
+    let username = format!("different-owner-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let token = build_test_ucan(&user_keys, tenant_id).await;
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::AUTHORIZATION,
+        format!("Bearer {token}")
+            .parse()
+            .expect("authorization header should parse"),
+    );
+
+    let (base_url, server_handle) = start_name_check_server(Some(other_pubkey)).await;
+    let _divine_name_server = EnvGuard::set("DIVINE_NAME_SERVER_URL", &base_url);
+    let _enable_divine_names = EnvGuard::set("ENABLE_DIVINE_NAMES", "1");
+
+    let response = auth::update_profile(
+        create_test_tenant(tenant_id),
+        State(create_test_auth_state(pool)),
+        headers,
+        Json(auth::ProfileData {
+            username: Some(username),
+            name: None,
+            about: None,
+            picture: None,
+            banner: None,
+            nip05: None,
+            website: None,
+            lud16: None,
+        }),
+    )
+    .await
+    .into_response();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
 
     server_handle.abort();
 }

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1411,6 +1411,27 @@ impl UserRepository {
         Ok(())
     }
 
+    /// Set a username only while the local row still has no username.
+    pub async fn update_username_if_missing(
+        &self,
+        pubkey: &str,
+        username: &str,
+        tenant_id: i64,
+    ) -> Result<bool, RepositoryError> {
+        let result = sqlx::query(
+            "UPDATE users SET username = $1, updated_at = $2
+             WHERE pubkey = $3 AND tenant_id = $4 AND username IS NULL",
+        )
+        .bind(username)
+        .bind(Utc::now())
+        .bind(pubkey)
+        .bind(tenant_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() == 1)
+    }
+
     /// Update a user's ATProto lifecycle state.
     pub async fn set_atproto_state(
         &self,


### PR DESCRIPTION
## Summary

- Reconcile app-claimed Divine usernames into `users.username` when ATProto status/enable finds a null local username.
- Preserve Divine name-server owner metadata for availability checks and allow same-owner active usernames through profile update.
- Add a shared timeout-bearing Divine name-server HTTP client and regression coverage for fallback, conflict, lookup failure, crosspost enable, and same-owner profile update.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Mobile can claim usernames directly against Divine name-server, leaving Keycast's local username null.
- That made ATProto status return `username: null` and blocked crosspost enable with "Username must be claimed before enabling ATProto".
- The profile workaround also failed because Keycast treated the user's own active Divine username as unavailable.
- The ATProto status path now performs idempotent write-on-read reconciliation from Divine name-server when the local username is missing.

## Related Issue

- Closes #321
- Related: divinevideo/divine-mobile#6357

## Testing

- [ ] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --no-run`
- [x] `cargo test -p keycast_api --lib`
- [ ] `cd api && cargo test --test atproto_http_test --test update_profile_divine_name_test` attempted locally; compilation succeeded, but runtime DB-backed tests could not connect because Docker/Postgres is not running on this machine (`docker ps` cannot connect to Docker daemon; targeted tests timed out connecting to `keycast_test`).
- [ ] Manual verification completed

## Visuals

- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
