### PR TITLE
fix(oauth): bind the authorization code to the requesting client_id

### DIFF
--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -2854,6 +2854,18 @@ async fn handle_authorization_code_grant(
     let previous_auth_id = auth_code.previous_auth_id;
     let is_headless = auth_code.is_headless;
 
+    // RFC 6749 §4.1.3 requires the token endpoint to ensure the authorization
+    // code was issued to the client_id in the request. RFC 6749 §5.2 specifies
+    // invalid_grant when a code was issued to another client.
+    if client_id != req.client_id {
+        tracing::warn!(
+            "Rejecting authorization code redemption: code was issued to a different client_id"
+        );
+        return Err(OAuthError::InvalidGrant(
+            "Authorization code was not issued to this client".into(),
+        ));
+    }
+
     // Validate redirect_uri matches
     if stored_redirect_uri != *redirect_uri {
         return Err(OAuthError::InvalidRequest(

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -2859,6 +2859,14 @@ async fn handle_authorization_code_grant(
     // invalid_grant when a code was issued to another client.
     if client_id != req.client_id {
         tracing::warn!(
+            event = "oauth_authorization_code_rejection",
+            grant_flow = "authorization_code",
+            outcome = "rejected",
+            reason_code = "client_id_mismatch",
+            http_status = StatusCode::BAD_REQUEST.as_u16(),
+            tenant_id,
+            stored_client_id = client_id.as_str(),
+            presented_client_id = req.client_id.as_str(),
             "Rejecting authorization code redemption: code was issued to a different client_id"
         );
         return Err(OAuthError::InvalidGrant(

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -1,7 +1,26 @@
 // ABOUTME: Shared test utilities and safety guards
 // ABOUTME: Ensures tests never accidentally connect to production database
 
+use chrono::Utc;
+use keycast_api::{
+    api::{
+        http::routes::AuthState,
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
 use sqlx::PgPool;
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+use zeroize::Zeroizing;
 
 #[allow(dead_code)]
 pub type AuthEventRow = (String, String, String, Option<String>, String, Option<i32>);
@@ -112,6 +131,66 @@ pub async fn setup_test_db() -> PgPool {
         .expect("Failed to run migrations");
 
     pool
+}
+
+pub struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+#[allow(dead_code)]
+pub async fn setup_oauth_test_db() -> PgPool {
+    std::env::set_var("BUNKER_RELAYS", "wss://relay.test.example");
+    setup_test_db().await
+}
+
+#[allow(dead_code)]
+pub fn create_test_auth_state(pool: PgPool) -> (AuthState, JoinHandle<()>) {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let producer_handle = secret_pool.spawn_producer();
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    let auth_state = AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    };
+
+    (auth_state, producer_handle)
+}
+
+#[allow(dead_code)]
+pub fn test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: 1,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
 }
 
 // Unit tests for the safety guard moved to a separate test file

--- a/api/tests/oauth_code_client_binding_test.rs
+++ b/api/tests/oauth_code_client_binding_test.rs
@@ -1,0 +1,221 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration tests binding an OAuth authorization code to the client it was issued to.
+// ABOUTME: Verifies RFC 6749 section 4.1.3 client_id matching at the token endpoint.
+
+mod common;
+
+use axum::{
+    body::to_bytes,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use chrono::{Duration, Utc};
+use keycast_api::{
+    api::{
+        http::{oauth, routes::AuthState},
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+const ISSUED_CLIENT_ID: &str = "Code Binding Test Client";
+const REDIRECT_URI: &str = "https://test.example.com/callback";
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    std::env::set_var("BUNKER_RELAYS", "wss://relay.test.example");
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+fn create_test_auth_state(pool: PgPool) -> (AuthState, JoinHandle<()>) {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let producer_handle = secret_pool.spawn_producer();
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    let auth_state = AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    };
+
+    (auth_state, producer_handle)
+}
+
+fn test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: 1,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+/// Insert a pending-registration authorization code issued to `ISSUED_CLIENT_ID`.
+async fn insert_authorization_code(pool: &PgPool, code: &str, user_pubkey: &str, email: &str) {
+    sqlx::query(
+        "INSERT INTO oauth_codes (
+            code, user_pubkey, client_id, redirect_uri, scope, expires_at, tenant_id, created_at,
+            pending_email, pending_password_hash, pending_email_verification_token,
+            pending_encrypted_secret
+         ) VALUES ($1, $2, $3, $4, 'policy:social', $5, 1, NOW(), $6, 'test-password-hash', $7, $8)",
+    )
+    .bind(code)
+    .bind(user_pubkey)
+    .bind(ISSUED_CLIENT_ID)
+    .bind(REDIRECT_URI)
+    .bind(Utc::now() + Duration::minutes(10))
+    .bind(email)
+    .bind(format!("verify-{code}"))
+    .bind(Keys::generate().secret_key().to_secret_bytes().to_vec())
+    .execute(pool)
+    .await
+    .expect("Should insert authorization code");
+}
+
+/// Redeem `code` at the token endpoint while presenting `presented_client_id`.
+async fn redeem_code(pool: &PgPool, code: &str, presented_client_id: &str) -> Response {
+    let (auth_state, producer_handle) = create_test_auth_state(pool.clone());
+
+    let result = oauth::token(
+        test_tenant(),
+        State(auth_state),
+        oauth::TokenRequestBody(oauth::TokenRequest {
+            grant_type: Some("authorization_code".to_string()),
+            code: Some(code.to_string()),
+            client_id: presented_client_id.to_string(),
+            redirect_uri: Some(REDIRECT_URI.to_string()),
+            code_verifier: None,
+            refresh_token: None,
+        }),
+    )
+    .await;
+
+    producer_handle.abort();
+
+    match result {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    }
+}
+
+async fn response_json(response: Response) -> serde_json::Value {
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Response body should be readable");
+    serde_json::from_slice(&bytes).expect("Response body should be JSON")
+}
+
+#[tokio::test]
+async fn redemption_by_a_different_client_is_rejected_and_leaves_the_code_unspent() {
+    let pool = setup_pool().await;
+    let user_pubkey = Keys::generate().public_key().to_hex();
+    let code = format!("binding-mismatch-{}", Uuid::new_v4());
+    let email = format!("binding-mismatch-{}@example.com", Uuid::new_v4());
+
+    insert_authorization_code(&pool, &code, &user_pubkey, &email).await;
+
+    let response = redeem_code(&pool, &code, "Some Other Client").await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response_json(response).await["error"],
+        serde_json::json!("invalid_grant")
+    );
+
+    // The code must survive the rejected redemption so the client it was issued
+    // to can still redeem it.
+    let code_still_present: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM oauth_codes WHERE tenant_id = 1 AND code = $1)",
+    )
+    .bind(&code)
+    .fetch_one(&pool)
+    .await
+    .expect("Query should succeed");
+    assert!(
+        code_still_present,
+        "Rejected redemption must not spend code"
+    );
+
+    let user_created: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM users WHERE tenant_id = 1 AND email = $1)")
+            .bind(&email)
+            .fetch_one(&pool)
+            .await
+            .expect("Query should succeed");
+    assert!(
+        !user_created,
+        "Rejected redemption must not complete the pending registration"
+    );
+
+    let _ = sqlx::query("DELETE FROM oauth_codes WHERE code = $1")
+        .bind(&code)
+        .execute(&pool)
+        .await;
+}
+
+#[tokio::test]
+async fn redemption_by_the_issued_client_succeeds() {
+    let pool = setup_pool().await;
+    let user_pubkey = Keys::generate().public_key().to_hex();
+    let code = format!("binding-match-{}", Uuid::new_v4());
+    let email = format!("binding-match-{}@example.com", Uuid::new_v4());
+
+    insert_authorization_code(&pool, &code, &user_pubkey, &email).await;
+
+    let response = redeem_code(&pool, &code, ISSUED_CLIENT_ID).await;
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/api/tests/oauth_code_client_binding_test.rs
+++ b/api/tests/oauth_code_client_binding_test.rs
@@ -5,105 +5,16 @@
 
 mod common;
 
-use axum::{
-    body::to_bytes,
-    extract::State,
-    http::StatusCode,
-    response::{IntoResponse, Response},
-};
+use axum::{body::to_bytes, extract::State, http::StatusCode, response::Response};
 use chrono::{Duration, Utc};
-use keycast_api::{
-    api::{
-        http::{oauth, routes::AuthState},
-        tenant::{Tenant, TenantExtractor},
-    },
-    bcrypt_queue::BcryptQueue,
-    handlers::http_rpc_handler::new_http_handler_cache,
-    state::KeycastState,
-};
-use keycast_core::{
-    encryption::{KeyManager, KeyManagerError},
-    secret_pool::SecretPool,
-};
-use moka::future::Cache;
 use nostr_sdk::Keys;
 use sqlx::PgPool;
-use std::sync::Arc;
-use tokio::task::JoinHandle;
 use uuid::Uuid;
-use zeroize::Zeroizing;
+
+use keycast_api::api::http::oauth;
 
 const ISSUED_CLIENT_ID: &str = "Code Binding Test Client";
 const REDIRECT_URI: &str = "https://test.example.com/callback";
-
-struct TestKeyManager;
-
-#[async_trait::async_trait]
-impl KeyManager for TestKeyManager {
-    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
-        Ok(plaintext_bytes.to_vec())
-    }
-
-    async fn decrypt(
-        &self,
-        ciphertext_bytes: &[u8],
-    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
-        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
-    }
-}
-
-async fn setup_pool() -> PgPool {
-    common::assert_test_database_url();
-    std::env::set_var("BUNKER_RELAYS", "wss://relay.test.example");
-    let database_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
-    let pool = PgPool::connect(&database_url)
-        .await
-        .expect("Failed to connect to database");
-
-    sqlx::migrate!("../database/migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations");
-
-    pool
-}
-
-fn create_test_auth_state(pool: PgPool) -> (AuthState, JoinHandle<()>) {
-    let bcrypt_queue = BcryptQueue::new();
-    let secret_pool = SecretPool::new(1);
-    let producer_handle = secret_pool.spawn_producer();
-    let tenant_cache = Cache::builder().max_capacity(10).build();
-    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
-
-    let auth_state = AuthState {
-        state: Arc::new(KeycastState {
-            db: pool,
-            key_manager,
-            signer_handlers: None,
-            http_handler_cache: new_http_handler_cache(),
-            server_keys: Keys::generate(),
-            tenant_cache,
-            bcrypt_sender: bcrypt_queue.sender(),
-            redis: None,
-            secret_pool: secret_pool.receiver(),
-        }),
-        auth_tx: None,
-    };
-
-    (auth_state, producer_handle)
-}
-
-fn test_tenant() -> TenantExtractor {
-    TenantExtractor(Arc::new(Tenant {
-        id: 1,
-        domain: "localhost".to_string(),
-        name: "Test Tenant".to_string(),
-        settings: None,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-    }))
-}
 
 /// Insert a pending-registration authorization code issued to `ISSUED_CLIENT_ID`.
 async fn insert_authorization_code(pool: &PgPool, code: &str, user_pubkey: &str, email: &str) {
@@ -129,10 +40,10 @@ async fn insert_authorization_code(pool: &PgPool, code: &str, user_pubkey: &str,
 
 /// Redeem `code` at the token endpoint while presenting `presented_client_id`.
 async fn redeem_code(pool: &PgPool, code: &str, presented_client_id: &str) -> Response {
-    let (auth_state, producer_handle) = create_test_auth_state(pool.clone());
+    let (auth_state, producer_handle) = common::create_test_auth_state(pool.clone());
 
     let result = oauth::token(
-        test_tenant(),
+        common::test_tenant(),
         State(auth_state),
         oauth::TokenRequestBody(oauth::TokenRequest {
             grant_type: Some("authorization_code".to_string()),
@@ -149,7 +60,7 @@ async fn redeem_code(pool: &PgPool, code: &str, presented_client_id: &str) -> Re
 
     match result {
         Ok(response) => response,
-        Err(error) => error.into_response(),
+        Err(error) => axum::response::IntoResponse::into_response(error),
     }
 }
 
@@ -162,7 +73,7 @@ async fn response_json(response: Response) -> serde_json::Value {
 
 #[tokio::test]
 async fn redemption_by_a_different_client_is_rejected_and_leaves_the_code_unspent() {
-    let pool = setup_pool().await;
+    let pool = common::setup_oauth_test_db().await;
     let user_pubkey = Keys::generate().public_key().to_hex();
     let code = format!("binding-mismatch-{}", Uuid::new_v4());
     let email = format!("binding-mismatch-{}@example.com", Uuid::new_v4());
@@ -209,7 +120,7 @@ async fn redemption_by_a_different_client_is_rejected_and_leaves_the_code_unspen
 
 #[tokio::test]
 async fn redemption_by_the_issued_client_succeeds() {
-    let pool = setup_pool().await;
+    let pool = common::setup_oauth_test_db().await;
     let user_pubkey = Keys::generate().public_key().to_hex();
     let code = format!("binding-match-{}", Uuid::new_v4());
     let email = format!("binding-match-{}@example.com", Uuid::new_v4());

--- a/api/tests/oauth_verifier_nsec_scope_test.rs
+++ b/api/tests/oauth_verifier_nsec_scope_test.rs
@@ -7,95 +7,10 @@ mod common;
 
 use axum::{extract::State, http::StatusCode};
 use chrono::{Duration, Utc};
-use keycast_api::{
-    api::{
-        http::{oauth, routes::AuthState},
-        tenant::{Tenant, TenantExtractor},
-    },
-    bcrypt_queue::BcryptQueue,
-    handlers::http_rpc_handler::new_http_handler_cache,
-    state::KeycastState,
-};
-use keycast_core::{
-    encryption::{KeyManager, KeyManagerError},
-    secret_pool::SecretPool,
-};
-use moka::future::Cache;
+use keycast_api::api::http::oauth;
 use nostr_sdk::{Keys, ToBech32};
 use sqlx::PgPool;
-use std::sync::Arc;
-use tokio::task::JoinHandle;
 use uuid::Uuid;
-use zeroize::Zeroizing;
-
-struct TestKeyManager;
-
-#[async_trait::async_trait]
-impl KeyManager for TestKeyManager {
-    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
-        Ok(plaintext_bytes.to_vec())
-    }
-
-    async fn decrypt(
-        &self,
-        ciphertext_bytes: &[u8],
-    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
-        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
-    }
-}
-
-async fn setup_pool() -> PgPool {
-    common::assert_test_database_url();
-    std::env::set_var("BUNKER_RELAYS", "wss://relay.test.example");
-    let database_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
-    let pool = PgPool::connect(&database_url)
-        .await
-        .expect("Failed to connect to database");
-
-    sqlx::migrate!("../database/migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations");
-
-    pool
-}
-
-fn create_test_auth_state(pool: PgPool) -> (AuthState, JoinHandle<()>) {
-    let bcrypt_queue = BcryptQueue::new();
-    let secret_pool = SecretPool::new(1);
-    let producer_handle = secret_pool.spawn_producer();
-    let tenant_cache = Cache::builder().max_capacity(10).build();
-    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
-
-    let auth_state = AuthState {
-        state: Arc::new(KeycastState {
-            db: pool,
-            key_manager,
-            signer_handlers: None,
-            http_handler_cache: new_http_handler_cache(),
-            server_keys: Keys::generate(),
-            tenant_cache,
-            bcrypt_sender: bcrypt_queue.sender(),
-            redis: None,
-            secret_pool: secret_pool.receiver(),
-        }),
-        auth_tx: None,
-    };
-
-    (auth_state, producer_handle)
-}
-
-fn test_tenant() -> TenantExtractor {
-    TenantExtractor(Arc::new(Tenant {
-        id: 1,
-        domain: "localhost".to_string(),
-        name: "Test Tenant".to_string(),
-        settings: None,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-    }))
-}
 
 async fn insert_pending_registration(
     pool: &PgPool,
@@ -130,10 +45,10 @@ async fn insert_pending_registration(
 }
 
 async fn exchange_code(pool: &PgPool, code: &str, verifier: &str) -> StatusCode {
-    let (auth_state, producer_handle) = create_test_auth_state(pool.clone());
+    let (auth_state, producer_handle) = common::create_test_auth_state(pool.clone());
 
     let result = oauth::token(
-        test_tenant(),
+        common::test_tenant(),
         State(auth_state),
         oauth::TokenRequestBody(oauth::TokenRequest {
             grant_type: Some("authorization_code".to_string()),
@@ -152,7 +67,7 @@ async fn exchange_code(pool: &PgPool, code: &str, verifier: &str) -> StatusCode 
 
 #[tokio::test]
 async fn headless_exchange_ignores_mismatching_verifier_nsec_and_uses_stored_secret() {
-    let pool = setup_pool().await;
+    let pool = common::setup_oauth_test_db().await;
     let registration_keys = Keys::generate();
     let unrelated_keys = Keys::generate();
     let registration_pubkey = registration_keys.public_key().to_hex();
@@ -197,7 +112,7 @@ async fn headless_exchange_ignores_mismatching_verifier_nsec_and_uses_stored_sec
 
 #[tokio::test]
 async fn browser_byok_exchange_extracts_validates_and_stores_verifier_nsec() {
-    let pool = setup_pool().await;
+    let pool = common::setup_oauth_test_db().await;
     let browser_keys = Keys::generate();
     let browser_pubkey = browser_keys.public_key().to_hex();
     let browser_secret = browser_keys.secret_key().to_secret_bytes();

--- a/docs/IDENTITY_INTEGRATION_GUIDE.md
+++ b/docs/IDENTITY_INTEGRATION_GUIDE.md
@@ -513,8 +513,17 @@ Exchange authorization code for bunker URL.
 }
 ```
 
+**Error (400 Bad Request):**
+```json
+{
+  "error": "invalid_grant",
+  "error_description": "Authorization code was not issued to this client"
+}
+```
+
 **Notes:**
 - Code is deleted after successful exchange (single-use)
+- `client_id` must match the value sent when the authorization code was issued
 - `redirect_uri` must match exactly
 - Creates new OAuth authorization with unique connection secret per app
 


### PR DESCRIPTION
## Summary

- The token endpoint now checks that the authorization code being redeemed was issued to the `client_id` in the token request, and returns `invalid_grant` when it was not.
- The new rejection path now emits structured diagnostic fields for the OAuth authorization-code flow.
- The public identity integration guide documents the new `invalid_grant` response and matching `client_id` requirement.
- Shared OAuth integration-test state setup now lives in `api/tests/common/mod.rs` instead of being copied across test files.

## Motivation

- RFC 6749 §4.1.3 requires the authorization server to ensure the authorization code was issued to the `client_id` in the request. RFC 6749 §5.2 defines `invalid_grant` for that case. This change adds that check.
- The comparison runs before redirect URI validation, PKCE handling, pending-registration completion, code deletion, and token issuance, so a rejected redemption leaves the code unspent.

## Related Issue

- Closes #337

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo test -p keycast_api --test oauth_code_client_binding_test --features integration-tests --no-run`
- [x] `cargo test -p keycast_api --test oauth_verifier_nsec_scope_test --features integration-tests --no-run`
- [ ] Runtime integration tests in this takeover environment: attempted targeted test execution, but local Postgres was unavailable and Docker was not running, so the tests timed out while connecting to the database before assertions ran.

New `api/tests/oauth_code_client_binding_test.rs` covers both directions: redemption presenting a different `client_id` is rejected with `invalid_grant` and leaves the authorization code and its pending registration intact, and redemption by the issuing client still completes. It drives the token handler through the `TokenRequestBody` extractor added in #166, matching the existing `oauth_verifier_nsec_scope_test.rs`.

Daniel's original PR run completed `cargo test --workspace --verbose`, `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`, `cargo fmt --all -- --check`, and the `integration-tests` suites for `keycast_core`, `keycast_api`, `keycast_signer`, and `cluster-hashring` against local Postgres and Redis. CI will re-run after the takeover push.

## Visuals

- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

## Scope

PKCE enforcement (#338) and requiring a registered client (#282) are separate and are not touched here. The `redirect_uri` mismatch response is likewise left as is.
