### PR TITLE
fix(oauth): return invalid_grant on PKCE verifier mismatch

### DIFF
--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -507,7 +507,9 @@ fn validate_pkce(
                     &computed_challenge[..16],
                     &code_challenge[..16]
                 );
-                return Err(OAuthError::InvalidRequest(
+                // RFC 7636 section 4.6: when the values are not equal the token endpoint
+                // MUST return `invalid_grant`.
+                return Err(OAuthError::InvalidGrant(
                     "Invalid code_verifier: PKCE validation failed".to_string(),
                 ));
             }
@@ -515,12 +517,20 @@ fn validate_pkce(
         }
         "plain" => {
             if code_verifier != code_challenge {
-                return Err(OAuthError::InvalidRequest(
+                // RFC 7636 section 4.6 applies to the `plain` comparison as well.
+                return Err(OAuthError::InvalidGrant(
                     "Invalid code_verifier: plain PKCE validation failed".to_string(),
                 ));
             }
             Ok(())
         }
+        // Left as-is, deliberately. RFC 7636 section 4.6 governs only the
+        // verifier-versus-challenge comparison, so it does not reach this arm, and section
+        // 4.4.1's `invalid_request` requirement is addressed to the authorization endpoint
+        // rather than to token exchange. Nothing in RFC 7636 assigns an error code to an
+        // unsupported transform discovered here, so the pre-existing behavior stands.
+        // Rejecting unsupported transforms up front at `/oauth/authorize`, which is what
+        // section 4.4.1 actually asks for, belongs to the mandatory-PKCE work.
         _ => Err(OAuthError::InvalidRequest(format!(
             "Unsupported code_challenge_method: {}",
             code_challenge_method
@@ -5141,5 +5151,74 @@ mod tests {
         assert!(
             matches!(err, OAuthError::InvalidRequest(msg) if msg.contains("Invalid redirect_uri"))
         );
+    }
+
+    // RFC 7636 Appendix B worked example. Using the published vector rather than a
+    // locally recomputed hash keeps the success case independent of this module's own
+    // hashing code, so a mistake there cannot make the failure cases pass by accident.
+    const RFC7636_VERIFIER: &str = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    const RFC7636_CHALLENGE: &str = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+    async fn error_body(err: OAuthError) -> (StatusCode, serde_json::Value) {
+        let response = err.into_response();
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("error response body should be readable");
+        let json = serde_json::from_slice(&bytes).expect("error response body should be JSON");
+        (status, json)
+    }
+
+    #[test]
+    fn validate_pkce_accepts_the_rfc7636_appendix_b_vector() {
+        validate_pkce(RFC7636_VERIFIER, RFC7636_CHALLENGE, "S256")
+            .expect("the published S256 vector must verify");
+    }
+
+    #[test]
+    fn validate_pkce_s256_mismatch_is_invalid_grant() {
+        let err = validate_pkce("a-different-verifier", RFC7636_CHALLENGE, "S256")
+            .expect_err("a mismatched verifier must be rejected");
+        assert!(
+            matches!(err, OAuthError::InvalidGrant(_)),
+            "RFC 7636 section 4.6 requires invalid_grant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_pkce_plain_mismatch_is_invalid_grant() {
+        let err = validate_pkce("verifier", "a-different-challenge", "plain")
+            .expect_err("a mismatched verifier must be rejected");
+        assert!(
+            matches!(err, OAuthError::InvalidGrant(_)),
+            "RFC 7636 section 4.6 requires invalid_grant, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn pkce_mismatch_serialises_as_an_rfc6749_invalid_grant_response() {
+        let err = validate_pkce("a-different-verifier", RFC7636_CHALLENGE, "S256")
+            .expect_err("a mismatched verifier must be rejected");
+        let (status, body) = error_body(err).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        // RFC 6749 section 5.2 requires the `error` member to carry the registered code
+        // itself, not prose. The pre-existing `invalid_request` path returns
+        // `{"error": "Invalid request: ..."}`, which this response must not resemble.
+        assert_eq!(body["error"], "invalid_grant");
+        assert!(
+            body["error_description"].is_string(),
+            "expected an error_description string, got {body}"
+        );
+    }
+
+    #[test]
+    fn validate_pkce_unsupported_method_remains_invalid_request() {
+        // Pins the boundary of this change rather than endorsing the result: RFC 7636
+        // section 4.6 scopes invalid_grant to the verifier comparison, so this arm is
+        // outside it and keeps its pre-existing behavior.
+        let err = validate_pkce(RFC7636_VERIFIER, RFC7636_CHALLENGE, "S512")
+            .expect_err("an unknown transform must be rejected");
+        assert!(matches!(err, OAuthError::InvalidRequest(_)), "got {err:?}");
     }
 }

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -502,10 +502,12 @@ fn validate_pkce(
                 base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&hash_bytes);
 
             if computed_challenge != code_challenge {
+                // `code_challenge` is stored verbatim from the authorization request, so it
+                // is not safe to slice by byte range here. Truncate by character instead.
                 tracing::warn!(
                     "PKCE validation failed: computed {} != stored {}",
-                    &computed_challenge[..16],
-                    &code_challenge[..16]
+                    challenge_log_prefix(&computed_challenge),
+                    challenge_log_prefix(code_challenge)
                 );
                 // RFC 7636 section 4.6: when the values are not equal the token endpoint
                 // MUST return `invalid_grant`.
@@ -536,6 +538,14 @@ fn validate_pkce(
             code_challenge_method
         ))),
     }
+}
+
+/// Truncate a PKCE challenge to a short, log-safe prefix.
+///
+/// Challenge values arrive unvalidated from clients, so truncation is done on character
+/// boundaries rather than by byte range.
+fn challenge_log_prefix(challenge: &str) -> String {
+    challenge.chars().take(16).collect()
 }
 
 /// Resolve policy ID from scope parameter.
@@ -5210,6 +5220,58 @@ mod tests {
             body["error_description"].is_string(),
             "expected an error_description string, got {body}"
         );
+    }
+
+    /// Run `validate_pkce` with a `WARN`-level subscriber installed, returning the
+    /// captured log events alongside the result.
+    ///
+    /// The failure branch formats the challenge inside `tracing::warn!`. Without an
+    /// interested subscriber the macro never evaluates its field expressions, so a test
+    /// that omits this would exercise none of that formatting while still passing.
+    fn validate_pkce_capturing_logs(
+        code_verifier: &str,
+        code_challenge: &str,
+        code_challenge_method: &str,
+    ) -> (Result<(), OAuthError>, Vec<serde_json::Value>) {
+        let logs = SharedLogWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(logs.clone())
+            .finish();
+        let result = tracing::subscriber::with_default(subscriber, || {
+            validate_pkce(code_verifier, code_challenge, code_challenge_method)
+        });
+        (result, logs.json_events())
+    }
+
+    #[test]
+    fn pkce_failure_logging_is_actually_exercised_by_these_tests() {
+        // Guards the two tests below: if the capture helper ever stops making the
+        // `warn!` fields evaluate, they would silently stop covering the formatting.
+        let (result, events) = validate_pkce_capturing_logs("wrong", RFC7636_CHALLENGE, "S256");
+        assert!(result.is_err());
+        assert!(
+            events.iter().any(|event| event["fields"]["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("PKCE validation failed"))),
+            "the failure branch must emit its warning, got {events:?}"
+        );
+    }
+
+    #[test]
+    fn validate_pkce_handles_a_short_stored_challenge() {
+        // `code_challenge` is persisted verbatim from the authorization request, so its
+        // length is not constrained. Rejection stays orderly and the failure log renders.
+        let (result, _) = validate_pkce_capturing_logs(RFC7636_VERIFIER, "abc", "S256");
+        assert!(matches!(result, Err(OAuthError::InvalidGrant(_))));
+    }
+
+    #[test]
+    fn validate_pkce_handles_a_multibyte_stored_challenge() {
+        // Nor is its character set constrained. Same expectation for a non-ASCII value.
+        let (result, _) = validate_pkce_capturing_logs(RFC7636_VERIFIER, &"€".repeat(20), "S256");
+        assert!(matches!(result, Err(OAuthError::InvalidGrant(_))));
     }
 
     #[test]

--- a/api/tests/oauth_pkce_error_code_test.rs
+++ b/api/tests/oauth_pkce_error_code_test.rs
@@ -1,0 +1,203 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration test pinning the token endpoint's PKCE failure response to RFC 7636 4.6.
+// ABOUTME: Drives the real handler so the assertion covers the wire body, not just the error enum.
+
+mod common;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use base64::Engine;
+use chrono::{Duration, Utc};
+use keycast_api::{
+    api::{
+        http::{oauth, routes::AuthState},
+        tenant::{Tenant, TenantExtractor},
+    },
+    bcrypt_queue::BcryptQueue,
+    handlers::http_rpc_handler::new_http_handler_cache,
+    state::KeycastState,
+};
+use keycast_core::{
+    encryption::{KeyManager, KeyManagerError},
+    secret_pool::SecretPool,
+};
+use moka::future::Cache;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+const CLIENT_ID: &str = "PKCE Error Code Test";
+const REDIRECT_URI: &str = "https://test.example.com/callback";
+
+struct TestKeyManager;
+
+#[async_trait::async_trait]
+impl KeyManager for TestKeyManager {
+    async fn encrypt(&self, plaintext_bytes: &[u8]) -> Result<Vec<u8>, KeyManagerError> {
+        Ok(plaintext_bytes.to_vec())
+    }
+
+    async fn decrypt(
+        &self,
+        ciphertext_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, KeyManagerError> {
+        Ok(Zeroizing::new(ciphertext_bytes.to_vec()))
+    }
+}
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    std::env::set_var("BUNKER_RELAYS", "wss://relay.test.example");
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+fn create_test_auth_state(pool: PgPool) -> (AuthState, JoinHandle<()>) {
+    let bcrypt_queue = BcryptQueue::new();
+    let secret_pool = SecretPool::new(1);
+    let producer_handle = secret_pool.spawn_producer();
+    let tenant_cache = Cache::builder().max_capacity(10).build();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(TestKeyManager));
+
+    let auth_state = AuthState {
+        state: Arc::new(KeycastState {
+            db: pool,
+            key_manager,
+            signer_handlers: None,
+            http_handler_cache: new_http_handler_cache(),
+            server_keys: Keys::generate(),
+            tenant_cache,
+            bcrypt_sender: bcrypt_queue.sender(),
+            redis: None,
+            secret_pool: secret_pool.receiver(),
+        }),
+        auth_tx: None,
+    };
+
+    (auth_state, producer_handle)
+}
+
+fn test_tenant() -> TenantExtractor {
+    TenantExtractor(Arc::new(Tenant {
+        id: 1,
+        domain: "localhost".to_string(),
+        name: "Test Tenant".to_string(),
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }))
+}
+
+/// S256 transform from RFC 7636 section 4.2.
+fn s256_challenge(verifier: &str) -> String {
+    let hash = sha256::digest(verifier);
+    let bytes = hex::decode(hash).expect("sha256 digest is hex");
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+async fn insert_code(pool: &PgPool, code: &str, challenge: &str, method: &str) -> Vec<u8> {
+    let keys = Keys::generate();
+    let secret = keys.secret_key().to_secret_bytes().to_vec();
+
+    sqlx::query(
+        "INSERT INTO oauth_codes (
+            code, user_pubkey, client_id, redirect_uri, scope, expires_at, tenant_id, created_at,
+            code_challenge, code_challenge_method, pending_email, pending_password_hash,
+            pending_email_verification_token, pending_encrypted_secret, is_headless
+         ) VALUES (
+            $1, $2, $3, $4, 'policy:social', $5, 1, NOW(), $6, $7, $8, 'test-password-hash',
+            $9, $10, false
+         )",
+    )
+    .bind(code)
+    .bind(keys.public_key().to_hex())
+    .bind(CLIENT_ID)
+    .bind(REDIRECT_URI)
+    .bind(Utc::now() + Duration::minutes(10))
+    .bind(challenge)
+    .bind(method)
+    .bind(format!("pkce-error-{}@example.com", Uuid::new_v4()))
+    .bind(format!("verify-{code}"))
+    .bind(&secret)
+    .execute(pool)
+    .await
+    .expect("Should insert OAuth code");
+
+    secret
+}
+
+/// Exchange a code and render the outcome exactly as axum would, so the assertions
+/// below see the real response body rather than the internal error enum.
+async fn exchange(pool: &PgPool, code: &str, verifier: &str) -> Response {
+    let (auth_state, producer_handle) = create_test_auth_state(pool.clone());
+
+    let result = oauth::token(
+        test_tenant(),
+        State(auth_state),
+        oauth::TokenRequestBody(oauth::TokenRequest {
+            grant_type: Some("authorization_code".to_string()),
+            code: Some(code.to_string()),
+            client_id: CLIENT_ID.to_string(),
+            redirect_uri: Some(REDIRECT_URI.to_string()),
+            code_verifier: Some(verifier.to_string()),
+            refresh_token: None,
+        }),
+    )
+    .await;
+
+    producer_handle.abort();
+    result.into_response()
+}
+
+async fn body_json(response: Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body should be readable");
+    serde_json::from_slice(&bytes).expect("response body should be JSON")
+}
+
+#[tokio::test]
+async fn token_endpoint_returns_invalid_grant_when_the_s256_verifier_does_not_match() {
+    let pool = setup_pool().await;
+    let verifier = format!("correct-verifier-{}", Uuid::new_v4());
+    let code = format!("pkce-mismatch-{}", Uuid::new_v4());
+    insert_code(&pool, &code, &s256_challenge(&verifier), "S256").await;
+
+    let response = exchange(&pool, &code, "a-verifier-that-does-not-match").await;
+    let status = response.status();
+    let body = body_json(response).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    // RFC 7636 section 4.6 requires invalid_grant, and RFC 6749 section 5.2 requires the
+    // registered code to be the value of `error` rather than free-text prose.
+    assert_eq!(body["error"], "invalid_grant", "body was {body}");
+}
+
+#[tokio::test]
+async fn token_endpoint_accepts_a_matching_s256_verifier() {
+    // Control for the test above: without this, an implementation that rejected every
+    // exchange with invalid_grant would still pass.
+    let pool = setup_pool().await;
+    let verifier = format!("correct-verifier-{}", Uuid::new_v4());
+    let code = format!("pkce-match-{}", Uuid::new_v4());
+    insert_code(&pool, &code, &s256_challenge(&verifier), "S256").await;
+
+    let response = exchange(&pool, &code, &verifier).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+}


### PR DESCRIPTION
## Summary

A PKCE verifier mismatch was reported with the wrong OAuth error.
RFC 7636 requires `invalid_grant` there, and the token endpoint returned `invalid_request` — not even in the registered form, since the `error` member carried an English sentence rather than an error code, so a client matching on it could not classify the failure.
The mismatch is now returned as `invalid_grant` in the RFC 6749 error shape, for both the `S256` and the `plain` comparison.

A second, separable commit hardens the failure log on the same statement: it truncated a client-supplied challenge by byte range, which could panic for values the server stores verbatim.
The log now truncates on character boundaries instead.
Nothing outside that log line changes.

The unsupported-transform branch is deliberately left alone. RFC 7636's `invalid_grant` requirement covers the verifier comparison only, and its `invalid_request` requirement for an unsupported transform is addressed to the authorization endpoint rather than to token exchange.

## Motivation

This is the smallest of the three problems in #338 and the only one independent of the others, so it ships on its own.
It carries no rollout risk, because it changes how an already-failing exchange is reported and not whether any exchange succeeds.

Requiring `code_challenge` on the redirect flow and rejecting `plain` are deliberately not here.
Those can reject clients that work today, and unlike a registered-client gap they have no runtime toggle, so they need client-coverage evidence before they land.

This changes OAuth token-endpoint behavior, which is sensitive operational surface.
The change is confined to the PKCE failure path; the success path and every other grant are untouched.

## Related Issue

- Part of #338. This lands step 3 only — steps 1 and 2 remain open, so this should not close the issue.

## Testing

The new tests cover the protocol result, the serialized response body, and the same failure through the real token handler against a database, so the assertion is on what a client actually receives rather than on an internal value.
The `S256` success case uses the worked example published in RFC 7636 rather than a locally recomputed hash, so a mistake in this module's own hashing cannot make the failure cases pass by accident.
Each test was confirmed to fail when the corresponding source change is reverted.

- [x] `cargo nextest run --workspace` — 500 passed, 15 skipped
- [x] `cargo test -p keycast_api --features integration-tests --lib --tests` — green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [ ] Manual verification completed

Not tested: `tests/qa/` is excluded from the workspace and needs a running server, so it did not run here. Its existing PKCE assertion is satisfied by the new response and needed no change.

## Visuals

- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
