### PR TITLE
fix(atproto): stop a failed enable from trapping crossposting on

### DIFF
--- a/api/src/api/http/atproto.rs
+++ b/api/src/api/http/atproto.rs
@@ -304,8 +304,9 @@ enum OptIn {
 
 /// Writes the pre-trigger opt-in and reports the resulting status.
 ///
-/// Shared by [`enable_user_atproto`] and [`reenable_user_atproto`] so both go
-/// through the same conditional write. See
+/// Shared by [`enable_user_atproto`] and
+/// [`reenable_user_atproto_with_trigger`] so both go through the same
+/// conditional write. See
 /// [`UserRepository::begin_atproto_enable`] for why the write is conditional and
 /// why it leaves `atproto_did` alone.
 async fn begin_atproto_opt_in(
@@ -371,8 +372,7 @@ where
     Ok(response)
 }
 
-/// Clears the opt-in that [`enable_user_atproto`] or [`reenable_user_atproto`]
-/// wrote ahead of the trigger.
+/// Clears the opt-in that [`begin_atproto_opt_in`] wrote ahead of the trigger.
 ///
 /// The enabled flag is set before the control plane is called, so a failed
 /// trigger leaves an opt-in that exists nowhere but this row. Keeping it makes
@@ -428,25 +428,6 @@ async fn roll_back_failed_enable(
     }
 
     Ok(())
-}
-
-pub async fn reenable_user_atproto(
-    repo: &UserRepository,
-    tenant_id: i64,
-    user_pubkey: &str,
-) -> Result<AtprotoStatusResponse, AtprotoControlError> {
-    let claimed_username = require_resolved_username(
-        resolve_username_with_fallback(repo, tenant_id, user_pubkey, |pubkey| async move {
-            divine_names::lookup_by_pubkey(&pubkey).await
-        })
-        .await?,
-    )?;
-
-    Ok(
-        begin_atproto_opt_in(repo, tenant_id, user_pubkey, claimed_username)
-            .await?
-            .0,
-    )
 }
 
 pub async fn reenable_user_atproto_with_trigger<F, Fut>(

--- a/api/src/api/http/atproto.rs
+++ b/api/src/api/http/atproto.rs
@@ -365,10 +365,15 @@ where
 /// control plane still owns, and [`disable_user_atproto_with_trigger`] depends
 /// on it to keep refusing a local-only disable for a provisioned account.
 ///
-/// The rollback only applies while the row still holds the `pending` state this
-/// request wrote. If the trigger did reach the control plane and provisioning
-/// reported back through the internal sync endpoint before the local call
-/// failed, that sync has already moved the row and must not be overwritten.
+/// The rollback only applies while the row is still `pending`. If the trigger
+/// did reach the control plane and provisioning reported back through the
+/// internal sync endpoint before the local call failed, that sync has already
+/// moved the row and must not be overwritten.
+///
+/// That guard is a state check and not a claim of request ownership: the row
+/// records no operation identity, so a rollback cannot tell its own `pending`
+/// write apart from one a later concurrent request left behind, and it can
+/// still compensate a newer opt-in.
 async fn roll_back_failed_enable(
     repo: &UserRepository,
     tenant_id: i64,

--- a/api/src/api/http/atproto.rs
+++ b/api/src/api/http/atproto.rs
@@ -283,8 +283,17 @@ pub async fn enable_user_atproto(
         return Err(AtprotoControlError::UsernameMismatch);
     }
 
-    repo.set_atproto_state(user_pubkey, tenant_id, true, Some("pending"), None, None)
-        .await?;
+    let existing_did = current_atproto_did(repo, tenant_id, user_pubkey).await?;
+
+    repo.set_atproto_state(
+        user_pubkey,
+        tenant_id,
+        true,
+        Some("pending"),
+        existing_did.as_deref(),
+        None,
+    )
+    .await?;
 
     let state = repo
         .get_atproto_state(user_pubkey, tenant_id)
@@ -292,6 +301,26 @@ pub async fn enable_user_atproto(
         .ok_or(AtprotoControlError::UserNotFound)?;
 
     Ok(map_state_to_response(Some(claimed_username), state))
+}
+
+/// Reads the DID currently on the row so a lifecycle write can carry it
+/// forward.
+///
+/// [`UserRepository::set_atproto_state`] writes `atproto_did` unconditionally,
+/// so passing `None` erases the link to a live repo. That column is what
+/// [`disable_user_atproto_with_trigger`] reads to decide whether a local-only
+/// disable is safe, so an enable that blanks it on its way through would let a
+/// later disable silently release a provisioned account.
+async fn current_atproto_did(
+    repo: &UserRepository,
+    tenant_id: i64,
+    user_pubkey: &str,
+) -> Result<Option<String>, AtprotoControlError> {
+    Ok(repo
+        .get_atproto_state(user_pubkey, tenant_id)
+        .await?
+        .ok_or(AtprotoControlError::UserNotFound)?
+        .did)
 }
 
 pub async fn enable_user_atproto_with_trigger<F, Fut>(
@@ -319,7 +348,8 @@ where
     Ok(response)
 }
 
-/// Clears the opt-in that [`enable_user_atproto`] wrote ahead of the trigger.
+/// Clears the opt-in that [`enable_user_atproto`] or [`reenable_user_atproto`]
+/// wrote ahead of the trigger.
 ///
 /// The enabled flag is set before the control plane is called, so a failed
 /// trigger leaves an opt-in that exists nowhere but this row. Keeping it makes
@@ -328,18 +358,24 @@ where
 /// If the trigger did reach the control plane before failing, provisioning
 /// reports back through the internal sync endpoint and the state converges
 /// there.
+///
+/// Any existing DID is carried through the rollback: it records a repo the
+/// control plane still owns, and [`disable_user_atproto_with_trigger`] reads it
+/// to keep refusing a local-only disable for a provisioned account.
 async fn roll_back_failed_enable(
     repo: &UserRepository,
     tenant_id: i64,
     user_pubkey: &str,
     error: &crate::atproto_provisioning::AtprotoProvisioningError,
 ) -> Result<(), AtprotoControlError> {
+    let existing_did = current_atproto_did(repo, tenant_id, user_pubkey).await?;
+
     repo.set_atproto_state(
         user_pubkey,
         tenant_id,
         false,
         Some("failed"),
-        None,
+        existing_did.as_deref(),
         Some(error.public_message()),
     )
     .await?;
@@ -359,8 +395,17 @@ pub async fn reenable_user_atproto(
         .await?,
     )?;
 
-    repo.set_atproto_state(user_pubkey, tenant_id, true, Some("pending"), None, None)
-        .await?;
+    let existing_did = current_atproto_did(repo, tenant_id, user_pubkey).await?;
+
+    repo.set_atproto_state(
+        user_pubkey,
+        tenant_id,
+        true,
+        Some("pending"),
+        existing_did.as_deref(),
+        None,
+    )
+    .await?;
 
     let state = repo
         .get_atproto_state(user_pubkey, tenant_id)
@@ -489,11 +534,6 @@ where
     F: FnOnce(String) -> Fut,
     Fut: Future<Output = Result<(), crate::atproto_provisioning::AtprotoProvisioningError>>,
 {
-    let _username = user_repo
-        .get_username(user_pubkey, tenant_id)
-        .await?
-        .ok_or(AtprotoControlError::UserNotFound)?;
-
     let current = user_repo
         .get_atproto_state(user_pubkey, tenant_id)
         .await?

--- a/api/src/api/http/atproto.rs
+++ b/api/src/api/http/atproto.rs
@@ -360,25 +360,29 @@ where
 /// there.
 ///
 /// Any existing DID is carried through the rollback: it records a repo the
-/// control plane still owns, and [`disable_user_atproto_with_trigger`] reads it
-/// to keep refusing a local-only disable for a provisioned account.
+/// control plane still owns, and [`disable_user_atproto_with_trigger`] depends
+/// on it to keep refusing a local-only disable for a provisioned account.
+///
+/// The rollback only applies while the row still holds the `pending` state this
+/// request wrote. If the trigger did reach the control plane and provisioning
+/// reported back through the internal sync endpoint before the local call
+/// failed, that sync has already moved the row and must not be overwritten.
 async fn roll_back_failed_enable(
     repo: &UserRepository,
     tenant_id: i64,
     user_pubkey: &str,
     error: &crate::atproto_provisioning::AtprotoProvisioningError,
 ) -> Result<(), AtprotoControlError> {
-    let existing_did = current_atproto_did(repo, tenant_id, user_pubkey).await?;
+    let rolled_back = repo
+        .roll_back_atproto_enable(user_pubkey, tenant_id, Some(error.public_message()))
+        .await?;
 
-    repo.set_atproto_state(
-        user_pubkey,
-        tenant_id,
-        false,
-        Some("failed"),
-        existing_did.as_deref(),
-        Some(error.public_message()),
-    )
-    .await?;
+    if !rolled_back {
+        tracing::info!(
+            "Skipped ATProto enable rollback for pubkey {}: the row is no longer pending, so provisioning state took precedence",
+            user_pubkey
+        );
+    }
 
     Ok(())
 }
@@ -534,18 +538,32 @@ where
     F: FnOnce(String) -> Fut,
     Fut: Future<Output = Result<(), crate::atproto_provisioning::AtprotoProvisioningError>>,
 {
-    let current = user_repo
-        .get_atproto_state(user_pubkey, tenant_id)
+    // Resolve the user before calling the control plane so a request for an
+    // unknown account still fails as `UserNotFound` rather than reaching the
+    // gateway. The DID is deliberately not read here: it is checked inside the
+    // conditional write below, because anything read before the trigger await
+    // can be stale by the time it would be acted on.
+    let username = user_repo
+        .get_username(user_pubkey, tenant_id)
         .await?
         .ok_or(AtprotoControlError::UserNotFound)?;
 
     if let Err(error) = trigger(user_pubkey.to_string()).await {
         // A provisioned account has a live repo that can keep publishing, so
         // reporting "off" without the control plane agreeing would be a lie.
-        // Without a DID there is nothing to publish from, and refusing here is
+        // Without a DID there is nothing to publish from, and refusing there is
         // what strands an account that a failed enable already left switched
         // on: every attempt to switch it back off hits the same outage.
-        if current.did.is_some() {
+        //
+        // The eligibility check is the `atproto_did IS NULL` predicate on this
+        // statement rather than an earlier read, so provisioning cannot attach a
+        // DID between the check and the write. A `false` result means the
+        // account became provisioned, and the request fails closed.
+        let released = user_repo
+            .disable_atproto_if_unprovisioned(user_pubkey, tenant_id)
+            .await?;
+
+        if !released {
             return Err(AtprotoControlError::ProvisioningTrigger(error));
         }
 
@@ -554,6 +572,15 @@ where
             user_pubkey,
             error
         );
+
+        session_repo.revoke_sessions_for_pubkey(user_pubkey).await?;
+
+        let state = user_repo
+            .get_atproto_state(user_pubkey, tenant_id)
+            .await?
+            .ok_or(AtprotoControlError::UserNotFound)?;
+
+        return Ok(map_state_to_response(username, state));
     }
 
     disable_user_atproto_and_revoke_sessions(user_repo, session_repo, tenant_id, user_pubkey).await

--- a/api/src/api/http/atproto.rs
+++ b/api/src/api/http/atproto.rs
@@ -312,20 +312,39 @@ where
         .ok_or(AtprotoControlError::UsernameNotClaimed)?;
 
     if let Err(error) = trigger(user_pubkey.to_string(), username.clone()).await {
-        let error_message = error.public_message();
-        repo.set_atproto_state(
-            user_pubkey,
-            tenant_id,
-            true,
-            Some("failed"),
-            None,
-            Some(error_message),
-        )
-        .await?;
+        roll_back_failed_enable(repo, tenant_id, user_pubkey, &error).await?;
         return Err(AtprotoControlError::ProvisioningTrigger(error));
     }
 
     Ok(response)
+}
+
+/// Clears the opt-in that [`enable_user_atproto`] wrote ahead of the trigger.
+///
+/// The enabled flag is set before the control plane is called, so a failed
+/// trigger leaves an opt-in that exists nowhere but this row. Keeping it makes
+/// the account read as "publishing" while no repo exists, and traps the user:
+/// turning it back off needs a control-plane call the same outage is refusing.
+/// If the trigger did reach the control plane before failing, provisioning
+/// reports back through the internal sync endpoint and the state converges
+/// there.
+async fn roll_back_failed_enable(
+    repo: &UserRepository,
+    tenant_id: i64,
+    user_pubkey: &str,
+    error: &crate::atproto_provisioning::AtprotoProvisioningError,
+) -> Result<(), AtprotoControlError> {
+    repo.set_atproto_state(
+        user_pubkey,
+        tenant_id,
+        false,
+        Some("failed"),
+        None,
+        Some(error.public_message()),
+    )
+    .await?;
+
+    Ok(())
 }
 
 pub async fn reenable_user_atproto(
@@ -364,16 +383,7 @@ where
     let response = reenable_user_atproto(repo, tenant_id, user_pubkey).await?;
 
     if let Err(error) = trigger(user_pubkey.to_string()).await {
-        let error_message = error.public_message();
-        repo.set_atproto_state(
-            user_pubkey,
-            tenant_id,
-            true,
-            Some("failed"),
-            None,
-            Some(error_message),
-        )
-        .await?;
+        roll_back_failed_enable(repo, tenant_id, user_pubkey, &error).await?;
         return Err(AtprotoControlError::ProvisioningTrigger(error));
     }
 
@@ -484,9 +494,27 @@ where
         .await?
         .ok_or(AtprotoControlError::UserNotFound)?;
 
-    trigger(user_pubkey.to_string())
-        .await
-        .map_err(AtprotoControlError::ProvisioningTrigger)?;
+    let current = user_repo
+        .get_atproto_state(user_pubkey, tenant_id)
+        .await?
+        .ok_or(AtprotoControlError::UserNotFound)?;
+
+    if let Err(error) = trigger(user_pubkey.to_string()).await {
+        // A provisioned account has a live repo that can keep publishing, so
+        // reporting "off" without the control plane agreeing would be a lie.
+        // Without a DID there is nothing to publish from, and refusing here is
+        // what strands an account that a failed enable already left switched
+        // on: every attempt to switch it back off hits the same outage.
+        if current.did.is_some() {
+            return Err(AtprotoControlError::ProvisioningTrigger(error));
+        }
+
+        tracing::warn!(
+            "Disabling unprovisioned ATProto account for pubkey {} locally after control-plane failure: {}",
+            user_pubkey,
+            error
+        );
+    }
 
     disable_user_atproto_and_revoke_sessions(user_repo, session_repo, tenant_id, user_pubkey).await
 }

--- a/api/src/api/http/atproto.rs
+++ b/api/src/api/http/atproto.rs
@@ -4,7 +4,9 @@ use axum::{
     http::{HeaderMap, StatusCode},
     Json,
 };
-use keycast_core::repositories::{AtprotoOAuthSessionRepository, RepositoryError, UserRepository};
+use keycast_core::repositories::{
+    AtprotoOAuthSessionRepository, ConditionalWrite, RepositoryError, UserRepository,
+};
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use std::future::Future;
@@ -373,15 +375,21 @@ async fn roll_back_failed_enable(
     user_pubkey: &str,
     error: &crate::atproto_provisioning::AtprotoProvisioningError,
 ) -> Result<(), AtprotoControlError> {
-    let rolled_back = repo
+    match repo
         .roll_back_atproto_enable(user_pubkey, tenant_id, Some(error.public_message()))
-        .await?;
-
-    if !rolled_back {
-        tracing::info!(
-            "Skipped ATProto enable rollback for pubkey {}: the row is no longer pending, so provisioning state took precedence",
-            user_pubkey
-        );
+        .await?
+    {
+        ConditionalWrite::Applied => {}
+        ConditionalWrite::Ineligible => {
+            tracing::info!(
+                "Skipped ATProto enable rollback for pubkey {}: the row is no longer pending, so provisioning state took precedence",
+                user_pubkey
+            );
+        }
+        // The row disappeared while the trigger was in flight. Report that as
+        // the missing user it is, matching what the caller saw before the
+        // rollback became conditional.
+        ConditionalWrite::NotFound => return Err(AtprotoControlError::UserNotFound),
     }
 
     Ok(())
@@ -559,12 +567,18 @@ where
         // statement rather than an earlier read, so provisioning cannot attach a
         // DID between the check and the write. A `false` result means the
         // account became provisioned, and the request fails closed.
-        let released = user_repo
+        match user_repo
             .disable_atproto_if_unprovisioned(user_pubkey, tenant_id)
-            .await?;
-
-        if !released {
-            return Err(AtprotoControlError::ProvisioningTrigger(error));
+            .await?
+        {
+            ConditionalWrite::Applied => {}
+            ConditionalWrite::Ineligible => {
+                return Err(AtprotoControlError::ProvisioningTrigger(error))
+            }
+            // The account was removed while the trigger was in flight. That is a
+            // missing user, not a provisioning outage, and the caller saw it as
+            // such before this write became conditional.
+            ConditionalWrite::NotFound => return Err(AtprotoControlError::UserNotFound),
         }
 
         tracing::warn!(

--- a/api/src/api/http/atproto.rs
+++ b/api/src/api/http/atproto.rs
@@ -285,48 +285,52 @@ pub async fn enable_user_atproto(
         return Err(AtprotoControlError::UsernameMismatch);
     }
 
-    let existing_did = current_atproto_did(repo, tenant_id, user_pubkey).await?;
-
-    repo.set_atproto_state(
-        user_pubkey,
-        tenant_id,
-        true,
-        Some("pending"),
-        existing_did.as_deref(),
-        None,
+    Ok(
+        begin_atproto_opt_in(repo, tenant_id, user_pubkey, claimed_username)
+            .await?
+            .0,
     )
-    .await?;
+}
+
+/// Whether the optimistic opt-in write actually moved the row.
+///
+/// A confirmed `ready` account is left alone, so there is nothing for a failed
+/// trigger to roll back and no reason to call the control plane again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OptIn {
+    Written,
+    AlreadyReady,
+}
+
+/// Writes the pre-trigger opt-in and reports the resulting status.
+///
+/// Shared by [`enable_user_atproto`] and [`reenable_user_atproto`] so both go
+/// through the same conditional write. See
+/// [`UserRepository::begin_atproto_enable`] for why the write is conditional and
+/// why it leaves `atproto_did` alone.
+async fn begin_atproto_opt_in(
+    repo: &UserRepository,
+    tenant_id: i64,
+    user_pubkey: &str,
+    claimed_username: String,
+) -> Result<(AtprotoStatusResponse, OptIn), AtprotoControlError> {
+    let opt_in = match repo.begin_atproto_enable(user_pubkey, tenant_id).await? {
+        ConditionalWrite::Applied => OptIn::Written,
+        ConditionalWrite::Ineligible => OptIn::AlreadyReady,
+        ConditionalWrite::NotFound => return Err(AtprotoControlError::UserNotFound),
+    };
 
     let state = repo
         .get_atproto_state(user_pubkey, tenant_id)
         .await?
         .ok_or(AtprotoControlError::UserNotFound)?;
 
-    Ok(map_state_to_response(Some(claimed_username), state))
-}
-
-/// Reads the DID currently on the row so a lifecycle write can carry it
-/// forward.
-///
-/// [`UserRepository::set_atproto_state`] writes `atproto_did` unconditionally,
-/// so passing `None` erases the link to a live repo. That column is what
-/// [`disable_user_atproto_with_trigger`] reads to decide whether a local-only
-/// disable is safe, so an enable that blanks it on its way through would let a
-/// later disable silently release a provisioned account.
-async fn current_atproto_did(
-    repo: &UserRepository,
-    tenant_id: i64,
-    user_pubkey: &str,
-) -> Result<Option<String>, AtprotoControlError> {
-    Ok(repo
-        .get_atproto_state(user_pubkey, tenant_id)
-        .await?
-        .ok_or(AtprotoControlError::UserNotFound)?
-        .did)
+    Ok((map_state_to_response(Some(claimed_username), state), opt_in))
 }
 
 pub async fn enable_user_atproto_with_trigger<F, Fut>(
     repo: &UserRepository,
+    session_repo: &AtprotoOAuthSessionRepository,
     tenant_id: i64,
     user_pubkey: &str,
     requested_username: &str,
@@ -336,14 +340,31 @@ where
     F: FnOnce(String, String) -> Fut,
     Fut: Future<Output = Result<(), crate::atproto_provisioning::AtprotoProvisioningError>>,
 {
-    let response = enable_user_atproto(repo, tenant_id, user_pubkey, requested_username).await?;
+    let claimed_username = require_resolved_username(
+        resolve_username_with_fallback(repo, tenant_id, user_pubkey, |pubkey| async move {
+            divine_names::lookup_by_pubkey(&pubkey).await
+        })
+        .await?,
+    )?;
+
+    if claimed_username != requested_username {
+        return Err(AtprotoControlError::UsernameMismatch);
+    }
+
+    let (response, opt_in) =
+        begin_atproto_opt_in(repo, tenant_id, user_pubkey, claimed_username).await?;
+
+    if opt_in == OptIn::AlreadyReady {
+        return Ok(response);
+    }
+
     let username = response
         .username
         .clone()
         .ok_or(AtprotoControlError::UsernameNotClaimed)?;
 
     if let Err(error) = trigger(user_pubkey.to_string(), username.clone()).await {
-        roll_back_failed_enable(repo, tenant_id, user_pubkey, &error).await?;
+        roll_back_failed_enable(repo, session_repo, tenant_id, user_pubkey, &error).await?;
         return Err(AtprotoControlError::ProvisioningTrigger(error));
     }
 
@@ -374,8 +395,15 @@ where
 /// records no operation identity, so a rollback cannot tell its own `pending`
 /// write apart from one a later concurrent request left behind, and it can
 /// still compensate a newer opt-in.
+///
+/// A rollback that lands reports the account as switched off, so it revokes
+/// ATProto OAuth sessions like every other path that does. The refresh grant
+/// checks only the session's own binding and never re-reads the lifecycle state,
+/// so a session left behind here would keep working against an account the
+/// status endpoint calls off.
 async fn roll_back_failed_enable(
     repo: &UserRepository,
+    session_repo: &AtprotoOAuthSessionRepository,
     tenant_id: i64,
     user_pubkey: &str,
     error: &crate::atproto_provisioning::AtprotoProvisioningError,
@@ -384,7 +412,9 @@ async fn roll_back_failed_enable(
         .roll_back_atproto_enable(user_pubkey, tenant_id, Some(error.public_message()))
         .await?
     {
-        ConditionalWrite::Applied => {}
+        ConditionalWrite::Applied => {
+            session_repo.revoke_sessions_for_pubkey(user_pubkey).await?;
+        }
         ConditionalWrite::Ineligible => {
             tracing::info!(
                 "Skipped ATProto enable rollback for pubkey {}: the row is no longer pending, so provisioning state took precedence",
@@ -412,28 +442,16 @@ pub async fn reenable_user_atproto(
         .await?,
     )?;
 
-    let existing_did = current_atproto_did(repo, tenant_id, user_pubkey).await?;
-
-    repo.set_atproto_state(
-        user_pubkey,
-        tenant_id,
-        true,
-        Some("pending"),
-        existing_did.as_deref(),
-        None,
+    Ok(
+        begin_atproto_opt_in(repo, tenant_id, user_pubkey, claimed_username)
+            .await?
+            .0,
     )
-    .await?;
-
-    let state = repo
-        .get_atproto_state(user_pubkey, tenant_id)
-        .await?
-        .ok_or(AtprotoControlError::UserNotFound)?;
-
-    Ok(map_state_to_response(Some(claimed_username), state))
 }
 
 pub async fn reenable_user_atproto_with_trigger<F, Fut>(
     repo: &UserRepository,
+    session_repo: &AtprotoOAuthSessionRepository,
     tenant_id: i64,
     user_pubkey: &str,
     trigger: F,
@@ -442,10 +460,22 @@ where
     F: FnOnce(String) -> Fut,
     Fut: Future<Output = Result<(), crate::atproto_provisioning::AtprotoProvisioningError>>,
 {
-    let response = reenable_user_atproto(repo, tenant_id, user_pubkey).await?;
+    let claimed_username = require_resolved_username(
+        resolve_username_with_fallback(repo, tenant_id, user_pubkey, |pubkey| async move {
+            divine_names::lookup_by_pubkey(&pubkey).await
+        })
+        .await?,
+    )?;
+
+    let (response, opt_in) =
+        begin_atproto_opt_in(repo, tenant_id, user_pubkey, claimed_username).await?;
+
+    if opt_in == OptIn::AlreadyReady {
+        return Ok(response);
+    }
 
     if let Err(error) = trigger(user_pubkey.to_string()).await {
-        roll_back_failed_enable(repo, tenant_id, user_pubkey, &error).await?;
+        roll_back_failed_enable(repo, session_repo, tenant_id, user_pubkey, &error).await?;
         return Err(AtprotoControlError::ProvisioningTrigger(error));
     }
 
@@ -660,6 +690,7 @@ where
         if current.state.as_deref() == Some("disabled") {
             return reenable_user_atproto_with_trigger(
                 user_repo,
+                session_repo,
                 tenant_id,
                 authenticated_user_pubkey,
                 reenable_trigger,
@@ -672,6 +703,7 @@ where
 
         return enable_user_atproto_with_trigger(
             user_repo,
+            session_repo,
             tenant_id,
             authenticated_user_pubkey,
             &username,
@@ -751,10 +783,12 @@ pub async fn enable_atproto(
 ) -> Result<(StatusCode, Json<AtprotoStatusResponse>), AuthError> {
     let tenant_id = tenant.0.id;
     let user_pubkey = extract_user_from_token(&headers, tenant_id).await?;
-    let repo = UserRepository::new(pool);
+    let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool);
 
     let response = enable_user_atproto_with_trigger(
         &repo,
+        &session_repo,
         tenant_id,
         &user_pubkey,
         &request.username,

--- a/api/tests/atproto_http_test.rs
+++ b/api/tests/atproto_http_test.rs
@@ -951,6 +951,102 @@ async fn enable_rollback_yields_to_a_sync_that_lands_during_the_trigger() {
     assert_eq!(status.did.as_deref(), Some("did:plc:syncwins"));
 }
 
+/// A conditional write that applies to no rows is ambiguous on its own: the
+/// account may have become ineligible, or it may be gone. Those map to
+/// different errors, and an account deleted while the trigger was in flight
+/// must still read as a missing user rather than a provisioning outage.
+#[tokio::test]
+async fn disable_reports_user_not_found_when_deleted_during_the_trigger() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-deleted-disable-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, atproto_enabled, atproto_state, created_at, updated_at)
+         VALUES ($1, $2, $3, true, 'failed', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let trigger_pool = pool.clone();
+    let trigger_pubkey = user_pubkey.clone();
+
+    let error = disable_user_atproto_with_trigger(
+        &repo,
+        &session_repo,
+        tenant_id,
+        &user_pubkey,
+        move |_pubkey| async move {
+            sqlx::query("DELETE FROM users WHERE pubkey = $1")
+                .bind(&trigger_pubkey)
+                .execute(&trigger_pool)
+                .await
+                .expect("failed to simulate account deletion");
+
+            Err(keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured)
+        },
+    )
+    .await
+    .expect_err("disable should fail once the account is gone");
+
+    assert_eq!(error.to_string(), "user not found");
+}
+
+/// Same classification requirement on the rollback path.
+#[tokio::test]
+async fn enable_rollback_reports_user_not_found_when_deleted_during_the_trigger() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-deleted-enable-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, created_at, updated_at)
+         VALUES ($1, $2, $3, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let trigger_pool = pool.clone();
+    let trigger_pubkey = user_pubkey.clone();
+
+    let error = enable_user_atproto_with_trigger(
+        &repo,
+        tenant_id,
+        &user_pubkey,
+        &username,
+        move |_pubkey, _username| async move {
+            sqlx::query("DELETE FROM users WHERE pubkey = $1")
+                .bind(&trigger_pubkey)
+                .execute(&trigger_pool)
+                .await
+                .expect("failed to simulate account deletion");
+
+            Err(keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured)
+        },
+    )
+    .await
+    .expect_err("enable should fail once the account is gone");
+
+    assert_eq!(error.to_string(), "user not found");
+}
+
 #[tokio::test]
 async fn disable_trigger_failure_preserves_existing_state() {
     let pool = common::setup_test_db().await;

--- a/api/tests/atproto_http_test.rs
+++ b/api/tests/atproto_http_test.rs
@@ -247,6 +247,134 @@ async fn enable_sets_pending_and_returns_accepted() {
     assert_eq!(response.error, None);
 }
 
+/// The pre-trigger opt-in write must leave `atproto_did` alone. It is the only
+/// local record that a live repo exists, and it is what the local-release path
+/// reads to decide whether reporting an account off is safe. Clearing it here
+/// and re-enabling would hand a provisioned account to that path.
+#[tokio::test]
+async fn enable_leaves_an_existing_did_in_place() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-enable-keeps-did-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, atproto_enabled, atproto_state, atproto_did, atproto_error, created_at, updated_at)
+         VALUES ($1, $2, $3, false, 'failed', 'did:plc:testkeepsdid', 'previous failure', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let response = enable_user_atproto(&repo, tenant_id, &user_pubkey, &username)
+        .await
+        .expect("enable should succeed");
+
+    assert!(response.enabled);
+    assert_eq!(response.state.as_deref(), Some("pending"));
+    assert_eq!(response.did.as_deref(), Some("did:plc:testkeepsdid"));
+    // The stale explanation from the previous attempt is cleared.
+    assert_eq!(response.error, None);
+}
+
+/// Same requirement on the re-enable path.
+#[tokio::test]
+async fn reenable_leaves_an_existing_did_in_place() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-reenable-keeps-did-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, atproto_enabled, atproto_state, atproto_did, created_at, updated_at)
+         VALUES ($1, $2, $3, false, 'disabled', 'did:plc:testreenablekeeps', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let response = reenable_user_atproto_with_trigger(
+        &repo,
+        &session_repo,
+        tenant_id,
+        &user_pubkey,
+        |_pubkey| async { Ok(()) },
+    )
+    .await
+    .expect("reenable should succeed");
+
+    assert!(response.enabled);
+    assert_eq!(response.state.as_deref(), Some("pending"));
+    assert_eq!(response.did.as_deref(), Some("did:plc:testreenablekeeps"));
+}
+
+/// A confirmed `ready` account has a live repo. The opt-in write is optimistic
+/// and a failed trigger rolls it back to `failed` with the opt-in off, so
+/// letting a redundant enable move that row would report a publishing account
+/// as switched off during any control-plane outage.
+#[tokio::test]
+async fn enable_leaves_a_ready_account_alone_and_skips_the_trigger() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-enable-ready-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, atproto_enabled, atproto_state, atproto_did, created_at, updated_at)
+         VALUES ($1, $2, $3, true, 'ready', 'did:plc:testalreadyready', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let trigger_calls = Arc::new(AtomicUsize::new(0));
+    let observed = trigger_calls.clone();
+
+    let response = enable_user_atproto_with_trigger(
+        &repo,
+        &session_repo,
+        tenant_id,
+        &user_pubkey,
+        &username,
+        move |_pubkey, _username| {
+            let observed = observed.clone();
+            async move {
+                observed.fetch_add(1, Ordering::SeqCst);
+                Err(
+                    keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured,
+                )
+            }
+        },
+    )
+    .await
+    .expect("enabling an already-ready account should succeed without the control plane");
+
+    assert_eq!(trigger_calls.load(Ordering::SeqCst), 0);
+    assert!(response.enabled);
+    assert_eq!(response.state.as_deref(), Some("ready"));
+    assert_eq!(response.did.as_deref(), Some("did:plc:testalreadyready"));
+}
+
 #[tokio::test]
 async fn disable_marks_disabled() {
     let pool = common::setup_test_db().await;
@@ -632,6 +760,7 @@ async fn crosspost_enable_reconciles_app_claimed_username() {
 async fn enable_dependency_failure_rolls_back_the_opt_in() {
     let pool = common::setup_test_db().await;
     let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
     let tenant_id = 1_i64;
 
     let keys = Keys::generate();
@@ -651,6 +780,7 @@ async fn enable_dependency_failure_rolls_back_the_opt_in() {
 
     let error = enable_user_atproto_with_trigger(
         &repo,
+        &session_repo,
         tenant_id,
         &user_pubkey,
         &username,
@@ -693,9 +823,12 @@ async fn enable_failure_keeps_the_did_so_disable_still_refuses() {
     let user_pubkey = keys.public_key().to_hex();
     let username = format!("alice-enable-provisioned-{}", &user_pubkey[..8]);
 
+    // Provisioning is in flight: the control plane has already attached a DID
+    // but has not reported `ready` yet, so the opt-in write still applies and a
+    // failed trigger still rolls it back.
     sqlx::query(
         "INSERT INTO users (pubkey, tenant_id, username, atproto_enabled, atproto_state, atproto_did, created_at, updated_at)
-         VALUES ($1, $2, $3, true, 'ready', 'did:plc:testprovisioned', NOW(), NOW())",
+         VALUES ($1, $2, $3, true, 'pending', 'did:plc:testprovisioned', NOW(), NOW())",
     )
     .bind(&user_pubkey)
     .bind(tenant_id)
@@ -706,6 +839,7 @@ async fn enable_failure_keeps_the_did_so_disable_still_refuses() {
 
     enable_user_atproto_with_trigger(
         &repo,
+        &session_repo,
         tenant_id,
         &user_pubkey,
         &username,
@@ -747,6 +881,7 @@ async fn enable_failure_keeps_the_did_so_disable_still_refuses() {
 async fn reenable_dependency_failure_rolls_back_the_opt_in() {
     let pool = common::setup_test_db().await;
     let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
     let tenant_id = 1_i64;
 
     let keys = Keys::generate();
@@ -764,9 +899,17 @@ async fn reenable_dependency_failure_rolls_back_the_opt_in() {
     .await
     .expect("failed to insert user");
 
-    let error = reenable_user_atproto_with_trigger(&repo, tenant_id, &user_pubkey, |_pubkey| async {
-        Err(keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured)
-    })
+    let error = reenable_user_atproto_with_trigger(
+        &repo,
+        &session_repo,
+        tenant_id,
+        &user_pubkey,
+        |_pubkey| async {
+            Err(
+                keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured,
+            )
+        },
+    )
     .await
     .expect_err("reenable should surface dependency failure");
 
@@ -899,6 +1042,7 @@ async fn disable_refuses_when_a_did_lands_during_the_trigger() {
 async fn enable_rollback_yields_to_a_sync_that_lands_during_the_trigger() {
     let pool = common::setup_test_db().await;
     let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
     let tenant_id = 1_i64;
 
     let keys = Keys::generate();
@@ -921,6 +1065,7 @@ async fn enable_rollback_yields_to_a_sync_that_lands_during_the_trigger() {
 
     enable_user_atproto_with_trigger(
         &repo,
+        &session_repo,
         tenant_id,
         &user_pubkey,
         &username,
@@ -1054,6 +1199,111 @@ async fn disable_escape_hatch_revokes_atproto_oauth_refresh_sessions() {
     );
 }
 
+/// A rollback also reports the account as switched off, so it owes the same
+/// revocation. The ATProto refresh grant checks only the session's own binding
+/// and never re-reads the lifecycle state, so a session left behind here would
+/// keep minting access tokens for an account the status endpoint calls off.
+#[tokio::test]
+async fn enable_rollback_revokes_atproto_oauth_refresh_sessions() {
+    let pool = common::setup_test_db().await;
+    let user_repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-rollback-revoke-{}", &user_pubkey[..8]);
+    let request_uri = format!("urn:ietf:params:oauth:request_uri:{}", Uuid::new_v4());
+    let refresh_token_hash =
+        hash_refresh_token(&format!("refresh-token-rollback-{}", Uuid::new_v4()));
+
+    // Provisioning is in flight, so the opt-in write still applies and a failed
+    // trigger still rolls it back.
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, atproto_enabled, atproto_state, atproto_did, created_at, updated_at)
+         VALUES ($1, $2, $3, true, 'pending', 'did:plc:testrollbackrevoke', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    session_repo
+        .create_par(CreateAtprotoOAuthSessionParams {
+            tenant_id,
+            client_id: "https://client.example".to_string(),
+            redirect_uri: "https://client.example/callback".to_string(),
+            scope: "atproto".to_string(),
+            state: Some("csrf-state".to_string()),
+            code_challenge: Some("challenge".to_string()),
+            code_challenge_method: Some("S256".to_string()),
+            request_uri: request_uri.clone(),
+            par_expires_at: Utc::now() + Duration::minutes(10),
+            dpop_jkt: Some("dpop-jkt".to_string()),
+            dpop_nonce: Some("dpop-nonce".to_string()),
+            client_auth_method: "none".to_string(),
+            client_auth_alg: None,
+            client_auth_kid: None,
+            client_auth_jkt: None,
+        })
+        .await
+        .expect("failed to create PAR session");
+
+    session_repo
+        .approve_request(&request_uri, &user_pubkey, "did:plc:testrollbackrevoke")
+        .await
+        .expect("failed to approve PAR session");
+
+    session_repo
+        .store_token_artifacts(
+            &request_uri,
+            IssueAtprotoTokensParams {
+                authorization_code: format!("auth-code-{}", Uuid::new_v4()),
+                authorization_code_expires_at: Utc::now() + Duration::minutes(5),
+                access_token_jti: format!("access-jti-{}", Uuid::new_v4()),
+                access_token_expires_at: Utc::now() + Duration::minutes(15),
+                refresh_token_hash: refresh_token_hash.clone(),
+                refresh_token_expires_at: Utc::now() + Duration::days(30),
+                dpop_jkt: Some("dpop-jkt".to_string()),
+                dpop_nonce: Some("dpop-nonce-2".to_string()),
+            },
+        )
+        .await
+        .expect("failed to issue ATProto OAuth session tokens");
+
+    enable_user_atproto_with_trigger(
+        &user_repo,
+        &session_repo,
+        tenant_id,
+        &user_pubkey,
+        &username,
+        |_pubkey, _username| async {
+            Err(keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured)
+        },
+    )
+    .await
+    .expect_err("enable should surface dependency failure");
+
+    let status = get_user_atproto_status(&user_repo, tenant_id, &user_pubkey)
+        .await
+        .expect("status should succeed");
+    assert!(!status.enabled);
+
+    let revoked_at: Option<chrono::DateTime<Utc>> = sqlx::query_scalar(
+        "SELECT refresh_token_revoked_at FROM atproto_oauth_sessions WHERE request_uri = $1",
+    )
+    .bind(&request_uri)
+    .fetch_one(&pool)
+    .await
+    .expect("failed to load refresh revocation marker");
+    assert!(
+        revoked_at.is_some(),
+        "a rollback that reports the account off must revoke refresh sessions"
+    );
+}
+
 /// A conditional write that applies to no rows is ambiguous on its own: the
 /// account may have become ineligible, or it may be gone. Those map to
 /// different errors, and an account deleted while the trigger was in flight
@@ -1109,6 +1359,7 @@ async fn disable_reports_user_not_found_when_deleted_during_the_trigger() {
 async fn enable_rollback_reports_user_not_found_when_deleted_during_the_trigger() {
     let pool = common::setup_test_db().await;
     let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
     let tenant_id = 1_i64;
 
     let keys = Keys::generate();
@@ -1131,6 +1382,7 @@ async fn enable_rollback_reports_user_not_found_when_deleted_during_the_trigger(
 
     let error = enable_user_atproto_with_trigger(
         &repo,
+        &session_repo,
         tenant_id,
         &user_pubkey,
         &username,

--- a/api/tests/atproto_http_test.rs
+++ b/api/tests/atproto_http_test.rs
@@ -9,7 +9,8 @@ use chrono::{Duration, Utc};
 use keycast_api::api::http::atproto::{
     disable_user_atproto, disable_user_atproto_and_revoke_sessions,
     disable_user_atproto_with_trigger, enable_user_atproto, enable_user_atproto_with_trigger,
-    get_user_atproto_status, resolve_username_with_fallback_enabled, set_user_atproto_crosspost,
+    get_user_atproto_status, reenable_user_atproto_with_trigger,
+    resolve_username_with_fallback_enabled, set_user_atproto_crosspost,
     sync_user_atproto_state_by_pubkey, SetCrosspostContext, UsernameResolution,
 };
 use keycast_api::api::http::auth::AuthError;
@@ -677,6 +678,111 @@ async fn enable_dependency_failure_rolls_back_the_opt_in() {
     assert_eq!(response.did, None);
     assert_eq!(
         response.error.as_deref(),
+        Some("ATProto enablement is temporarily unavailable. Please try again later."),
+    );
+}
+
+#[tokio::test]
+async fn enable_failure_keeps_the_did_so_disable_still_refuses() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-enable-provisioned-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, atproto_enabled, atproto_state, atproto_did, created_at, updated_at)
+         VALUES ($1, $2, $3, true, 'ready', 'did:plc:testprovisioned', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    enable_user_atproto_with_trigger(
+        &repo,
+        tenant_id,
+        &user_pubkey,
+        &username,
+        |_pubkey, _username| async {
+            Err(keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured)
+        },
+    )
+    .await
+    .expect_err("enable should surface dependency failure");
+
+    // The rollback must not blank the DID of an account the control plane has
+    // already provisioned: that column is the only local record that a live
+    // repo exists.
+    let status = get_user_atproto_status(&repo, tenant_id, &user_pubkey)
+        .await
+        .expect("status should succeed");
+    assert!(!status.enabled);
+    assert_eq!(status.state.as_deref(), Some("failed"));
+    assert_eq!(status.did.as_deref(), Some("did:plc:testprovisioned"));
+
+    // And with the DID intact, turning it off still refuses to report "off"
+    // while the control plane cannot confirm it.
+    disable_user_atproto_with_trigger(
+        &repo,
+        &session_repo,
+        tenant_id,
+        &user_pubkey,
+        |_pubkey| async {
+            Err(
+                keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured,
+            )
+        },
+    )
+    .await
+    .expect_err("disable should refuse while a provisioned repo exists");
+}
+
+#[tokio::test]
+async fn reenable_dependency_failure_rolls_back_the_opt_in() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-reenable-failed-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, atproto_enabled, atproto_state, atproto_did, created_at, updated_at)
+         VALUES ($1, $2, $3, false, 'disabled', 'did:plc:testreenable', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let error = reenable_user_atproto_with_trigger(&repo, tenant_id, &user_pubkey, |_pubkey| async {
+        Err(keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured)
+    })
+    .await
+    .expect_err("reenable should surface dependency failure");
+
+    assert_eq!(
+        error.to_string(),
+        "ATProto enablement is temporarily unavailable. Please try again later."
+    );
+
+    let status = get_user_atproto_status(&repo, tenant_id, &user_pubkey)
+        .await
+        .expect("status should succeed");
+    assert!(!status.enabled);
+    assert_eq!(status.state.as_deref(), Some("failed"));
+    assert_eq!(status.did.as_deref(), Some("did:plc:testreenable"));
+    assert_eq!(
+        status.error.as_deref(),
         Some("ATProto enablement is temporarily unavailable. Please try again later."),
     );
 }

--- a/api/tests/atproto_http_test.rs
+++ b/api/tests/atproto_http_test.rs
@@ -834,6 +834,123 @@ async fn disable_trigger_failure_clears_a_stuck_unprovisioned_opt_in() {
     assert_eq!(status.state.as_deref(), Some("disabled"));
 }
 
+/// The escape hatch must not act on a DID it read before calling the control
+/// plane. Provisioning can attach one while that call is in flight, and the
+/// account would then be reported off while a live repo can still publish.
+///
+/// The trigger closure performs the interleaving: it attaches a DID, as the
+/// internal sync endpoint would, and only then reports the failure.
+#[tokio::test]
+async fn disable_refuses_when_a_did_lands_during_the_trigger() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-did-lands-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, atproto_enabled, atproto_state, created_at, updated_at)
+         VALUES ($1, $2, $3, true, 'failed', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let trigger_pool = pool.clone();
+    let trigger_pubkey = user_pubkey.clone();
+
+    disable_user_atproto_with_trigger(
+        &repo,
+        &session_repo,
+        tenant_id,
+        &user_pubkey,
+        move |_pubkey| async move {
+            sqlx::query("UPDATE users SET atproto_did = $1 WHERE pubkey = $2")
+                .bind("did:plc:landedmidflight")
+                .bind(&trigger_pubkey)
+                .execute(&trigger_pool)
+                .await
+                .expect("failed to simulate provisioning sync");
+
+            Err(keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured)
+        },
+    )
+    .await
+    .expect_err("disable must fail closed once the account is provisioned");
+
+    // The account keeps its DID and is not reported as switched off.
+    let status = get_user_atproto_status(&repo, tenant_id, &user_pubkey)
+        .await
+        .expect("status should succeed");
+    assert_eq!(status.did.as_deref(), Some("did:plc:landedmidflight"));
+    assert_ne!(status.state.as_deref(), Some("disabled"));
+}
+
+/// A rollback must not clobber provisioning that reported back while the
+/// trigger call was still in flight. The opt-in is only taken back while the
+/// row still holds the `pending` state the same request wrote.
+#[tokio::test]
+async fn enable_rollback_yields_to_a_sync_that_lands_during_the_trigger() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-sync-wins-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, created_at, updated_at)
+         VALUES ($1, $2, $3, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let trigger_pool = pool.clone();
+    let trigger_pubkey = user_pubkey.clone();
+
+    enable_user_atproto_with_trigger(
+        &repo,
+        tenant_id,
+        &user_pubkey,
+        &username,
+        move |_pubkey, _username| async move {
+            sync_user_atproto_state_by_pubkey(
+                &UserRepository::new(trigger_pool),
+                &trigger_pubkey,
+                true,
+                Some("ready"),
+                Some("did:plc:syncwins"),
+                None,
+            )
+            .await
+            .expect("internal sync should succeed");
+
+            Err(keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured)
+        },
+    )
+    .await
+    .expect_err("enable should still surface the dependency failure");
+
+    // Provisioning won: the account stays ready instead of being rolled back.
+    let status = get_user_atproto_status(&repo, tenant_id, &user_pubkey)
+        .await
+        .expect("status should succeed");
+    assert!(status.enabled);
+    assert_eq!(status.state.as_deref(), Some("ready"));
+    assert_eq!(status.did.as_deref(), Some("did:plc:syncwins"));
+}
+
 #[tokio::test]
 async fn disable_trigger_failure_preserves_existing_state() {
     let pool = common::setup_test_db().await;

--- a/api/tests/atproto_http_test.rs
+++ b/api/tests/atproto_http_test.rs
@@ -951,6 +951,109 @@ async fn enable_rollback_yields_to_a_sync_that_lands_during_the_trigger() {
     assert_eq!(status.did.as_deref(), Some("did:plc:syncwins"));
 }
 
+/// Session revocation is required on every path that reports an account as
+/// switched off, including the local release taken when the control plane is
+/// unreachable. The other escape-hatch tests create no OAuth session, so none
+/// of them would notice if that revocation were dropped from this branch.
+#[tokio::test]
+async fn disable_escape_hatch_revokes_atproto_oauth_refresh_sessions() {
+    let pool = common::setup_test_db().await;
+    let user_repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-hatch-revoke-{}", &user_pubkey[..8]);
+    let request_uri = format!("urn:ietf:params:oauth:request_uri:{}", Uuid::new_v4());
+    let refresh_token_hash =
+        hash_refresh_token(&format!("refresh-token-hatch-revoke-{}", Uuid::new_v4()));
+
+    // Stuck and unprovisioned: the shape the escape hatch exists to release.
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, atproto_enabled, atproto_state, created_at, updated_at)
+         VALUES ($1, $2, $3, true, 'failed', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    session_repo
+        .create_par(CreateAtprotoOAuthSessionParams {
+            tenant_id,
+            client_id: "https://client.example".to_string(),
+            redirect_uri: "https://client.example/callback".to_string(),
+            scope: "atproto".to_string(),
+            state: Some("csrf-state".to_string()),
+            code_challenge: Some("challenge".to_string()),
+            code_challenge_method: Some("S256".to_string()),
+            request_uri: request_uri.clone(),
+            par_expires_at: Utc::now() + Duration::minutes(10),
+            dpop_jkt: Some("dpop-jkt".to_string()),
+            dpop_nonce: Some("dpop-nonce".to_string()),
+            client_auth_method: "none".to_string(),
+            client_auth_alg: None,
+            client_auth_kid: None,
+            client_auth_jkt: None,
+        })
+        .await
+        .expect("failed to create PAR session");
+
+    session_repo
+        .approve_request(&request_uri, &user_pubkey, "did:plc:testhatch")
+        .await
+        .expect("failed to approve PAR session");
+
+    session_repo
+        .store_token_artifacts(
+            &request_uri,
+            IssueAtprotoTokensParams {
+                authorization_code: format!("auth-code-{}", Uuid::new_v4()),
+                authorization_code_expires_at: Utc::now() + Duration::minutes(5),
+                access_token_jti: format!("access-jti-{}", Uuid::new_v4()),
+                access_token_expires_at: Utc::now() + Duration::minutes(15),
+                refresh_token_hash: refresh_token_hash.clone(),
+                refresh_token_expires_at: Utc::now() + Duration::days(30),
+                dpop_jkt: Some("dpop-jkt".to_string()),
+                dpop_nonce: Some("dpop-nonce-2".to_string()),
+            },
+        )
+        .await
+        .expect("failed to issue ATProto OAuth session tokens");
+
+    let response = disable_user_atproto_with_trigger(
+        &user_repo,
+        &session_repo,
+        tenant_id,
+        &user_pubkey,
+        |_pubkey| async {
+            Err(
+                keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured,
+            )
+        },
+    )
+    .await
+    .expect("escape hatch should release an unprovisioned account");
+
+    assert!(!response.enabled);
+    assert_eq!(response.state.as_deref(), Some("disabled"));
+
+    let revoked_at: Option<chrono::DateTime<Utc>> = sqlx::query_scalar(
+        "SELECT refresh_token_revoked_at FROM atproto_oauth_sessions WHERE request_uri = $1",
+    )
+    .bind(&request_uri)
+    .fetch_one(&pool)
+    .await
+    .expect("failed to load refresh revocation marker");
+    assert!(
+        revoked_at.is_some(),
+        "the local release must still revoke refresh sessions"
+    );
+}
+
 /// A conditional write that applies to no rows is ambiguous on its own: the
 /// account may have become ineligible, or it may be gone. Those map to
 /// different errors, and an account deleted while the trigger was in flight

--- a/api/tests/atproto_http_test.rs
+++ b/api/tests/atproto_http_test.rs
@@ -628,7 +628,7 @@ async fn crosspost_enable_reconciles_app_claimed_username() {
 }
 
 #[tokio::test]
-async fn enable_dependency_failure_marks_failed_state_with_safe_message() {
+async fn enable_dependency_failure_rolls_back_the_opt_in() {
     let pool = common::setup_test_db().await;
     let repo = UserRepository::new(pool.clone());
     let tenant_id = 1_i64;
@@ -669,13 +669,63 @@ async fn enable_dependency_failure_marks_failed_state_with_safe_message() {
         .await
         .expect("status should succeed");
     assert_eq!(response.username.as_deref(), Some(username.as_str()));
-    assert!(response.enabled);
+    // The opt-in is written before the trigger runs, so a failed trigger must
+    // take it back — otherwise the account reads as publishing with no repo
+    // behind it, and switching it off needs the control plane that just failed.
+    assert!(!response.enabled);
     assert_eq!(response.state.as_deref(), Some("failed"));
     assert_eq!(response.did, None);
     assert_eq!(
         response.error.as_deref(),
         Some("ATProto enablement is temporarily unavailable. Please try again later."),
     );
+}
+
+#[tokio::test]
+async fn disable_trigger_failure_clears_a_stuck_unprovisioned_opt_in() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-disable-stuck-{}", &user_pubkey[..8]);
+
+    // The shape a failed enable left behind before the rollback above shipped.
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, atproto_enabled, atproto_state, created_at, updated_at)
+         VALUES ($1, $2, $3, true, 'failed', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let response = disable_user_atproto_with_trigger(
+        &repo,
+        &session_repo,
+        tenant_id,
+        &user_pubkey,
+        |_pubkey| async {
+            Err(
+                keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured,
+            )
+        },
+    )
+    .await
+    .expect("disable should succeed without a provisioned account");
+
+    assert!(!response.enabled);
+    assert_eq!(response.state.as_deref(), Some("disabled"));
+
+    let status = get_user_atproto_status(&repo, tenant_id, &user_pubkey)
+        .await
+        .expect("status should succeed");
+    assert!(!status.enabled);
+    assert_eq!(status.state.as_deref(), Some("disabled"));
 }
 
 #[tokio::test]
@@ -1280,6 +1330,52 @@ async fn crosspost_disable_uses_disable_trigger() {
     assert_eq!(opt_in_calls.load(Ordering::SeqCst), 0);
     assert_eq!(reenable_calls.load(Ordering::SeqCst), 0);
     assert_eq!(disable_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn crosspost_disable_releases_a_stuck_account_during_an_outage() {
+    let pool = common::setup_test_db().await;
+    let repo = UserRepository::new(pool.clone());
+    let session_repo = AtprotoOAuthSessionRepository::new(pool.clone());
+    let tenant_id = 1_i64;
+
+    let keys = Keys::generate();
+    let user_pubkey = keys.public_key().to_hex();
+    let username = format!("alice-stuck-crosspost-{}", &user_pubkey[..8]);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, username, atproto_enabled, atproto_state, created_at, updated_at)
+         VALUES ($1, $2, $3, true, 'failed', NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(tenant_id)
+    .bind(&username)
+    .execute(&pool)
+    .await
+    .expect("failed to insert user");
+
+    let response = set_user_atproto_crosspost(
+        SetCrosspostContext {
+            user_repo: &repo,
+            session_repo: &session_repo,
+            tenant_id,
+            authenticated_user_pubkey: &user_pubkey,
+            requested_pubkey: &user_pubkey,
+            enabled: false,
+        },
+        |_pubkey, _requested_username, _crosspost_enabled| async { Ok(()) },
+        |_pubkey| async { Ok(()) },
+        |_pubkey| async {
+            Err(
+                keycast_api::atproto_provisioning::AtprotoProvisioningError::DependencyNotConfigured,
+            )
+        },
+    )
+    .await
+    .expect("crosspost disable should not need a reachable control plane here");
+
+    assert!(!response.enabled);
+    assert_eq!(response.state.as_deref(), Some("disabled"));
 }
 
 #[tokio::test]

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -40,7 +40,7 @@ pub use stored_key::StoredKeyRepository;
 pub use team::TeamRepository;
 pub use user::{
     AccountStatusRow, AccountStatusWithMinorRow, AdminUserDetails, AdminUserLookup,
-    AdminUserMatchKind, ClaimConsumeOutcome, DeleteAccountResult, FinalizeEmailOutcome,
-    FullAdminStatusRow, PendingEmailChange, PendingEmailSide, UserRepository,
+    AdminUserMatchKind, ClaimConsumeOutcome, ConditionalWrite, DeleteAccountResult,
+    FinalizeEmailOutcome, FullAdminStatusRow, PendingEmailChange, PendingEmailSide, UserRepository,
     VerificationTokenData, VerifiedMinorRow,
 };

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1470,6 +1470,89 @@ impl UserRepository {
         Ok(())
     }
 
+    /// Roll back an ATProto opt-in that this request wrote, but only if the row
+    /// still holds the `pending` state that request left behind.
+    ///
+    /// The opt-in is written before the control plane is called, so a failed
+    /// trigger has to take it back. Doing that with an unconditional write races
+    /// the control plane: if the trigger did land and provisioning reported back
+    /// through the internal sync endpoint before the local call failed, a blind
+    /// rollback would overwrite a successful `ready` state. Guarding on
+    /// `atproto_state = 'pending'` makes the check and the write one step, so a
+    /// sync that already moved the row wins.
+    ///
+    /// `atproto_did` is deliberately left out of the `SET` clause. That preserves
+    /// any DID without reading it first, so there is no window between reading
+    /// the DID and writing it back.
+    ///
+    /// Returns whether the rollback applied.
+    pub async fn roll_back_atproto_enable(
+        &self,
+        pubkey: &str,
+        tenant_id: i64,
+        error: Option<&str>,
+    ) -> Result<bool, RepositoryError> {
+        let now = Utc::now();
+        let result = sqlx::query(
+            "UPDATE users
+             SET atproto_enabled = false,
+                 atproto_state = 'failed',
+                 atproto_error = $1,
+                 atproto_updated_at = $2,
+                 updated_at = $2
+             WHERE pubkey = $3
+               AND tenant_id = $4
+               AND atproto_state = 'pending'",
+        )
+        .bind(error)
+        .bind(now)
+        .bind(pubkey)
+        .bind(tenant_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Release an ATProto opt-in locally, but only while the account has no DID.
+    ///
+    /// This backs the escape hatch that lets a user switch crossposting off when
+    /// the control plane is unreachable. It is only safe without the control
+    /// plane's agreement when there is no repo to publish from, so the absence of
+    /// a DID is the authorization for the write and must be checked in the same
+    /// statement. Reading the DID first and deciding afterwards leaves a window —
+    /// as wide as the control-plane request timeout — in which provisioning can
+    /// attach a DID and the account is then reported off while still live.
+    ///
+    /// Returns whether the local release applied. A `false` result means the
+    /// account is no longer eligible, so the caller must fail closed.
+    pub async fn disable_atproto_if_unprovisioned(
+        &self,
+        pubkey: &str,
+        tenant_id: i64,
+    ) -> Result<bool, RepositoryError> {
+        let now = Utc::now();
+        let result = sqlx::query(
+            "UPDATE users
+             SET atproto_enabled = false,
+                 atproto_state = 'disabled',
+                 atproto_did = NULL,
+                 atproto_error = NULL,
+                 atproto_updated_at = $1,
+                 updated_at = $1
+             WHERE pubkey = $2
+               AND tenant_id = $3
+               AND atproto_did IS NULL",
+        )
+        .bind(now)
+        .bind(pubkey)
+        .bind(tenant_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
     /// Update a user's ATProto lifecycle state using globally unique pubkey lookup.
     pub async fn set_atproto_state_by_pubkey(
         &self,

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -439,6 +439,34 @@ pub enum ClaimConsumeOutcome {
     UserNotClaimable,
 }
 
+/// Outcome of a conditional ATProto lifecycle write.
+///
+/// These writes are guarded so the condition that authorizes them is evaluated
+/// in the same statement that applies them. That makes "nothing was written"
+/// ambiguous on its own: the row may still exist but no longer qualify, or it
+/// may be gone. Callers map those to different errors, so the two are reported
+/// separately and are determined from a single statement rather than a second
+/// lookup that would reintroduce the race the guard removes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConditionalWrite {
+    /// The predicate matched and the row was updated.
+    Applied,
+    /// The row exists but no longer satisfies the predicate.
+    Ineligible,
+    /// No such user row.
+    NotFound,
+}
+
+fn classify_conditional_write(existed: i64, updated: i64) -> ConditionalWrite {
+    if updated > 0 {
+        ConditionalWrite::Applied
+    } else if existed > 0 {
+        ConditionalWrite::Ineligible
+    } else {
+        ConditionalWrite::NotFound
+    }
+}
+
 /// Repository for user-related database operations.
 #[derive(Debug, Clone)]
 pub struct UserRepository {
@@ -1473,6 +1501,9 @@ impl UserRepository {
     /// Roll back an ATProto opt-in that this request wrote, but only if the row
     /// still holds the `pending` state that request left behind.
     ///
+    /// See [`ConditionalWrite`] for why the result distinguishes an ineligible
+    /// row from a missing one.
+    ///
     /// The opt-in is written before the control plane is called, so a failed
     /// trigger has to take it back. Doing that with an unconditional write races
     /// the control plane: if the trigger did land and provisioning reported back
@@ -1485,33 +1516,40 @@ impl UserRepository {
     /// any DID without reading it first, so there is no window between reading
     /// the DID and writing it back.
     ///
-    /// Returns whether the rollback applied.
     pub async fn roll_back_atproto_enable(
         &self,
         pubkey: &str,
         tenant_id: i64,
         error: Option<&str>,
-    ) -> Result<bool, RepositoryError> {
+    ) -> Result<ConditionalWrite, RepositoryError> {
         let now = Utc::now();
-        let result = sqlx::query(
-            "UPDATE users
-             SET atproto_enabled = false,
-                 atproto_state = 'failed',
-                 atproto_error = $1,
-                 atproto_updated_at = $2,
-                 updated_at = $2
-             WHERE pubkey = $3
-               AND tenant_id = $4
-               AND atproto_state = 'pending'",
+        let (existed, updated): (i64, i64) = sqlx::query_as(
+            "WITH target AS (
+                 SELECT 1 FROM users WHERE pubkey = $3 AND tenant_id = $4
+             ), applied AS (
+                 UPDATE users
+                 SET atproto_enabled = false,
+                     atproto_state = 'failed',
+                     atproto_error = $1,
+                     atproto_updated_at = $2,
+                     updated_at = $2
+                 WHERE pubkey = $3
+                   AND tenant_id = $4
+                   AND atproto_state = 'pending'
+                 RETURNING 1
+             )
+             SELECT
+                 (SELECT COUNT(*) FROM target) AS existed,
+                 (SELECT COUNT(*) FROM applied) AS updated",
         )
         .bind(error)
         .bind(now)
         .bind(pubkey)
         .bind(tenant_id)
-        .execute(&self.pool)
+        .fetch_one(&self.pool)
         .await?;
 
-        Ok(result.rows_affected() > 0)
+        Ok(classify_conditional_write(existed, updated))
     }
 
     /// Release an ATProto opt-in locally, but only while the account has no DID.
@@ -1524,33 +1562,41 @@ impl UserRepository {
     /// as wide as the control-plane request timeout — in which provisioning can
     /// attach a DID and the account is then reported off while still live.
     ///
-    /// Returns whether the local release applied. A `false` result means the
-    /// account is no longer eligible, so the caller must fail closed.
+    /// Anything other than [`ConditionalWrite::Applied`] means the local release
+    /// did not happen and the caller must fail closed.
     pub async fn disable_atproto_if_unprovisioned(
         &self,
         pubkey: &str,
         tenant_id: i64,
-    ) -> Result<bool, RepositoryError> {
+    ) -> Result<ConditionalWrite, RepositoryError> {
         let now = Utc::now();
-        let result = sqlx::query(
-            "UPDATE users
-             SET atproto_enabled = false,
-                 atproto_state = 'disabled',
-                 atproto_did = NULL,
-                 atproto_error = NULL,
-                 atproto_updated_at = $1,
-                 updated_at = $1
-             WHERE pubkey = $2
-               AND tenant_id = $3
-               AND atproto_did IS NULL",
+        let (existed, updated): (i64, i64) = sqlx::query_as(
+            "WITH target AS (
+                 SELECT 1 FROM users WHERE pubkey = $2 AND tenant_id = $3
+             ), applied AS (
+                 UPDATE users
+                 SET atproto_enabled = false,
+                     atproto_state = 'disabled',
+                     atproto_did = NULL,
+                     atproto_error = NULL,
+                     atproto_updated_at = $1,
+                     updated_at = $1
+                 WHERE pubkey = $2
+                   AND tenant_id = $3
+                   AND atproto_did IS NULL
+                 RETURNING 1
+             )
+             SELECT
+                 (SELECT COUNT(*) FROM target) AS existed,
+                 (SELECT COUNT(*) FROM applied) AS updated",
         )
         .bind(now)
         .bind(pubkey)
         .bind(tenant_id)
-        .execute(&self.pool)
+        .fetch_one(&self.pool)
         .await?;
 
-        Ok(result.rows_affected() > 0)
+        Ok(classify_conditional_write(existed, updated))
     }
 
     /// Update a user's ATProto lifecycle state using globally unique pubkey lookup.

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1498,8 +1498,7 @@ impl UserRepository {
         Ok(())
     }
 
-    /// Roll back an ATProto opt-in that this request wrote, but only if the row
-    /// still holds the `pending` state that request left behind.
+    /// Roll back an ATProto opt-in, but only while the row is still `pending`.
     ///
     /// See [`ConditionalWrite`] for why the result distinguishes an ineligible
     /// row from a missing one.
@@ -1516,6 +1515,11 @@ impl UserRepository {
     /// any DID without reading it first, so there is no window between reading
     /// the DID and writing it back.
     ///
+    /// The predicate is a state check, **not** a claim of request ownership. The
+    /// row carries no operation identity, so this cannot tell its own `pending`
+    /// write apart from one left by a later concurrent request, and a rollback
+    /// can still compensate a newer opt-in. Distinguishing those needs an
+    /// operation generation on the row, which this does not attempt.
     pub async fn roll_back_atproto_enable(
         &self,
         pubkey: &str,

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1498,6 +1498,67 @@ impl UserRepository {
         Ok(())
     }
 
+    /// Record an ATProto opt-in ahead of the control-plane trigger, unless the
+    /// account is already confirmed live.
+    ///
+    /// See [`ConditionalWrite`] for why the result distinguishes an ineligible
+    /// row from a missing one. [`ConditionalWrite::Ineligible`] here means the
+    /// account is already `ready`, so there is nothing to opt in to.
+    ///
+    /// A confirmed `ready` account is excluded because this write is optimistic:
+    /// it moves the row to `pending` before the control plane is called, and a
+    /// failed trigger then rolls it back to `failed` with the opt-in off. Doing
+    /// that to an account with a live repo would report it as switched off while
+    /// it can still publish — the same lie
+    /// [`Self::disable_atproto_if_unprovisioned`] exists to prevent on the
+    /// disable path. `pending` is deliberately still eligible, so a stuck opt-in
+    /// can be retried against the control plane.
+    ///
+    /// `atproto_did` is deliberately left out of the `SET` clause, for the same
+    /// reason as [`Self::roll_back_atproto_enable`]: reading the DID and writing
+    /// it back leaves a window in which provisioning can attach one, and the
+    /// write then erases the only local record that a live repo exists. That
+    /// record is what [`Self::disable_atproto_if_unprovisioned`] reads to decide
+    /// whether a local-only release is safe, so losing it would let a later
+    /// disable report a live account as switched off. Omitting the column
+    /// preserves any DID without a read to go stale.
+    pub async fn begin_atproto_enable(
+        &self,
+        pubkey: &str,
+        tenant_id: i64,
+    ) -> Result<ConditionalWrite, RepositoryError> {
+        let now = Utc::now();
+        let (existed, updated): (i64, i64) = sqlx::query_as(
+            "WITH target AS (
+                 SELECT 1 FROM users WHERE pubkey = $2 AND tenant_id = $3
+             ), applied AS (
+                 UPDATE users
+                 SET atproto_enabled = true,
+                     atproto_state = 'pending',
+                     atproto_error = NULL,
+                     atproto_updated_at = $1,
+                     updated_at = $1
+                 WHERE pubkey = $2
+                   AND tenant_id = $3
+                   AND NOT (
+                       atproto_enabled
+                       AND atproto_state IS NOT DISTINCT FROM 'ready'
+                   )
+                 RETURNING 1
+             )
+             SELECT
+                 (SELECT COUNT(*) FROM target) AS existed,
+                 (SELECT COUNT(*) FROM applied) AS updated",
+        )
+        .bind(now)
+        .bind(pubkey)
+        .bind(tenant_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(classify_conditional_write(existed, updated))
+    }
+
     /// Roll back an ATProto opt-in, but only while the row is still `pending`.
     ///
     /// See [`ConditionalWrite`] for why the result distinguishes an ineligible

--- a/e2e/tests/bluesky-settings.spec.ts
+++ b/e2e/tests/bluesky-settings.spec.ts
@@ -172,8 +172,10 @@ test.describe("Bluesky settings", () => {
       lud16: null,
     };
 
+    // The shape a failed enable leaves behind: the opt-in is rolled back, so
+    // the failure is carried by the state and the error alone.
     let atproto: AtprotoStatusResponse = {
-      enabled: true,
+      enabled: false,
       state: "failed",
       did: null,
       error: "provisioning service returned 502 Bad Gateway: gateway unavailable",

--- a/web/src/lib/atproto_status.svelte.ts
+++ b/web/src/lib/atproto_status.svelte.ts
@@ -107,7 +107,10 @@ export class AtprotoSettingsModel {
       return "ready";
     }
 
-    if (this.status.enabled && this.status.state === "failed") {
+    // A failed enable rolls the opt-in back to `enabled: false`, so the failure
+    // is reported by the state alone. Requiring `enabled` here would drop the
+    // "last attempt failed" explanation and show the plain enable card instead.
+    if (this.status.state === "failed") {
       return "failed";
     }
 


### PR DESCRIPTION
## Summary

- `enable_user_atproto_with_trigger` / `reenable_user_atproto_with_trigger` now roll the opt-in back to `enabled=false` when the control-plane trigger fails, instead of leaving `enabled=true, state='failed'`.
- `disable_user_atproto_with_trigger` completes the local disable when the trigger fails **and** the account has no DID. A provisioned account (DID present) still returns the error, unchanged.
- The lifecycle writes now carry the existing `atproto_did` forward instead of nulling it, so the DID that gates the disable above survives a failed enable.
- The web settings card keys its failure phase on the state alone, since a rolled-back enable no longer reports `enabled=true`.
- Tests: the existing enable-failure test now pins the rollback; new tests cover a provisioned enable failure (DID kept, disable still refused), the reenable rollback, and disabling a stuck unprovisioned account both directly and through `set_user_atproto_crosspost`.

## Motivation

`enable_user_atproto` persists `enabled=true, state='pending'` before it calls the control plane, and on trigger failure the old code wrote `enabled=true, state='failed'`. That leaves an opt-in that exists nowhere except that row — no gateway record, no repo, no DID — while `/api/user/atproto/status` reports crossposting as on.

The second half is what makes it a trap rather than a cosmetic wrong flag: the disable path calls the control plane *first* and only writes `disabled` after it succeeds. So while the control plane is unavailable, the same outage that refused the enable also refuses the disable, and the account stays switched on with no way for the user to switch it off.

This is reproducible in production right now. In the mobile client (`divinevideo/divine-mobile`, Settings → Bluesky Publishing) the toggle reads as on with status "Account provisioning failed", and turning it off returns the scoped 503 from #281 ("Bluesky publishing is temporarily unavailable"). Verified on a real Samsung Galaxy against production `login.divine.video`; the handle it advertises (`<username>.divine.video`) resolves nowhere — no `/.well-known/atproto-did`, no `_atproto` TXT record, `Profile not found` from the public Bluesky API.

Design notes for review:

- **Why roll back rather than keep the intent.** If the trigger never reached the control plane, the intent exists only here and is safe to drop; the user can retry. If it *did* land before the response failed, provisioning reports back through `internal_sync_atproto` and the state converges there — so the rollback is self-healing in that race, whereas today's stuck flag is not.
- **Why the disable escape hatch is gated on the DID.** Without a DID there is no repo to publish from, so honouring "off" locally cannot produce a false "off". With one, refusing is correct: a live account could keep publishing while the user believes it is off. That boundary is the existing `disable_trigger_failure_preserves_existing_state` test, which stays green.
- **Why the enable path stopped nulling the DID.** `set_atproto_state` writes `atproto_did` unconditionally, and every lifecycle write passed `None` — so the enable path erased the exact signal the gate above depends on. An enable against an already-provisioned account, or a control-plane sync landing mid-write, left `did=NULL` with a live repo behind it, and the next disable would then take the unprovisioned path. Carrying the DID through is safe: a stale DID authorizes nothing on its own (`ready_atproto_identity` also requires `state='ready'`), and provisioning overwrites it through the internal sync.
- **Known limit of the escape hatch.** It is a local release, not a remote one. If the original enable did reach the control plane, a late `internal_sync_atproto` can report `enabled=true` and switch the account back on after the user turned it off — the mirror image of the convergence that makes the enable rollback safe. Recovering from that needs the gateway to be reachable again, which is the same condition that makes the normal disable work.
- **Out of scope.** Whatever is making `DIVINE_SKY_ATPROTO_CONTROL_PLANE_URL` (`divine-handle-gateway`) fail in production is an operational issue this PR does not touch — it only stops that outage from leaving accounts in an unrecoverable state. A durable retry queue for remote disables is likewise out of scope; the gateway remains the source of truth for the remote link.

## Related Issue

- Closes #none

## Testing

- [ ] `cargo test --workspace --verbose` — **not run locally**: this machine has neither Docker nor a local Postgres, and the ATProto suites need `common::setup_test_db`. Please let CI confirm the five touched tests in `api/tests/atproto_http_test.rs`.
- [ ] `e2e/tests/bluesky-settings.spec.ts` — **not run locally** (needs the Playwright stack); the fixture change is mock-only.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p keycast_api --lib` — 190 passed
- [x] `cargo test -p keycast_api --test atproto_http_test --no-run` — the new tests compile
- CI note: run 30899938228 first failed in `test_suggest_users_for_admin_uses_the_email_trigram_index` (`keycast_core`, untouched here). Re-running the identical commit passed; the plan assertion depends on ambient row counts and is tracked in #335. Every test in this PR passed in both runs.
- [x] Manual verification: reproduced the stuck state on a production account from the mobile client (see Motivation). The fix itself is not manually verified — it needs a deploy.

## Visuals

- [x] No visual change to the mobile client. In the keycast web card, an account whose enable failed now renders the existing "Failed" state (badge, last-error text, retry button) instead of the plain enable card — no new UI.
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
