### PR TITLE
docs: record deployment source of truth and transaction-mode pooling constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,17 +114,17 @@ When touching OAuth, auth/session behavior, NIP-05/profile behavior, signer flow
 
 - New schema changes live in `database/migrations/` as a new timestamped migration. Do not edit shipped migrations.
 - Use SQLx for queries so compile-time verification stays meaningful. If you change a query, regenerate `sqlx-data.json` (where applicable) and commit it with the source change.
-- Locally, `bun run db:reset` recreates the dev database; `bun run db:migrate` applies new migrations. Production migrations are run via `tools/run-migrations.sh` from the deploy pipeline.
+- Locally, `bun run db:reset` recreates the dev database; `bun run db:migrate` applies new migrations. Production migrations are run by the deploy path as a dedicated one-shot job before serving rollout: the `keycast-migrate` Cloud Run Job for Cloud Run and the `keycast-db-migrate` ArgoCD sync hook for GKE. Both execute `./keycast --migrate`, which runs the embedded `sqlx::migrate!` migrations.
 
 ### Transaction-Mode Pooling
 
-Every environment runs a transaction-mode connection pooler in front of Postgres. The backend serving a connection can change between transactions, which breaks anything that assumes session continuity.
+When Keycast runs behind a transaction-mode connection pooler, the backend serving a connection can change between transactions, which breaks anything that assumes session continuity. Local dev and CI connect directly to Postgres unless explicitly using the loadtest pooler harness.
 
 - Do not use session-level `SET`; use `SET LOCAL` inside a transaction and confirm it cannot leak past its own unit of work. Do not use `LISTEN`/`NOTIFY`, `WITH HOLD` cursors, or session-scoped advisory locks. Use `pg_advisory_xact_lock`, which releases at commit.
 - Do not stream results with `.fetch()` across a transaction boundary. The connection may not survive it.
 - `SQLX_STATEMENT_CACHE` is only safe because the poolers set `max_prepared_statements`. Do not raise the cache above what the pooler tracks, and do not assume caching is safe against a pooler without it. sqlx caches prepared statements per connection, and in transaction mode a cached statement may not exist on the backend you land on.
 - Prepared-statement failures under pooling are **load-dependent**. Under low traffic the pooler has no pressure to reassign backends, so each client behaves as if it were in session mode and the bug never appears. A clean staging run is not evidence that a change is safe under production load.
-- Migrations run out-of-band via `tools/run-migrations.sh` rather than on startup, which avoids the `pg_advisory_lock` contention that `sqlx::migrate!` would cause across many instances. Keep it that way.
+- Serving instances must not run migrations on startup. Migrations run in the dedicated jobs above, before rollout, and their migration database URL must bypass the transaction-mode pooler because `sqlx::migrate!` uses a session-scoped advisory lock.
 
 ## Secrets, Local Stack, And Deployment
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - Database migrations live in `database/migrations/`. End-to-end and integration coverage lives in `e2e/` and `tests/`.
 - Operational and design notes live in `docs/` (start with `ARCHITECTURE.md`, `DEVELOPMENT.md`, `DEPLOYMENT.md`, `SECURITY.md`, and the OAuth/signer-specific guides). `CLAUDE.md` is also kept current and is the fastest orientation read.
 - Older docs can drift. If documentation conflicts, trust the current implementation, targeted tests, and the newest focused doc over historical notes.
+- Read `docs/DEPLOYMENT.md` before doing anything that depends on where production runs — deploys, incident response, infrastructure changes, or reasoning about live state. Keycast is mid-migration: `login.divine.video` is served by Cloud Run, while GKE/ArgoCD serves staging and poc. A resource whose name contains `prod` or `production` is not evidence that it serves production traffic, and neither is a staged overlay or a pinned image tag.
 
 ## Worktree-First Task Workflow
 
@@ -114,6 +115,16 @@ When touching OAuth, auth/session behavior, NIP-05/profile behavior, signer flow
 - New schema changes live in `database/migrations/` as a new timestamped migration. Do not edit shipped migrations.
 - Use SQLx for queries so compile-time verification stays meaningful. If you change a query, regenerate `sqlx-data.json` (where applicable) and commit it with the source change.
 - Locally, `bun run db:reset` recreates the dev database; `bun run db:migrate` applies new migrations. Production migrations are run via `tools/run-migrations.sh` from the deploy pipeline.
+
+### Transaction-Mode Pooling
+
+Every environment runs a transaction-mode connection pooler in front of Postgres. The backend serving a connection can change between transactions, which breaks anything that assumes session continuity.
+
+- Do not use session-level `SET`; use `SET LOCAL` inside a transaction and confirm it cannot leak past its own unit of work. Do not use `LISTEN`/`NOTIFY`, `WITH HOLD` cursors, or session-scoped advisory locks. Use `pg_advisory_xact_lock`, which releases at commit.
+- Do not stream results with `.fetch()` across a transaction boundary. The connection may not survive it.
+- `SQLX_STATEMENT_CACHE` is only safe because the poolers set `max_prepared_statements`. Do not raise the cache above what the pooler tracks, and do not assume caching is safe against a pooler without it. sqlx caches prepared statements per connection, and in transaction mode a cached statement may not exist on the backend you land on.
+- Prepared-statement failures under pooling are **load-dependent**. Under low traffic the pooler has no pressure to reassign backends, so each client behaves as if it were in session mode and the bug never appears. A clean staging run is not evidence that a change is safe under production load.
+- Migrations run out-of-band via `tools/run-migrations.sh` rather than on startup, which avoids the `pg_advisory_lock` contention that `sqlx::migrate!` would cause across many instances. Keep it that way.
 
 ## Secrets, Local Stack, And Deployment
 

--- a/core/src/database.rs
+++ b/core/src/database.rs
@@ -134,8 +134,8 @@ impl Database {
             }
         };
 
-        // Migrations are run manually via tools/run-migrations.sh before deployment
-        // This avoids pg_advisory_lock thundering herd when many instances start simultaneously
+        // Migrations run before rollout through dedicated jobs that execute `./keycast --migrate`.
+        // Serving instances intentionally do not run sqlx::migrate! on startup.
 
         eprintln!("✅ PostgreSQL database initialized successfully");
 

--- a/docs/superpowers/plans/2026-06-23-self-serve-email-change.md
+++ b/docs/superpowers/plans/2026-06-23-self-serve-email-change.md
@@ -12,7 +12,7 @@ Implements GitHub issue #223. Validated against `main` @ 3d36601.
 
 ## Global Constraints
 
-- Migrations are forward-only, timestamped `YYYYMMDDHHmmss_name.sql`, run via `sqlx::migrate!` and `tools/run-migrations.sh`. No down migrations.
+- Migrations are forward-only, timestamped `YYYYMMDDHHmmss_name.sql`, and run via `sqlx::migrate!` or `sqlx migrate run` against the target database. No down migrations.
 - `event_type`, `endpoint`, `outcome` in `AuthEvent` are `&'static str`.
 - Anti-enumeration: the initiate endpoint always returns HTTP 200 success regardless of outcome.
 - Re-use `normalize_registration_email()` for all email normalization (case/dot bypass protection).
@@ -80,7 +80,7 @@ CREATE INDEX idx_users_pending_email_new_token
 
 - [ ] **Step 2: Run migration against the test DB**
 
-Run: `tools/run-migrations.sh` (or `sqlx migrate run` against `DATABASE_URL`). Expected: applies cleanly.
+Run: `sqlx migrate run` against `DATABASE_URL`. Expected: applies cleanly.
 
 - [ ] **Step 3: Commit** — `feat(db): add pending email change columns`
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
 		"db:reset": "bun run deps:up && sqlx database reset -y --database-url postgres://postgres:password@localhost/keycast --source ./database/migrations",
 		"db:migrate": "bun run deps:up && sqlx migrate run --database-url postgres://postgres:password@localhost/keycast --source ./database/migrations",
 		"db:test:setup": "bun run deps:up && sqlx database setup --database-url postgres://postgres:password@localhost/keycast_test --source ./database/migrations",
-		"db:migrate:prod": "./tools/run-migrations.sh",
-		"db:sql:prod": "./tools/run-sql.sh",
 		"key:generate": "./scripts/generate_key.sh",
 		"key:generate:force": "./scripts/generate_key.sh --force",
 		"setup:hooks": "cp scripts/hooks/pre-push .git/hooks/ && chmod +x .git/hooks/pre-push",


### PR DESCRIPTION
## Summary

Two things a future reader or agent currently has to rediscover the hard way.

First, where production actually runs. Keycast is mid-migration, and a resource named `prod` or `production` is not evidence that it serves production traffic. This has already caused one documented correction (#276), which fixed `docs/DEPLOYMENT.md` but never reached the agent-facing entry point.

Second, what transaction-mode connection pooling forbids when a Keycast environment is configured behind a pooler. The backend serving a connection can change between transactions, so code and operational docs need to avoid session-continuity assumptions.

## What Changed

`AGENTS.md` gains a pointer telling readers to check `docs/DEPLOYMENT.md` before doing anything that depends on where production runs, with enough of the answer inline that someone who skips the pointer still does not get it wrong.

`AGENTS.md` also gains a short `Transaction-Mode Pooling` subsection under `Database And Migrations` covering what breaks: session-level `SET`, `LISTEN`/`NOTIFY`, `WITH HOLD` cursors, session-scoped advisory locks, and streaming results across a transaction boundary. It records why `SQLX_STATEMENT_CACHE` is safe only when poolers set `max_prepared_statements`, and why these failures are load-dependent.

The migration guidance now matches the current deploy paths: serving instances do not run migrations on startup; dedicated Cloud Run and GKE jobs execute `./keycast --migrate`, which runs the embedded `sqlx::migrate!` migrations. Migration database URLs must bypass any transaction-mode pooler because SQLx migrations use a session-scoped advisory lock.

The takeover commit also removes package scripts that pointed at deleted production helper scripts and fixes the same stale migration command in an existing implementation plan.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- `bun run test:deploy-preflight`
- `jq -e . package.json`
- `git diff --check origin/main...HEAD`
- `cargo test --workspace --lib`

Attempted `cargo test --workspace`, but the local Docker dependency stack was unavailable (`/Users/lizsw/.docker/run/docker.sock` missing), and the DB-backed integration tests failed with `PoolTimedOut`.

## Risks

No runtime behavior change. This updates docs, comments, and removes two broken package scripts for deleted production helpers.

## Follow-ups

`docs/MONITORING.md` has nothing on connection-pool exhaustion, and Cloud Run has no readiness probe configured, so the DB-aware `readyz` handler is unused there. Both are separate from this change.
