### PR TITLE
fix(oauth): reject a refresh grant whose client_id is not the one the token was issued to

### DIFF
--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -2619,7 +2619,7 @@ async fn handle_refresh_token_grant_inner(
 
     // Consume refresh token atomically (validates + marks as consumed)
     // This implements one-time use per RFC 9700 token rotation
-    let token_record = match refresh_token_repo.consume(refresh_token).await {
+    let token_record = match refresh_token_repo.consume(refresh_token, tenant_id).await {
         Ok(Some(token_record)) => token_record,
         Err(error) => {
             // Same reasoning as the binding lookup above: the token's state is
@@ -2722,7 +2722,7 @@ async fn handle_refresh_token_grant_inner(
         .await
         .map_err(|error| {
             refresh_grant_rejection(
-                OAuthError::from(error),
+                OAuthError::Database(error.to_string()),
                 RefreshTokenRejectionReason::StoredKeyLookupFailed,
                 stored_client_id.as_deref(),
             )
@@ -2798,7 +2798,7 @@ async fn handle_refresh_token_grant_inner(
         .await
         .map_err(|error| {
             refresh_grant_rejection(
-                OAuthError::from(error),
+                OAuthError::Database(error.to_string()),
                 RefreshTokenRejectionReason::RotatedTokenInsertFailed,
                 stored_client_id.as_deref(),
             )

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -391,7 +391,10 @@ pub enum OAuthError {
     InvalidEmail,
     InvalidRequest(String),
     InvalidGrant(String), // RFC 6749 - for invalid/expired refresh tokens or auth codes
-    Database(sqlx::Error),
+    /// A database operation failed, so the request could not be judged. Holds
+    /// the rendered diagnostic: callers reach this from `sqlx::Error` and from
+    /// `RepositoryError`, which has already rendered its own.
+    Database(String),
     Encryption(String),
     ServerError(String),
 }
@@ -471,7 +474,7 @@ impl IntoResponse for OAuthError {
 
 impl From<sqlx::Error> for OAuthError {
     fn from(e: sqlx::Error) -> Self {
-        OAuthError::Database(e)
+        OAuthError::Database(e.to_string())
     }
 }
 
@@ -545,7 +548,7 @@ async fn resolve_policy_from_scope(pool: &sqlx::PgPool, scope: &str) -> Result<i
                 "Unknown policy '{}'. See GET /api/policies for available options.",
                 policy_slug
             )),
-            _ => OAuthError::Database(sqlx::Error::Protocol(e.to_string())),
+            _ => OAuthError::Database(e.to_string()),
         })?;
 
     Ok(requested_policy.id)
@@ -2449,6 +2452,8 @@ async fn handle_refresh_token_grant(
 #[derive(Clone, Copy, Debug)]
 enum RefreshTokenRejectionReason {
     MissingRefreshToken,
+    BindingLookupFailed,
+    ClientMismatch,
     ConsumeFailed,
     DiagnosticLookupFailed,
     TokenNotFound,
@@ -2472,6 +2477,8 @@ impl RefreshTokenRejectionReason {
     const fn as_str(self) -> &'static str {
         match self {
             Self::MissingRefreshToken => "missing_refresh_token",
+            Self::BindingLookupFailed => "refresh_token_binding_lookup_failed",
+            Self::ClientMismatch => "refresh_token_client_mismatch",
             Self::ConsumeFailed => "refresh_token_consume_failed",
             Self::DiagnosticLookupFailed => "refresh_token_diagnostic_lookup_failed",
             Self::TokenNotFound => "refresh_token_not_found",
@@ -2568,20 +2575,63 @@ async fn handle_refresh_token_grant_inner(
         )
     })?;
 
+    let refresh_token_repo = RefreshTokenRepository::new(pool.clone());
+    let token_hash = hash_refresh_token(refresh_token);
+
+    // RFC 6749 §10.4 requires the authorization server to maintain the binding
+    // between a refresh token and the client it was issued to. This endpoint
+    // does not authenticate clients, so neither that section's "verify ...
+    // whenever the client identity can be authenticated" nor §6's
+    // authenticated-client check applies here, and the presented client_id is
+    // self-asserted: a caller that already holds this refresh token can assert
+    // the bound value and pass. Token rotation in `consume` below stays the
+    // §10.4 abuse-detection mechanism. What this comparison does establish is
+    // that a caller presenting itself as one client cannot redeem a refresh
+    // token the server issued to another, and that the contradiction is
+    // refused rather than served.
+    //
+    // It runs before `consume` so a rejected request does not spend the
+    // token; the binding is read without mutating it.
+    if let Some(binding) = refresh_token_repo
+        .find_binding(&token_hash, tenant_id)
+        .await
+        .map_err(|error| {
+            // A failed lookup means the binding could not be established, not
+            // that the caller sent a bad request. Reporting it as a generic
+            // service-unavailable keeps the repository diagnostic out of the
+            // response body and out of RFC 6749 §5.2's error codes, which
+            // describe client errors.
+            refresh_grant_rejection(
+                OAuthError::Database(error.to_string()),
+                RefreshTokenRejectionReason::BindingLookupFailed,
+                None,
+            )
+        })?
+    {
+        if binding.client_id.as_deref() != Some(req.client_id.as_str()) {
+            return Err(refresh_grant_rejection(
+                OAuthError::InvalidGrant("Refresh token was not issued to this client".into()),
+                RefreshTokenRejectionReason::ClientMismatch,
+                binding.client_id.as_deref(),
+            ));
+        }
+    }
+
     // Consume refresh token atomically (validates + marks as consumed)
     // This implements one-time use per RFC 9700 token rotation
-    let refresh_token_repo = RefreshTokenRepository::new(pool.clone());
     let token_record = match refresh_token_repo.consume(refresh_token).await {
         Ok(Some(token_record)) => token_record,
         Err(error) => {
+            // Same reasoning as the binding lookup above: the token's state is
+            // unknown, so this is an operational failure rather than a client
+            // error.
             return Err(refresh_grant_rejection(
-                OAuthError::from(error),
+                OAuthError::Database(error.to_string()),
                 RefreshTokenRejectionReason::ConsumeFailed,
                 None,
             ));
         }
         Ok(None) => {
-            let token_hash = hash_refresh_token(refresh_token);
             let diagnostic_record = refresh_token_repo
                 .find_by_token_hash(&token_hash)
                 .await
@@ -2962,7 +3012,7 @@ async fn handle_authorization_code_grant(
                 code,
             )
             .await
-            .map_err(|e| OAuthError::Database(sqlx::Error::Protocol(e.to_string())))?;
+            .map_err(|e| OAuthError::Database(e.to_string()))?;
 
         tracing::info!(
             "Created user + personal_keys atomically for: {} (email: {})",
@@ -4701,7 +4751,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn refresh_grant_consume_failure_logs_once_without_credentials() {
+    async fn refresh_grant_binding_lookup_failure_logs_once_without_credentials() {
         let logs = SharedLogWriter::default();
         let subscriber = tracing_subscriber::fmt()
             .json()
@@ -4729,7 +4779,17 @@ mod tests {
             Ok(_) => panic!("unavailable database should reject the refresh grant"),
             Err(error) => error,
         };
-        assert_eq!(error.status_code(), StatusCode::BAD_REQUEST);
+        // An unreachable database is an operational failure, not a client
+        // error, and the response must not carry the repository diagnostic.
+        assert_eq!(error.status_code(), StatusCode::SERVICE_UNAVAILABLE);
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response_json(response).await,
+            serde_json::json!({
+                "error": "Service temporarily unavailable. Please try again in a few minutes."
+            })
+        );
 
         let rejection_events: Vec<_> = logs
             .json_events()
@@ -4738,8 +4798,10 @@ mod tests {
             .collect();
         assert_eq!(rejection_events.len(), 1);
         let fields = &rejection_events[0]["fields"];
-        assert_eq!(fields["reason_code"], "refresh_token_consume_failed");
-        assert_eq!(fields["http_status"], 400);
+        // The binding lookup is the first database call on this path, so an
+        // unreachable database fails there rather than in `consume`.
+        assert_eq!(fields["reason_code"], "refresh_token_binding_lookup_failed");
+        assert_eq!(fields["http_status"], 503);
         assert_eq!(fields["client_id"], "unavailable");
 
         let event_json = rejection_events[0].to_string();
@@ -4758,6 +4820,14 @@ mod tests {
             (
                 RefreshTokenRejectionReason::MissingRefreshToken,
                 "missing_refresh_token",
+            ),
+            (
+                RefreshTokenRejectionReason::BindingLookupFailed,
+                "refresh_token_binding_lookup_failed",
+            ),
+            (
+                RefreshTokenRejectionReason::ClientMismatch,
+                "refresh_token_client_mismatch",
             ),
             (
                 RefreshTokenRejectionReason::ConsumeFailed,
@@ -4968,6 +5038,17 @@ mod tests {
             (
                 OAuthError::Encryption("decrypt failed".to_string()),
                 RefreshTokenRejectionReason::StoredKeyDecryptFailed,
+                StatusCode::SERVICE_UNAVAILABLE,
+                serde_json::json!({
+                    "error": "Service temporarily unavailable. Please try again in a few minutes."
+                }),
+            ),
+            (
+                OAuthError::Database(
+                    "Database error: pool timed out while waiting for an open connection"
+                        .to_string(),
+                ),
+                RefreshTokenRejectionReason::BindingLookupFailed,
                 StatusCode::SERVICE_UNAVAILABLE,
                 serde_json::json!({
                     "error": "Service temporarily unavailable. Please try again in a few minutes."

--- a/api/tests/oauth_refresh_client_binding_test.rs
+++ b/api/tests/oauth_refresh_client_binding_test.rs
@@ -1,0 +1,289 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration tests for the refresh-token grant's client binding at /api/oauth/token.
+// ABOUTME: Covers rejection of a mismatched client_id and continued success for the bound client.
+
+mod common;
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse};
+use chrono::{Duration, Utc};
+use keycast_api::{
+    api::{
+        http::{oauth, routes::AuthState},
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    repositories::RefreshTokenRepository,
+    secret_pool::SecretPool,
+    types::refresh_token::hash_refresh_token,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+const TENANT_ID: i64 = 1;
+const BOUND_CLIENT_ID: &str = "bound-client";
+const OTHER_CLIENT_ID: &str = "other-client";
+
+/// Identity key manager: `personal_keys.encrypted_secret_key` holds the raw
+/// secret bytes, matching the other OAuth integration tests.
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    std::env::set_var("BUNKER_RELAYS", "wss://relay.test.example");
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+fn create_test_auth_state(pool: PgPool) -> (AuthState, JoinHandle<()>) {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let producer_handle = secret_pool.spawn_producer();
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    let auth_state = AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    };
+
+    (auth_state, producer_handle)
+}
+
+fn test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: TENANT_ID,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+/// An authorization owned by `BOUND_CLIENT_ID` plus a live refresh token for it.
+/// Returns the user pubkey and the raw refresh token.
+async fn seed_authorization_with_refresh_token(pool: &PgPool) -> (String, String) {
+    let user_keys = Keys::generate();
+    let user_pubkey = user_keys.public_key().to_hex();
+    let user_secret = user_keys.secret_key().to_secret_bytes();
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(TENANT_ID)
+    .execute(pool)
+    .await
+    .expect("Should insert test user");
+
+    sqlx::query(
+        "INSERT INTO personal_keys (user_pubkey, encrypted_secret_key, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, $3, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(user_secret.as_ref())
+    .bind(TENANT_ID)
+    .execute(pool)
+    .await
+    .expect("Should insert personal keys");
+
+    let authorization_id: i32 = sqlx::query_scalar(
+        "INSERT INTO oauth_authorizations
+         (user_pubkey, redirect_origin, client_id, bunker_public_key, secret_hash, relays,
+          tenant_id, handle_expires_at, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'secret-hash', '[]', $5,
+                 NOW() + INTERVAL '30 days', NOW(), NOW())
+         RETURNING id",
+    )
+    .bind(&user_pubkey)
+    .bind(format!(
+        "https://refresh-binding-{}.example",
+        Uuid::new_v4()
+    ))
+    .bind(BOUND_CLIENT_ID)
+    .bind(Keys::generate().public_key().to_hex())
+    .bind(TENANT_ID)
+    .fetch_one(pool)
+    .await
+    .expect("Should insert OAuth authorization");
+
+    let refresh_token = format!("refresh-token-{}", Uuid::new_v4());
+    RefreshTokenRepository::new(pool.clone())
+        .create(&refresh_token, authorization_id, TENANT_ID)
+        .await
+        .expect("Should insert refresh token");
+
+    (user_pubkey, refresh_token)
+}
+
+async fn refresh(
+    pool: &PgPool,
+    refresh_token: &str,
+    client_id: &str,
+) -> Result<axum::response::Response, oauth::OAuthError> {
+    let (auth_state, producer_handle) = create_test_auth_state(pool.clone());
+
+    let result = oauth::token(
+        test_tenant(),
+        State(auth_state),
+        oauth::TokenRequestBody(oauth::TokenRequest {
+            grant_type: Some("refresh_token".to_string()),
+            code: None,
+            client_id: client_id.to_string(),
+            redirect_uri: None,
+            code_verifier: None,
+            refresh_token: Some(refresh_token.to_string()),
+        }),
+    )
+    .await;
+
+    producer_handle.abort();
+    result
+}
+
+async fn consumed_at(pool: &PgPool, refresh_token: &str) -> Option<chrono::DateTime<Utc>> {
+    sqlx::query_scalar("SELECT consumed_at FROM oauth_refresh_tokens WHERE token_hash = $1")
+        .bind(hash_refresh_token(refresh_token))
+        .fetch_one(pool)
+        .await
+        .expect("Refresh token row should exist")
+}
+
+async fn response_json(response: axum::response::Response) -> serde_json::Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Response body should be readable");
+    serde_json::from_slice(&body).expect("Response body should be JSON")
+}
+
+async fn cleanup(pool: &PgPool, user_pubkey: &str) {
+    sqlx::query("DELETE FROM users WHERE pubkey = $1")
+        .bind(user_pubkey)
+        .execute(pool)
+        .await
+        .expect("Should clean up test user");
+}
+
+#[tokio::test]
+async fn refresh_grant_rejects_a_client_id_other_than_the_one_the_token_was_issued_to() {
+    let pool = setup_pool().await;
+    let (user_pubkey, refresh_token) = seed_authorization_with_refresh_token(&pool).await;
+
+    let response = refresh(&pool, &refresh_token, OTHER_CLIENT_ID)
+        .await
+        .expect_err("A client_id other than the bound one must be rejected")
+        .into_response();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response_json(response).await,
+        serde_json::json!({
+            "error": "invalid_grant",
+            "error_description": "Refresh token was not issued to this client"
+        })
+    );
+
+    // The rejection happens before rotation, so the bound client's token survives.
+    assert_eq!(consumed_at(&pool, &refresh_token).await, None);
+
+    cleanup(&pool, &user_pubkey).await;
+}
+
+#[tokio::test]
+async fn refresh_grant_still_succeeds_for_the_client_the_token_was_issued_to() {
+    let pool = setup_pool().await;
+    let (user_pubkey, refresh_token) = seed_authorization_with_refresh_token(&pool).await;
+
+    let response = refresh(&pool, &refresh_token, BOUND_CLIENT_ID)
+        .await
+        .expect("The bound client must still be able to refresh");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await;
+    let rotated = body["refresh_token"]
+        .as_str()
+        .expect("Successful refresh returns a rotated refresh token");
+    assert_ne!(rotated, refresh_token);
+    assert!(body["access_token"].as_str().is_some());
+
+    // The presented token is spent and the rotated one is live.
+    assert!(consumed_at(&pool, &refresh_token).await.is_some());
+    assert_eq!(consumed_at(&pool, rotated).await, None);
+
+    cleanup(&pool, &user_pubkey).await;
+}
+
+#[tokio::test]
+async fn refresh_grant_rejects_a_mismatched_client_before_disclosing_token_state() {
+    let pool = setup_pool().await;
+    let (user_pubkey, refresh_token) = seed_authorization_with_refresh_token(&pool).await;
+
+    sqlx::query("UPDATE oauth_refresh_tokens SET expires_at = $1 WHERE token_hash = $2")
+        .bind(Utc::now() - Duration::days(1))
+        .bind(hash_refresh_token(&refresh_token))
+        .execute(&pool)
+        .await
+        .expect("Should expire the refresh token");
+
+    let response = refresh(&pool, &refresh_token, OTHER_CLIENT_ID)
+        .await
+        .expect_err("An expired token presented by another client must be rejected")
+        .into_response();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response_json(response).await,
+        serde_json::json!({
+            "error": "invalid_grant",
+            "error_description": "Refresh token was not issued to this client"
+        })
+    );
+
+    cleanup(&pool, &user_pubkey).await;
+}

--- a/api/tests/oauth_refresh_client_binding_test.rs
+++ b/api/tests/oauth_refresh_client_binding_test.rs
@@ -94,9 +94,9 @@ fn create_test_auth_state(pool: PgPool) -> (AuthState, JoinHandle<()>) {
     (auth_state, producer_handle)
 }
 
-fn test_tenant() -> TenantExtractor {
+fn test_tenant_with_id(id: i64) -> TenantExtractor {
     TenantExtractor(Arc::new(Tenant {
-        id: TENANT_ID,
+        id,
         domain: "localhost".to_string(),
         name: "Test Tenant".to_string(),
         settings: None,
@@ -167,10 +167,19 @@ async fn refresh(
     refresh_token: &str,
     client_id: &str,
 ) -> Result<axum::response::Response, oauth::OAuthError> {
+    refresh_for_tenant(pool, refresh_token, client_id, TENANT_ID).await
+}
+
+async fn refresh_for_tenant(
+    pool: &PgPool,
+    refresh_token: &str,
+    client_id: &str,
+    tenant_id: i64,
+) -> Result<axum::response::Response, oauth::OAuthError> {
     let (auth_state, producer_handle) = create_test_auth_state(pool.clone());
 
     let result = oauth::token(
-        test_tenant(),
+        test_tenant_with_id(tenant_id),
         State(auth_state),
         oauth::TokenRequestBody(oauth::TokenRequest {
             grant_type: Some("refresh_token".to_string()),
@@ -284,6 +293,30 @@ async fn refresh_grant_rejects_a_mismatched_client_before_disclosing_token_state
             "error_description": "Refresh token was not issued to this client"
         })
     );
+
+    cleanup(&pool, &user_pubkey).await;
+}
+
+#[tokio::test]
+async fn refresh_grant_rejects_a_cross_tenant_request_without_consuming_the_token() {
+    let pool = setup_pool().await;
+    let (user_pubkey, refresh_token) = seed_authorization_with_refresh_token(&pool).await;
+
+    let response = refresh_for_tenant(&pool, &refresh_token, BOUND_CLIENT_ID, TENANT_ID + 1)
+        .await
+        .expect_err("A refresh token must not be accepted from another tenant")
+        .into_response();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response_json(response).await,
+        serde_json::json!({
+            "error": "invalid_grant",
+            "error_description": "Invalid or expired refresh token"
+        })
+    );
+
+    assert_eq!(consumed_at(&pool, &refresh_token).await, None);
 
     cleanup(&pool, &user_pubkey).await;
 }

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -32,7 +32,7 @@ pub use oauth_code::{
 };
 pub use personal_keys::PersonalKeysRepository;
 pub use policy::PolicyRepository;
-pub use refresh_token::RefreshTokenRepository;
+pub use refresh_token::{RefreshTokenBinding, RefreshTokenRepository};
 pub use registered_client::{
     test_redirect_pattern, RegisteredClient, RegisteredClientRepository, RegisteredClientUpdate,
 };

--- a/core/src/repositories/refresh_token.rs
+++ b/core/src/repositories/refresh_token.rs
@@ -4,6 +4,16 @@ use sqlx::PgPool;
 use crate::repositories::RepositoryError;
 use crate::types::refresh_token::{hash_refresh_token, RefreshToken, REFRESH_TOKEN_EXPIRY_DAYS};
 
+/// The client a refresh token is bound to, resolved without consuming the token.
+///
+/// `client_id` mirrors the column on `oauth_authorizations`, which is nullable,
+/// so an absent value means the binding is not recorded rather than that it is
+/// empty.
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub struct RefreshTokenBinding {
+    pub client_id: Option<String>,
+}
+
 /// Repository for OAuth refresh token operations.
 /// Implements token rotation per RFC 9700 - each token is one-time use.
 #[derive(Debug)]
@@ -91,6 +101,37 @@ impl RefreshTokenRepository {
              WHERE token_hash = $1",
         )
         .bind(token_hash)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    /// Resolve the client a refresh token is bound to, without consuming it.
+    ///
+    /// Returns `None` when no token with this hash exists in the tenant, which
+    /// keeps the caller's existing handling of unknown tokens intact. Expired
+    /// and already-consumed tokens are included, because the binding they carry
+    /// is what decides whether the caller is entitled to learn their state.
+    ///
+    /// # Errors
+    ///
+    /// Returns `RepositoryError` if the database query fails.
+    pub async fn find_binding(
+        &self,
+        token_hash: &str,
+        tenant_id: i64,
+    ) -> Result<Option<RefreshTokenBinding>, RepositoryError> {
+        sqlx::query_as::<_, RefreshTokenBinding>(
+            "SELECT oa.client_id
+             FROM oauth_refresh_tokens AS rt
+             JOIN oauth_authorizations AS oa
+               ON oa.id = rt.authorization_id
+              AND oa.tenant_id = rt.tenant_id
+             WHERE rt.token_hash = $1
+               AND rt.tenant_id = $2",
+        )
+        .bind(token_hash)
+        .bind(tenant_id)
         .fetch_optional(&self.pool)
         .await
         .map_err(Into::into)
@@ -239,6 +280,77 @@ mod integration_tests {
             .find_by_token_hash(&"0".repeat(64))
             .await
             .expect("unknown-token lookup should execute")
+            .is_none());
+
+        sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&user_pubkey)
+            .execute(&pool)
+            .await
+            .expect("clean up test user");
+    }
+
+    #[tokio::test]
+    async fn binding_lookup_resolves_the_owning_client_within_the_tenant_only() {
+        let pool = setup_pool().await;
+        let repo = RefreshTokenRepository::new(pool.clone());
+        let user_pubkey = Keys::generate().public_key().to_hex();
+        let origin = format!("https://binding-test-{}.example", Uuid::new_v4());
+
+        sqlx::query(
+            "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+             VALUES ($1, 1, NOW(), NOW())",
+        )
+        .bind(&user_pubkey)
+        .execute(&pool)
+        .await
+        .expect("create test user");
+        let authorization_id: i32 = sqlx::query_scalar(
+            "INSERT INTO oauth_authorizations
+             (user_pubkey, redirect_origin, client_id, bunker_public_key, secret_hash, relays,
+              tenant_id, handle_expires_at, created_at, updated_at)
+             VALUES ($1, $2, 'stored-client', $3, 'secret-hash', '[]', 1,
+                     NOW() + INTERVAL '30 days', NOW(), NOW())
+             RETURNING id",
+        )
+        .bind(&user_pubkey)
+        .bind(&origin)
+        .bind(Keys::generate().public_key().to_hex())
+        .fetch_one(&pool)
+        .await
+        .expect("create test authorization");
+
+        let raw_token = generate_refresh_token();
+        let token_hash = hash_refresh_token(&raw_token);
+        repo.create(&raw_token, authorization_id, 1)
+            .await
+            .expect("create refresh token");
+
+        assert_eq!(
+            repo.find_binding(&token_hash, 1)
+                .await
+                .expect("binding lookup should execute"),
+            Some(RefreshTokenBinding {
+                client_id: Some("stored-client".to_string()),
+            })
+        );
+        assert!(repo
+            .find_binding(&token_hash, 2)
+            .await
+            .expect("cross-tenant lookup should execute")
+            .is_none());
+        assert!(repo
+            .find_binding(&"0".repeat(64), 1)
+            .await
+            .expect("unknown-token lookup should execute")
+            .is_none());
+
+        // The lookup must not consume or otherwise disturb the token.
+        assert!(repo
+            .find_by_token_hash(&token_hash)
+            .await
+            .expect("state lookup should execute")
+            .expect("token should still exist")
+            .consumed_at
             .is_none());
 
         sqlx::query("DELETE FROM users WHERE pubkey = $1")

--- a/core/src/repositories/refresh_token.rs
+++ b/core/src/repositories/refresh_token.rs
@@ -65,18 +65,24 @@ impl RefreshTokenRepository {
     /// # Errors
     ///
     /// Returns `RepositoryError` if database query fails.
-    pub async fn consume(&self, token: &str) -> Result<Option<RefreshToken>, RepositoryError> {
+    pub async fn consume(
+        &self,
+        token: &str,
+        tenant_id: i64,
+    ) -> Result<Option<RefreshToken>, RepositoryError> {
         let token_hash = hash_refresh_token(token);
 
         let result = sqlx::query_as::<_, RefreshToken>(
             "UPDATE oauth_refresh_tokens
              SET consumed_at = NOW()
              WHERE token_hash = $1
+               AND tenant_id = $2
                AND consumed_at IS NULL
                AND expires_at > NOW()
              RETURNING *",
         )
         .bind(&token_hash)
+        .bind(tenant_id)
         .fetch_optional(&self.pool)
         .await?;
 
@@ -266,7 +272,19 @@ mod integration_tests {
             .expect("raw-token lookup should execute")
             .is_none());
 
-        repo.consume(&raw_token)
+        assert!(repo
+            .consume(&raw_token, 2)
+            .await
+            .expect("cross-tenant consume should execute")
+            .is_none());
+        let still_active = repo
+            .find_by_token_hash(&token_hash)
+            .await
+            .expect("lookup refresh token after cross-tenant consume")
+            .expect("refresh token should still exist");
+        assert!(still_active.consumed_at.is_none());
+
+        repo.consume(&raw_token, 1)
             .await
             .expect("consume refresh token")
             .expect("refresh token should be consumable");

--- a/docs/SILENT_REAUTH_IMPLEMENTATION.md
+++ b/docs/SILENT_REAUTH_IMPLEMENTATION.md
@@ -240,6 +240,7 @@ async fn handle_refresh_token_grant(
     req: TokenRequest,
 ) -> Result<impl IntoResponse, OAuthError> {
     let pool = &state.pool;
+    let tenant_id = state.tenant_id;
 
     // 1. Validate request
     let refresh_token = req.refresh_token.ok_or_else(|| {
@@ -249,7 +250,7 @@ async fn handle_refresh_token_grant(
     // 2. Consume refresh token (atomic: validates + marks as used)
     let refresh_repo = RefreshTokenRepository::new(pool.clone());
     let token_record = refresh_repo
-        .consume(&refresh_token)
+        .consume(&refresh_token, tenant_id)
         .await
         .map_err(|e| OAuthError::Database(e))?
         .ok_or_else(|| {


### PR DESCRIPTION
## Summary

- The refresh-token grant at `/api/oauth/token` now compares the request's
  `client_id` with the `client_id` recorded for the authorization that owns the
  refresh token, and answers `invalid_grant` (RFC 6749 §5.2) when they differ or
  when the recorded binding is absent.
- The comparison runs before the refresh token is consumed, through a new
  tenant-scoped `RefreshTokenRepository::find_binding` that reads the binding
  without mutating it.
- Refresh-token consumption is also tenant-scoped, so a token presented on the
  wrong tenant is rejected without spending the owning tenant's token.
- Rejection reason codes `refresh_token_client_mismatch` and
  `refresh_token_binding_lookup_failed` join the existing structured rejection
  log, which continues to log only the recorded `client_id` and never the
  presented one.
- Database failures on this grant now answer with the generic 503 that other
  dependency failures already use, rather than a 400 carrying a repository
  diagnostic. `OAuthError::Database` now holds a rendered string, which let the
  old synthetic `sqlx::Error::Protocol` wrappers go away.

## Motivation

RFC 6749 §6 states that a refresh token is bound to the client it was issued to.
§10.4 requires the authorization server to maintain that binding, to verify it
whenever the client identity can be authenticated, and — where client
authentication is not possible — to deploy other means of detecting abuse,
giving refresh token rotation as its example.

This endpoint does not authenticate clients, so the requirement it can meet is
the one §10.4 states unconditionally: maintain the binding. The step beyond
recording it is to compare it, which is what this change adds. Rotation,
implemented in `RefreshTokenRepository::consume`, remains the §10.4
abuse-detection mechanism and is now constrained to the request tenant.

Scope note for reviewers. Because this endpoint does not authenticate clients,
the presented `client_id` is self-asserted. The comparison is a consistency
check between the request and the recorded binding; it is not a
client-authentication control and should not be reviewed or relied on as one.
Nothing issued on this path derives from the request's `client_id` — the access
token's origin, the policy, the bunker key and the authorization handle all come
from the stored authorization.

This is deliberately not the RFC 6749 §4.1.3 comparison that #339 makes on the
authorization-code grant. §4.1.3 defines that comparison for the code grant;
§6 defines no equivalent parameter for this one, so the two grants need
different reasoning and different tests.

## Ordering, and its consequences

The comparison runs before `consume` so that a rejected mismatched-client request
does not spend the caller's refresh token. Tenant-scoping `consume` separately
ensures a cross-tenant request cannot spend a token before being rejected.

Two consequences are deliberate and worth reviewing as such:

1. A refresh token presented with a non-matching `client_id` is answered with
   the mismatch result even when that token is expired or already consumed, so
   its lifecycle state is not disclosed to a caller that does not own it.
2. With the database unreachable, the first failing call on this path is now the
   binding lookup rather than `consume`, reported as
   `refresh_token_binding_lookup_failed`.

## Compatibility

Each first-party client sends one constant `client_id` for authorize, code
exchange and refresh alike — `keycast-login/src/oauth.ts` uses its configured
client id on all three, and the mobile app's Flutter OAuth client does the same.
`web/`, `e2e/` and `examples/` do not exercise the refresh grant. Refresh tokens
are only ever attached to a newly created authorization, whose `client_id` is
written from the authorization code on the single insert path, so the recorded
binding is present for any live refresh token.

## Related Issue

- Closes #340

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo test -p keycast_core refresh_token`
- [x] `cargo test -p keycast_api --test oauth_refresh_client_binding_test`
- [ ] `cargo test -p keycast_api --features integration-tests --test oauth_refresh_client_binding_test` (local Docker/Postgres unavailable in takeover environment; CI covers this)
- [ ] `cargo test -p keycast_core --features integration-tests refresh_token` (local Docker/Postgres unavailable in takeover environment; CI covers this)
- [ ] `cargo test --workspace --verbose` (local run reached DB-backed suites and failed on `PoolTimedOut`; CI covers this)
- [x] The original rejection tests were confirmed non-vacuous: with the new comparison
      removed, `refresh_grant_rejects_a_client_id_other_than_the_one_the_token_was_issued_to`
      fails by receiving HTTP 200, and
      `refresh_grant_rejects_a_mismatched_client_before_disclosing_token_state`
      fails by receiving `"Invalid or expired refresh token"` in place of the
      mismatch description. The success test still passes with the comparison
      removed, so it is not what makes the rejection tests meaningful.

## Visuals

- [x] No visual change
