### PR TITLE
fix(atproto-oauth): return invalid_grant for PKCE mismatch

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -60,6 +60,9 @@ components:
         code:
           type: string
           description: Stable application error code, when available
+        error_description:
+          type: string
+          description: Human-readable detail accompanying an RFC 6749 OAuth error code, when available
       required:
         - error
 
@@ -1046,7 +1049,7 @@ paths:
                   sub:
                     type: string
         '400':
-          description: Invalid grant or DPoP proof
+          description: Invalid grant or DPoP proof. A PKCE `code_verifier` that does not match the stored `code_challenge` returns the RFC 6749 error code `invalid_grant` with an `error_description`.
           content:
             application/json:
               schema:

--- a/api/src/api/http/atproto_oauth.rs
+++ b/api/src/api/http/atproto_oauth.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{Query, State},
-    http::{HeaderMap, HeaderValue},
+    http::{HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Redirect},
     Form, Json,
 };
@@ -1146,7 +1146,17 @@ pub async fn token(
 
             let expected_challenge = pkce_challenge(code_verifier);
             if session.code_challenge.as_deref() != Some(expected_challenge.as_str()) {
-                return Err(AuthError::BadRequest("Invalid PKCE verifier".to_string()));
+                tracing::warn!(
+                    client_id = %client_id,
+                    has_stored_code_challenge = session.code_challenge.is_some(),
+                    "ATProto OAuth PKCE verifier mismatch"
+                );
+                return Err(AuthError::OAuthProtocol {
+                    status: StatusCode::BAD_REQUEST,
+                    error: "invalid_grant",
+                    description: "PKCE code_verifier does not match the stored code_challenge"
+                        .to_string(),
+                });
             }
 
             let session_nonce = session.dpop_nonce.clone().ok_or_else(|| {

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -505,6 +505,11 @@ pub enum AuthError {
     EmailSendFailed(String),
     DuplicateKey, // Nostr pubkey already registered (BYOK case)
     InvalidEmail,
+    OAuthProtocol {
+        status: StatusCode,
+        error: &'static str,
+        description: String,
+    },
     BadRequest(String),
     Forbidden(String),   // User has no authorization for this origin
     KeyEgressDenied,     // Policy refuses raw-key egress for this account
@@ -641,6 +646,20 @@ impl IntoResponse for AuthError {
                 StatusCode::UNAUTHORIZED,
                 "Verification code or token has expired. Please request a new one.".to_string(),
             ),
+            AuthError::OAuthProtocol {
+                status,
+                error,
+                description,
+            } => {
+                return (
+                    status,
+                    Json(serde_json::json!({
+                        "error": error,
+                        "error_description": description,
+                    })),
+                )
+                    .into_response();
+            }
             AuthError::BadRequest(msg) => (
                 StatusCode::BAD_REQUEST,
                 msg,

--- a/api/tests/atproto_oauth_http_test.rs
+++ b/api/tests/atproto_oauth_http_test.rs
@@ -456,6 +456,153 @@ async fn par_authorize_and_token_exchange_with_existing_login_session() {
 
 #[tokio::test]
 #[serial]
+async fn atproto_token_exchange_rejects_mismatched_pkce_verifier_with_invalid_grant() {
+    let server_keys = configure_atproto_env();
+
+    let pool = common::setup_test_db().await;
+    let app = app(pool.clone());
+
+    let user_keys = Keys::generate();
+    let user_pubkey = user_keys.public_key().to_hex();
+    let user_did = "did:plc:testpkcemismatch";
+    let email = format!("pkce-mismatch-{}@example.com", Uuid::new_v4());
+    let code_verifier = "pkce-verifier-1234567890";
+    let code_challenge = pkce_challenge(code_verifier);
+    let dpop_key = dpop_key_material();
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, email_verified, atproto_enabled, atproto_state, atproto_did, created_at, updated_at)
+         VALUES ($1, 1, $2, true, true, 'ready', $3, NOW(), NOW())",
+    )
+    .bind(&user_pubkey)
+    .bind(&email)
+    .bind(user_did)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let par_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/atproto/oauth/par")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .header(
+                    "DPoP",
+                    dpop_proof(&dpop_key, "POST", &http_uri("/atproto/oauth/par"), None, None),
+                )
+                .body(Body::from(format!(
+                    "client_id={}&redirect_uri={}&scope=atproto&state=csrf-pkce-mismatch&code_challenge={}&code_challenge_method=S256",
+                    urlencoding::encode("https://client.example"),
+                    urlencoding::encode("https://client.example/callback"),
+                    urlencoding::encode(&code_challenge),
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(par_response.status(), StatusCode::OK);
+    let par_body = par_response.into_body().collect().await.unwrap().to_bytes();
+    let par_payload: Value = serde_json::from_slice(&par_body).unwrap();
+    let request_uri = par_payload["request_uri"].as_str().unwrap().to_string();
+
+    let redirect_to_login = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/atproto/oauth/authorize?request_uri={}",
+                    urlencoding::encode(&request_uri)
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(redirect_to_login.status(), StatusCode::SEE_OTHER);
+
+    let session_token = generate_server_signed_ucan(
+        &user_keys.public_key(),
+        1,
+        &email,
+        "https://login.divine.video",
+        None,
+        &server_keys,
+        true,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let authorized = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/atproto/oauth/authorize?request_uri={}",
+                    urlencoding::encode(&request_uri)
+                ))
+                .header(header::COOKIE, format!("keycast_session={session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(authorized.status(), StatusCode::SEE_OTHER);
+    let callback_location = authorized
+        .headers()
+        .get(header::LOCATION)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let callback_url = reqwest::Url::parse(&callback_location).unwrap();
+    let code = callback_url
+        .query_pairs()
+        .find(|(key, _)| key == "code")
+        .map(|(_, value)| value.to_string())
+        .unwrap();
+
+    let token_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/atproto/oauth/token")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "grant_type=authorization_code&code={}&client_id={}&redirect_uri={}&code_verifier={}",
+                    urlencoding::encode(&code),
+                    urlencoding::encode("https://client.example"),
+                    urlencoding::encode("https://client.example/callback"),
+                    urlencoding::encode("different-pkce-verifier"),
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(token_response.status(), StatusCode::BAD_REQUEST);
+    let token_body = token_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
+    let token_payload: Value = serde_json::from_slice(&token_body).unwrap();
+
+    assert_eq!(token_payload["error"], "invalid_grant");
+    assert!(token_payload["error_description"]
+        .as_str()
+        .is_some_and(|description| !description.is_empty()));
+}
+
+#[tokio::test]
+#[serial]
 async fn authorize_rejects_when_atproto_link_is_not_ready() {
     let server_keys = configure_atproto_env();
 


### PR DESCRIPTION
## Summary

- Add an OAuth protocol error shape to AuthError for RFC 6749-style token endpoint responses.
- Return invalid_grant with error_description when the ATProto token endpoint rejects a mismatched PKCE code_verifier.
- Add a focused ATProto OAuth token endpoint regression test for the wire response.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Clients need the registered OAuth error code to classify PKCE verifier mismatch failures instead of parsing prose.
- The change is limited to an already-failing ATProto token exchange path; successful token exchange behavior is unchanged.

## Related Issue

- Closes #344

## Testing

- [ ] cargo test --workspace --verbose
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated
- [x] cargo fmt --all -- --check
- [x] cargo test --workspace --no-run
- [ ] cd api && cargo test --test atproto_oauth_http_test (blocked locally: Docker daemon unavailable, so tests timed out connecting to keycast_test Postgres)
- [ ] Manual verification completed

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved