### PR TITLE
fix: repair merged compile regressions

### DIFF
--- a/api/tests/oauth_refresh_first_party_test.rs
+++ b/api/tests/oauth_refresh_first_party_test.rs
@@ -14,7 +14,7 @@ use chrono::{Duration, Utc};
 use keycast_api::{
     api::{
         http::oauth::{authorize_get, AuthorizeRequest},
-        http::oauth::{token, TokenRequest},
+        http::oauth::{token, TokenRequest, TokenRequestBody},
         tenant::{Tenant, TenantExtractor},
     },
     bcrypt_queue::BcryptQueue,
@@ -324,7 +324,14 @@ fn build_oauth_app(pool: PgPool) -> Router {
             "/oauth/token",
             post(move |Json(req): Json<TokenRequest>| {
                 let auth_state = token_state.clone();
-                async move { token(create_test_tenant(), State(auth_state), Json(req)).await }
+                async move {
+                    token(
+                        create_test_tenant(),
+                        State(auth_state),
+                        TokenRequestBody(req),
+                    )
+                    .await
+                }
             }),
         )
 }

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -1920,7 +1920,7 @@ impl UserRepository {
         )
         .bind(old_pubkey)
         .bind(tenant_id)
-        .fetch_one(&mut *tx)
+        .fetch_one(&mut **tx)
         .await?;
 
         // Orphan old identity (transfer email/password/username to NULL)
@@ -1969,7 +1969,7 @@ impl UserRepository {
         .bind(now)
         .bind(old_pubkey)
         .bind(tenant_id)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await?;
 
         // Create personal_keys for new identity


### PR DESCRIPTION
## Summary

- Pass the underlying Postgres connection to SQLx calls added to the borrowed key-rotation transaction.
- Adapt the first-party refresh integration test to the current OAuth token request extractor.

## Motivation

The latest two merges introduced incompatible assumptions from their older branch bases. Current `main` failed to compile in CI: the ActivityPub key-rotation code passed a borrowed transaction where SQLx requires its underlying connection, and the first-party refresh test called the token handler with the previous request extractor type.

## Related Issue

- No related issue.

## Testing

- [x] `cargo test --workspace --verbose`
- [x] Integration-feature tests for core, API, signer, and cluster coordination
- [x] Targeted OAuth refresh, key rotation, and ActivityPub signing tests
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] `cd web && bun run check`
- [x] `cd web && bun run test`
- [x] Local focused code review completed with no findings
- [ ] Manual verification completed

## Visuals

- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
