### PR TITLE
fix(auth): preserve first-party deletion on refresh

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1501,6 +1501,7 @@ pub async fn create_bunker(
             secret_hash,
             relays: relays_json.clone(),
             policy_id,
+            is_first_party: false,
             client_pubkey: None,
             authorization_handle: None,
             handle_expires_at,
@@ -4903,7 +4904,7 @@ pub async fn delete_account(
         tracing::warn!(
             event = "account_deletion_denied",
             tenant_id = tenant_id,
-            user = &user_pubkey[..8],
+            user_pubkey = %user_pubkey,
             redirect_origin = %redirect_origin,
             "Denied: not user-signed and not first-party"
         );
@@ -4916,7 +4917,7 @@ pub async fn delete_account(
     tracing::info!(
         event = "account_deletion_started",
         tenant_id = tenant_id,
-        user = &user_pubkey[..8],
+        user_pubkey = %user_pubkey,
         is_user_signed = is_user_signed,
         is_first_party = is_first_party,
         redirect_origin = %redirect_origin,
@@ -4932,7 +4933,7 @@ pub async fn delete_account(
             tracing::error!(
                 event = "account_deletion_failed",
                 tenant_id = tenant_id,
-                user = &user_pubkey[..8],
+                user_pubkey = %user_pubkey,
                 error = %e,
                 "Database error during deletion"
             );
@@ -4960,7 +4961,7 @@ pub async fn delete_account(
     tracing::info!(
         event = "account_deletion_completed",
         tenant_id = tenant_id,
-        user = &user_pubkey[..8],
+        user_pubkey = %user_pubkey,
         teams_removed = result.teams_removed,
         oauth_auths_deleted = result.oauth_authorizations_deleted,
         bunkers_notified = result.bunker_pubkeys.len(),
@@ -4975,9 +4976,63 @@ pub async fn delete_account(
 
 #[cfg(test)]
 mod tests {
+    use super::generate_server_signed_ucan;
     use super::validate_origin;
     use super::AccountStatusResponse;
     use axum::response::IntoResponse;
+    use ucan::Ucan;
+
+    #[tokio::test]
+    async fn server_signed_ucan_includes_first_party_only_when_requested() {
+        let user_keys = Keys::generate();
+        let server_keys = Keys::generate();
+
+        let first_party_token = generate_server_signed_ucan(
+            &user_keys.public_key(),
+            1,
+            "user@example.test",
+            "https://first-party.example.test",
+            None,
+            &server_keys,
+            true,
+            None,
+            None,
+        )
+        .await
+        .expect("first-party UCAN");
+        let first_party_ucan =
+            Ucan::try_from_token_string(&first_party_token).expect("decode first-party UCAN");
+        assert!(
+            first_party_ucan
+                .facts()
+                .iter()
+                .any(|fact| fact.get("first_party").and_then(|v| v.as_bool()) == Some(true)),
+            "first-party sessions must carry the deletion authorization fact"
+        );
+
+        let third_party_token = generate_server_signed_ucan(
+            &user_keys.public_key(),
+            1,
+            "user@example.test",
+            "https://third-party.example.test",
+            None,
+            &server_keys,
+            false,
+            None,
+            None,
+        )
+        .await
+        .expect("third-party UCAN");
+        let third_party_ucan =
+            Ucan::try_from_token_string(&third_party_token).expect("decode third-party UCAN");
+        assert!(
+            third_party_ucan
+                .facts()
+                .iter()
+                .all(|fact| fact.get("first_party").is_none()),
+            "third-party sessions must not gain account deletion authority"
+        );
+    }
 
     #[cfg(feature = "integration-tests")]
     #[tokio::test]

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -561,10 +561,7 @@ pub async fn headless_authorize(
     let pool = &auth_state.state.db;
     let tenant_id = tenant.0.id;
 
-    // Extract user from UCAN Bearer token with tenant validation
-    let user_pubkey = super::auth::extract_user_from_token(&headers, tenant_id)
-        .await
-        .map_err(|_| HeadlessError::Unauthorized)?;
+    let user_pubkey = extract_first_party_or_user_signed_user(&headers, tenant_id).await?;
 
     tracing::info!(
         event = "headless_authorize",
@@ -612,6 +609,50 @@ pub async fn headless_authorize(
         code,
         state: req.state,
     }))
+}
+
+async fn extract_first_party_or_user_signed_user(
+    headers: &HeaderMap,
+    tenant_id: i64,
+) -> Result<String, HeadlessError> {
+    let auth_header = if let Some(auth_header) = headers.get("Authorization") {
+        auth_header
+            .to_str()
+            .map_err(|_| HeadlessError::Unauthorized)?
+            .to_string()
+    } else if let Some(token) = super::auth::extract_ucan_from_cookie(headers) {
+        format!("Bearer {}", token)
+    } else {
+        return Err(HeadlessError::Unauthorized);
+    };
+
+    let (user_pubkey, redirect_origin, _, ucan) =
+        crate::ucan_auth::validate_ucan_token(&auth_header, tenant_id)
+            .await
+            .map_err(|_| HeadlessError::Unauthorized)?;
+
+    let issuer = crate::ucan_auth::did_to_nostr_pubkey(ucan.issuer())
+        .map_err(|_| HeadlessError::Unauthorized)?
+        .to_hex();
+    let is_user_signed = issuer == user_pubkey;
+    let is_first_party = ucan
+        .facts()
+        .iter()
+        .find_map(|fact| fact.get("first_party").and_then(|value| value.as_bool()))
+        .unwrap_or(false);
+
+    if !is_user_signed && !is_first_party {
+        tracing::warn!(
+            event = "headless_authorize_denied",
+            tenant_id = tenant_id,
+            user_pubkey = %user_pubkey,
+            redirect_origin = %redirect_origin,
+            "Denied: bearer token is not user-signed or first-party"
+        );
+        return Err(HeadlessError::Unauthorized);
+    }
+
+    Ok(user_pubkey)
 }
 
 // ============================================================================

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -2662,8 +2662,8 @@ async fn handle_refresh_token_grant_inner(
         keycast_core::bunker_key::derive_bunker_keys(&user_secret_key, &oauth_auth.secret_hash);
     let bunker_public_key = bunker_keys.public_key();
 
-    // Generate new UCAN access token (server-signed)
-    // Note: refresh tokens don't preserve first_party status - users need fresh headless login
+    // Generate new UCAN access token (server-signed). First-party status belongs to the
+    // authorization, not to a single access token, so refresh rotation preserves it.
     let stored_pubkey =
         nostr_sdk::PublicKey::from_hex(&oauth_auth.user_pubkey).map_err(|error| {
             refresh_grant_rejection(
@@ -2679,7 +2679,7 @@ async fn handle_refresh_token_grant_inner(
         &oauth_auth.redirect_origin,
         Some(&bunker_public_key.to_hex()),
         &auth_state.state.server_keys,
-        false, // Refresh tokens are not first-party
+        oauth_auth.is_first_party,
         None,
         user_status.as_ref(),
     )
@@ -3167,6 +3167,7 @@ async fn create_oauth_authorization_and_token(
             secret_hash,
             relays: relays_json.clone(),
             policy_id: Some(policy_id),
+            is_first_party: is_headless,
             client_pubkey: None,
             authorization_handle: Some(authorization_handle.clone()),
             handle_expires_at,
@@ -4326,6 +4327,7 @@ pub async fn connect_post(
             secret_hash,
             relays: relays_json.clone(),
             policy_id: None,
+            is_first_party: false,
             client_pubkey: Some(form.client_pubkey.clone()),
             authorization_handle: Some(authorization_handle.clone()),
             handle_expires_at,

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -167,6 +167,7 @@ async fn store_oauth_code(
     expires_at: chrono::DateTime<Utc>,
     previous_auth_id: Option<i32>,
     state: Option<&str>,
+    is_headless: bool,
 ) -> Result<(), OAuthError> {
     let repo = OAuthCodeRepository::new(pool.clone());
     repo.store(StoreOAuthCodeParams {
@@ -181,7 +182,7 @@ async fn store_oauth_code(
         expires_at,
         previous_auth_id,
         state,
-        is_headless: false,
+        is_headless,
     })
     .await?;
     Ok(())
@@ -649,18 +650,22 @@ pub async fn authorize_get(
 
     // Check for silent re-authentication via authorization_handle (primary mechanism)
     if let Some(ref pubkey) = user_pubkey {
-        let previous_auth_id: Option<i32> = if let Some(ref handle) = params.authorization_handle {
-            tracing::info!(
-                "Auto-approve check via authorization_handle for user {}",
-                pubkey
-            );
+        let (previous_auth_id, inherited_first_party): (Option<i32>, bool) =
+            if let Some(ref handle) = params.authorization_handle {
+                tracing::info!(
+                    "Auto-approve check via authorization_handle for user {}",
+                    pubkey
+                );
 
-            // Look up by handle, scoped to this user
-            let repo = OAuthAuthorizationRepository::new(pool.clone());
-            repo.find_id_by_handle(handle, pubkey).await?
-        } else {
-            None
-        };
+                // Look up by handle, scoped to this user
+                let repo = OAuthAuthorizationRepository::new(pool.clone());
+                match repo.find_first_party_by_handle(handle, pubkey).await? {
+                    Some((id, is_first_party)) => (Some(id), is_first_party),
+                    None => (None, false),
+                }
+            } else {
+                (None, false)
+            };
 
         tracing::info!(
             "Authorization handle lookup: found={}",
@@ -698,6 +703,7 @@ pub async fn authorize_get(
                 expires_at,
                 previous_auth_id,
                 params.state.as_deref(),
+                inherited_first_party,
             )
             .await?;
 
@@ -719,11 +725,11 @@ pub async fn authorize_get(
     if let Some(ref pubkey) = user_pubkey {
         let redirect_origin = extract_origin(&params.redirect_uri)?;
         let repo = OAuthAuthorizationRepository::new(pool.clone());
-        let has_active_origin_authorization = repo
-            .has_active_for_origin(pubkey, &redirect_origin, tenant_id)
+        let active_origin_first_party = repo
+            .active_first_party_for_origin(pubkey, &redirect_origin, tenant_id)
             .await?;
 
-        if has_active_origin_authorization {
+        if let Some(is_first_party) = active_origin_first_party {
             has_existing_authorization = true;
 
             if !force_consent {
@@ -755,6 +761,7 @@ pub async fn authorize_get(
                     expires_at,
                     None,
                     params.state.as_deref(),
+                    is_first_party,
                 )
                 .await?;
 
@@ -2351,6 +2358,7 @@ pub async fn authorize_post(
         expires_at,
         None,
         req.state.as_deref(),
+        false,
     )
     .await?;
 

--- a/api/tests/headless_auth_test.rs
+++ b/api/tests/headless_auth_test.rs
@@ -15,8 +15,11 @@ use chrono::{Duration, Utc};
 use keycast_api::{
     api::{
         http::{
+            auth::generate_server_signed_ucan,
             auth_observability::request_id_middleware,
-            headless::{headless_login, HeadlessLoginRequest},
+            headless::{
+                headless_authorize, headless_login, HeadlessAuthorizeRequest, HeadlessLoginRequest,
+            },
         },
         tenant::{Tenant, TenantExtractor},
     },
@@ -29,14 +32,17 @@ use keycast_core::{
     secret_pool::SecretPool,
 };
 use moka::future::Cache;
-use nostr_sdk::Keys;
+use nostr_sdk::{Keys, ToBech32};
 use sqlx::PgPool;
 use std::sync::Arc;
+use tokio::sync::Mutex;
 use tower::ServiceExt;
 use uuid::Uuid;
 use zeroize::Zeroizing;
 
 mod common;
+
+static SERVER_NSEC_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
 async fn setup_pool() -> PgPool {
     common::assert_test_database_url();
@@ -118,6 +124,21 @@ fn create_test_tenant() -> TenantExtractor {
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }))
+}
+
+fn build_headless_authorize_app(auth_state: keycast_api::api::http::routes::AuthState) -> Router {
+    Router::new().route(
+        "/headless/authorize",
+        post(
+            move |headers: axum::http::HeaderMap, Json(req): Json<HeadlessAuthorizeRequest>| {
+                let auth_state = auth_state.clone();
+                async move {
+                    headless_authorize(create_test_tenant(), State(auth_state), headers, Json(req))
+                        .await
+                }
+            },
+        ),
+    )
 }
 
 // ============================================================================
@@ -453,6 +474,156 @@ async fn test_headless_authorize_creates_code() {
     assert_eq!(record.1, "policy:readonly");
 
     // Cleanup
+    cleanup_test_user(&pool, &pubkey).await;
+}
+
+#[tokio::test]
+async fn test_headless_authorize_rejects_third_party_bearer_token() {
+    let _server_nsec_guard = SERVER_NSEC_TEST_LOCK.lock().await;
+    let pool = setup_pool().await;
+    let keys = Keys::generate();
+    let pubkey = keys.public_key().to_hex();
+    let email = format!(
+        "headless-authorize-third-party-{}@example.com",
+        Uuid::new_v4()
+    );
+
+    cleanup_test_user(&pool, &pubkey).await;
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, email_verified, created_at, updated_at)
+         VALUES ($1, 1, $2, true, NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .bind(&email)
+    .execute(&pool)
+    .await
+    .expect("Should create user");
+
+    let server_keys = Keys::generate();
+    std::env::set_var(
+        "SERVER_NSEC",
+        server_keys.secret_key().to_bech32().expect("server nsec"),
+    );
+    let bearer = generate_server_signed_ucan(
+        &keys.public_key(),
+        1,
+        &email,
+        "https://third-party.example.com",
+        None,
+        &server_keys,
+        false,
+        None,
+        None,
+    )
+    .await
+    .expect("third-party UCAN");
+
+    let response = build_headless_authorize_app(create_test_auth_state(pool.clone()))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/headless/authorize")
+                .header("authorization", format!("Bearer {}", bearer))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "client_id": "ThirdPartyApp",
+                        "redirect_uri": "https://third-party.example.com/callback",
+                        "scope": "policy:full"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("headless authorize request should complete");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let code_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM oauth_codes WHERE user_pubkey = $1")
+            .bind(&pubkey)
+            .fetch_one(&pool)
+            .await
+            .expect("oauth code count should query");
+    assert_eq!(code_count, 0);
+
+    cleanup_test_user(&pool, &pubkey).await;
+}
+
+#[tokio::test]
+async fn test_headless_authorize_accepts_first_party_bearer_token() {
+    let _server_nsec_guard = SERVER_NSEC_TEST_LOCK.lock().await;
+    let pool = setup_pool().await;
+    let keys = Keys::generate();
+    let pubkey = keys.public_key().to_hex();
+    let email = format!(
+        "headless-authorize-first-party-{}@example.com",
+        Uuid::new_v4()
+    );
+
+    cleanup_test_user(&pool, &pubkey).await;
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, email_verified, created_at, updated_at)
+         VALUES ($1, 1, $2, true, NOW(), NOW())",
+    )
+    .bind(&pubkey)
+    .bind(&email)
+    .execute(&pool)
+    .await
+    .expect("Should create user");
+
+    let server_keys = Keys::generate();
+    std::env::set_var(
+        "SERVER_NSEC",
+        server_keys.secret_key().to_bech32().expect("server nsec"),
+    );
+    let bearer = generate_server_signed_ucan(
+        &keys.public_key(),
+        1,
+        &email,
+        "https://first-party.example.com",
+        None,
+        &server_keys,
+        true,
+        None,
+        None,
+    )
+    .await
+    .expect("first-party UCAN");
+
+    let response = build_headless_authorize_app(create_test_auth_state(pool.clone()))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/headless/authorize")
+                .header("authorization", format!("Bearer {}", bearer))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "client_id": "FirstPartyApp",
+                        "redirect_uri": "https://first-party.example.com/callback",
+                        "scope": "policy:full"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("headless authorize request should complete");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let is_headless: bool =
+        sqlx::query_scalar("SELECT is_headless FROM oauth_codes WHERE user_pubkey = $1")
+            .bind(&pubkey)
+            .fetch_one(&pool)
+            .await
+            .expect("oauth code should exist");
+    assert!(is_headless);
+
     cleanup_test_user(&pool, &pubkey).await;
 }
 

--- a/api/tests/oauth_refresh_first_party_test.rs
+++ b/api/tests/oauth_refresh_first_party_test.rs
@@ -5,14 +5,15 @@
 
 use axum::{
     body::Body,
-    extract::State,
-    http::{Request, StatusCode},
-    routing::post,
+    extract::{Query, State},
+    http::{header, HeaderMap, Request, StatusCode},
+    routing::{get, post},
     Json, Router,
 };
 use chrono::{Duration, Utc};
 use keycast_api::{
     api::{
+        http::oauth::{authorize_get, AuthorizeRequest},
         http::oauth::{token, TokenRequest},
         tenant::{Tenant, TenantExtractor},
     },
@@ -28,15 +29,16 @@ use keycast_core::{
     secret_pool::SecretPool,
 };
 use moka::future::Cache;
-use nostr_sdk::Keys;
+use nostr_sdk::{Keys, Url};
 use sqlx::PgPool;
 use std::sync::{Arc, Once};
 use tower::ServiceExt;
-use ucan::Ucan;
+use ucan::{builder::UcanBuilder, Ucan};
 use uuid::Uuid;
 use zeroize::Zeroizing;
 
 mod common;
+use keycast_api::ucan_auth::{nostr_pubkey_to_did, NostrKeyMaterial};
 
 const TENANT_ID: i64 = 1;
 
@@ -114,6 +116,14 @@ struct SeededAuthorization {
     refresh_token: String,
 }
 
+struct SeededReauthAuthorization {
+    user_keys: Keys,
+    user_pubkey: String,
+    email: String,
+    redirect_uri: String,
+    authorization_handle: String,
+}
+
 /// Seed a user, their stored key, an OAuth authorization with the requested
 /// first-party status, and a live refresh token bound to that authorization.
 async fn seed_authorization(pool: &PgPool, is_first_party: bool) -> SeededAuthorization {
@@ -180,6 +190,72 @@ async fn seed_authorization(pool: &PgPool, is_first_party: bool) -> SeededAuthor
     }
 }
 
+async fn seed_reauth_authorization(pool: &PgPool) -> SeededReauthAuthorization {
+    let user_keys = Keys::generate();
+    let user_pubkey = user_keys.public_key().to_hex();
+    let email = format!("reauth-first-party-{}@example.test", Uuid::new_v4());
+    let redirect_uri = format!("https://reauth-{}.example.test/callback", Uuid::new_v4());
+    let redirect_origin = redirect_uri
+        .strip_suffix("/callback")
+        .expect("test redirect URI should have callback suffix")
+        .to_string();
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, email_verified, created_at, updated_at)
+         VALUES ($1, $2, $3, true, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(TENANT_ID)
+    .bind(&email)
+    .execute(pool)
+    .await
+    .expect("Failed to create test user");
+
+    sqlx::query(
+        "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id)
+         VALUES ($1, $2, $3)",
+    )
+    .bind(&user_pubkey)
+    .bind(user_keys.secret_key().secret_bytes().to_vec())
+    .bind(TENANT_ID)
+    .execute(pool)
+    .await
+    .expect("Failed to create personal key");
+
+    let secret_hash = format!("reauth-connection-secret-{}", Uuid::new_v4());
+    let bunker_public_key =
+        keycast_core::bunker_key::derive_bunker_keys(user_keys.secret_key(), &secret_hash)
+            .public_key()
+            .to_hex();
+    let authorization_handle = Uuid::new_v4().to_string();
+
+    OAuthAuthorizationRepository::new(pool.clone())
+        .create(CreateOAuthAuthorizationParams {
+            tenant_id: TENANT_ID,
+            user_pubkey: user_pubkey.clone(),
+            redirect_origin,
+            client_id: "Reauth Test Client".to_string(),
+            bunker_public_key,
+            secret_hash,
+            relays: "[]".to_string(),
+            policy_id: None,
+            is_first_party: true,
+            client_pubkey: None,
+            authorization_handle: Some(authorization_handle.clone()),
+            handle_expires_at: Utc::now() + Duration::days(30),
+        })
+        .await
+        .expect("Failed to create OAuth authorization");
+
+    SeededReauthAuthorization {
+        user_keys,
+        user_pubkey,
+        email,
+        redirect_uri,
+        authorization_handle,
+    }
+}
+
 async fn cleanup(pool: &PgPool, user_pubkey: &str) {
     let _ = sqlx::query(
         "DELETE FROM oauth_refresh_tokens WHERE authorization_id IN
@@ -202,17 +278,63 @@ async fn cleanup(pool: &PgPool, user_pubkey: &str) {
         .await;
 }
 
+async fn user_signed_session_token(keys: &Keys, email: &str, redirect_origin: &str) -> String {
+    let key_material = NostrKeyMaterial::from_keys(keys.clone());
+    let user_did = nostr_pubkey_to_did(&keys.public_key());
+    let facts = serde_json::json!({
+        "tenant_id": TENANT_ID,
+        "email": email,
+        "redirect_origin": redirect_origin,
+    });
+
+    UcanBuilder::default()
+        .issued_by(&key_material)
+        .for_audience(&user_did)
+        .with_lifetime(3600)
+        .with_fact(facts)
+        .build()
+        .expect("session UCAN should build")
+        .sign()
+        .await
+        .expect("session UCAN should sign")
+        .encode()
+        .expect("session UCAN should encode")
+}
+
+fn build_oauth_app(pool: PgPool) -> Router {
+    let auth_state = create_test_auth_state(pool);
+    let authorize_state = auth_state.clone();
+    let token_state = auth_state;
+
+    Router::new()
+        .route(
+            "/oauth/authorize",
+            get(
+                move |headers: HeaderMap, Query(req): Query<AuthorizeRequest>| {
+                    let auth_state = authorize_state.clone();
+                    async move {
+                        authorize_get(create_test_tenant(), State(auth_state), headers, Query(req))
+                            .await
+                    }
+                },
+            ),
+        )
+        .route(
+            "/oauth/token",
+            post(move |Json(req): Json<TokenRequest>| {
+                let auth_state = token_state.clone();
+                async move { token(create_test_tenant(), State(auth_state), Json(req)).await }
+            }),
+        )
+}
+
 /// Exchange a refresh token through the real `/oauth/token` route and return the
 /// `first_party` fact carried by the rotated access token.
-async fn refreshed_access_token_is_first_party(pool: &PgPool, refresh_token: &str) -> bool {
-    let auth_state = create_test_auth_state(pool.clone());
-    let app = Router::new().route(
-        "/oauth/token",
-        post(move |Json(req): Json<TokenRequest>| {
-            let auth_state = auth_state.clone();
-            async move { token(create_test_tenant(), State(auth_state), Json(req)).await }
-        }),
-    );
+async fn refreshed_access_token_is_first_party(
+    pool: &PgPool,
+    refresh_token: &str,
+) -> Result<bool, String> {
+    let app = build_oauth_app(pool.clone());
 
     let response = app
         .oneshot(
@@ -232,28 +354,136 @@ async fn refreshed_access_token_is_first_party(pool: &PgPool, refresh_token: &st
                 .unwrap(),
         )
         .await
-        .expect("refresh grant request should complete");
+        .map_err(|error| format!("refresh grant request should complete: {}", error))?;
 
-    assert_eq!(
-        response.status(),
-        StatusCode::OK,
-        "refresh grant should succeed"
-    );
+    if response.status() != StatusCode::OK {
+        return Err(format!(
+            "refresh grant should succeed: {}",
+            response.status()
+        ));
+    }
 
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
-        .expect("response body should be readable");
-    let payload: serde_json::Value =
-        serde_json::from_slice(&body).expect("response body should be JSON");
+        .map_err(|error| format!("response body should be readable: {}", error))?;
+    let payload: serde_json::Value = serde_json::from_slice(&body)
+        .map_err(|error| format!("response body should be JSON: {}", error))?;
     let access_token = payload["access_token"]
         .as_str()
-        .expect("refresh response should carry an access_token");
+        .ok_or_else(|| "refresh response should carry an access_token".to_string())?;
 
-    Ucan::try_from_token_string(access_token)
-        .expect("rotated access token should decode as a UCAN")
+    Ok(Ucan::try_from_token_string(access_token)
+        .map_err(|error| format!("rotated access token should decode as a UCAN: {}", error))?
         .facts()
         .iter()
-        .any(|fact| fact.get("first_party").and_then(|v| v.as_bool()) == Some(true))
+        .any(|fact| fact.get("first_party").and_then(|v| v.as_bool()) == Some(true)))
+}
+
+#[tokio::test]
+async fn silent_reauth_preserves_first_party_authorization() {
+    let pool = setup_pool().await;
+    let seeded = seed_reauth_authorization(&pool).await;
+    let session_token = user_signed_session_token(
+        &seeded.user_keys,
+        &seeded.email,
+        "https://keycast.example.test",
+    )
+    .await;
+
+    let app = build_oauth_app(pool.clone());
+    let authorize_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!(
+                    "/oauth/authorize?client_id={}&redirect_uri={}&scope=policy:full&authorization_handle={}",
+                    urlencoding::encode("Reauth Test Client"),
+                    urlencoding::encode(&seeded.redirect_uri),
+                    urlencoding::encode(&seeded.authorization_handle),
+                ))
+                .header(
+                    "cookie",
+                    format!("keycast_session={}", session_token),
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("silent reauth request should complete");
+
+    let authorize_status = authorize_response.status();
+    if authorize_status != StatusCode::SEE_OTHER {
+        cleanup(&pool, &seeded.user_pubkey).await;
+        assert_eq!(authorize_status, StatusCode::SEE_OTHER);
+    }
+    let location = authorize_response
+        .headers()
+        .get(header::LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .expect("silent reauth should redirect with a code");
+    let redirect = Url::parse(location).expect("redirect location should be a valid URL");
+    let code = redirect
+        .query_pairs()
+        .find_map(|(key, value)| (key == "code").then(|| value.into_owned()))
+        .expect("redirect should carry authorization code");
+
+    let token_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/oauth/token")
+                .header("host", "localhost")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "grant_type": "authorization_code",
+                        "client_id": "Reauth Test Client",
+                        "redirect_uri": seeded.redirect_uri,
+                        "code": code,
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("token exchange should complete");
+
+    let token_status = token_response.status();
+    if token_status != StatusCode::OK {
+        cleanup(&pool, &seeded.user_pubkey).await;
+        assert_eq!(token_status, StatusCode::OK);
+    }
+
+    let active_is_first_party: bool = sqlx::query_scalar(
+        "SELECT is_first_party FROM oauth_authorizations
+         WHERE user_pubkey = $1 AND revoked_at IS NULL
+         ORDER BY created_at DESC LIMIT 1",
+    )
+    .bind(&seeded.user_pubkey)
+    .fetch_one(&pool)
+    .await
+    .expect("replacement authorization should exist");
+    let old_revoked_at: Option<chrono::DateTime<Utc>> = sqlx::query_scalar(
+        "SELECT revoked_at FROM oauth_authorizations
+         WHERE user_pubkey = $1 AND authorization_handle = $2",
+    )
+    .bind(&seeded.user_pubkey)
+    .bind(&seeded.authorization_handle)
+    .fetch_one(&pool)
+    .await
+    .expect("old authorization should exist");
+
+    cleanup(&pool, &seeded.user_pubkey).await;
+
+    assert!(
+        active_is_first_party,
+        "silent reauth replacement must preserve first-party deletion authority"
+    );
+    assert!(
+        old_revoked_at.is_some(),
+        "silent reauth should still revoke the replaced authorization"
+    );
 }
 
 /// The regression this guards: a first-party session that refreshes immediately
@@ -263,9 +493,11 @@ async fn refresh_grant_preserves_first_party_fact() {
     let pool = setup_pool().await;
     let seeded = seed_authorization(&pool, true).await;
 
-    let is_first_party = refreshed_access_token_is_first_party(&pool, &seeded.refresh_token).await;
+    let result = refreshed_access_token_is_first_party(&pool, &seeded.refresh_token).await;
 
     cleanup(&pool, &seeded.user_pubkey).await;
+
+    let is_first_party = result.expect("refresh grant should return a decodable access token");
 
     assert!(
         is_first_party,
@@ -279,9 +511,11 @@ async fn refresh_grant_withholds_first_party_fact_from_third_party_authorization
     let pool = setup_pool().await;
     let seeded = seed_authorization(&pool, false).await;
 
-    let is_first_party = refreshed_access_token_is_first_party(&pool, &seeded.refresh_token).await;
+    let result = refreshed_access_token_is_first_party(&pool, &seeded.refresh_token).await;
 
     cleanup(&pool, &seeded.user_pubkey).await;
+
+    let is_first_party = result.expect("refresh grant should return a decodable access token");
 
     assert!(
         !is_first_party,

--- a/api/tests/oauth_refresh_first_party_test.rs
+++ b/api/tests/oauth_refresh_first_party_test.rs
@@ -81,6 +81,7 @@ impl KeyManager for TestKeyManager {
 fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthState {
     let bcrypt_queue = BcryptQueue::new();
     let secret_pool = SecretPool::new(1);
+    let _producer_handle = secret_pool.spawn_producer();
     let tenant_cache = Cache::builder().max_capacity(10).build();
     let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
 

--- a/api/tests/oauth_refresh_first_party_test.rs
+++ b/api/tests/oauth_refresh_first_party_test.rs
@@ -1,0 +1,290 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration tests for refresh-token rotation preserving first-party deletion authority
+// ABOUTME: Guards DELETE /user/account authorization against silently losing the first_party UCAN fact
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    routing::post,
+    Json, Router,
+};
+use chrono::{Duration, Utc};
+use keycast_api::{
+    api::{
+        http::oauth::{token, TokenRequest},
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    repositories::{
+        CreateOAuthAuthorizationParams, OAuthAuthorizationRepository, RefreshTokenRepository,
+    },
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use std::sync::{Arc, Once};
+use tower::ServiceExt;
+use ucan::Ucan;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+mod common;
+
+const TENANT_ID: i64 = 1;
+
+static BUNKER_RELAYS_INIT: Once = Once::new();
+
+/// The refresh response reconstructs a bunker URL, which reads the deployment-wide
+/// relay configuration. Set it once so parallel tests never race on the write.
+fn configure_bunker_relays() {
+    BUNKER_RELAYS_INIT.call_once(|| {
+        std::env::set_var("BUNKER_RELAYS", "wss://relay.test.example");
+    });
+}
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    configure_bunker_relays();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database")
+}
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthState {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    keycast_api::api::http::routes::AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    }
+}
+
+fn create_test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: TENANT_ID,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+struct SeededAuthorization {
+    user_pubkey: String,
+    refresh_token: String,
+}
+
+/// Seed a user, their stored key, an OAuth authorization with the requested
+/// first-party status, and a live refresh token bound to that authorization.
+async fn seed_authorization(pool: &PgPool, is_first_party: bool) -> SeededAuthorization {
+    let user_keys = Keys::generate();
+    let user_pubkey = user_keys.public_key().to_hex();
+    let email = format!("refresh-first-party-{}@example.test", Uuid::new_v4());
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, email_verified, created_at, updated_at)
+         VALUES ($1, $2, $3, true, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(TENANT_ID)
+    .bind(&email)
+    .execute(pool)
+    .await
+    .expect("Failed to create test user");
+
+    // TestKeyManager is the identity transform, so the stored ciphertext is the raw secret.
+    sqlx::query(
+        "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id)
+         VALUES ($1, $2, $3)",
+    )
+    .bind(&user_pubkey)
+    .bind(user_keys.secret_key().secret_bytes().to_vec())
+    .bind(TENANT_ID)
+    .execute(pool)
+    .await
+    .expect("Failed to create personal key");
+
+    let secret_hash = format!("connection-secret-{}", Uuid::new_v4());
+    let bunker_public_key =
+        keycast_core::bunker_key::derive_bunker_keys(user_keys.secret_key(), &secret_hash)
+            .public_key()
+            .to_hex();
+
+    let authorization_id = OAuthAuthorizationRepository::new(pool.clone())
+        .create(CreateOAuthAuthorizationParams {
+            tenant_id: TENANT_ID,
+            user_pubkey: user_pubkey.clone(),
+            redirect_origin: format!("https://refresh-{}.example.test", Uuid::new_v4()),
+            client_id: "Refresh Test Client".to_string(),
+            bunker_public_key,
+            secret_hash,
+            relays: "[]".to_string(),
+            policy_id: None,
+            is_first_party,
+            client_pubkey: None,
+            authorization_handle: Some(Uuid::new_v4().to_string()),
+            handle_expires_at: Utc::now() + Duration::days(30),
+        })
+        .await
+        .expect("Failed to create OAuth authorization");
+
+    let refresh_token = format!("refresh-token-{}", Uuid::new_v4());
+    RefreshTokenRepository::new(pool.clone())
+        .create(&refresh_token, authorization_id, TENANT_ID)
+        .await
+        .expect("Failed to create refresh token");
+
+    SeededAuthorization {
+        user_pubkey,
+        refresh_token,
+    }
+}
+
+async fn cleanup(pool: &PgPool, user_pubkey: &str) {
+    let _ = sqlx::query(
+        "DELETE FROM oauth_refresh_tokens WHERE authorization_id IN
+         (SELECT id FROM oauth_authorizations WHERE user_pubkey = $1)",
+    )
+    .bind(user_pubkey)
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM oauth_authorizations WHERE user_pubkey = $1")
+        .bind(user_pubkey)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM personal_keys WHERE user_pubkey = $1")
+        .bind(user_pubkey)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+        .bind(user_pubkey)
+        .execute(pool)
+        .await;
+}
+
+/// Exchange a refresh token through the real `/oauth/token` route and return the
+/// `first_party` fact carried by the rotated access token.
+async fn refreshed_access_token_is_first_party(pool: &PgPool, refresh_token: &str) -> bool {
+    let auth_state = create_test_auth_state(pool.clone());
+    let app = Router::new().route(
+        "/oauth/token",
+        post(move |Json(req): Json<TokenRequest>| {
+            let auth_state = auth_state.clone();
+            async move { token(create_test_tenant(), State(auth_state), Json(req)).await }
+        }),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/oauth/token")
+                .header("host", "localhost")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "grant_type": "refresh_token",
+                        "client_id": "Refresh Test Client",
+                        "refresh_token": refresh_token,
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("refresh grant request should complete");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "refresh grant should succeed"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body should be readable");
+    let payload: serde_json::Value =
+        serde_json::from_slice(&body).expect("response body should be JSON");
+    let access_token = payload["access_token"]
+        .as_str()
+        .expect("refresh response should carry an access_token");
+
+    Ucan::try_from_token_string(access_token)
+        .expect("rotated access token should decode as a UCAN")
+        .facts()
+        .iter()
+        .any(|fact| fact.get("first_party").and_then(|v| v.as_bool()) == Some(true))
+}
+
+/// The regression this guards: a first-party session that refreshes immediately
+/// before deleting its account must keep the fact `delete_account` requires.
+#[tokio::test]
+async fn refresh_grant_preserves_first_party_fact() {
+    let pool = setup_pool().await;
+    let seeded = seed_authorization(&pool, true).await;
+
+    let is_first_party = refreshed_access_token_is_first_party(&pool, &seeded.refresh_token).await;
+
+    cleanup(&pool, &seeded.user_pubkey).await;
+
+    assert!(
+        is_first_party,
+        "refreshing a first-party authorization must keep account-deletion authority"
+    );
+}
+
+/// Third-party apps must not gain deletion authority by refreshing.
+#[tokio::test]
+async fn refresh_grant_withholds_first_party_fact_from_third_party_authorization() {
+    let pool = setup_pool().await;
+    let seeded = seed_authorization(&pool, false).await;
+
+    let is_first_party = refreshed_access_token_is_first_party(&pool, &seeded.refresh_token).await;
+
+    cleanup(&pool, &seeded.user_pubkey).await;
+
+    assert!(
+        !is_first_party,
+        "third-party authorizations must never gain account-deletion authority via refresh"
+    );
+}

--- a/core/src/repositories/oauth_authorization.rs
+++ b/core/src/repositories/oauth_authorization.rs
@@ -104,6 +104,26 @@ impl OAuthAuthorizationRepository {
         .map_err(Into::into)
     }
 
+    pub async fn find_first_party_by_handle(
+        &self,
+        authorization_handle: &str,
+        user_pubkey: &str,
+    ) -> Result<Option<(i32, bool)>, RepositoryError> {
+        sqlx::query_as::<_, (i32, bool)>(
+            "SELECT id, is_first_party FROM oauth_authorizations
+             WHERE authorization_handle = $1
+               AND user_pubkey = $2
+               AND revoked_at IS NULL
+               AND (expires_at IS NULL OR expires_at > NOW())
+               AND handle_expires_at > NOW()",
+        )
+        .bind(authorization_handle)
+        .bind(user_pubkey)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
     /// Create a new OAuth authorization and return its ID.
     pub async fn create(
         &self,
@@ -337,6 +357,31 @@ impl OAuthAuthorizationRepository {
         .fetch_optional(&self.pool)
         .await?;
         Ok(exists.is_some())
+    }
+
+    pub async fn active_first_party_for_origin(
+        &self,
+        user_pubkey: &str,
+        redirect_origin: &str,
+        tenant_id: i64,
+    ) -> Result<Option<bool>, RepositoryError> {
+        sqlx::query_scalar(
+            "SELECT is_first_party FROM oauth_authorizations
+             WHERE user_pubkey = $1
+               AND redirect_origin = $2
+               AND tenant_id = $3
+               AND revoked_at IS NULL
+               AND (expires_at IS NULL OR expires_at > NOW())
+               AND handle_expires_at > NOW()
+             ORDER BY created_at DESC
+             LIMIT 1",
+        )
+        .bind(user_pubkey)
+        .bind(redirect_origin)
+        .bind(tenant_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(Into::into)
     }
 
     /// Find the most recent bunker pubkey for a user.

--- a/core/src/repositories/oauth_authorization.rs
+++ b/core/src/repositories/oauth_authorization.rs
@@ -18,6 +18,7 @@ pub struct CreateOAuthAuthorizationParams {
     pub secret_hash: String,
     pub relays: String,
     pub policy_id: Option<i32>,
+    pub is_first_party: bool,
     pub client_pubkey: Option<String>,
     pub authorization_handle: Option<String>,
     pub handle_expires_at: DateTime<Utc>,
@@ -43,7 +44,7 @@ impl OAuthAuthorizationRepository {
             "SELECT id, user_pubkey, redirect_origin, client_id, bunker_public_key,
                     secret_hash, relays, policy_id, tenant_id, client_pubkey, connected_client_pubkey,
                     connected_at, created_at, updated_at, revoked_at, expires_at,
-                    handle_expires_at, authorization_handle
+                    handle_expires_at, authorization_handle, is_first_party
              FROM oauth_authorizations WHERE tenant_id = $1 AND id = $2",
         )
         .bind(tenant_id)
@@ -112,9 +113,9 @@ impl OAuthAuthorizationRepository {
         sqlx::query_scalar::<_, i32>(
             "INSERT INTO oauth_authorizations
              (tenant_id, user_pubkey, redirect_origin, client_id, bunker_public_key,
-              secret_hash, relays, policy_id, client_pubkey, authorization_handle, handle_expires_at,
-              created_at, updated_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+              secret_hash, relays, policy_id, is_first_party, client_pubkey, authorization_handle,
+              handle_expires_at, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
              RETURNING id",
         )
         .bind(params.tenant_id)
@@ -125,6 +126,7 @@ impl OAuthAuthorizationRepository {
         .bind(&params.secret_hash)
         .bind(&params.relays)
         .bind(params.policy_id)
+        .bind(params.is_first_party)
         .bind(&params.client_pubkey)
         .bind(&params.authorization_handle)
         .bind(params.handle_expires_at)
@@ -510,6 +512,49 @@ mod tests {
 
         let result = repo.find(1, 999999).await;
         assert!(matches!(result, Err(RepositoryError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_create_and_find_preserves_first_party_flag() {
+        use nostr_sdk::Keys;
+        use uuid::Uuid;
+
+        let pool = setup_pool().await;
+        let repo = OAuthAuthorizationRepository::new(pool.clone());
+
+        let user = Keys::generate().public_key().to_hex();
+        let bunker_pubkey = Keys::generate().public_key().to_hex();
+        let origin = format!("https://first-party-{}.example.com", Uuid::new_v4());
+
+        sqlx::query("INSERT INTO users (pubkey, tenant_id, created_at, updated_at) VALUES ($1, 1, NOW(), NOW()) ON CONFLICT (pubkey) DO NOTHING")
+            .bind(&user)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let id = repo
+            .create(CreateOAuthAuthorizationParams {
+                tenant_id: 1,
+                user_pubkey: user.clone(),
+                redirect_origin: origin,
+                client_id: "First Party".to_string(),
+                bunker_public_key: bunker_pubkey,
+                secret_hash: "$2b$10$test_hash".to_string(),
+                relays: "[]".to_string(),
+                policy_id: None,
+                is_first_party: true,
+                client_pubkey: None,
+                authorization_handle: None,
+                handle_expires_at: Utc::now() + chrono::Duration::days(30),
+            })
+            .await
+            .unwrap();
+
+        let authorization = repo.find(1, id).await.unwrap();
+        assert!(
+            authorization.is_first_party,
+            "refresh rotation must be able to recover first-party session authority"
+        );
     }
 
     #[tokio::test]

--- a/core/src/types/oauth_authorization.rs
+++ b/core/src/types/oauth_authorization.rs
@@ -26,6 +26,8 @@ pub struct OAuthAuthorization {
     pub relays: Relays,
     /// Optional policy for permission restrictions
     pub policy_id: Option<i32>,
+    /// Whether this authorization came from a first-party flow.
+    pub is_first_party: bool,
     /// Tenant ID for multi-tenancy isolation
     pub tenant_id: i64,
     /// App's ephemeral pubkey for NIP-46 communication (NIP-46: `client-pubkey`)
@@ -86,7 +88,7 @@ impl OAuthAuthorization {
             "SELECT id, user_pubkey, redirect_origin, client_id, bunker_public_key,
                     secret_hash, relays, policy_id, tenant_id, client_pubkey, connected_client_pubkey,
                     connected_at, created_at, updated_at, revoked_at, expires_at,
-                    handle_expires_at, authorization_handle
+                    handle_expires_at, authorization_handle, is_first_party
              FROM oauth_authorizations WHERE tenant_id = $1 AND id = $2",
         )
         .bind(tenant_id)

--- a/database/migrations/20260803120000_add_oauth_authorization_first_party.sql
+++ b/database/migrations/20260803120000_add_oauth_authorization_first_party.sql
@@ -1,0 +1,4 @@
+-- Preserve whether an OAuth authorization was created by the first-party headless flow.
+-- Refresh-token rotation reads this flag when minting a replacement UCAN.
+ALTER TABLE oauth_authorizations
+ADD COLUMN IF NOT EXISTS is_first_party BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary

- Preserve first-party account deletion authorization across OAuth refresh-token rotation.
- Add an `oauth_authorizations.is_first_party` flag so the refresh grant can mint replacement UCANs with `first_party: true` only for authorizations that originally came from a first-party flow.
- Gate `/api/headless/authorize` so a third-party OAuth bearer token cannot mint a first-party authorization.
- Preserve first-party status through silent OAuth re-authentication when replacing an existing first-party authorization.
- Keep `DELETE /user/account` on the existing UCAN authorization path; it no longer gains a NIP-98 bypass.
- Stop truncating account-deletion pubkeys in structured logs.
- Add integration coverage for refresh rotation, headless authorize gating, and silent re-auth first-party preservation.

## Motivation

Authorization for account deletion depends on a UCAN fact (`first_party`) that was previously present only on the original headless-flow access token. Clients refresh immediately before deletion, so a returning first-party user could lose the fact and be denied after the client had already published an irreversible NIP-62 vanish.

The safer fix is to persist first-party status on the OAuth authorization and preserve it during refresh-token rotation while keeping third-party OAuth apps outside the account-deletion boundary.

## Related Issue

- Closes #323
- Client-side context: divinevideo/divine-mobile#4881, divinevideo/divine-mobile#5756

## Review notes

- This remains an authorization change in a security-critical path and should get a human security/platform review.
- Existing authorizations created before this migration have `is_first_party = false`; users with old sessions may need to re-authenticate once to get a first-party authorization carrying the new persisted flag. There is no safe server-side backfill, because `client_id` and `redirect_uri` are caller-supplied at `/api/headless/login`.
- `first_party` now persists for the life of eligible first-party authorizations rather than for a single access token, so deletion authority is renewable via refresh where it previously expired with the access token.
- Deploy ordering is safe with the current mobile fallback to bearer-token deletion, and `cloudbuild.yaml` runs migrations before the deploy step.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo check -p keycast_api --tests --features integration-tests`
- [x] `cargo test -p keycast_api server_signed_ucan_includes_first_party_only_when_requested`
- [x] Local DB-backed targeted tests were attempted but could not run because Docker/Postgres is unavailable here (`PoolTimedOut`):
  - `cargo test -p keycast_api --features integration-tests --test headless_auth_test headless_authorize`
  - `cargo test -p keycast_api --features integration-tests --test oauth_refresh_first_party_test`
  - `cargo test -p keycast_core --features integration-tests --lib repositories::oauth_authorization`
- [x] GitHub CI DB-backed checks passed on commit `40ae627`.

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
