### PR TITLE
fix(api): bound HTTP RPC latency

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -41,6 +41,7 @@ subtle = "2.6"
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tower = { version = "0.5", features = ["timeout", "util"] }
 tower-http = { version = "0.6", features = ["trace", "util", "cors", "fs"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
@@ -63,7 +64,6 @@ redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "aio
 cluster-hashring = { path = "../cluster-hashring" }
 
 [dev-dependencies]
-tower = { version = "0.5", features = ["util"] }
 hyper = { version = "1.5", features = ["full"] }
 http-body-util = "0.1"
 aes-gcm = "0.10"

--- a/api/src/activity_log.rs
+++ b/api/src/activity_log.rs
@@ -1,6 +1,7 @@
 // ABOUTME: Bounded OAuth activity logger for HTTP RPC requests
 // ABOUTME: Coalesces authorization activity updates so request handlers never spawn DB work
 
+use keycast_core::metrics::METRICS;
 use sqlx::PgPool;
 use std::{
     collections::BTreeMap,
@@ -19,12 +20,21 @@ const DEFAULT_QUEUE_CAPACITY: usize = 4096;
 const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 const DEFAULT_MAX_BATCH_IDS: usize = 256;
 
+/// Ceiling on retained-but-unwritten authorization ids after failed flushes.
+/// A failed flush is retried on the next tick rather than discarded, but a
+/// database that stays unhappy must not grow this map without bound.
+const MAX_RETAINED_IDS: usize = 4096;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActivityLogResult {
     Queued,
     Dropped,
     SkippedNonOauth,
     Disabled,
+    /// The writer has already stopped. Distinct from `Disabled` because it is a
+    /// lost update: the API keeps serving in-flight requests through the HTTP
+    /// drain after the writer exits, and those records have nowhere to go.
+    WriterStopped,
 }
 
 #[derive(Debug, Clone)]
@@ -88,7 +98,7 @@ impl ActivityLogger {
                 self.dropped_total.fetch_add(1, Ordering::Relaxed);
                 ActivityLogResult::Dropped
             }
-            Err(mpsc::error::TrySendError::Closed(_)) => ActivityLogResult::Disabled,
+            Err(mpsc::error::TrySendError::Closed(_)) => ActivityLogResult::WriterStopped,
         }
     }
 
@@ -136,7 +146,7 @@ impl ActivityLogWorker {
                     }
                 }
                 _ = flush_interval.tick() => {
-                    flush_pending(&self.pool, &mut pending).await;
+                    self.flush(&mut pending).await;
                 }
                 _ = &mut shutdown_notified => {
                     break;
@@ -144,29 +154,43 @@ impl ActivityLogWorker {
             }
 
             if pending.len() >= self.max_batch_ids {
-                flush_pending(&self.pool, &mut pending).await;
+                self.flush(&mut pending).await;
             }
         }
 
         while let Ok(event) = self.receiver.try_recv() {
             accumulate(&mut pending, event.authorization_id);
         }
-        flush_pending(&self.pool, &mut pending).await;
+        self.flush(&mut pending).await;
+    }
+
+    async fn flush(&self, pending: &mut BTreeMap<i64, i64>) {
+        let lost = flush_pending(&self.pool, pending).await;
+        if lost > 0 {
+            METRICS.add_http_rpc_activity_dropped(lost);
+        }
     }
 }
 
 fn accumulate(pending: &mut BTreeMap<i64, i64>, authorization_id: i64) {
-    *pending.entry(authorization_id).or_insert(0) += 1;
+    accumulate_by(pending, authorization_id, 1);
 }
 
-async fn flush_pending(pool: &PgPool, pending: &mut BTreeMap<i64, i64>) {
+fn accumulate_by(pending: &mut BTreeMap<i64, i64>, authorization_id: i64, count: i64) {
+    *pending.entry(authorization_id).or_insert(0) += count;
+}
+
+/// Writes the coalesced counts and returns the number of events that were lost
+/// outright. A failed write is normally retained for the next flush; it is only
+/// given up when retaining it would grow `pending` past [`MAX_RETAINED_IDS`].
+async fn flush_pending(pool: &PgPool, pending: &mut BTreeMap<i64, i64>) -> u64 {
     if pending.is_empty() {
-        return;
+        return 0;
     }
 
     let ids: Vec<i64> = pending.keys().copied().collect();
     let counts: Vec<i64> = pending.values().copied().collect();
-    pending.clear();
+    let batch = std::mem::take(pending);
 
     if let Err(error) = sqlx::query(
         "UPDATE oauth_authorizations AS oa
@@ -182,12 +206,30 @@ async fn flush_pending(pool: &PgPool, pending: &mut BTreeMap<i64, i64>) {
     .execute(pool)
     .await
     {
+        for (id, count) in batch {
+            accumulate_by(pending, id, count);
+        }
+
+        if pending.len() > MAX_RETAINED_IDS {
+            let lost: u64 = pending.values().map(|count| *count as u64).sum();
+            pending.clear();
+            tracing::error!(
+                error = %error,
+                batch_size = ids.len(),
+                lost_events = lost,
+                "Gave up on OAuth authorization activity after repeated flush failures"
+            );
+            return lost;
+        }
+
         tracing::error!(
             error = %error,
             batch_size = ids.len(),
-            "Failed to flush OAuth authorization activity"
+            "Failed to flush OAuth authorization activity, retaining for the next flush"
         );
     }
+
+    0
 }
 
 #[cfg(test)]
@@ -282,6 +324,46 @@ mod tests {
             .await
             .expect("worker should observe a shutdown signalled outside its select")
             .expect("worker task should not panic");
+    }
+
+    #[tokio::test]
+    async fn failed_flush_retains_counts_for_the_next_attempt() {
+        // Port 1 refuses instantly, so the write fails without a long wait.
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(Duration::from_millis(200))
+            .connect_lazy("postgres://postgres:postgres@127.0.0.1:1/x")
+            .expect("lazy pool");
+        let mut pending = BTreeMap::new();
+        accumulate(&mut pending, 42);
+        accumulate(&mut pending, 42);
+        accumulate(&mut pending, 7);
+
+        let lost = flush_pending(&pool, &mut pending).await;
+
+        assert_eq!(lost, 0, "a single failure gives up nothing");
+        assert_eq!(
+            pending.get(&42),
+            Some(&2),
+            "coalesced counts survive a failed write"
+        );
+        assert_eq!(pending.get(&7), Some(&1));
+    }
+
+    #[tokio::test]
+    async fn flush_gives_up_and_reports_loss_once_retention_is_exceeded() {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(Duration::from_millis(200))
+            .connect_lazy("postgres://postgres:postgres@127.0.0.1:1/x")
+            .expect("lazy pool");
+        let mut pending: BTreeMap<i64, i64> =
+            (0..=MAX_RETAINED_IDS as i64).map(|id| (id, 1)).collect();
+
+        let lost = flush_pending(&pool, &mut pending).await;
+
+        assert_eq!(lost, MAX_RETAINED_IDS as u64 + 1);
+        assert!(pending.is_empty(), "the retained map is bounded");
     }
 
     #[test]

--- a/api/src/activity_log.rs
+++ b/api/src/activity_log.rs
@@ -1,0 +1,272 @@
+// ABOUTME: Bounded OAuth activity logger for HTTP RPC requests
+// ABOUTME: Coalesces authorization activity updates so request handlers never spawn DB work
+
+use sqlx::PgPool;
+use std::{
+    collections::BTreeMap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+use tokio::{
+    sync::{mpsc, Notify},
+    time::MissedTickBehavior,
+};
+
+const DEFAULT_QUEUE_CAPACITY: usize = 4096;
+const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
+const DEFAULT_MAX_BATCH_IDS: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivityLogResult {
+    Queued,
+    Dropped,
+    SkippedNonOauth,
+    Disabled,
+}
+
+#[derive(Debug, Clone)]
+pub struct ActivityLogger {
+    sender: Option<mpsc::Sender<ActivityLogEvent>>,
+    dropped_total: Arc<AtomicU64>,
+}
+
+impl ActivityLogger {
+    pub fn new(pool: PgPool) -> (Self, ActivityLogWorker) {
+        Self::with_config(
+            pool,
+            DEFAULT_QUEUE_CAPACITY,
+            DEFAULT_FLUSH_INTERVAL,
+            DEFAULT_MAX_BATCH_IDS,
+        )
+    }
+
+    pub fn with_config(
+        pool: PgPool,
+        queue_capacity: usize,
+        flush_interval: Duration,
+        max_batch_ids: usize,
+    ) -> (Self, ActivityLogWorker) {
+        let (sender, receiver) = mpsc::channel(queue_capacity);
+        let dropped_total = Arc::new(AtomicU64::new(0));
+
+        (
+            Self {
+                sender: Some(sender),
+                dropped_total: dropped_total.clone(),
+            },
+            ActivityLogWorker {
+                pool,
+                receiver,
+                flush_interval,
+                max_batch_ids,
+            },
+        )
+    }
+
+    pub fn disabled() -> Self {
+        Self {
+            sender: None,
+            dropped_total: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub fn record(&self, is_oauth: bool, authorization_id: i64) -> ActivityLogResult {
+        if !is_oauth {
+            return ActivityLogResult::SkippedNonOauth;
+        }
+
+        let Some(sender) = &self.sender else {
+            return ActivityLogResult::Disabled;
+        };
+
+        match sender.try_send(ActivityLogEvent { authorization_id }) {
+            Ok(()) => ActivityLogResult::Queued,
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.dropped_total.fetch_add(1, Ordering::Relaxed);
+                ActivityLogResult::Dropped
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => ActivityLogResult::Disabled,
+        }
+    }
+
+    pub fn dropped_total(&self) -> u64 {
+        self.dropped_total.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug)]
+struct ActivityLogEvent {
+    authorization_id: i64,
+}
+
+pub struct ActivityLogWorker {
+    pool: PgPool,
+    receiver: mpsc::Receiver<ActivityLogEvent>,
+    flush_interval: Duration,
+    max_batch_ids: usize,
+}
+
+impl ActivityLogWorker {
+    pub async fn run(mut self) {
+        let mut pending: BTreeMap<i64, i64> = BTreeMap::new();
+        let mut flush_interval = tokio::time::interval(self.flush_interval);
+        flush_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                event = self.receiver.recv() => {
+                    match event {
+                        Some(event) => accumulate(&mut pending, event.authorization_id),
+                        None => break,
+                    }
+                }
+                _ = flush_interval.tick() => {
+                    flush_pending(&self.pool, &mut pending).await;
+                }
+            }
+
+            if pending.len() >= self.max_batch_ids {
+                flush_pending(&self.pool, &mut pending).await;
+            }
+        }
+
+        while let Ok(event) = self.receiver.try_recv() {
+            accumulate(&mut pending, event.authorization_id);
+        }
+        flush_pending(&self.pool, &mut pending).await;
+    }
+
+    pub async fn run_until_shutdown(mut self, shutdown: Arc<Notify>) {
+        let mut pending: BTreeMap<i64, i64> = BTreeMap::new();
+        let mut flush_interval = tokio::time::interval(self.flush_interval);
+        flush_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                event = self.receiver.recv() => {
+                    match event {
+                        Some(event) => accumulate(&mut pending, event.authorization_id),
+                        None => break,
+                    }
+                }
+                _ = flush_interval.tick() => {
+                    flush_pending(&self.pool, &mut pending).await;
+                }
+                _ = shutdown.notified() => {
+                    break;
+                }
+            }
+
+            if pending.len() >= self.max_batch_ids {
+                flush_pending(&self.pool, &mut pending).await;
+            }
+        }
+
+        while let Ok(event) = self.receiver.try_recv() {
+            accumulate(&mut pending, event.authorization_id);
+        }
+        flush_pending(&self.pool, &mut pending).await;
+    }
+}
+
+fn accumulate(pending: &mut BTreeMap<i64, i64>, authorization_id: i64) {
+    *pending.entry(authorization_id).or_insert(0) += 1;
+}
+
+async fn flush_pending(pool: &PgPool, pending: &mut BTreeMap<i64, i64>) {
+    if pending.is_empty() {
+        return;
+    }
+
+    let ids: Vec<i64> = pending.keys().copied().collect();
+    let counts: Vec<i64> = pending.values().copied().collect();
+    pending.clear();
+
+    if let Err(error) = sqlx::query(
+        "UPDATE oauth_authorizations AS oa
+         SET last_activity = NOW(),
+             activity_count = oa.activity_count + batch.count_delta::integer
+         FROM (
+             SELECT * FROM UNNEST($1::bigint[], $2::bigint[])
+         ) AS batch(id, count_delta)
+         WHERE oa.id = batch.id",
+    )
+    .bind(&ids)
+    .bind(&counts)
+    .execute(pool)
+    .await
+    {
+        tracing::error!(
+            error = %error,
+            batch_size = ids.len(),
+            "Failed to flush OAuth authorization activity"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::postgres::PgPoolOptions;
+
+    #[test]
+    fn disabled_logger_does_not_queue() {
+        let logger = ActivityLogger::disabled();
+
+        assert_eq!(logger.record(false, 1), ActivityLogResult::SkippedNonOauth);
+        assert_eq!(logger.record(true, 1), ActivityLogResult::Disabled);
+        assert_eq!(logger.dropped_total(), 0);
+    }
+
+    #[tokio::test]
+    async fn logger_drops_when_queue_is_full() {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgres://postgres:postgres@localhost/keycast_test")
+            .expect("lazy pool");
+        let (logger, _worker) =
+            ActivityLogger::with_config(pool, 1, Duration::from_secs(60), DEFAULT_MAX_BATCH_IDS);
+
+        assert_eq!(logger.record(true, 10), ActivityLogResult::Queued);
+        assert_eq!(logger.record(true, 11), ActivityLogResult::Dropped);
+        assert_eq!(logger.dropped_total(), 1);
+    }
+
+    #[tokio::test]
+    async fn worker_exits_on_shutdown_even_when_sender_is_alive() {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgres://postgres:postgres@localhost/keycast_test")
+            .expect("lazy pool");
+        let (_logger, worker) =
+            ActivityLogger::with_config(pool, 1, Duration::from_secs(60), DEFAULT_MAX_BATCH_IDS);
+        let shutdown = Arc::new(Notify::new());
+        let shutdown_for_task = shutdown.clone();
+
+        let worker_task = tokio::spawn(async move {
+            worker.run_until_shutdown(shutdown_for_task).await;
+        });
+        tokio::task::yield_now().await;
+        shutdown.notify_waiters();
+
+        tokio::time::timeout(Duration::from_secs(1), worker_task)
+            .await
+            .expect("worker should observe shutdown")
+            .expect("worker task should not panic");
+    }
+
+    #[test]
+    fn accumulate_coalesces_authorization_counts() {
+        let mut pending = BTreeMap::new();
+
+        accumulate(&mut pending, 42);
+        accumulate(&mut pending, 42);
+        accumulate(&mut pending, 7);
+
+        assert_eq!(pending.get(&42), Some(&2));
+        assert_eq!(pending.get(&7), Some(&1));
+    }
+}

--- a/api/src/activity_log.rs
+++ b/api/src/activity_log.rs
@@ -110,40 +110,23 @@ pub struct ActivityLogWorker {
 }
 
 impl ActivityLogWorker {
-    pub async fn run(mut self) {
-        let mut pending: BTreeMap<i64, i64> = BTreeMap::new();
-        let mut flush_interval = tokio::time::interval(self.flush_interval);
-        flush_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
-        loop {
-            tokio::select! {
-                event = self.receiver.recv() => {
-                    match event {
-                        Some(event) => accumulate(&mut pending, event.authorization_id),
-                        None => break,
-                    }
-                }
-                _ = flush_interval.tick() => {
-                    flush_pending(&self.pool, &mut pending).await;
-                }
-            }
-
-            if pending.len() >= self.max_batch_ids {
-                flush_pending(&self.pool, &mut pending).await;
-            }
-        }
-
-        while let Ok(event) = self.receiver.try_recv() {
-            accumulate(&mut pending, event.authorization_id);
-        }
-        flush_pending(&self.pool, &mut pending).await;
-    }
-
     pub async fn run_until_shutdown(mut self, shutdown: Arc<Notify>) {
         let mut pending: BTreeMap<i64, i64> = BTreeMap::new();
         let mut flush_interval = tokio::time::interval(self.flush_interval);
         flush_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
+        // `Notify::notify_waiters` (what graceful shutdown calls) only wakes
+        // waiters already registered when it fires; it stores no permit. A
+        // `notified()` future created fresh on each `select!` iteration is not
+        // registered while the loop is inside `flush_pending`, so a shutdown
+        // landing in that window would be lost forever and this task would
+        // never exit — the sender lives in the process-lifetime `KeycastState`,
+        // so `recv()` never returns `None` either. Register once, up front, and
+        // keep that registration across iterations.
+        let shutdown_notified = shutdown.notified();
+        tokio::pin!(shutdown_notified);
+        shutdown_notified.as_mut().enable();
+
         loop {
             tokio::select! {
                 event = self.receiver.recv() => {
@@ -155,7 +138,7 @@ impl ActivityLogWorker {
                 _ = flush_interval.tick() => {
                     flush_pending(&self.pool, &mut pending).await;
                 }
-                _ = shutdown.notified() => {
+                _ = &mut shutdown_notified => {
                     break;
                 }
             }
@@ -255,6 +238,49 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), worker_task)
             .await
             .expect("worker should observe shutdown")
+            .expect("worker task should not panic");
+    }
+
+    /// Graceful shutdown calls `Notify::notify_waiters`, which wakes only the
+    /// waiters registered at that instant. This drives the worker into the
+    /// middle of a flush (a Postgres handshake against a listener that accepts
+    /// but never replies) and signals shutdown there, so the worker is *not*
+    /// parked in its `select!` when the signal lands.
+    #[tokio::test]
+    async fn worker_observes_shutdown_signalled_during_a_flush() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind blackhole listener");
+        let port = listener.local_addr().expect("listener addr").port();
+        let _blackhole = tokio::spawn(async move {
+            let mut accepted = Vec::new();
+            while let Ok((socket, _)) = listener.accept().await {
+                accepted.push(socket);
+            }
+        });
+
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(Duration::from_secs(2))
+            .connect_lazy(&format!("postgres://postgres:postgres@127.0.0.1:{port}/x"))
+            .expect("lazy pool");
+        // `max_batch_ids = 1` makes the worker flush as soon as it takes the
+        // event, so the shutdown below lands while it is inside that flush.
+        let (logger, worker) = ActivityLogger::with_config(pool, 8, Duration::from_secs(60), 1);
+        let shutdown = Arc::new(Notify::new());
+        let shutdown_for_task = shutdown.clone();
+
+        let worker_task = tokio::spawn(async move {
+            worker.run_until_shutdown(shutdown_for_task).await;
+        });
+
+        assert_eq!(logger.record(true, 1), ActivityLogResult::Queued);
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        shutdown.notify_waiters();
+
+        tokio::time::timeout(Duration::from_secs(15), worker_task)
+            .await
+            .expect("worker should observe a shutdown signalled outside its select")
             .expect("worker task should not panic");
     }
 

--- a/api/src/activity_log.rs
+++ b/api/src/activity_log.rs
@@ -3,14 +3,7 @@
 
 use keycast_core::metrics::METRICS;
 use sqlx::PgPool;
-use std::{
-    collections::BTreeMap,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use tokio::{
     sync::{mpsc, Notify},
     time::MissedTickBehavior,
@@ -31,16 +24,14 @@ pub enum ActivityLogResult {
     Dropped,
     SkippedNonOauth,
     Disabled,
-    /// The writer has already stopped. Distinct from `Disabled` because it is a
-    /// lost update: the API keeps serving in-flight requests through the HTTP
-    /// drain after the writer exits, and those records have nowhere to go.
+    /// The writer has already stopped. Distinct from `Disabled` because the
+    /// record would have been accepted before shutdown drain completed.
     WriterStopped,
 }
 
 #[derive(Debug, Clone)]
 pub struct ActivityLogger {
     sender: Option<mpsc::Sender<ActivityLogEvent>>,
-    dropped_total: Arc<AtomicU64>,
 }
 
 impl ActivityLogger {
@@ -60,12 +51,10 @@ impl ActivityLogger {
         max_batch_ids: usize,
     ) -> (Self, ActivityLogWorker) {
         let (sender, receiver) = mpsc::channel(queue_capacity);
-        let dropped_total = Arc::new(AtomicU64::new(0));
 
         (
             Self {
                 sender: Some(sender),
-                dropped_total: dropped_total.clone(),
             },
             ActivityLogWorker {
                 pool,
@@ -77,10 +66,7 @@ impl ActivityLogger {
     }
 
     pub fn disabled() -> Self {
-        Self {
-            sender: None,
-            dropped_total: Arc::new(AtomicU64::new(0)),
-        }
+        Self { sender: None }
     }
 
     pub fn record(&self, is_oauth: bool, authorization_id: i64) -> ActivityLogResult {
@@ -94,16 +80,9 @@ impl ActivityLogger {
 
         match sender.try_send(ActivityLogEvent { authorization_id }) {
             Ok(()) => ActivityLogResult::Queued,
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                self.dropped_total.fetch_add(1, Ordering::Relaxed);
-                ActivityLogResult::Dropped
-            }
+            Err(mpsc::error::TrySendError::Full(_)) => ActivityLogResult::Dropped,
             Err(mpsc::error::TrySendError::Closed(_)) => ActivityLogResult::WriterStopped,
         }
-    }
-
-    pub fn dropped_total(&self) -> u64 {
-        self.dropped_total.load(Ordering::Relaxed)
     }
 }
 
@@ -263,6 +242,7 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use sqlx::postgres::PgPoolOptions;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     #[test]
     fn disabled_logger_does_not_queue() {
@@ -270,7 +250,6 @@ mod tests {
 
         assert_eq!(logger.record(false, 1), ActivityLogResult::SkippedNonOauth);
         assert_eq!(logger.record(true, 1), ActivityLogResult::Disabled);
-        assert_eq!(logger.dropped_total(), 0);
     }
 
     #[tokio::test]
@@ -284,7 +263,6 @@ mod tests {
 
         assert_eq!(logger.record(true, 10), ActivityLogResult::Queued);
         assert_eq!(logger.record(true, 11), ActivityLogResult::Dropped);
-        assert_eq!(logger.dropped_total(), 1);
     }
 
     #[tokio::test]

--- a/api/src/activity_log.rs
+++ b/api/src/activity_log.rs
@@ -261,6 +261,7 @@ async fn flush_pending(pool: &PgPool, pending: &mut BTreeMap<i64, i64>) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use sqlx::postgres::PgPoolOptions;
 
     #[test]
@@ -315,6 +316,7 @@ mod tests {
     /// but never replies) and signals shutdown there, so the worker is *not*
     /// parked in its `select!` when the signal lands.
     #[tokio::test]
+    #[serial(activity_log_dropped_metric)]
     async fn worker_observes_shutdown_signalled_during_a_flush() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
@@ -396,6 +398,7 @@ mod tests {
     /// answers, so the accept count is a direct measurement of how many times
     /// the worker retried a failing write.
     #[tokio::test]
+    #[serial(activity_log_dropped_metric)]
     async fn a_failing_flush_stops_the_batch_size_trigger_from_retrying_per_event() {
         const EVENTS: i64 = 10;
 
@@ -450,7 +453,12 @@ mod tests {
             .expect("worker task should not panic");
     }
 
+    // Serialised with the other tests whose shutdown drain feeds the same
+    // process-global counter: a concurrent add landing inside the before/after
+    // window would satisfy this assertion without the code under test doing
+    // anything, and that contamination only ever pushes the test toward passing.
     #[tokio::test]
+    #[serial(activity_log_dropped_metric)]
     async fn a_failed_final_flush_reports_the_counts_it_could_not_write() {
         let pool = PgPoolOptions::new()
             .max_connections(1)

--- a/api/src/activity_log.rs
+++ b/api/src/activity_log.rs
@@ -137,6 +137,15 @@ impl ActivityLogWorker {
         tokio::pin!(shutdown_notified);
         shutdown_notified.as_mut().enable();
 
+        // Because a failed flush retains its batch, `pending.len()` stays above
+        // `max_batch_ids` while the database is unhappy. Without this latch the
+        // size trigger below would then fire on every single received event —
+        // one acquire attempt per RPC request, competing for the very pool this
+        // change exists to relieve. While it is set, only the interval tick
+        // retries, which is the pacing the size trigger was never meant to
+        // override.
+        let mut last_flush_failed = false;
+
         loop {
             tokio::select! {
                 event = self.receiver.recv() => {
@@ -146,15 +155,15 @@ impl ActivityLogWorker {
                     }
                 }
                 _ = flush_interval.tick() => {
-                    self.flush(&mut pending).await;
+                    last_flush_failed = !self.flush(&mut pending).await;
                 }
                 _ = &mut shutdown_notified => {
                     break;
                 }
             }
 
-            if pending.len() >= self.max_batch_ids {
-                self.flush(&mut pending).await;
+            if !last_flush_failed && pending.len() >= self.max_batch_ids {
+                last_flush_failed = !self.flush(&mut pending).await;
             }
         }
 
@@ -162,13 +171,30 @@ impl ActivityLogWorker {
             accumulate(&mut pending, event.authorization_id);
         }
         self.flush(&mut pending).await;
+
+        // Last chance is gone: the task is about to return and `pending` dies
+        // with it, so anything still retained is lost and has to say so.
+        if !pending.is_empty() {
+            let lost: u64 = pending.values().map(|count| *count as u64).sum();
+            METRICS.add_http_rpc_activity_dropped(lost);
+            tracing::error!(
+                lost_events = lost,
+                "Lost OAuth authorization activity: the final flush before shutdown failed"
+            );
+        }
     }
 
-    async fn flush(&self, pending: &mut BTreeMap<i64, i64>) {
+    /// Returns whether the write succeeded, so the caller can stop using the
+    /// batch-size trigger while the database is failing.
+    async fn flush(&self, pending: &mut BTreeMap<i64, i64>) -> bool {
+        let before = pending.len();
         let lost = flush_pending(&self.pool, pending).await;
         if lost > 0 {
             METRICS.add_http_rpc_activity_dropped(lost);
         }
+        // A successful write always empties the map; a failure either retains
+        // the batch or gives it up and reports the loss.
+        before == 0 || (pending.is_empty() && lost == 0)
     }
 }
 
@@ -364,6 +390,97 @@ mod tests {
 
         assert_eq!(lost, MAX_RETAINED_IDS as u64 + 1);
         assert!(pending.is_empty(), "the retained map is bounded");
+    }
+
+    /// Every flush attempt opens one connection to this listener, which never
+    /// answers, so the accept count is a direct measurement of how many times
+    /// the worker retried a failing write.
+    #[tokio::test]
+    async fn a_failing_flush_stops_the_batch_size_trigger_from_retrying_per_event() {
+        const EVENTS: i64 = 10;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind blackhole listener");
+        let port = listener.local_addr().expect("listener addr").port();
+        let attempts = Arc::new(AtomicU64::new(0));
+        let attempts_for_listener = attempts.clone();
+        let _blackhole = tokio::spawn(async move {
+            let mut accepted = Vec::new();
+            while let Ok((socket, _)) = listener.accept().await {
+                attempts_for_listener.fetch_add(1, Ordering::Relaxed);
+                accepted.push(socket);
+            }
+        });
+
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(Duration::from_millis(200))
+            .connect_lazy(&format!("postgres://postgres:postgres@127.0.0.1:{port}/x"))
+            .expect("lazy pool");
+        // A 60s interval never fires inside this test, so only the batch-size
+        // trigger can drive a flush. `max_batch_ids = 1` means every event is
+        // eligible to trigger one.
+        let (logger, worker) = ActivityLogger::with_config(pool, 64, Duration::from_secs(60), 1);
+        let shutdown = Arc::new(Notify::new());
+        let shutdown_for_task = shutdown.clone();
+        let worker_task = tokio::spawn(async move {
+            worker.run_until_shutdown(shutdown_for_task).await;
+        });
+
+        for id in 1..=EVENTS {
+            assert_eq!(logger.record(true, id), ActivityLogResult::Queued);
+        }
+        // Long enough for the worker to take every event and, without the
+        // latch, to have attempted a flush for each one.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let attempted = attempts.load(Ordering::Relaxed);
+        assert!(
+            attempted <= 2,
+            "worker made {attempted} write attempts for {EVENTS} events while the database \
+             was failing; the batch-size trigger is retrying per event instead of leaving \
+             retries to the interval"
+        );
+
+        shutdown.notify_waiters();
+        tokio::time::timeout(Duration::from_secs(10), worker_task)
+            .await
+            .expect("worker should exit")
+            .expect("worker task should not panic");
+    }
+
+    #[tokio::test]
+    async fn a_failed_final_flush_reports_the_counts_it_could_not_write() {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(Duration::from_millis(200))
+            .connect_lazy("postgres://postgres:postgres@127.0.0.1:1/x")
+            .expect("lazy pool");
+        let (logger, worker) = ActivityLogger::with_config(pool, 8, Duration::from_secs(60), 64);
+        let shutdown = Arc::new(Notify::new());
+        let shutdown_for_task = shutdown.clone();
+        let worker_task = tokio::spawn(async move {
+            worker.run_until_shutdown(shutdown_for_task).await;
+        });
+
+        assert_eq!(logger.record(true, 900), ActivityLogResult::Queued);
+        assert_eq!(logger.record(true, 900), ActivityLogResult::Queued);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let before = METRICS.http_rpc_activity_dropped.load(Ordering::Relaxed);
+        shutdown.notify_waiters();
+        tokio::time::timeout(Duration::from_secs(10), worker_task)
+            .await
+            .expect("worker should exit")
+            .expect("worker task should not panic");
+        let after = METRICS.http_rpc_activity_dropped.load(Ordering::Relaxed);
+
+        assert!(
+            after >= before + 2,
+            "the two events the final flush could not write must be reported as lost \
+             (counter went {before} -> {after})"
+        );
     }
 
     #[test]

--- a/api/src/api/error.rs
+++ b/api/src/api/error.rs
@@ -45,7 +45,12 @@ impl From<RepositoryError> for ApiError {
             RepositoryError::NotFound(msg) => ApiError::NotFound(msg),
             RepositoryError::Duplicate => ApiError::BadRequest("Already exists".to_string()),
             RepositoryError::Integrity(msg) => ApiError::BadRequest(msg),
-            RepositoryError::Database(msg) => ApiError::Internal(msg),
+            // No 503-shaped variant here yet, so a transient acquire failure
+            // keeps the pre-existing 500 on these endpoints. The HTTP RPC path
+            // maps it to a retryable 503 of its own.
+            RepositoryError::Database(msg) | RepositoryError::Unavailable(msg) => {
+                ApiError::Internal(msg)
+            }
         }
     }
 }

--- a/api/src/api/error.rs
+++ b/api/src/api/error.rs
@@ -32,6 +32,9 @@ pub enum ApiError {
     #[error("Internal server error: {0}")]
     Internal(String),
 
+    #[error("Service unavailable: {0}")]
+    ServiceUnavailable(String),
+
     #[error("User error: {0}")]
     User(#[from] UserError),
 
@@ -45,12 +48,8 @@ impl From<RepositoryError> for ApiError {
             RepositoryError::NotFound(msg) => ApiError::NotFound(msg),
             RepositoryError::Duplicate => ApiError::BadRequest("Already exists".to_string()),
             RepositoryError::Integrity(msg) => ApiError::BadRequest(msg),
-            // No 503-shaped variant here yet, so a transient acquire failure
-            // keeps the pre-existing 500 on these endpoints. The HTTP RPC path
-            // maps it to a retryable 503 of its own.
-            RepositoryError::Database(msg) | RepositoryError::Unavailable(msg) => {
-                ApiError::Internal(msg)
-            }
+            RepositoryError::Database(msg) => ApiError::Internal(msg),
+            RepositoryError::Unavailable(msg) => ApiError::ServiceUnavailable(msg),
         }
     }
 }
@@ -74,6 +73,10 @@ impl ApiError {
 
     pub fn internal(msg: impl Into<String>) -> Self {
         Self::Internal(msg.into())
+    }
+
+    pub fn service_unavailable(msg: impl Into<String>) -> Self {
+        Self::ServiceUnavailable(msg.into())
     }
 
     pub fn conflict(msg: impl Into<String>) -> Self {
@@ -103,6 +106,13 @@ impl IntoResponse for ApiError {
                     "Something went wrong. Please try again.".to_string(),
                 )
             }
+            ApiError::ServiceUnavailable(msg) => {
+                tracing::warn!("Service unavailable: {}", msg);
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Service temporarily unavailable. Please try again.".to_string(),
+                )
+            }
             ApiError::User(e) => {
                 tracing::error!("User error: {}", e);
                 (
@@ -128,3 +138,16 @@ impl IntoResponse for ApiError {
 }
 
 pub type ApiResult<T> = Result<T, ApiError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repository_unavailable_maps_to_503() {
+        let response =
+            ApiError::from(RepositoryError::Unavailable("pool timed out".into())).into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -2194,9 +2194,8 @@ fn map_repo_error(err: RepositoryError) -> ApiError {
         }
         RepositoryError::NotFound(msg) => ApiError::not_found(msg),
         RepositoryError::Integrity(msg) => ApiError::bad_request(msg),
-        RepositoryError::Database(msg) | RepositoryError::Unavailable(msg) => {
-            ApiError::Internal(msg)
-        }
+        RepositoryError::Database(msg) => ApiError::Internal(msg),
+        RepositoryError::Unavailable(msg) => ApiError::service_unavailable(msg),
     }
 }
 

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -2194,7 +2194,9 @@ fn map_repo_error(err: RepositoryError) -> ApiError {
         }
         RepositoryError::NotFound(msg) => ApiError::not_found(msg),
         RepositoryError::Integrity(msg) => ApiError::bad_request(msg),
-        RepositoryError::Database(msg) => ApiError::Internal(msg),
+        RepositoryError::Database(msg) | RepositoryError::Unavailable(msg) => {
+            ApiError::Internal(msg)
+        }
     }
 }
 

--- a/api/src/api/http/atproto.rs
+++ b/api/src/api/http/atproto.rs
@@ -745,7 +745,8 @@ fn map_control_error(error: AtprotoControlError) -> AuthError {
             tracing::warn!("ATProto repository integrity error: {}", err);
             AuthError::BadRequest("ATProto state update is invalid".to_string())
         }
-        AtprotoControlError::Repository(RepositoryError::Database(err)) => {
+        AtprotoControlError::Repository(RepositoryError::Database(err))
+        | AtprotoControlError::Repository(RepositoryError::Unavailable(err)) => {
             tracing::error!("ATProto repository error: {}", err);
             AuthError::ServiceUnavailable {
                 message: "ATProto state is temporarily unavailable. Please try again shortly."

--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -5318,6 +5318,7 @@ mod tests {
                 bcrypt_sender: bcrypt_queue.sender(),
                 redis: None,
                 secret_pool: secret_pool.receiver(),
+                activity_logger: crate::activity_log::ActivityLogger::disabled(),
             }),
             auth_tx: None,
         }
@@ -5423,6 +5424,7 @@ mod tests {
                 bcrypt_sender: bcrypt_queue.sender(),
                 redis: None,
                 secret_pool: secret_pool.receiver(),
+                activity_logger: crate::activity_log::ActivityLogger::disabled(),
             }),
             auth_tx: None,
         }

--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -798,6 +798,7 @@ mod tests {
                 bcrypt_sender: bcrypt_queue.sender(),
                 redis: None,
                 secret_pool: secret_pool.receiver(),
+                activity_logger: crate::activity_log::ActivityLogger::disabled(),
             }),
             auth_tx: None,
         }

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -414,6 +414,28 @@ async fn nostr_rpc_inner(
     Ok(Json(NostrRpcResponse::success(result)))
 }
 
+/// Classify a repository error from the cold RPC path.
+///
+/// A pool acquire timeout under saturation is transient, so it gets the same
+/// retryable 503 the warm status check already returns. Anything else stays a
+/// 500. Detail goes to the log, never to the response: this endpoint is reached
+/// before the caller is known to be legitimate, and connect-level failures carry
+/// host, DNS and TLS text.
+fn map_repo_error(context: &str, error: keycast_core::repositories::RepositoryError) -> RpcError {
+    use keycast_core::repositories::RepositoryError;
+
+    match error {
+        RepositoryError::Unavailable(detail) => {
+            tracing::warn!(context, %detail, "HTTP RPC database unavailable");
+            RpcError::Unavailable("Database temporarily unavailable".to_string())
+        }
+        other => {
+            tracing::error!(context, error = %other, "HTTP RPC database error");
+            RpcError::Internal(format!("Database error: {}", context))
+        }
+    }
+}
+
 fn http_rpc_outcome(response: &Result<Json<NostrRpcResponse>, RpcError>) -> &'static str {
     match response {
         Ok(_) => "success",
@@ -459,10 +481,13 @@ async fn check_user_status_active(
                 acquire_started.elapsed(),
             );
             METRICS.observe_http_rpc_status_check("unavailable", status_started.elapsed());
-            return Err(RpcError::Unavailable(format!(
-                "Database connection unavailable checking user status: {}",
-                e
-            )));
+            // Detail to the log only: connect-level failures carry host, DNS and
+            // TLS text and this response is reachable before the caller is known
+            // to be legitimate.
+            tracing::warn!(error = %e, "HTTP RPC could not acquire a connection for the status check");
+            return Err(RpcError::Unavailable(
+                "Database temporarily unavailable".to_string(),
+            ));
         }
     };
 
@@ -475,7 +500,8 @@ async fn check_user_status_active(
     .await
     .map_err(|e| {
         METRICS.observe_http_rpc_status_check("error", status_started.elapsed());
-        RpcError::Internal(format!("Database error checking user status: {}", e))
+        tracing::error!(error = %e, "HTTP RPC user status query failed");
+        RpcError::Internal("Database error checking user status".to_string())
     })?;
 
     let result = match status {
@@ -581,7 +607,7 @@ async fn load_handler_on_demand(
     let auth_data = oauth_auth_repo
         .find_by_bunker_pubkey_for_tenant(bunker_pubkey_hex, tenant_id)
         .await
-        .map_err(|e| RpcError::Internal(format!("Database error: {}", e)))?;
+        .map_err(|e| map_repo_error("loading authorization", e))?;
 
     let (auth_id, user_pubkey, auth_handle_opt, expires_at, revoked_at, policy_id) =
         auth_data.ok_or(RpcError::Auth(AuthError::InvalidToken))?;
@@ -589,9 +615,10 @@ async fn load_handler_on_demand(
     // Load permissions for this authorization's policy (if any)
     let permissions: Vec<Box<dyn CustomPermission>> = if let Some(pid) = policy_id {
         let policy_repo = PolicyRepository::new(pool.clone());
-        let db_permissions = policy_repo.get_permissions(pid).await.map_err(|e| {
-            RpcError::Internal(format!("Database error loading permissions: {}", e))
-        })?;
+        let db_permissions = policy_repo
+            .get_permissions(pid)
+            .await
+            .map_err(|e| map_repo_error("loading permissions", e))?;
 
         // Convert to CustomPermission trait objects
         db_permissions
@@ -608,7 +635,7 @@ async fn load_handler_on_demand(
     let encrypted_secret: Vec<u8> = personal_keys_repo
         .find_encrypted_key_for_tenant(&user_pubkey, tenant_id)
         .await
-        .map_err(|e| RpcError::Internal(format!("Database error: {}", e)))?
+        .map_err(|e| map_repo_error("loading personal key", e))?
         .ok_or_else(|| RpcError::Internal("Personal keys not found".to_string()))?;
 
     // Decrypt the secret key
@@ -753,7 +780,7 @@ async fn load_preloaded_user_handler(
     if user_repo
         .is_unclaimed(user_pubkey_hex, tenant_id)
         .await
-        .map_err(|e| RpcError::Internal(format!("Database error: {}", e)))?
+        .map_err(|e| map_repo_error("checking preloaded user", e))?
         .is_none()
     {
         tracing::warn!(
@@ -768,7 +795,7 @@ async fn load_preloaded_user_handler(
     let encrypted_secret: Vec<u8> = personal_keys_repo
         .find_encrypted_key_for_tenant(user_pubkey_hex, tenant_id)
         .await
-        .map_err(|e| RpcError::Internal(format!("Database error: {}", e)))?
+        .map_err(|e| map_repo_error("loading preloaded personal key", e))?
         .ok_or_else(|| {
             RpcError::Internal("Personal keys not found for preloaded user".to_string())
         })?;
@@ -1230,6 +1257,33 @@ mod tests {
     use p256::ecdsa::signature::Signer;
     use p256::ecdsa::{Signature as P256Signature, SigningKey};
     use rand::rngs::OsRng;
+
+    #[test]
+    fn cold_path_pool_exhaustion_is_a_retryable_503_without_leaking_detail() {
+        use keycast_core::repositories::RepositoryError;
+
+        let unavailable = map_repo_error(
+            "loading authorization",
+            RepositoryError::Unavailable("pool timed out".into()),
+        );
+        assert_eq!(http_rpc_outcome(&Err(unavailable)), "unavailable");
+
+        let leaky = map_repo_error(
+            "loading authorization",
+            RepositoryError::Unavailable("connect to db.internal:5432 refused".into()),
+        );
+        let body = format!("{:?}", leaky);
+        assert!(
+            !body.contains("db.internal"),
+            "connect-level detail must stay in the log, not the response: {body}"
+        );
+
+        let internal = map_repo_error(
+            "loading authorization",
+            RepositoryError::Database("relation does not exist".into()),
+        );
+        assert_eq!(http_rpc_outcome(&Err(internal)), "error");
+    }
 
     #[test]
     fn handler_timeout_is_a_504_observed_as_its_own_outcome() {

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -268,7 +268,7 @@ async fn nostr_rpc_inner(
                 handler.authorization_id()
             );
 
-            spawn_log_activity(pool.clone(), handler.is_oauth(), handler.authorization_id());
+            log_activity(&auth_state, handler.is_oauth(), handler.authorization_id());
 
             JsonValue::String(signature)
         }
@@ -1241,9 +1241,9 @@ fn log_activity(auth_state: &AuthState, is_oauth: bool, authorization_id: i64) {
             METRICS.inc_http_rpc_activity_dropped();
             tracing::warn!("Dropped OAuth authorization activity update because queue is full");
         }
-        // The writer stops at the start of the HTTP drain while axum keeps
-        // serving in-flight requests, so this is a real lost update and not the
-        // no-op that a never-configured logger is.
+        // The writer should stop after the HTTP drain. If it is already gone,
+        // this is a real lost update and not the no-op that a never-configured
+        // logger is.
         ActivityLogResult::WriterStopped => {
             METRICS.inc_http_rpc_activity_dropped();
             tracing::warn!(

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -1,6 +1,7 @@
 // ABOUTME: REST RPC API that mirrors NIP-46 methods for low-latency signing
 // ABOUTME: Allows HTTP-based signing instead of relay-based NIP-46 communication
 
+use crate::activity_log::ActivityLogResult;
 use crate::handlers::http_rpc_handler::{HandlerError, HttpRpcHandler};
 use axum::{
     extract::State,
@@ -21,8 +22,7 @@ use nostr_sdk::{Event, JsonUtil, Keys, PublicKey, UnsignedEvent};
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use sqlx::PgPool;
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use super::auth::AuthError;
 use super::routes::AuthState;
@@ -79,6 +79,7 @@ pub enum RpcError {
     SigningFailed(String),
     EncryptionFailed(String),
     DecryptionFailed(String),
+    Unavailable(String),
     Internal(String),
 }
 
@@ -95,6 +96,7 @@ impl IntoResponse for RpcError {
             RpcError::SigningFailed(msg) => (StatusCode::BAD_REQUEST, msg),
             RpcError::EncryptionFailed(msg) => (StatusCode::BAD_REQUEST, msg),
             RpcError::DecryptionFailed(msg) => (StatusCode::BAD_REQUEST, msg),
+            RpcError::Unavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg),
             RpcError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
         };
 
@@ -146,6 +148,20 @@ pub async fn nostr_rpc(
     State(auth_state): State<AuthState>,
     headers: HeaderMap,
     Json(req): Json<NostrRpcRequest>,
+) -> Result<Json<NostrRpcResponse>, RpcError> {
+    let method = req.method.clone();
+    let started = Instant::now();
+    let response = nostr_rpc_inner(tenant, auth_state, headers, req).await;
+    let outcome = http_rpc_outcome(&response);
+    METRICS.observe_http_rpc_request(&method, outcome, started.elapsed());
+    response
+}
+
+async fn nostr_rpc_inner(
+    tenant: crate::api::tenant::TenantExtractor,
+    auth_state: AuthState,
+    headers: HeaderMap,
+    req: NostrRpcRequest,
 ) -> Result<Json<NostrRpcResponse>, RpcError> {
     // Track total HTTP RPC requests
     METRICS.inc_http_rpc_request();
@@ -204,8 +220,7 @@ pub async fn nostr_rpc(
                 signed.kind.as_u16()
             );
 
-            // Log activity in background (non-blocking)
-            spawn_log_activity(pool.clone(), handler.is_oauth(), handler.authorization_id());
+            log_activity(&auth_state, handler.is_oauth(), handler.authorization_id());
 
             serde_json::to_value(&signed)
                 .map_err(|e| RpcError::Internal(format!("JSON serialization failed: {}", e)))?
@@ -240,8 +255,7 @@ pub async fn nostr_rpc(
             // Crypto runs on spawn_blocking to avoid blocking async workers
             let ciphertext = handler.nip44_encrypt(&recipient_pubkey, &plaintext).await?;
 
-            // Log activity in background (non-blocking)
-            spawn_log_activity(pool.clone(), handler.is_oauth(), handler.authorization_id());
+            log_activity(&auth_state, handler.is_oauth(), handler.authorization_id());
 
             JsonValue::String(ciphertext)
         }
@@ -253,8 +267,7 @@ pub async fn nostr_rpc(
             // Crypto runs on spawn_blocking to avoid blocking async workers
             let plaintext = handler.nip44_decrypt(&sender_pubkey, &ciphertext).await?;
 
-            // Log activity in background (non-blocking)
-            spawn_log_activity(pool.clone(), handler.is_oauth(), handler.authorization_id());
+            log_activity(&auth_state, handler.is_oauth(), handler.authorization_id());
 
             // Expose secret only at serialization boundary
             JsonValue::String(plaintext.expose_secret().to_string())
@@ -285,7 +298,7 @@ pub async fn nostr_rpc(
             let results = unwrap_gift_wrap_batch(&handler, &req.params).await;
 
             // One coalesced activity log for the whole batch (per-request semantics).
-            spawn_log_activity(pool.clone(), handler.is_oauth(), handler.authorization_id());
+            log_activity(&auth_state, handler.is_oauth(), handler.authorization_id());
 
             JsonValue::Array(results)
         }
@@ -330,7 +343,7 @@ pub async fn nostr_rpc(
             let results = wrap_gift_wrap_batch(&handler, &batch.rumor, &batch.recipients).await;
 
             // One coalesced activity update for the whole RPC request.
-            spawn_log_activity(pool.clone(), handler.is_oauth(), handler.authorization_id());
+            log_activity(&auth_state, handler.is_oauth(), handler.authorization_id());
 
             JsonValue::Array(results)
         }
@@ -346,8 +359,7 @@ pub async fn nostr_rpc(
             // Crypto runs on spawn_blocking to avoid blocking async workers
             let ciphertext = handler.nip04_encrypt(&recipient_pubkey, &plaintext).await?;
 
-            // Log activity in background (non-blocking)
-            spawn_log_activity(pool.clone(), handler.is_oauth(), handler.authorization_id());
+            log_activity(&auth_state, handler.is_oauth(), handler.authorization_id());
 
             JsonValue::String(ciphertext)
         }
@@ -359,8 +371,7 @@ pub async fn nostr_rpc(
             // Crypto runs on spawn_blocking to avoid blocking async workers
             let plaintext = handler.nip04_decrypt(&sender_pubkey, &ciphertext).await?;
 
-            // Log activity in background (non-blocking)
-            spawn_log_activity(pool.clone(), handler.is_oauth(), handler.authorization_id());
+            log_activity(&auth_state, handler.is_oauth(), handler.authorization_id());
 
             // Expose secret only at serialization boundary
             JsonValue::String(plaintext.expose_secret().to_string())
@@ -377,6 +388,21 @@ pub async fn nostr_rpc(
     Ok(Json(NostrRpcResponse::success(result)))
 }
 
+fn http_rpc_outcome(response: &Result<Json<NostrRpcResponse>, RpcError>) -> &'static str {
+    match response {
+        Ok(_) => "success",
+        Err(RpcError::Auth(_)) => "auth_error",
+        Err(RpcError::InvalidParams(_))
+        | Err(RpcError::UnsupportedMethod(_))
+        | Err(RpcError::SigningFailed(_))
+        | Err(RpcError::EncryptionFailed(_))
+        | Err(RpcError::DecryptionFailed(_)) => "client_error",
+        Err(RpcError::AccountSuspended(_)) => "account_restricted",
+        Err(RpcError::Unavailable(_)) => "unavailable",
+        Err(RpcError::Internal(_)) => "error",
+    }
+}
+
 /// Check that the user's account is active before allowing mutating operations.
 /// This runs a DB query per request (not cached) so status changes take effect immediately.
 /// Returns the account's `verified_minor` flag (same row, no extra query) for
@@ -386,19 +412,65 @@ async fn check_user_status_active(
     user_pubkey_hex: &str,
     tenant_id: i64,
 ) -> Result<bool, RpcError> {
+    let status_started = Instant::now();
+    METRICS.set_http_rpc_db_pool_state(pool.size(), pool.num_idle() as u32);
+
+    let acquire_started = Instant::now();
+    let mut conn = match pool.acquire().await {
+        Ok(conn) => {
+            METRICS.observe_http_rpc_db_acquire(
+                "check_user_status_active",
+                "success",
+                acquire_started.elapsed(),
+            );
+            conn
+        }
+        Err(e) => {
+            METRICS.observe_http_rpc_db_acquire(
+                "check_user_status_active",
+                "unavailable",
+                acquire_started.elapsed(),
+            );
+            METRICS.observe_http_rpc_status_check("unavailable", status_started.elapsed());
+            return Err(RpcError::Unavailable(format!(
+                "Database connection unavailable checking user status: {}",
+                e
+            )));
+        }
+    };
+
     let status: Option<(String, bool)> = sqlx::query_as(
         "SELECT status, verified_minor FROM users WHERE pubkey = $1 AND tenant_id = $2",
     )
     .bind(user_pubkey_hex)
     .bind(tenant_id)
-    .fetch_optional(pool)
+    .fetch_optional(&mut *conn)
     .await
-    .map_err(|e| RpcError::Internal(format!("Database error checking user status: {}", e)))?;
+    .map_err(|e| {
+        METRICS.observe_http_rpc_status_check("error", status_started.elapsed());
+        RpcError::Internal(format!("Database error checking user status: {}", e))
+    })?;
 
-    match status {
+    let result = match status {
         Some((s, verified_minor)) if s == "active" => Ok(verified_minor),
         Some(_) => Err(RpcError::AccountSuspended("Account restricted".to_string())),
         None => Err(RpcError::Auth(AuthError::InvalidToken)),
+    };
+
+    METRICS.observe_http_rpc_status_check(
+        http_rpc_outcome_for_status_check(&result),
+        status_started.elapsed(),
+    );
+    result
+}
+
+fn http_rpc_outcome_for_status_check(result: &Result<bool, RpcError>) -> &'static str {
+    match result {
+        Ok(_) => "success",
+        Err(RpcError::Auth(_)) => "auth_error",
+        Err(RpcError::AccountSuspended(_)) => "account_restricted",
+        Err(RpcError::Unavailable(_)) => "unavailable",
+        Err(_) => "error",
     }
 }
 
@@ -1099,26 +1171,20 @@ async fn unwrap_gift_wrap_batch(
     results
 }
 
-/// Spawn activity logging in background (non-blocking)
-/// Updates oauth_authorizations stats without blocking the response
-fn spawn_log_activity(pool: PgPool, is_oauth: bool, authorization_id: i64) {
-    if !is_oauth {
-        return;
-    }
-
-    tokio::spawn(async move {
-        if let Err(e) = sqlx::query(
-            "UPDATE oauth_authorizations
-             SET last_activity = NOW(), activity_count = activity_count + 1
-             WHERE id = $1",
-        )
-        .bind(authorization_id)
-        .execute(&pool)
-        .await
-        {
-            tracing::error!("Failed to update oauth_authorizations activity: {}", e);
+fn log_activity(auth_state: &AuthState, is_oauth: bool, authorization_id: i64) {
+    match auth_state
+        .state
+        .activity_logger
+        .record(is_oauth, authorization_id)
+    {
+        ActivityLogResult::Queued
+        | ActivityLogResult::SkippedNonOauth
+        | ActivityLogResult::Disabled => {}
+        ActivityLogResult::Dropped => {
+            METRICS.inc_http_rpc_activity_dropped();
+            tracing::warn!("Dropped OAuth authorization activity update because queue is full");
         }
-    });
+    }
 }
 
 #[cfg(test)]

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -32,7 +32,10 @@ use super::routes::AuthState;
 
 /// Wall-clock bound for a single HTTP RPC request, held just under the route's
 /// tower timeout so this handler is the one that normally reports the timeout.
-const HANDLER_TIMEOUT: Duration = Duration::from_secs(8);
+///
+/// Defined in `core` because the budgets nested inside it — the SQLx acquire
+/// timeout and the KMS retry loop — are asserted against it there.
+const HANDLER_TIMEOUT: Duration = keycast_core::request_bounds::HTTP_RPC_HANDLER_TIMEOUT;
 
 /// Maximum gift wraps accepted in a single `nip17_unwrap_batch` request.
 /// Bounds per-request work and keeps the body well under axum's 2 MB default

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -22,10 +22,17 @@ use nostr_sdk::{Event, JsonUtil, Keys, PublicKey, UnsignedEvent};
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use super::auth::AuthError;
 use super::routes::AuthState;
+
+/// Wall-clock bound for a single HTTP RPC request, held just under the route's
+/// tower timeout so this handler is the one that normally reports the timeout.
+const HANDLER_TIMEOUT: Duration = Duration::from_secs(8);
 
 /// Maximum gift wraps accepted in a single `nip17_unwrap_batch` request.
 /// Bounds per-request work and keeps the body well under axum's 2 MB default
@@ -80,6 +87,7 @@ pub enum RpcError {
     EncryptionFailed(String),
     DecryptionFailed(String),
     Unavailable(String),
+    Timeout(String),
     Internal(String),
 }
 
@@ -97,6 +105,7 @@ impl IntoResponse for RpcError {
             RpcError::EncryptionFailed(msg) => (StatusCode::BAD_REQUEST, msg),
             RpcError::DecryptionFailed(msg) => (StatusCode::BAD_REQUEST, msg),
             RpcError::Unavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg),
+            RpcError::Timeout(msg) => (StatusCode::GATEWAY_TIMEOUT, msg),
             RpcError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
         };
 
@@ -151,7 +160,24 @@ pub async fn nostr_rpc(
 ) -> Result<Json<NostrRpcResponse>, RpcError> {
     let method = req.method.clone();
     let started = Instant::now();
-    let response = nostr_rpc_inner(tenant, auth_state, headers, req).await;
+    // The route also carries a tower timeout, but that layer drops this future
+    // whole, so a request bounded there records no latency sample at all — the
+    // long tail this endpoint exists to measure would be the one bucket that
+    // stays empty. Bound the handler here instead, where the method label and
+    // the observation survive, and leave the layer as a wider backstop for the
+    // work outside this function.
+    let response = match tokio::time::timeout(
+        HANDLER_TIMEOUT,
+        nostr_rpc_inner(tenant, auth_state, headers, req),
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(_) => Err(RpcError::Timeout(format!(
+            "RPC request timed out after {}s",
+            HANDLER_TIMEOUT.as_secs()
+        ))),
+    };
     let outcome = http_rpc_outcome(&response);
     METRICS.observe_http_rpc_request(&method, outcome, started.elapsed());
     response
@@ -399,6 +425,7 @@ fn http_rpc_outcome(response: &Result<Json<NostrRpcResponse>, RpcError>) -> &'st
         | Err(RpcError::DecryptionFailed(_)) => "client_error",
         Err(RpcError::AccountSuspended(_)) => "account_restricted",
         Err(RpcError::Unavailable(_)) => "unavailable",
+        Err(RpcError::Timeout(_)) => "timeout",
         Err(RpcError::Internal(_)) => "error",
     }
 }
@@ -1194,6 +1221,20 @@ mod tests {
     use p256::ecdsa::signature::Signer;
     use p256::ecdsa::{Signature as P256Signature, SigningKey};
     use rand::rngs::OsRng;
+
+    #[test]
+    fn handler_timeout_is_a_504_observed_as_its_own_outcome() {
+        let timed_out: Result<Json<NostrRpcResponse>, RpcError> =
+            Err(RpcError::Timeout("RPC request timed out after 8s".into()));
+
+        assert_eq!(http_rpc_outcome(&timed_out), "timeout");
+        assert_eq!(
+            RpcError::Timeout("RPC request timed out after 8s".into())
+                .into_response()
+                .status(),
+            StatusCode::GATEWAY_TIMEOUT
+        );
+    }
 
     fn create_test_handler_with_dpop(expected_jkt: Option<String>) -> HttpRpcHandler {
         let keys = Keys::generate();

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -1211,6 +1211,15 @@ fn log_activity(auth_state: &AuthState, is_oauth: bool, authorization_id: i64) {
             METRICS.inc_http_rpc_activity_dropped();
             tracing::warn!("Dropped OAuth authorization activity update because queue is full");
         }
+        // The writer stops at the start of the HTTP drain while axum keeps
+        // serving in-flight requests, so this is a real lost update and not the
+        // no-op that a never-configured logger is.
+        ActivityLogResult::WriterStopped => {
+            METRICS.inc_http_rpc_activity_dropped();
+            tracing::warn!(
+                "Dropped OAuth authorization activity update because the writer stopped"
+            );
+        }
     }
 }
 

--- a/api/src/api/http/oauth.rs
+++ b/api/src/api/http/oauth.rs
@@ -4708,6 +4708,7 @@ mod tests {
                 bcrypt_sender: bcrypt_queue.sender(),
                 redis: None,
                 secret_pool: secret_pool.receiver(),
+                activity_logger: crate::activity_log::ActivityLogger::disabled(),
             }),
             auth_tx: None,
         }

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -1,12 +1,14 @@
 use axum::{
+    error_handling::HandleErrorLayer,
     http::StatusCode,
     response::IntoResponse,
     routing::{delete, get, patch, post, put},
-    Router,
+    BoxError, Router,
 };
 use keycast_core::authorization_channel::AuthorizationSender;
 use sqlx::PgPool;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
+use tower::{timeout::error::Elapsed, ServiceBuilder};
 
 use crate::api::http::{
     admin, ap, atproto, atproto_oauth, auth, claim, headless, metrics, nostr_rpc, oauth, policies,
@@ -15,6 +17,22 @@ use crate::api::http::{
 use crate::state::KeycastState;
 use axum::response::Json as AxumJson;
 use serde_json::Value as JsonValue;
+
+async fn nostr_rpc_timeout_error(error: BoxError) -> axum::response::Response {
+    if error.is::<Elapsed>() {
+        (
+            StatusCode::GATEWAY_TIMEOUT,
+            AxumJson(serde_json::json!({ "error": "RPC request timed out" })),
+        )
+            .into_response()
+    } else {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            AxumJson(serde_json::json!({ "error": "Unhandled RPC service error" })),
+        )
+            .into_response()
+    }
+}
 
 // State wrapper to pass state to auth handlers
 #[derive(Clone)]
@@ -98,8 +116,13 @@ pub fn api_routes(
         .with_state(auth_state.clone());
 
     // NIP-46 RPC endpoint (OAuth access token auth, public CORS for third-party apps)
+    let nostr_rpc_timeout = ServiceBuilder::new()
+        .layer(HandleErrorLayer::new(nostr_rpc_timeout_error))
+        .layer(tower::timeout::TimeoutLayer::new(Duration::from_secs(8)));
+
     let nostr_rpc_routes = Router::new()
         .route("/nostr", post(nostr_rpc::nostr_rpc))
+        .layer(nostr_rpc_timeout)
         .with_state(auth_state.clone());
 
     // ActivityPub RSA signing endpoints (service-token OR UCAN auth; tenant from Host)
@@ -434,4 +457,40 @@ pub async fn nostr_discovery_public(
         .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
         .body(Body::from(serde_json::to_string(&discovery).unwrap()))
         .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn nostr_rpc_timeout_layer_maps_elapsed_to_504() {
+        let app = Router::new()
+            .route(
+                "/slow",
+                get(|| async {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    "ok"
+                }),
+            )
+            .layer(
+                ServiceBuilder::new()
+                    .layer(HandleErrorLayer::new(nostr_rpc_timeout_error))
+                    .layer(tower::timeout::TimeoutLayer::new(Duration::from_millis(1))),
+            );
+
+        let response = app
+            .oneshot(Request::builder().uri("/slow").body(Body::empty()).unwrap())
+            .await
+            .expect("timeout response");
+
+        assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let body: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(body["error"], "RPC request timed out");
+    }
 }

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -116,9 +116,13 @@ pub fn api_routes(
         .with_state(auth_state.clone());
 
     // NIP-46 RPC endpoint (OAuth access token auth, public CORS for third-party apps)
+    // Backstop only. The handler carries its own 8s bound so timed-out requests
+    // still land in the RPC latency histogram with their method label; this
+    // layer covers what runs outside the handler (body read, extractors) and
+    // sits above that bound so it does not pre-empt the observed path.
     let nostr_rpc_timeout = ServiceBuilder::new()
         .layer(HandleErrorLayer::new(nostr_rpc_timeout_error))
-        .layer(tower::timeout::TimeoutLayer::new(Duration::from_secs(8)));
+        .layer(tower::timeout::TimeoutLayer::new(Duration::from_secs(10)));
 
     let nostr_rpc_routes = Router::new()
         .route("/nostr", post(nostr_rpc::nostr_rpc))

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod activity_log;
 pub mod api;
 pub mod atproto_provisioning;
 pub mod bcrypt_queue;

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -1,3 +1,4 @@
+use crate::activity_log::ActivityLogger;
 use crate::api::tenant::Tenant;
 use crate::bcrypt_queue::BcryptSender;
 use crate::handlers::http_rpc_handler::HttpHandlerCache;
@@ -46,6 +47,8 @@ pub struct KeycastState {
     /// Pre-computed secret pool for instant authorization creation
     /// Background producer generates (secret, bcrypt_hash) pairs ahead of time
     pub secret_pool: SecretPoolReceiver,
+    /// Bounded writer for OAuth authorization activity updates.
+    pub activity_logger: ActivityLogger,
 }
 
 pub static KEYCAST_STATE: OnceCell<Arc<KeycastState>> = OnceCell::new();

--- a/api/tests/ap_signing_integration_test.rs
+++ b/api/tests/ap_signing_integration_test.rs
@@ -77,6 +77,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/auth_debug_test.rs
+++ b/api/tests/auth_debug_test.rs
@@ -75,6 +75,7 @@ fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthS
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/batch_lookup_test.rs
+++ b/api/tests/batch_lookup_test.rs
@@ -67,6 +67,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/clear_verified_minor_test.rs
+++ b/api/tests/clear_verified_minor_test.rs
@@ -68,6 +68,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -174,6 +174,7 @@ pub fn create_test_auth_state(pool: PgPool) -> (AuthState, JoinHandle<()>) {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     };

--- a/api/tests/create_minor_account_test.rs
+++ b/api/tests/create_minor_account_test.rs
@@ -67,6 +67,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/divine_name_promotion_timeout_test.rs
+++ b/api/tests/divine_name_promotion_timeout_test.rs
@@ -148,6 +148,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/divine_username_email_collision_test.rs
+++ b/api/tests/divine_username_email_collision_test.rs
@@ -172,6 +172,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/divine_username_lookup_test.rs
+++ b/api/tests/divine_username_lookup_test.rs
@@ -103,6 +103,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/headless_auth_test.rs
+++ b/api/tests/headless_auth_test.rs
@@ -110,6 +110,7 @@ fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthS
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/key_egress_hardening_test.rs
+++ b/api/tests/key_egress_hardening_test.rs
@@ -111,6 +111,7 @@ fn create_test_auth_state_with_redis(
             bcrypt_sender: bcrypt_queue.sender(),
             redis,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/login_observability_test.rs
+++ b/api/tests/login_observability_test.rs
@@ -86,6 +86,7 @@ fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthS
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -11,6 +11,7 @@ use base64::{
     Engine as _,
 };
 use chrono::{Duration, Utc};
+use keycast_api::activity_log::ActivityLogger;
 use keycast_api::api::{
     http::{
         auth::{sign_event, AuthError, SignEventRequest},
@@ -115,6 +116,14 @@ fn create_test_tenant_extractor(tenant_id: i64) -> TenantExtractor {
 }
 
 fn create_test_auth_state(pool: PgPool, key_manager: Arc<Box<dyn KeyManager>>) -> AuthState {
+    create_test_auth_state_with_activity_logger(pool, key_manager, ActivityLogger::disabled())
+}
+
+fn create_test_auth_state_with_activity_logger(
+    pool: PgPool,
+    key_manager: Arc<Box<dyn KeyManager>>,
+    activity_logger: ActivityLogger,
+) -> AuthState {
     let bcrypt_queue = BcryptQueue::new();
     let secret_pool = SecretPool::new(1);
     let tenant_cache = Cache::builder().max_capacity(10).build();
@@ -130,6 +139,7 @@ fn create_test_auth_state(pool: PgPool, key_manager: Arc<Box<dyn KeyManager>>) -
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger,
         }),
         auth_tx: None,
     }
@@ -1379,6 +1389,7 @@ async fn test_warm_cache_preload_handler_rejected_after_ucan_expiry() {
                 bcrypt_sender: bcrypt_queue.sender(),
                 redis: None,
                 secret_pool: secret_pool.receiver(),
+                activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
             }),
             auth_tx: None,
         }
@@ -1496,6 +1507,7 @@ async fn test_server_signed_non_preload_redirect_origin_rejected() {
                 bcrypt_sender: bcrypt_queue.sender(),
                 redis: None,
                 secret_pool: secret_pool.receiver(),
+                activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
             }),
             auth_tx: None,
         }
@@ -1803,6 +1815,23 @@ async fn setup_wrap_rpc_account(
     expires_at: Option<chrono::DateTime<Utc>>,
     revoked_at: Option<chrono::DateTime<Utc>>,
 ) -> WrapRpcAccount {
+    setup_wrap_rpc_account_with_activity_logger(
+        pool,
+        tenant_id,
+        expires_at,
+        revoked_at,
+        ActivityLogger::disabled(),
+    )
+    .await
+}
+
+async fn setup_wrap_rpc_account_with_activity_logger(
+    pool: &PgPool,
+    tenant_id: i64,
+    expires_at: Option<chrono::DateTime<Utc>>,
+    revoked_at: Option<chrono::DateTime<Utc>>,
+    activity_logger: ActivityLogger,
+) -> WrapRpcAccount {
     let (user_keys, pubkey) = create_test_user();
     let key_manager = FileKeyManager::new().expect("Failed to create key manager");
     insert_user(pool, tenant_id, &pubkey).await;
@@ -1826,9 +1855,10 @@ async fn setup_wrap_rpc_account(
         Some(&bunker_pubkey),
     )
     .await;
-    let auth_state = create_test_auth_state(
+    let auth_state = create_test_auth_state_with_activity_logger(
         pool.clone(),
         Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+        activity_logger,
     );
 
     WrapRpcAccount {
@@ -2062,7 +2092,18 @@ async fn test_suspended_user_denied_nip17_unwrap_batch() {
 async fn test_nip17_wrap_batch_happy_path_order_duplicates_partial_failure_and_activity() {
     let pool = setup_db().await;
     let tenant_id = create_test_tenant(&pool).await;
-    let account = setup_wrap_rpc_account(&pool, tenant_id, None, None).await;
+    let (activity_logger, activity_worker) =
+        ActivityLogger::with_config(pool.clone(), 16, std::time::Duration::from_millis(10), 16);
+    let activity_shutdown = Arc::new(tokio::sync::Notify::new());
+    let activity_worker_shutdown = activity_shutdown.clone();
+    let activity_worker = tokio::spawn(async move {
+        activity_worker
+            .run_until_shutdown(activity_worker_shutdown)
+            .await;
+    });
+    let account =
+        setup_wrap_rpc_account_with_activity_logger(&pool, tenant_id, None, None, activity_logger)
+            .await;
     let recipient = Keys::generate();
     let rumor = wrap_rumor_param(
         &account.user_keys,
@@ -2142,6 +2183,11 @@ async fn test_nip17_wrap_batch_happy_path_order_duplicates_partial_failure_and_a
         activity_count, 1,
         "the whole batch records exactly one coalesced activity update"
     );
+
+    activity_shutdown.notify_one();
+    activity_worker
+        .await
+        .expect("activity worker exits after shutdown");
 }
 
 #[tokio::test]

--- a/api/tests/oauth_pkce_error_code_test.rs
+++ b/api/tests/oauth_pkce_error_code_test.rs
@@ -85,6 +85,7 @@ fn create_test_auth_state(pool: PgPool) -> (AuthState, JoinHandle<()>) {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     };

--- a/api/tests/oauth_refresh_client_binding_test.rs
+++ b/api/tests/oauth_refresh_client_binding_test.rs
@@ -87,6 +87,7 @@ fn create_test_auth_state(pool: PgPool) -> (AuthState, JoinHandle<()>) {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     };

--- a/api/tests/oauth_refresh_first_party_test.rs
+++ b/api/tests/oauth_refresh_first_party_test.rs
@@ -96,6 +96,7 @@ fn create_test_auth_state(pool: PgPool) -> keycast_api::api::http::routes::AuthS
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/registered_clients_admin_http_test.rs
+++ b/api/tests/registered_clients_admin_http_test.rs
@@ -136,6 +136,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/registered_clients_audit_test.rs
+++ b/api/tests/registered_clients_audit_test.rs
@@ -83,6 +83,7 @@ fn make_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/update_profile_divine_name_test.rs
+++ b/api/tests/update_profile_divine_name_test.rs
@@ -61,6 +61,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/user_lookup_test.rs
+++ b/api/tests/user_lookup_test.rs
@@ -119,6 +119,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/user_status_admin_test.rs
+++ b/api/tests/user_status_admin_test.rs
@@ -73,6 +73,7 @@ fn create_test_auth_state(pool: PgPool) -> AuthState {
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/api/tests/verified_minor_dm_gate_test.rs
+++ b/api/tests/verified_minor_dm_gate_test.rs
@@ -98,6 +98,7 @@ fn create_test_auth_state(pool: PgPool, key_manager: Arc<Box<dyn KeyManager>>) -
             bcrypt_sender: bcrypt_queue.sender(),
             redis: None,
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }
@@ -1067,6 +1068,7 @@ async fn minor_user_sign_fast_path_denial_is_forbidden_not_503() {
         bcrypt_sender: BcryptQueue::new().sender(),
         redis: None,
         secret_pool: SecretPool::new(1).receiver(),
+        activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
     });
     let mallory = Keys::generate();
 

--- a/api/tests/verified_minor_key_egress_test.rs
+++ b/api/tests/verified_minor_key_egress_test.rs
@@ -104,6 +104,7 @@ async fn create_test_auth_state(pool: PgPool, key_manager: Arc<Box<dyn KeyManage
             bcrypt_sender: bcrypt_queue.sender(),
             redis: Some(PrefixedRedis::new(connection, Some(prefix))),
             secret_pool: secret_pool.receiver(),
+            activity_logger: keycast_api::activity_log::ActivityLogger::disabled(),
         }),
         auth_tx: None,
     }

--- a/core/src/database.rs
+++ b/core/src/database.rs
@@ -11,7 +11,7 @@ use tokio::time::sleep;
 // Example: 100 instances × 10 connections = 1000 client connections → 200 backend connections
 // Override with SQLX_POOL_SIZE env var (higher = better throughput per instance)
 const DEFAULT_MAX_CONNECTIONS_PER_INSTANCE: u32 = 10;
-const ACQUIRE_TIMEOUT_SECS: u64 = 60;
+const ACQUIRE_TIMEOUT_SECS: u64 = 5;
 const MAX_CONNECTION_ATTEMPTS: u32 = 5;
 
 #[derive(Error, Debug)]

--- a/core/src/database.rs
+++ b/core/src/database.rs
@@ -11,7 +11,7 @@ use tokio::time::sleep;
 // Example: 100 instances × 10 connections = 1000 client connections → 200 backend connections
 // Override with SQLX_POOL_SIZE env var (higher = better throughput per instance)
 const DEFAULT_MAX_CONNECTIONS_PER_INSTANCE: u32 = 10;
-const ACQUIRE_TIMEOUT_SECS: u64 = 5;
+const ACQUIRE_TIMEOUT_SECS: u64 = 60;
 const MAX_CONNECTION_ATTEMPTS: u32 = 5;
 
 #[derive(Error, Debug)]

--- a/core/src/encryption/gcp_key_manager.rs
+++ b/core/src/encryption/gcp_key_manager.rs
@@ -25,12 +25,13 @@ const KMS_BASE_DELAY_MS: u64 = 100;
 /// case here is 2s + 0.1s + 2s + 0.2s + 2s = 6.3s. At 5s per attempt the second
 /// and third attempts could never deliver a response inside that budget, so the
 /// retries were dead weight on the hot path: the request was cancelled mid-loop
-/// instead of failing over. Keep [`KMS_TOTAL_BUDGET`] under the request bound
-/// if any of these are retuned.
+/// instead of failing over. `kms_retry_loop_fits_inside_the_http_rpc_request_bound`
+/// holds that arithmetic if any of these are retuned.
 const KMS_ATTEMPT_TIMEOUT_SECS: u64 = 2;
 
-/// Worst-case wall clock for a full [`MAX_KMS_RETRIES`] loop, asserted in tests
-/// so a change to any of the three constants has to face the request bound.
+/// Worst-case wall clock for a full [`MAX_KMS_RETRIES`] loop, asserted below so
+/// a change to any of the three constants has to face the request bound.
+#[cfg(test)]
 const KMS_TOTAL_BUDGET: Duration = Duration::from_millis(
     KMS_ATTEMPT_TIMEOUT_SECS * 1000 * MAX_KMS_RETRIES as u64
         + KMS_BASE_DELAY_MS

--- a/core/src/encryption/gcp_key_manager.rs
+++ b/core/src/encryption/gcp_key_manager.rs
@@ -16,6 +16,9 @@ const MAX_KMS_RETRIES: u32 = 3;
 /// Base delay for exponential backoff (doubles each attempt: 100ms, 200ms, 400ms).
 const KMS_BASE_DELAY_MS: u64 = 100;
 
+/// Per-attempt wall clock bound for Google Cloud KMS calls.
+const KMS_ATTEMPT_TIMEOUT_SECS: u64 = 5;
+
 pub struct GcpKeyManager {
     client: Client,
     key_name: String,
@@ -90,9 +93,14 @@ impl KeyManager for GcpKeyManager {
         let mut attempt = 0u32;
         let response = loop {
             attempt += 1;
-            match self.client.encrypt(request.clone(), None).await {
-                Ok(resp) => break resp,
-                Err(e) if attempt < MAX_KMS_RETRIES => {
+            match tokio::time::timeout(
+                Duration::from_secs(KMS_ATTEMPT_TIMEOUT_SECS),
+                self.client.encrypt(request.clone(), None),
+            )
+            .await
+            {
+                Ok(Ok(resp)) => break resp,
+                Ok(Err(e)) if attempt < MAX_KMS_RETRIES => {
                     let delay_ms = KMS_BASE_DELAY_MS * 2u64.pow(attempt - 1);
                     warn!(
                         attempt = attempt,
@@ -103,11 +111,33 @@ impl KeyManager for GcpKeyManager {
                     );
                     tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     error!("KMS encrypt failed after {} attempts: {}", attempt, e);
                     return Err(KeyManagerError::EncryptionError(format!(
                         "KMS encryption failed after {} attempts: {}",
                         attempt, e
+                    )));
+                }
+                Err(_) if attempt < MAX_KMS_RETRIES => {
+                    let delay_ms = KMS_BASE_DELAY_MS * 2u64.pow(attempt - 1);
+                    warn!(
+                        attempt = attempt,
+                        max_retries = MAX_KMS_RETRIES,
+                        timeout_secs = KMS_ATTEMPT_TIMEOUT_SECS,
+                        delay_ms = delay_ms,
+                        "KMS encrypt timed out, retrying"
+                    );
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                }
+                Err(_) => {
+                    error!(
+                        attempt = attempt,
+                        timeout_secs = KMS_ATTEMPT_TIMEOUT_SECS,
+                        "KMS encrypt timed out after all attempts"
+                    );
+                    return Err(KeyManagerError::EncryptionError(format!(
+                        "KMS encryption timed out after {} attempts",
+                        attempt
                     )));
                 }
             }
@@ -139,9 +169,14 @@ impl KeyManager for GcpKeyManager {
         let mut attempt = 0u32;
         let response = loop {
             attempt += 1;
-            match self.client.decrypt(request.clone(), None).await {
-                Ok(resp) => break resp,
-                Err(e) if attempt < MAX_KMS_RETRIES => {
+            match tokio::time::timeout(
+                Duration::from_secs(KMS_ATTEMPT_TIMEOUT_SECS),
+                self.client.decrypt(request.clone(), None),
+            )
+            .await
+            {
+                Ok(Ok(resp)) => break resp,
+                Ok(Err(e)) if attempt < MAX_KMS_RETRIES => {
                     let delay_ms = KMS_BASE_DELAY_MS * 2u64.pow(attempt - 1);
                     warn!(
                         attempt = attempt,
@@ -152,11 +187,33 @@ impl KeyManager for GcpKeyManager {
                     );
                     tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     error!("KMS decrypt failed after {} attempts: {}", attempt, e);
                     return Err(KeyManagerError::DecryptionError(format!(
                         "KMS decryption failed after {} attempts: {}",
                         attempt, e
+                    )));
+                }
+                Err(_) if attempt < MAX_KMS_RETRIES => {
+                    let delay_ms = KMS_BASE_DELAY_MS * 2u64.pow(attempt - 1);
+                    warn!(
+                        attempt = attempt,
+                        max_retries = MAX_KMS_RETRIES,
+                        timeout_secs = KMS_ATTEMPT_TIMEOUT_SECS,
+                        delay_ms = delay_ms,
+                        "KMS decrypt timed out, retrying"
+                    );
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                }
+                Err(_) => {
+                    error!(
+                        attempt = attempt,
+                        timeout_secs = KMS_ATTEMPT_TIMEOUT_SECS,
+                        "KMS decrypt timed out after all attempts"
+                    );
+                    return Err(KeyManagerError::DecryptionError(format!(
+                        "KMS decryption timed out after {} attempts",
+                        attempt
                     )));
                 }
             }

--- a/core/src/encryption/gcp_key_manager.rs
+++ b/core/src/encryption/gcp_key_manager.rs
@@ -17,7 +17,25 @@ const MAX_KMS_RETRIES: u32 = 3;
 const KMS_BASE_DELAY_MS: u64 = 100;
 
 /// Per-attempt wall clock bound for Google Cloud KMS calls.
-const KMS_ATTEMPT_TIMEOUT_SECS: u64 = 5;
+///
+/// Sized so the whole retry loop fits inside the HTTP RPC request budget. A
+/// cold-path signing request reaches `decrypt` behind an 8s handler bound
+/// (`HANDLER_TIMEOUT` in `api/src/api/http/nostr_rpc.rs`), and with
+/// [`MAX_KMS_RETRIES`] attempts plus [`KMS_BASE_DELAY_MS`] backoff the worst
+/// case here is 2s + 0.1s + 2s + 0.2s + 2s = 6.3s. At 5s per attempt the second
+/// and third attempts could never deliver a response inside that budget, so the
+/// retries were dead weight on the hot path: the request was cancelled mid-loop
+/// instead of failing over. Keep [`KMS_TOTAL_BUDGET`] under the request bound
+/// if any of these are retuned.
+const KMS_ATTEMPT_TIMEOUT_SECS: u64 = 2;
+
+/// Worst-case wall clock for a full [`MAX_KMS_RETRIES`] loop, asserted in tests
+/// so a change to any of the three constants has to face the request bound.
+const KMS_TOTAL_BUDGET: Duration = Duration::from_millis(
+    KMS_ATTEMPT_TIMEOUT_SECS * 1000 * MAX_KMS_RETRIES as u64
+        + KMS_BASE_DELAY_MS
+        + KMS_BASE_DELAY_MS * 2,
+);
 
 pub struct GcpKeyManager {
     client: Client,
@@ -230,6 +248,21 @@ impl KeyManager for GcpKeyManager {
 mod tests {
     use super::*;
     use tokio;
+
+    /// The KMS retry loop sits under the HTTP RPC handler bound on the cold
+    /// signing path. If it can outlast that bound the later attempts can never
+    /// produce a response, so retuning any of the three constants has to keep
+    /// this true.
+    #[test]
+    fn kms_retry_loop_fits_inside_the_http_rpc_request_bound() {
+        const HTTP_RPC_HANDLER_TIMEOUT: Duration = Duration::from_secs(8);
+
+        assert!(
+            KMS_TOTAL_BUDGET < HTTP_RPC_HANDLER_TIMEOUT,
+            "KMS retry loop worst case {KMS_TOTAL_BUDGET:?} must stay under the \
+             {HTTP_RPC_HANDLER_TIMEOUT:?} HTTP RPC handler bound"
+        );
+    }
 
     #[tokio::test]
     async fn test_encrypt_decrypt_roundtrip() {

--- a/core/src/encryption/gcp_key_manager.rs
+++ b/core/src/encryption/gcp_key_manager.rs
@@ -26,7 +26,13 @@ const KMS_BASE_DELAY_MS: u64 = 100;
 /// and third attempts could never deliver a response inside that budget, so the
 /// retries were dead weight on the hot path: the request was cancelled mid-loop
 /// instead of failing over. `kms_retry_loop_fits_inside_the_http_rpc_request_bound`
-/// holds that arithmetic if any of these are retuned.
+/// holds that arithmetic against
+/// [`crate::request_bounds::HTTP_RPC_HANDLER_TIMEOUT`] if any of these are
+/// retuned.
+///
+/// 6.3s reserves the KMS loop alone. A cold handler load does its database work
+/// before it reaches `decrypt`, so more than ~1.7s of database latency ahead of
+/// this still cancels the request mid-loop.
 const KMS_ATTEMPT_TIMEOUT_SECS: u64 = 2;
 
 /// Worst-case wall clock for a full [`MAX_KMS_RETRIES`] loop, asserted below so
@@ -256,7 +262,7 @@ mod tests {
     /// this true.
     #[test]
     fn kms_retry_loop_fits_inside_the_http_rpc_request_bound() {
-        const HTTP_RPC_HANDLER_TIMEOUT: Duration = Duration::from_secs(8);
+        use crate::request_bounds::HTTP_RPC_HANDLER_TIMEOUT;
 
         assert!(
             KMS_TOTAL_BUDGET < HTTP_RPC_HANDLER_TIMEOUT,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod instance;
 pub mod metrics;
 pub mod oauth_scopes;
 pub mod repositories;
+pub mod request_bounds;
 pub mod secret_pool;
 pub mod secret_types;
 pub mod signing_handler;

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -126,7 +126,8 @@ pub struct Metrics {
     pub http_rpc_db_pool_size: AtomicU64,
     /// Current SQLx idle connection count observed by HTTP RPC.
     pub http_rpc_db_pool_idle: AtomicU64,
-    /// OAuth activity updates dropped because the bounded queue was full.
+    /// OAuth activity updates that never reached the database: queue full,
+    /// writer already stopped, or given up after repeated flush failures.
     pub http_rpc_activity_dropped: AtomicU64,
 
     // === Auth Metrics ===
@@ -314,8 +315,12 @@ impl Metrics {
     }
 
     pub fn inc_http_rpc_activity_dropped(&self) {
+        self.add_http_rpc_activity_dropped(1);
+    }
+
+    pub fn add_http_rpc_activity_dropped(&self, count: u64) {
         self.http_rpc_activity_dropped
-            .fetch_add(1, Ordering::Relaxed);
+            .fetch_add(count, Ordering::Relaxed);
     }
 
     // === Auth metric methods ===
@@ -648,7 +653,7 @@ impl Metrics {
         ));
 
         output.push_str(
-            "\n# HELP keycast_http_rpc_activity_dropped_total OAuth activity updates dropped because the HTTP RPC activity queue was full\n",
+            "\n# HELP keycast_http_rpc_activity_dropped_total OAuth activity updates that never reached the database (queue full, writer stopped, or given up after repeated flush failures)\n",
         );
         output.push_str("# TYPE keycast_http_rpc_activity_dropped_total counter\n");
         output.push_str(&format!(

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -830,6 +830,7 @@ fn normalize_http_rpc_outcome(outcome: &str) -> &'static str {
         "client_error" => "client_error",
         "account_restricted" => "account_restricted",
         "unavailable" => "unavailable",
+        "timeout" => "timeout",
         "error" => "error",
         _ => "other",
     }

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -12,6 +12,10 @@ use std::{
 };
 
 const AUTH_DURATION_BUCKETS: [f64; 8] = [0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0];
+const HTTP_RPC_DURATION_BUCKETS: [f64; 12] = [
+    0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+];
+const HTTP_RPC_ACQUIRE_BUCKETS: [f64; 9] = [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.5, 1.0, 5.0];
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 struct AuthRequestKey {
@@ -31,6 +35,52 @@ struct AuthDurationMetric {
     buckets: [u64; AUTH_DURATION_BUCKETS.len()],
     count: u64,
     sum: f64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct HttpRpcDurationKey {
+    method: String,
+    outcome: String,
+}
+
+#[derive(Clone, Debug)]
+struct HttpRpcDurationMetric {
+    buckets: [u64; HTTP_RPC_DURATION_BUCKETS.len()],
+    count: u64,
+    sum: f64,
+}
+
+impl Default for HttpRpcDurationMetric {
+    fn default() -> Self {
+        Self {
+            buckets: [0; HTTP_RPC_DURATION_BUCKETS.len()],
+            count: 0,
+            sum: 0.0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct HttpRpcAcquireKey {
+    operation: String,
+    outcome: String,
+}
+
+#[derive(Clone, Debug)]
+struct HttpRpcAcquireMetric {
+    buckets: [u64; HTTP_RPC_ACQUIRE_BUCKETS.len()],
+    count: u64,
+    sum: f64,
+}
+
+impl Default for HttpRpcAcquireMetric {
+    fn default() -> Self {
+        Self {
+            buckets: [0; HTTP_RPC_ACQUIRE_BUCKETS.len()],
+            count: 0,
+            sum: 0.0,
+        }
+    }
 }
 
 /// Global metrics counters accessible from any crate
@@ -72,6 +122,12 @@ pub struct Metrics {
     pub http_rpc_success: AtomicU64,
     /// HTTP RPC authorization errors
     pub http_rpc_auth_errors: AtomicU64,
+    /// Current SQLx pool size observed by HTTP RPC.
+    pub http_rpc_db_pool_size: AtomicU64,
+    /// Current SQLx idle connection count observed by HTTP RPC.
+    pub http_rpc_db_pool_idle: AtomicU64,
+    /// OAuth activity updates dropped because the bounded queue was full.
+    pub http_rpc_activity_dropped: AtomicU64,
 
     // === Auth Metrics ===
     /// Total successful user registrations
@@ -94,6 +150,9 @@ pub struct Metrics {
     auth_request_durations: Mutex<BTreeMap<AuthDurationKey, AuthDurationMetric>>,
     auth_audit_write_failures_total: Mutex<BTreeMap<String, u64>>,
     auth_email_send_failures_total: Mutex<BTreeMap<String, u64>>,
+    http_rpc_request_durations: Mutex<BTreeMap<HttpRpcDurationKey, HttpRpcDurationMetric>>,
+    http_rpc_status_check_durations: Mutex<BTreeMap<String, HttpRpcDurationMetric>>,
+    http_rpc_db_acquire_durations: Mutex<BTreeMap<HttpRpcAcquireKey, HttpRpcAcquireMetric>>,
 }
 
 impl Metrics {
@@ -117,6 +176,9 @@ impl Metrics {
             http_rpc_cache_size: AtomicU64::new(0),
             http_rpc_success: AtomicU64::new(0),
             http_rpc_auth_errors: AtomicU64::new(0),
+            http_rpc_db_pool_size: AtomicU64::new(0),
+            http_rpc_db_pool_idle: AtomicU64::new(0),
+            http_rpc_activity_dropped: AtomicU64::new(0),
             // Auth metrics
             registrations_total: AtomicU64::new(0),
             logins_total: AtomicU64::new(0),
@@ -130,6 +192,9 @@ impl Metrics {
             auth_request_durations: Mutex::new(BTreeMap::new()),
             auth_audit_write_failures_total: Mutex::new(BTreeMap::new()),
             auth_email_send_failures_total: Mutex::new(BTreeMap::new()),
+            http_rpc_request_durations: Mutex::new(BTreeMap::new()),
+            http_rpc_status_check_durations: Mutex::new(BTreeMap::new()),
+            http_rpc_db_acquire_durations: Mutex::new(BTreeMap::new()),
         }
     }
 
@@ -203,6 +268,54 @@ impl Metrics {
 
     pub fn inc_http_rpc_auth_error(&self) {
         self.http_rpc_auth_errors.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn observe_http_rpc_request(&self, method: &str, outcome: &str, duration: Duration) {
+        let method = normalize_http_rpc_method(method).to_string();
+        let outcome = normalize_http_rpc_outcome(outcome).to_string();
+        let mut duration_metrics = self
+            .http_rpc_request_durations
+            .lock()
+            .expect("http rpc duration metrics lock poisoned");
+        let metric = duration_metrics
+            .entry(HttpRpcDurationKey { method, outcome })
+            .or_default();
+        observe_http_rpc_duration(metric, duration);
+    }
+
+    pub fn observe_http_rpc_status_check(&self, outcome: &str, duration: Duration) {
+        let outcome = normalize_http_rpc_outcome(outcome).to_string();
+        let mut duration_metrics = self
+            .http_rpc_status_check_durations
+            .lock()
+            .expect("http rpc status check metrics lock poisoned");
+        let metric = duration_metrics.entry(outcome).or_default();
+        observe_http_rpc_duration(metric, duration);
+    }
+
+    pub fn observe_http_rpc_db_acquire(&self, operation: &str, outcome: &str, duration: Duration) {
+        let operation = normalize_http_rpc_db_operation(operation).to_string();
+        let outcome = normalize_http_rpc_outcome(outcome).to_string();
+        let mut duration_metrics = self
+            .http_rpc_db_acquire_durations
+            .lock()
+            .expect("http rpc db acquire metrics lock poisoned");
+        let metric = duration_metrics
+            .entry(HttpRpcAcquireKey { operation, outcome })
+            .or_default();
+        observe_http_rpc_acquire_duration(metric, duration);
+    }
+
+    pub fn set_http_rpc_db_pool_state(&self, size: u32, idle: u32) {
+        self.http_rpc_db_pool_size
+            .store(size as u64, Ordering::Relaxed);
+        self.http_rpc_db_pool_idle
+            .store(idle as u64, Ordering::Relaxed);
+    }
+
+    pub fn inc_http_rpc_activity_dropped(&self) {
+        self.http_rpc_activity_dropped
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     // === Auth metric methods ===
@@ -426,6 +539,123 @@ impl Metrics {
             self.http_rpc_auth_errors.load(Ordering::Relaxed)
         ));
 
+        output.push_str(
+            "\n# HELP keycast_http_rpc_request_duration_seconds HTTP RPC request latency by method and outcome\n",
+        );
+        output.push_str("# TYPE keycast_http_rpc_request_duration_seconds histogram\n");
+        for (key, metric) in self
+            .http_rpc_request_durations
+            .lock()
+            .expect("http rpc duration metrics lock poisoned")
+            .iter()
+        {
+            for (index, bucket) in HTTP_RPC_DURATION_BUCKETS.iter().enumerate() {
+                output.push_str(&format!(
+                    "keycast_http_rpc_request_duration_seconds_bucket{{method=\"{}\",outcome=\"{}\",le=\"{}\"}} {}\n",
+                    key.method, key.outcome, bucket, metric.buckets[index]
+                ));
+            }
+            output.push_str(&format!(
+                "keycast_http_rpc_request_duration_seconds_bucket{{method=\"{}\",outcome=\"{}\",le=\"+Inf\"}} {}\n",
+                key.method, key.outcome, metric.count
+            ));
+            output.push_str(&format!(
+                "keycast_http_rpc_request_duration_seconds_sum{{method=\"{}\",outcome=\"{}\"}} {}\n",
+                key.method, key.outcome, metric.sum
+            ));
+            output.push_str(&format!(
+                "keycast_http_rpc_request_duration_seconds_count{{method=\"{}\",outcome=\"{}\"}} {}\n",
+                key.method, key.outcome, metric.count
+            ));
+        }
+
+        output.push_str(
+            "\n# HELP keycast_http_rpc_status_check_duration_seconds HTTP RPC live user status check latency by outcome\n",
+        );
+        output.push_str("# TYPE keycast_http_rpc_status_check_duration_seconds histogram\n");
+        for (outcome, metric) in self
+            .http_rpc_status_check_durations
+            .lock()
+            .expect("http rpc status check metrics lock poisoned")
+            .iter()
+        {
+            for (index, bucket) in HTTP_RPC_DURATION_BUCKETS.iter().enumerate() {
+                output.push_str(&format!(
+                    "keycast_http_rpc_status_check_duration_seconds_bucket{{outcome=\"{}\",le=\"{}\"}} {}\n",
+                    outcome, bucket, metric.buckets[index]
+                ));
+            }
+            output.push_str(&format!(
+                "keycast_http_rpc_status_check_duration_seconds_bucket{{outcome=\"{}\",le=\"+Inf\"}} {}\n",
+                outcome, metric.count
+            ));
+            output.push_str(&format!(
+                "keycast_http_rpc_status_check_duration_seconds_sum{{outcome=\"{}\"}} {}\n",
+                outcome, metric.sum
+            ));
+            output.push_str(&format!(
+                "keycast_http_rpc_status_check_duration_seconds_count{{outcome=\"{}\"}} {}\n",
+                outcome, metric.count
+            ));
+        }
+
+        output.push_str(
+            "\n# HELP keycast_http_rpc_db_acquire_duration_seconds HTTP RPC DB acquire wait by operation and outcome\n",
+        );
+        output.push_str("# TYPE keycast_http_rpc_db_acquire_duration_seconds histogram\n");
+        for (key, metric) in self
+            .http_rpc_db_acquire_durations
+            .lock()
+            .expect("http rpc db acquire metrics lock poisoned")
+            .iter()
+        {
+            for (index, bucket) in HTTP_RPC_ACQUIRE_BUCKETS.iter().enumerate() {
+                output.push_str(&format!(
+                    "keycast_http_rpc_db_acquire_duration_seconds_bucket{{operation=\"{}\",outcome=\"{}\",le=\"{}\"}} {}\n",
+                    key.operation, key.outcome, bucket, metric.buckets[index]
+                ));
+            }
+            output.push_str(&format!(
+                "keycast_http_rpc_db_acquire_duration_seconds_bucket{{operation=\"{}\",outcome=\"{}\",le=\"+Inf\"}} {}\n",
+                key.operation, key.outcome, metric.count
+            ));
+            output.push_str(&format!(
+                "keycast_http_rpc_db_acquire_duration_seconds_sum{{operation=\"{}\",outcome=\"{}\"}} {}\n",
+                key.operation, key.outcome, metric.sum
+            ));
+            output.push_str(&format!(
+                "keycast_http_rpc_db_acquire_duration_seconds_count{{operation=\"{}\",outcome=\"{}\"}} {}\n",
+                key.operation, key.outcome, metric.count
+            ));
+        }
+
+        output.push_str(
+            "\n# HELP keycast_http_rpc_db_pool_size Current SQLx pool size observed by HTTP RPC\n",
+        );
+        output.push_str("# TYPE keycast_http_rpc_db_pool_size gauge\n");
+        output.push_str(&format!(
+            "keycast_http_rpc_db_pool_size {}\n",
+            self.http_rpc_db_pool_size.load(Ordering::Relaxed)
+        ));
+
+        output.push_str(
+            "\n# HELP keycast_http_rpc_db_pool_idle Current SQLx idle connection count observed by HTTP RPC\n",
+        );
+        output.push_str("# TYPE keycast_http_rpc_db_pool_idle gauge\n");
+        output.push_str(&format!(
+            "keycast_http_rpc_db_pool_idle {}\n",
+            self.http_rpc_db_pool_idle.load(Ordering::Relaxed)
+        ));
+
+        output.push_str(
+            "\n# HELP keycast_http_rpc_activity_dropped_total OAuth activity updates dropped because the HTTP RPC activity queue was full\n",
+        );
+        output.push_str("# TYPE keycast_http_rpc_activity_dropped_total counter\n");
+        output.push_str(&format!(
+            "keycast_http_rpc_activity_dropped_total {}\n",
+            self.http_rpc_activity_dropped.load(Ordering::Relaxed)
+        ));
+
         // Auth metrics
         output
             .push_str("\n# HELP keycast_registrations_total Total successful user registrations\n");
@@ -557,6 +787,61 @@ impl Metrics {
     }
 }
 
+fn observe_http_rpc_duration(metric: &mut HttpRpcDurationMetric, duration: Duration) {
+    let seconds = duration.as_secs_f64();
+    metric.count += 1;
+    metric.sum += seconds;
+    for (index, bucket) in HTTP_RPC_DURATION_BUCKETS.iter().enumerate() {
+        if seconds <= *bucket {
+            metric.buckets[index] += 1;
+        }
+    }
+}
+
+fn observe_http_rpc_acquire_duration(metric: &mut HttpRpcAcquireMetric, duration: Duration) {
+    let seconds = duration.as_secs_f64();
+    metric.count += 1;
+    metric.sum += seconds;
+    for (index, bucket) in HTTP_RPC_ACQUIRE_BUCKETS.iter().enumerate() {
+        if seconds <= *bucket {
+            metric.buckets[index] += 1;
+        }
+    }
+}
+
+fn normalize_http_rpc_method(method: &str) -> &'static str {
+    match method {
+        "get_public_key" => "get_public_key",
+        "sign_event" => "sign_event",
+        "nip04_encrypt" => "nip04_encrypt",
+        "nip04_decrypt" => "nip04_decrypt",
+        "nip44_encrypt" => "nip44_encrypt",
+        "nip44_decrypt" => "nip44_decrypt",
+        "nip17_unwrap_batch" => "nip17_unwrap_batch",
+        "nip17_wrap_batch" => "nip17_wrap_batch",
+        _ => "unsupported",
+    }
+}
+
+fn normalize_http_rpc_outcome(outcome: &str) -> &'static str {
+    match outcome {
+        "success" => "success",
+        "auth_error" => "auth_error",
+        "client_error" => "client_error",
+        "account_restricted" => "account_restricted",
+        "unavailable" => "unavailable",
+        "error" => "error",
+        _ => "other",
+    }
+}
+
+fn normalize_http_rpc_db_operation(operation: &str) -> &'static str {
+    match operation {
+        "check_user_status_active" => "check_user_status_active",
+        _ => "other",
+    }
+}
+
 fn normalize_auth_endpoint(endpoint: &str) -> &'static str {
     match endpoint {
         "/api/auth/register" => "/api/auth/register",
@@ -668,5 +953,38 @@ mod tests {
         ));
         assert!(output
             .contains("keycast_auth_email_send_failures_total{template=\"password_reset\"} 1"));
+    }
+
+    #[test]
+    fn test_http_rpc_labeled_metrics_render_long_tail_buckets() {
+        let metrics = Metrics::new();
+
+        metrics.observe_http_rpc_request("nip44_encrypt", "success", Duration::from_secs(23));
+        metrics.observe_http_rpc_status_check("success", Duration::from_millis(25));
+        metrics.observe_http_rpc_db_acquire(
+            "check_user_status_active",
+            "success",
+            Duration::from_millis(20),
+        );
+        metrics.set_http_rpc_db_pool_state(50, 2);
+        metrics.inc_http_rpc_activity_dropped();
+
+        let output = metrics.to_prometheus();
+
+        assert!(output.contains(
+            "keycast_http_rpc_request_duration_seconds_bucket{method=\"nip44_encrypt\",outcome=\"success\",le=\"30\"} 1"
+        ));
+        assert!(output.contains(
+            "keycast_http_rpc_request_duration_seconds_bucket{method=\"nip44_encrypt\",outcome=\"success\",le=\"10\"} 0"
+        ));
+        assert!(output.contains(
+            "keycast_http_rpc_status_check_duration_seconds_count{outcome=\"success\"} 1"
+        ));
+        assert!(output.contains(
+            "keycast_http_rpc_db_acquire_duration_seconds_count{operation=\"check_user_status_active\",outcome=\"success\"} 1"
+        ));
+        assert!(output.contains("keycast_http_rpc_db_pool_size 50"));
+        assert!(output.contains("keycast_http_rpc_db_pool_idle 2"));
+        assert!(output.contains("keycast_http_rpc_activity_dropped_total 1"));
     }
 }

--- a/core/src/repositories/error.rs
+++ b/core/src/repositories/error.rs
@@ -22,6 +22,13 @@ pub enum RepositoryError {
     /// A database error occurred
     #[error("Database error: {0}")]
     Database(String),
+
+    /// The database could not be reached in time -- typically a pool acquire
+    /// timeout under connection saturation. Separated from [`Self::Database`]
+    /// because it is transient: callers should surface it as retryable rather
+    /// than as an internal failure.
+    #[error("Database unavailable: {0}")]
+    Unavailable(String),
 }
 
 impl From<sqlx::Error> for RepositoryError {
@@ -40,6 +47,8 @@ impl From<sqlx::Error> for RepositoryError {
                     _ => Self::Database(db_err.message().to_string()),
                 }
             }
+            sqlx::Error::PoolTimedOut => Self::Unavailable("pool timed out".into()),
+            sqlx::Error::PoolClosed => Self::Unavailable("pool closed".into()),
             other => Self::Database(other.to_string()),
         }
     }

--- a/core/src/request_bounds.rs
+++ b/core/src/request_bounds.rs
@@ -1,0 +1,13 @@
+// ABOUTME: Wall-clock bounds shared between the HTTP RPC handler and the work it waits on
+// ABOUTME: Lives in core so a retune has to face every budget nested inside it
+
+use std::time::Duration;
+
+/// Wall-clock bound for a single HTTP RPC request on `/api/nostr`.
+///
+/// This is the ceiling every other budget on that path has to fit inside: the
+/// SQLx acquire timeout, the KMS retry loop on a cold handler load, and any
+/// future per-dependency bound. It lives here rather than next to the handler
+/// so `core` can assert those budgets against it — a bound the code below it
+/// cannot see is a bound nothing can hold it to.
+pub const HTTP_RPC_HANDLER_TIMEOUT: Duration = Duration::from_secs(8);

--- a/core/tests/pool_nesting_test.rs
+++ b/core/tests/pool_nesting_test.rs
@@ -11,7 +11,7 @@
 //! it would be testing something that cannot happen.
 //!
 //! Production runs `max_connections = 10` per instance with
-//! `ACQUIRE_TIMEOUT_SECS = 5` (`core/src/database.rs`). A code path that holds
+//! `ACQUIRE_TIMEOUT_SECS = 60` (`core/src/database.rs`). A code path that holds
 //! an open transaction while independently acquiring a second connection from
 //! the same pool needs TWO connections to serve ONE request. That does not fail
 //! in a quiet test suite -- it fails under concurrency, by stalling every

--- a/core/tests/pool_nesting_test.rs
+++ b/core/tests/pool_nesting_test.rs
@@ -131,7 +131,7 @@ where
                  whole time and starving every other endpoint on the instance.\n\n\
                  Fix: thread the open transaction into the inner call (`&mut *tx`) instead of \
                  letting it reach for the pool.",
-                stall = 60,
+                stall = 5,
             );
         }
         Err(error) => panic!("{label} did not reach its expected success path: {error:?}"),

--- a/core/tests/pool_nesting_test.rs
+++ b/core/tests/pool_nesting_test.rs
@@ -141,7 +141,7 @@ where
 fn is_pool_timeout(error: &RepositoryError) -> bool {
     matches!(
         error,
-        RepositoryError::Database(message)
+        RepositoryError::Unavailable(message) | RepositoryError::Database(message)
             if message.contains("PoolTimedOut") || message.contains("pool timed out")
     )
 }

--- a/core/tests/pool_nesting_test.rs
+++ b/core/tests/pool_nesting_test.rs
@@ -11,12 +11,14 @@
 //! it would be testing something that cannot happen.
 //!
 //! Production runs `max_connections = 10` per instance with
-//! `ACQUIRE_TIMEOUT_SECS = 60` (`core/src/database.rs`). A code path that holds
+//! `ACQUIRE_TIMEOUT_SECS = 5` (`core/src/database.rs`). A code path that holds
 //! an open transaction while independently acquiring a second connection from
 //! the same pool needs TWO connections to serve ONE request. That does not fail
 //! in a quiet test suite -- it fails under concurrency, by stalling every
-//! stalled request for the full 60s while it keeps holding its first
-//! connection. One exposed handler can starve login, OAuth and the signer.
+//! stalled request for the full acquire timeout while it keeps holding its
+//! first connection. One exposed handler can starve login, OAuth and the
+//! signer. The shorter timeout caps how long each stall lasts; it does not stop
+//! the second connection from being demanded.
 //!
 //! Concurrency tests cannot pin this down: whether they trip depends on burst
 //! size versus pool size, which makes them knife edges that pass for the wrong

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -1425,13 +1425,14 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     // drained during graceful shutdown.
     let task_tracker = TaskTracker::new();
     let shutdown_signal = Arc::new(Notify::new());
+    let activity_log_shutdown = Arc::new(Notify::new());
 
     let (activity_logger, activity_log_worker) =
         keycast_api::activity_log::ActivityLogger::new(database.pool.clone());
-    let activity_log_shutdown = shutdown_signal.clone();
+    let activity_log_shutdown_for_task = activity_log_shutdown.clone();
     task_tracker.spawn(async move {
         activity_log_worker
-            .run_until_shutdown(activity_log_shutdown)
+            .run_until_shutdown(activity_log_shutdown_for_task)
             .await;
     });
     tracing::info!("✔︎ OAuth activity logger initialized (bounded queue: 4096)");
@@ -1899,13 +1900,14 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     // deregister (it cancels the shared token), so it cannot re-register us
     // after this point.
     //
-    // Then close the relay queue so relay workers stop accepting new events,
-    // drain queued relay work while the relay client remains connected, then
-    // tear down the relay client (stopping signer.run()'s subscription) and
-    // wait for signer + other tracked tasks. This runs **after** HTTP drain so
-    // NIP-46 requests that arrived before the queue closed have a chance to
-    // complete and publish responses back to the requesting client before we
-    // disconnect from the relays.
+    // Then stop the activity writer after HTTP handlers are drained, close the
+    // relay queue so relay workers stop accepting new events, drain queued relay
+    // work while the relay client remains connected, then tear down the relay
+    // client (stopping signer.run()'s subscription) and wait for signer + other
+    // tracked tasks. This runs **after** HTTP drain so NIP-46 requests that
+    // arrived before the queue closed have a chance to complete and publish
+    // responses back to the requesting client before we disconnect from the
+    // relays.
     //
     // `drain_signer_or_abort` bounds the drain by the signer budget REMAINING
     // after the deregister (split into a drain sub-budget plus a reserved
@@ -1925,6 +1927,7 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         timings.signer_drain,
     )
     .await;
+    activity_log_shutdown.notify_waiters();
     let signer_handle_for_abort = signer_handle;
     let close_relay_queue = move || relay_queue.close();
     // Factory (not a single future) so the relay close can be re-attempted on

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -1421,6 +1421,21 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     let _secret_pool_producer = secret_pool.spawn_producer();
     tracing::info!("✔︎ Secret pool initialized (capacity: 100, bcrypt cost: 10)");
 
+    // Setup task tracking before API state so API-owned background workers are
+    // drained during graceful shutdown.
+    let task_tracker = TaskTracker::new();
+    let shutdown_signal = Arc::new(Notify::new());
+
+    let (activity_logger, activity_log_worker) =
+        keycast_api::activity_log::ActivityLogger::new(database.pool.clone());
+    let activity_log_shutdown = shutdown_signal.clone();
+    task_tracker.spawn(async move {
+        activity_log_worker
+            .run_until_shutdown(activity_log_shutdown)
+            .await;
+    });
+    tracing::info!("✔︎ OAuth activity logger initialized (bounded queue: 4096)");
+
     // Create API state with http_handler_cache for on-demand loading
     // Note: api no longer depends on signer's handler cache (decoupled)
     let api_state = Arc::new(keycast_api::state::KeycastState {
@@ -1433,6 +1448,7 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
         bcrypt_sender,
         redis: Some(prefixed_redis),
         secret_pool: secret_pool_receiver,
+        activity_logger,
     });
 
     // Set global state for routes that use it
@@ -1692,11 +1708,9 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
     tracing::info!("✔︎ API server ready on port {}", api_port);
 
     // Setup graceful shutdown with TaskTracker for background tasks
-    let shutdown_signal = Arc::new(Notify::new());
     let shutdown_for_api = shutdown_signal.clone();
     let client_for_shutdown = signer.client();
     let pool_for_shutdown = database.pool.clone();
-    let task_tracker = TaskTracker::new();
 
     // Spawn API server with graceful shutdown
     let api_handle = tokio::spawn(async move {


### PR DESCRIPTION
## Summary

- Adds HTTP RPC latency, status-check, DB acquire, pool state, and activity-drop metrics with buckets that cover 30s/60s tails.
- Bounds `/api/nostr` with an 8s handler timeout (504) behind a wider tower backstop, and bounds the GCP KMS retry loop inside that request budget.
- Replaces per-request detached OAuth activity updates with a bounded batching writer drained after HTTP shutdown.
- Maps pool exhaustion to a retryable 503 on the warm status check, the cold handler-load path, and shared API repository-error paths without echoing connect-level detail into pre-auth responses.
- Keeps account status and minor-protection flags live per request; this intentionally does not add a short TTL status cache.
- `KMS_ATTEMPT_TIMEOUT_SECS = 2` is process-wide for GCP KMS encrypt/decrypt calls. It is sized for the cold HTTP RPC signing path, but also affects key creation, signer cold loads, and admin paths that use the GCP key manager.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Prevent HTTP Nostr RPC calls from sitting behind shared resource contention long enough to break DM delivery.
- Make pool acquire waits, live status checks, and long-tail RPC latency visible before future capacity decisions.
- Remove out-of-band per-request DB acquisitions from the hot path.

## Related Issue

- Refs #291

Remaining work for #291: the per-request `SELECT status, verified_minor` pool checkout is still on every mutating RPC, because a suspension or minor-protection flip has to take effect on the next request. #291 ranked caching that first. This bounds and instruments the symptom rather than removing that demand, so it does not close the issue on its own.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo test -p keycast_api activity_log::tests`
- [x] `cargo test -p keycast_api repository_unavailable_maps_to_503`
- [x] `cargo test -p keycast_api cold_path_pool_exhaustion_is_a_retryable_503_without_leaking_detail`
- [x] `cargo test -p keycast_core kms_retry_loop_fits_inside_the_http_rpc_request_bound`
- [x] `cargo test --workspace --verbose` attempted; local run failed before exercising this diff because `api/tests/common/mod.rs` could not connect to the test database (`PoolTimedOut`) in `atproto_http_test`.
- [x] `bun run test` attempted; local run could not start Docker dependencies because Docker was unavailable at `unix:///Users/lizsw/.docker/run/docker.sock`.
- [x] Earlier reviewer-run checks on this PR: `bun run test:ci` with Docker Postgres + Redis (`520 tests run: 520 passed, 16 skipped` plus integration-feature suites), `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`, and `cargo fmt --all -- --check`.

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
