### PR TITLE
test(e2e): scope the consent account assertion to the session identity

### DIFF
--- a/e2e/tests/oauth.spec.ts
+++ b/e2e/tests/oauth.spec.ts
@@ -142,7 +142,7 @@ test.describe("OAuth consent flow", () => {
     await page.locator("text=Continue as").click();
 
     await expect(page.locator("text=Signed in as")).toBeVisible();
-    await expect(page.locator(`text=${email}`)).toBeVisible();
+    await expect(page.locator(".session_identity")).toHaveText(email);
     await page.locator("text=Use a different account").click();
 
     await expect(page.locator("h1")).toContainText("Sign in");


### PR DESCRIPTION
## Summary

- Scope the consent-page account assertion in `e2e/tests/oauth.spec.ts` to `.session_identity` instead of a bare `text=<email>` match, which resolved to two elements and tripped Playwright strict mode.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

The scheduled E2E workflow reported 55 passed / 1 failed. The failure was a strict-mode violation in "consent keeps the chosen account explicit and allows switching":

```
strict mode violation: locator('text=<email>') resolved to 2 elements:
    1) <span id="display_name">…</span>
    2) <div class="session_identity">…</div>
```

The consent page renders the account twice. `.session_identity` is server-rendered from the session's email. `#display_name` starts as `your account` and is then overwritten client-side by `loadProfile()`, which falls back to the same email when the user has no Nostr profile. Once that runs, both elements carry the string and the locator is ambiguous.

That made the assertion a race: it only passed when it ran inside the short window before the profile load completed, which is why the suite failed intermittently on this one test rather than every run.

`.session_identity` is the element the assertion is actually about — it sits directly under the "Signed in as" label checked on the previous line — and it is server-rendered, so it is not mutated at runtime. `getByText(email).first()` was rejected: DOM order puts `#display_name` first, so `.first()` would bind the assertion to the element that client-side code rewrites, silencing the error without removing the ambiguity. `toHaveText` also pins the exact account rather than merely asserting some element contains the string.

Test-only change. No production code is touched.

## Related Issue

- None. No open issue tracks this failure; it was found in the scheduled E2E run.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo test --workspace --verbose` — not applicable, no Rust source changed
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated` — not applicable, no Rust source changed
- [x] Manual verification completed

Verified against a local stack (postgres 16, redis 7, `relay_builder`, keycast debug binary) mirroring `.github/workflows/e2e.yaml`:

1. **Reproduced the exact failure.** A temporary probe drove the consent page as the test does and waited for the client-side profile load. `text=<email>` went from 1 match to 2, and asserting on it then produced the identical strict-mode error naming `#display_name` and `.session_identity`. The scoped locator passed on the same page in the same state.
2. **Confirmed the match count is fixed at 2 and does not grow with database state.** After four full suite runs (135 accumulated users), the old locator still matched exactly 2 and `.session_identity` matched 1. Each test mints a unique email and the page renders only the current session's identity.
3. **Full-suite A/B on one harness and database**, unmodified `main` vs this branch: 42 passed / 14 failed on both, with identical failing-test sets — no regressions, nothing incidentally fixed. All three oauth consent specs pass here.

The 14 failures common to both sides are local-harness artifacts unrelated to this change and are deliberately left alone: `e2e/helpers/redis.ts:4` hardcodes `redis://localhost:16379` with no env override, `claim.spec.ts:83` hardcodes `http://localhost:3000`, and `nip05-badge.spec.ts` collides on a fixed username against a reused database.

Note that `.github/workflows/e2e.yaml` runs on `schedule` and `workflow_dispatch` only, never on `pull_request`, so there is no E2E check on this PR to confirm the fix in CI.

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
