### PR TITLE
feat(rpc): add creator-binding canonical signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ curl -X POST https://login.divine.video/api/nostr \
   }'
 ```
 
+`POST /api/nostr` also supports `sign_canonical` for C2PA creator-binding payloads.
+Pass a single base64-encoded creator-binding JSON payload; Keycast validates the
+payload shape and authorization policy before returning a deterministic BIP-340
+signature as lowercase hex.
+
 An OpenAPI description is served at `/docs/openapi.json` and lives at [`api/openapi.yaml`](./api/openapi.yaml).
 
 ## Architecture

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -8,7 +8,9 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use base64::prelude::*;
 use chrono::{DateTime, Utc};
+use keycast_core::creator_binding::MAX_CREATOR_BINDING_PAYLOAD_BYTES;
 use keycast_core::metrics::METRICS;
 use keycast_core::repositories::{
     OAuthAuthorizationRepository, PersonalKeysRepository, PolicyRepository, UserRepository,
@@ -113,6 +115,7 @@ impl From<HandlerError> for RpcError {
             HandlerError::PermissionDenied => {
                 RpcError::Auth(AuthError::Forbidden("Operation denied by policy".into()))
             }
+            HandlerError::InvalidRequest(msg) => RpcError::InvalidParams(msg),
             HandlerError::Signing(msg) => RpcError::SigningFailed(msg),
             HandlerError::Encryption(msg) => RpcError::EncryptionFailed(msg),
         }
@@ -124,6 +127,7 @@ impl From<HandlerError> for RpcError {
 /// Supports all NIP-46 methods:
 /// - get_public_key: Returns user's hex pubkey
 /// - sign_event: Signs an unsigned event
+/// - sign_canonical: Signs a base64-encoded creator-binding payload
 /// - nip04_encrypt: Encrypts plaintext using NIP-04
 /// - nip04_decrypt: Decrypts ciphertext using NIP-04
 /// - nip44_encrypt: Encrypts plaintext using NIP-44
@@ -205,6 +209,24 @@ pub async fn nostr_rpc(
 
             serde_json::to_value(&signed)
                 .map_err(|e| RpcError::Internal(format!("JSON serialization failed: {}", e)))?
+        }
+
+        "sign_canonical" => {
+            let payload = parse_canonical_payload_params(&req.params)?;
+
+            // Creator-binding payloads are not DMs, so the verified_minor DM
+            // containment gate does not apply. Handler validity and custom
+            // signing permissions still apply before signing.
+            let signature = handler.sign_canonical(payload).await?;
+
+            tracing::info!(
+                "RPC: Signed creator-binding payload authorization_id={}",
+                handler.authorization_id()
+            );
+
+            spawn_log_activity(pool.clone(), handler.is_oauth(), handler.authorization_id());
+
+            JsonValue::String(signature)
         }
 
         "nip44_encrypt" => {
@@ -894,6 +916,39 @@ fn parse_decrypt_params(params: &[JsonValue]) -> Result<(PublicKey, String), Rpc
     Ok((pubkey, ciphertext.to_string()))
 }
 
+/// Parse sign_canonical params: [base64_payload]
+fn parse_canonical_payload_params(params: &[JsonValue]) -> Result<Vec<u8>, RpcError> {
+    if params.len() != 1 {
+        return Err(RpcError::InvalidParams(
+            "Expected base64 payload parameter".into(),
+        ));
+    }
+
+    let encoded = params
+        .first()
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| RpcError::InvalidParams("Missing base64 payload parameter".into()))?;
+
+    let max_encoded_len = MAX_CREATOR_BINDING_PAYLOAD_BYTES.div_ceil(3) * 4;
+    if encoded.len() > max_encoded_len {
+        return Err(RpcError::InvalidParams(
+            "Creator-binding payload exceeds maximum size".into(),
+        ));
+    }
+
+    let payload = BASE64_STANDARD
+        .decode(encoded)
+        .map_err(|e| RpcError::InvalidParams(format!("Invalid base64 payload: {}", e)))?;
+
+    if payload.len() > MAX_CREATOR_BINDING_PAYLOAD_BYTES {
+        return Err(RpcError::InvalidParams(
+            "Creator-binding payload exceeds maximum size".into(),
+        ));
+    }
+
+    Ok(payload)
+}
+
 struct Nip17WrapBatchParams {
     rumor: UnsignedEvent,
     recipients: Vec<Result<PublicKey, ()>>,
@@ -1069,7 +1124,7 @@ fn spawn_log_activity(pool: PgPool, is_oauth: bool, authorization_id: i64) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use p256::ecdsa::signature::Signer;
     use p256::ecdsa::{Signature as P256Signature, SigningKey};
     use rand::rngs::OsRng;
@@ -1202,6 +1257,46 @@ mod tests {
         )];
         let result = parse_encrypt_params(&params);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_canonical_payload_params() {
+        let payload = br#"{"version":1}"#;
+        let params = vec![JsonValue::String(BASE64_STANDARD.encode(payload))];
+
+        let parsed =
+            parse_canonical_payload_params(&params).expect("valid base64 payload should parse");
+
+        assert_eq!(parsed, payload);
+    }
+
+    #[test]
+    fn test_parse_canonical_payload_params_rejects_invalid_base64() {
+        let params = vec![JsonValue::String("***".to_string())];
+
+        let err = parse_canonical_payload_params(&params).expect_err("invalid base64 rejects");
+
+        match err {
+            RpcError::InvalidParams(message) => {
+                assert!(message.contains("Invalid base64 payload"));
+            }
+            other => panic!("expected InvalidParams, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_canonical_payload_params_rejects_oversize_payload() {
+        let payload = vec![b'a'; MAX_CREATOR_BINDING_PAYLOAD_BYTES + 1];
+        let params = vec![JsonValue::String(BASE64_STANDARD.encode(payload))];
+
+        let err = parse_canonical_payload_params(&params).expect_err("oversize payload rejects");
+
+        match err {
+            RpcError::InvalidParams(message) => {
+                assert!(message.contains("exceeds maximum size"));
+            }
+            other => panic!("expected InvalidParams, got {other:?}"),
+        }
     }
 
     fn wrap_rumor_value(author: PublicKey, recipient: PublicKey) -> JsonValue {

--- a/api/src/handlers/http_rpc_handler.rs
+++ b/api/src/handlers/http_rpc_handler.rs
@@ -881,6 +881,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_sign_canonical_rejects_extra_top_level_field() {
+        // Regression: an unknown top-level field is caller-controlled content that
+        // would be signed with the user's key while `content_filter` only inspects
+        // `claims`. Validation must reject it before signing.
+        let handler = create_test_handler(None, None);
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&creator_binding_payload(handler.public_key())).unwrap();
+        value["note"] = serde_json::json!("arbitrary caller-controlled text");
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        let result = handler.sign_canonical(payload).await;
+        assert!(matches!(result, Err(HandlerError::InvalidRequest(_))));
+    }
+
+    #[tokio::test]
     async fn test_sign_canonical_denied_by_readonly_permission() {
         let handler =
             create_test_handler_with_permissions(None, None, vec![decrypt_only_permission()]);

--- a/api/src/handlers/http_rpc_handler.rs
+++ b/api/src/handlers/http_rpc_handler.rs
@@ -2,6 +2,7 @@
 // ABOUTME: Caches authorization metadata AND permissions for spam protection without DB hits
 
 use chrono::{DateTime, Utc};
+use keycast_core::creator_binding::validate_creator_binding_payload;
 use keycast_core::secret_types::DecryptedPlaintext;
 use keycast_core::signing_session::{CacheKey, SigningSession};
 use keycast_core::traits::CustomPermission;
@@ -23,6 +24,8 @@ pub enum HandlerError {
     AuthorizationInvalid,
     #[error("permission denied")]
     PermissionDenied,
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
     #[error("signing error: {0}")]
     Signing(String),
     #[error("encryption error: {0}")]
@@ -237,6 +240,31 @@ impl HttpRpcHandler {
         }
     }
 
+    /// Validate creator-binding signing permission against cached policy rules.
+    ///
+    /// Creator-binding payloads are not Nostr events, so the permission trait
+    /// maps them to the closest signing capability instead of fabricating an
+    /// event kind at the RPC layer.
+    pub fn validate_sign_creator_binding_permission(
+        &self,
+        payload: &[u8],
+    ) -> Result<(), HandlerError> {
+        if self.permissions.is_empty() {
+            return Ok(());
+        }
+
+        let allowed = self
+            .permissions
+            .iter()
+            .all(|p| p.can_sign_creator_binding(payload));
+
+        if allowed {
+            Ok(())
+        } else {
+            Err(HandlerError::PermissionDenied)
+        }
+    }
+
     /// Validate encryption permission against cached policy rules (no DB hit)
     pub fn validate_encrypt_permission(
         &self,
@@ -358,6 +386,22 @@ impl HttpRpcHandler {
             .map_err(|e| HandlerError::Signing(e.to_string()))
     }
 
+    /// Sign a validated creator-binding payload after checking validity and permissions.
+    pub async fn sign_canonical(&self, payload: Vec<u8>) -> Result<String, HandlerError> {
+        if !self.is_valid() {
+            return Err(HandlerError::AuthorizationInvalid);
+        }
+
+        validate_creator_binding_payload(&payload, self.public_key())
+            .map_err(|e| HandlerError::InvalidRequest(e.to_string()))?;
+        self.validate_sign_creator_binding_permission(&payload)?;
+
+        self.signing
+            .sign_canonical(payload)
+            .await
+            .map_err(|e| HandlerError::Signing(e.to_string()))
+    }
+
     /// Encrypt plaintext using NIP-44 after checking validity and permissions
     /// (CPU-bound crypto runs on spawn_blocking via SigningSession)
     pub async fn nip44_encrypt(
@@ -443,9 +487,9 @@ impl HttpRpcHandler {
                 .map_err(|error| match error {
                     HandlerError::AuthorizationInvalid => WrapError::AuthorizationInvalid,
                     HandlerError::PermissionDenied => WrapError::PermissionDenied,
-                    HandlerError::Encryption(_) | HandlerError::Signing(_) => {
-                        WrapError::EncryptFailed
-                    }
+                    HandlerError::InvalidRequest(_)
+                    | HandlerError::Encryption(_)
+                    | HandlerError::Signing(_) => WrapError::EncryptFailed,
                 })?;
 
         let seal = EventBuilder::new(Kind::Seal, ciphertext)
@@ -454,7 +498,9 @@ impl HttpRpcHandler {
         let signed_seal = self.sign_event(seal).await.map_err(|error| match error {
             HandlerError::AuthorizationInvalid => WrapError::AuthorizationInvalid,
             HandlerError::PermissionDenied => WrapError::PermissionDenied,
-            HandlerError::Signing(_) | HandlerError::Encryption(_) => WrapError::SignFailed,
+            HandlerError::InvalidRequest(_)
+            | HandlerError::Signing(_)
+            | HandlerError::Encryption(_) => WrapError::SignFailed,
         })?;
 
         let recipient = *recipient;
@@ -689,6 +735,39 @@ mod tests {
         .expect("allowed_kinds test permission")
     }
 
+    fn decrypt_only_permission() -> Box<dyn CustomPermission> {
+        use keycast_core::types::permission::{JsonConfig, Permission};
+
+        let now = Utc::now();
+        Permission {
+            id: 1,
+            identifier: "decrypt_only".to_string(),
+            config: JsonConfig(serde_json::json!({})),
+            created_at: now,
+            updated_at: now,
+        }
+        .to_custom_permission()
+        .expect("decrypt_only test permission")
+    }
+
+    fn creator_binding_payload(pubkey: PublicKey) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "version": 1,
+            "pubkey": pubkey.to_hex(),
+            "sig_alg": "nostr.secp256k1",
+            "created_at": "2026-04-29T00:00:00Z",
+            "claims": {
+                "nip05": "creator@example.com"
+            },
+            "referenced_assertions": [],
+            "hard_binding": {
+                "alg": "sha256",
+                "value": "39341a12a2f77007d6e72841f667523d39463a825d82c6c98981881283fb7ed0"
+            }
+        }))
+        .expect("valid creator binding")
+    }
+
     #[test]
     fn test_is_valid_no_expiration() {
         let handler = create_test_handler(None, None);
@@ -764,6 +843,75 @@ mod tests {
 
         let result = handler.sign_event(unsigned).await;
         assert!(matches!(result, Err(HandlerError::AuthorizationInvalid)));
+    }
+
+    #[tokio::test]
+    async fn test_sign_canonical_when_valid() {
+        let handler = create_test_handler(None, None);
+        let payload = creator_binding_payload(handler.public_key());
+
+        let sig = handler
+            .sign_canonical(payload)
+            .await
+            .expect("creator-binding signing should succeed");
+
+        assert_eq!(sig.len(), 128);
+        assert!(sig.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[tokio::test]
+    async fn test_sign_canonical_when_expired() {
+        let expires = Utc::now() - chrono::Duration::hours(1);
+        let handler = create_test_handler(Some(expires), None);
+        let payload = creator_binding_payload(handler.public_key());
+
+        let result = handler.sign_canonical(payload).await;
+        assert!(matches!(result, Err(HandlerError::AuthorizationInvalid)));
+    }
+
+    #[tokio::test]
+    async fn test_sign_canonical_requires_creator_binding_payload() {
+        let handler = create_test_handler(None, None);
+
+        let result = handler
+            .sign_canonical(b"divine-creator-binding-test".to_vec())
+            .await;
+
+        assert!(matches!(result, Err(HandlerError::InvalidRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn test_sign_canonical_denied_by_readonly_permission() {
+        let handler =
+            create_test_handler_with_permissions(None, None, vec![decrypt_only_permission()]);
+        let payload = creator_binding_payload(handler.public_key());
+
+        let result = handler.sign_canonical(payload).await;
+        assert!(matches!(result, Err(HandlerError::PermissionDenied)));
+    }
+
+    #[tokio::test]
+    async fn test_sign_canonical_allowed_by_profile_kind_permission() {
+        let handler =
+            create_test_handler_with_permissions(None, None, vec![allowed_kinds_permission(&[0])]);
+        let payload = creator_binding_payload(handler.public_key());
+
+        let sig = handler
+            .sign_canonical(payload)
+            .await
+            .expect("kind 0 policy should allow creator-binding signing");
+
+        assert_eq!(sig.len(), 128);
+    }
+
+    #[tokio::test]
+    async fn test_sign_canonical_denied_by_non_profile_kind_permission() {
+        let handler =
+            create_test_handler_with_permissions(None, None, vec![allowed_kinds_permission(&[1])]);
+        let payload = creator_binding_payload(handler.public_key());
+
+        let result = handler.sign_canonical(payload).await;
+        assert!(matches!(result, Err(HandlerError::PermissionDenied)));
     }
 
     #[tokio::test]

--- a/api/src/technical_docs.rs
+++ b/api/src/technical_docs.rs
@@ -213,7 +213,7 @@ pub async fn technical_docs() -> Html<&'static str> {
         <li><code>connect</code> - Initial connection handshake</li>
         <li><code>get_public_key</code> - Returns user's public key</li>
         <li><code>sign_event</code> - Signs a Nostr event</li>
-        <li><code>sign_canonical</code> - Signs a C2PA creator-binding payload</li>
+        <li><code>sign_canonical</code> - Signs a C2PA creator-binding payload (Divine extension, <code>POST /api/nostr</code> only; not available over the bunker transport)</li>
         <li><code>nip04_encrypt</code> - Legacy DM encryption</li>
         <li><code>nip04_decrypt</code> - Legacy DM decryption</li>
         <li><code>nip44_encrypt</code> - Modern DM encryption (preferred)</li>

--- a/api/src/technical_docs.rs
+++ b/api/src/technical_docs.rs
@@ -213,6 +213,7 @@ pub async fn technical_docs() -> Html<&'static str> {
         <li><code>connect</code> - Initial connection handshake</li>
         <li><code>get_public_key</code> - Returns user's public key</li>
         <li><code>sign_event</code> - Signs a Nostr event</li>
+        <li><code>sign_canonical</code> - Signs a C2PA creator-binding payload</li>
         <li><code>nip04_encrypt</code> - Legacy DM encryption</li>
         <li><code>nip04_decrypt</code> - Legacy DM decryption</li>
         <li><code>nip44_encrypt</code> - Modern DM encryption (preferred)</li>

--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -6,7 +6,10 @@
 mod common;
 
 use axum::{extract::State, http::HeaderMap, Json};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use base64::{
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+    Engine as _,
+};
 use chrono::{Duration, Utc};
 use keycast_api::api::{
     http::{
@@ -398,6 +401,35 @@ async fn create_kind_restricted_policy(pool: &PgPool, allowed_kinds: Vec<u16>) -
     policy_id
 }
 
+async fn policy_id_by_slug(pool: &PgPool, slug: &str) -> i32 {
+    sqlx::query_scalar("SELECT id FROM policies WHERE slug = $1")
+        .bind(slug)
+        .fetch_one(pool)
+        .await
+        .expect("seeded policy should exist")
+}
+
+fn creator_binding_payload(pubkey: &str) -> Vec<u8> {
+    serde_json::to_vec(&json!({
+        "version": 1,
+        "pubkey": pubkey,
+        "sig_alg": "nostr.secp256k1",
+        "created_at": "2026-04-29T00:00:00Z",
+        "claims": {
+            "nip05": "creator@example.com",
+            "website": "https://example.com"
+        },
+        "referenced_assertions": [
+            {"url": "self#jumbf=/c2pa/assertions/c2pa.hash.data"}
+        ],
+        "hard_binding": {
+            "alg": "sha256",
+            "value": "39341a12a2f77007d6e72841f667523d39463a825d82c6c98981881283fb7ed0"
+        }
+    }))
+    .expect("valid creator-binding JSON")
+}
+
 /// Simulates load_handler_on_demand - loads user keys from DB and creates HttpRpcHandler
 /// Note: This loads regardless of expiration/revocation - caller should check is_valid()
 async fn load_handler_from_db(
@@ -766,6 +798,329 @@ async fn test_sign_event_blocked_by_policy() {
         .expect("Signing allowed event should succeed");
 
     signed.verify().expect("Signature should be valid");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_sign_canonical_returns_hex_signature_for_profile_policy() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (user_keys, pubkey) = create_test_user();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(
+        FileKeyManager::new().expect("Failed to create key manager"),
+    ));
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &user_keys,
+        key_manager.as_ref().as_ref(),
+    )
+    .await;
+
+    let policy_id = create_kind_restricted_policy(&pool, vec![0]).await;
+    let redirect_origin = format!("https://canonical-ok-{}.example.com", Uuid::new_v4());
+    let (_auth_id, bunker_pubkey) = create_test_oauth_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        Some(policy_id),
+        None,
+        None,
+    )
+    .await;
+    let token = build_self_signed_ucan(
+        &user_keys,
+        tenant_id,
+        &redirect_origin,
+        Some(&bunker_pubkey),
+    )
+    .await;
+    let auth_state = create_test_auth_state(pool.clone(), key_manager);
+    let payload = creator_binding_payload(&pubkey);
+
+    let response = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state,
+        &format!("Bearer {}", token),
+        None,
+        NostrRpcRequest {
+            method: "sign_canonical".to_string(),
+            params: vec![Value::String(STANDARD.encode(payload))],
+        },
+    )
+    .await
+    .expect("sign_canonical should succeed");
+
+    let signature = response
+        .result
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .expect("signature result");
+    assert_eq!(signature.len(), 128);
+    assert!(signature.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_sign_canonical_rejects_invalid_payload_without_unsupported_latch_text() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (user_keys, pubkey) = create_test_user();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(
+        FileKeyManager::new().expect("Failed to create key manager"),
+    ));
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &user_keys,
+        key_manager.as_ref().as_ref(),
+    )
+    .await;
+
+    let policy_id = create_kind_restricted_policy(&pool, vec![0]).await;
+    let redirect_origin = format!("https://canonical-invalid-{}.example.com", Uuid::new_v4());
+    let (_auth_id, bunker_pubkey) = create_test_oauth_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        Some(policy_id),
+        None,
+        None,
+    )
+    .await;
+    let token = build_self_signed_ucan(
+        &user_keys,
+        tenant_id,
+        &redirect_origin,
+        Some(&bunker_pubkey),
+    )
+    .await;
+    let auth_state = create_test_auth_state(pool.clone(), key_manager);
+
+    let err = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state,
+        &format!("Bearer {}", token),
+        None,
+        NostrRpcRequest {
+            method: "sign_canonical".to_string(),
+            params: vec![Value::String(
+                STANDARD.encode("divine-creator-binding-test"),
+            )],
+        },
+    )
+    .await
+    .expect_err("bare string payload should be rejected");
+
+    match err {
+        RpcError::InvalidParams(message) => {
+            let lower = message.to_lowercase();
+            assert!(!lower.contains("unsupported method"));
+            assert!(!lower.contains("method not found"));
+        }
+        other => panic!("expected InvalidParams, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_sign_canonical_denied_by_non_profile_policy() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (user_keys, pubkey) = create_test_user();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(
+        FileKeyManager::new().expect("Failed to create key manager"),
+    ));
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &user_keys,
+        key_manager.as_ref().as_ref(),
+    )
+    .await;
+
+    let policy_id = create_kind_restricted_policy(&pool, vec![1]).await;
+    let redirect_origin = format!("https://canonical-policy-{}.example.com", Uuid::new_v4());
+    let (_auth_id, bunker_pubkey) = create_test_oauth_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        Some(policy_id),
+        None,
+        None,
+    )
+    .await;
+    let token = build_self_signed_ucan(
+        &user_keys,
+        tenant_id,
+        &redirect_origin,
+        Some(&bunker_pubkey),
+    )
+    .await;
+    let auth_state = create_test_auth_state(pool.clone(), key_manager);
+
+    let err = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state,
+        &format!("Bearer {}", token),
+        None,
+        NostrRpcRequest {
+            method: "sign_canonical".to_string(),
+            params: vec![Value::String(
+                STANDARD.encode(creator_binding_payload(&pubkey)),
+            )],
+        },
+    )
+    .await
+    .expect_err("kind 1 policy should deny creator-binding signing");
+
+    match err {
+        RpcError::Auth(AuthError::Forbidden(message)) => {
+            assert_eq!(message, "Operation denied by policy");
+        }
+        other => panic!("expected Forbidden, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_sign_canonical_denied_by_readonly_policy() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (user_keys, pubkey) = create_test_user();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(
+        FileKeyManager::new().expect("Failed to create key manager"),
+    ));
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &user_keys,
+        key_manager.as_ref().as_ref(),
+    )
+    .await;
+
+    let policy_id = policy_id_by_slug(&pool, "readonly").await;
+    let redirect_origin = format!("https://canonical-readonly-{}.example.com", Uuid::new_v4());
+    let (_auth_id, bunker_pubkey) = create_test_oauth_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        Some(policy_id),
+        None,
+        None,
+    )
+    .await;
+    let token = build_self_signed_ucan(
+        &user_keys,
+        tenant_id,
+        &redirect_origin,
+        Some(&bunker_pubkey),
+    )
+    .await;
+    let auth_state = create_test_auth_state(pool.clone(), key_manager);
+
+    let err = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state,
+        &format!("Bearer {}", token),
+        None,
+        NostrRpcRequest {
+            method: "sign_canonical".to_string(),
+            params: vec![Value::String(
+                STANDARD.encode(creator_binding_payload(&pubkey)),
+            )],
+        },
+    )
+    .await
+    .expect_err("readonly policy should deny creator-binding signing");
+
+    match err {
+        RpcError::Auth(AuthError::Forbidden(message)) => {
+            assert_eq!(message, "Operation denied by policy");
+        }
+        other => panic!("expected Forbidden, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_suspended_user_denied_nostr_rpc_sign_canonical() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (user_keys, pubkey) = create_test_user();
+    let key_manager: Arc<Box<dyn KeyManager>> = Arc::new(Box::new(
+        FileKeyManager::new().expect("Failed to create key manager"),
+    ));
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &user_keys,
+        key_manager.as_ref().as_ref(),
+    )
+    .await;
+
+    let policy_id = create_kind_restricted_policy(&pool, vec![0]).await;
+    let redirect_origin = format!("https://canonical-suspend-{}.example.com", Uuid::new_v4());
+    let (_auth_id, bunker_pubkey) = create_test_oauth_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        Some(policy_id),
+        None,
+        None,
+    )
+    .await;
+    suspend_user(&pool, &pubkey, tenant_id).await;
+
+    let token = build_self_signed_ucan(
+        &user_keys,
+        tenant_id,
+        &redirect_origin,
+        Some(&bunker_pubkey),
+    )
+    .await;
+    let auth_state = create_test_auth_state(pool.clone(), key_manager);
+
+    let err = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state,
+        &format!("Bearer {}", token),
+        None,
+        NostrRpcRequest {
+            method: "sign_canonical".to_string(),
+            params: vec![Value::String(
+                STANDARD.encode(creator_binding_payload(&pubkey)),
+            )],
+        },
+    )
+    .await
+    .expect_err("suspended user should be denied creator-binding signing");
+
+    match err {
+        RpcError::AccountSuspended(message) => {
+            assert_eq!(message, "Account restricted");
+        }
+        other => panic!("expected AccountSuspended, got {other:?}"),
+    }
 }
 
 // ============================================================================

--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -419,9 +419,8 @@ fn creator_binding_payload(pubkey: &str) -> Vec<u8> {
             "nip05": "creator@example.com",
             "website": "https://example.com"
         },
-        "referenced_assertions": [
-            {"url": "self#jumbf=/c2pa/assertions/c2pa.hash.data"}
-        ],
+        // divine-mobile sends a sorted list of assertion label strings.
+        "referenced_assertions": ["c2pa.actions.v2", "cawg.training-mining"],
         "hard_binding": {
             "alg": "sha256",
             "value": "39341a12a2f77007d6e72841f667523d39463a825d82c6c98981881283fb7ed0"

--- a/core/src/creator_binding.rs
+++ b/core/src/creator_binding.rs
@@ -7,6 +7,23 @@ use thiserror::Error;
 
 pub const MAX_CREATOR_BINDING_PAYLOAD_BYTES: usize = 64 * 1024;
 
+/// The exact top-level fields divine-mobile's `NostrCreatorBindingService` emits.
+///
+/// The allowlist is closed on purpose: every byte of the payload is signed with
+/// the user's key, so anything accepted here becomes attacker-chosen content
+/// inside a signed blob and escapes the `content_filter` policy, which only
+/// inspects creator-supplied `claims`. Adding a field must happen in lockstep
+/// with the mobile client.
+const ALLOWED_TOP_LEVEL_FIELDS: [&str; 7] = [
+    "version",
+    "pubkey",
+    "sig_alg",
+    "created_at",
+    "claims",
+    "referenced_assertions",
+    "hard_binding",
+];
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum CreatorBindingError {
     #[error("creator-binding payload exceeds maximum size")]
@@ -31,11 +48,17 @@ pub enum CreatorBindingError {
     PreSignedPayload,
     #[error("creator-binding payload is invalid JSON")]
     InvalidJson,
+    #[error("creator-binding payload has unexpected field: {0}")]
+    UnexpectedField(String),
 }
 
 /// Validate that a canonical-signing payload is a creator-binding assertion for
 /// the signing key. The caller signs the original bytes after this check, so this
 /// function must not reserialize or normalize the JSON.
+///
+/// The accepted shape is closed, not just checked for required fields: unknown
+/// top-level fields are rejected so the signed bytes cannot carry
+/// caller-controlled content past the policy layer.
 pub fn validate_creator_binding_payload(
     payload: &[u8],
     signer_pubkey: PublicKey,
@@ -50,6 +73,13 @@ pub fn validate_creator_binding_payload(
 
     if object.contains_key("signature") || object.contains_key("sig") {
         return Err(CreatorBindingError::PreSignedPayload);
+    }
+
+    if let Some(unexpected) = object
+        .keys()
+        .find(|key| !ALLOWED_TOP_LEVEL_FIELDS.contains(&key.as_str()))
+    {
+        return Err(CreatorBindingError::UnexpectedField(unexpected.clone()));
     }
 
     match object.get("version").and_then(Value::as_u64) {
@@ -214,6 +244,33 @@ mod tests {
 
         let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
         assert_eq!(err, CreatorBindingError::InvalidUtf8);
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_field() {
+        // An extra field would otherwise ride into the signed bytes untouched by
+        // `content_filter`, which only inspects `claims`.
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value["note"] = json!("arbitrary caller-controlled text");
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(
+            err,
+            CreatorBindingError::UnexpectedField("note".to_string())
+        );
+    }
+
+    #[test]
+    fn accepts_payload_without_optional_created_at() {
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value.as_object_mut().unwrap().remove("created_at");
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        validate_creator_binding_payload(&payload, keys.public_key())
+            .expect("created_at is allowed but not required");
     }
 
     #[test]

--- a/core/src/creator_binding.rs
+++ b/core/src/creator_binding.rs
@@ -10,10 +10,12 @@ pub const MAX_CREATOR_BINDING_PAYLOAD_BYTES: usize = 64 * 1024;
 /// The exact top-level fields divine-mobile's `NostrCreatorBindingService` emits.
 ///
 /// The allowlist is closed on purpose: every byte of the payload is signed with
-/// the user's key, so anything accepted here becomes attacker-chosen content
-/// inside a signed blob and escapes the `content_filter` policy, which only
-/// inspects creator-supplied `claims`. Adding a field must happen in lockstep
-/// with the mobile client.
+/// the user's key, so anything accepted here becomes caller-chosen content
+/// inside a signed blob. `content_filter` scans only the free-text fields
+/// (`claims`, `created_at`, `referenced_assertions`), so an unknown field would
+/// bypass policy entirely. Adding a field means updating this list, the
+/// per-field shape checks below, and `ContentFilter::can_sign_creator_binding`
+/// together, in lockstep with the mobile client.
 const ALLOWED_TOP_LEVEL_FIELDS: [&str; 7] = [
     "version",
     "pubkey",
@@ -40,10 +42,12 @@ pub enum CreatorBindingError {
     PubkeyMismatch,
     #[error("creator-binding claims must be an object")]
     InvalidClaims,
-    #[error("creator-binding referenced_assertions must be an array")]
+    #[error("creator-binding referenced_assertions must be an array of strings")]
     InvalidReferencedAssertions,
-    #[error("creator-binding hard_binding must be an object")]
+    #[error("creator-binding hard_binding must be {{alg: \"sha256\", value: <64 hex>}}")]
     InvalidHardBinding,
+    #[error("creator-binding created_at must be a string")]
+    InvalidCreatedAt,
     #[error("creator-binding payload must not include a signature")]
     PreSignedPayload,
     #[error("creator-binding payload is invalid JSON")]
@@ -101,14 +105,57 @@ pub fn validate_creator_binding_payload(
         return Err(CreatorBindingError::InvalidClaims);
     }
 
-    if !object
-        .get("referenced_assertions")
-        .is_some_and(Value::is_array)
+    // `created_at` is optional, but when present it must be a plain string so it
+    // cannot smuggle structured caller data.
+    if object
+        .get("created_at")
+        .is_some_and(|value| !value.is_string())
     {
-        return Err(CreatorBindingError::InvalidReferencedAssertions);
+        return Err(CreatorBindingError::InvalidCreatedAt);
     }
 
-    if !object.get("hard_binding").is_some_and(Value::is_object) {
+    // divine-mobile sends a sorted `List<String>` of assertion labels.
+    match object
+        .get("referenced_assertions")
+        .and_then(Value::as_array)
+    {
+        Some(items) if items.iter().all(Value::is_string) => {}
+        _ => return Err(CreatorBindingError::InvalidReferencedAssertions),
+    }
+
+    validate_hard_binding(object.get("hard_binding"))?;
+
+    Ok(())
+}
+
+/// `hard_binding` is pinned to exactly `{alg: "sha256", value: <64 lowercase hex>}`.
+///
+/// Pinning it leaves no free-text surface here, which is what lets the content
+/// filter skip this field: a hex digest would otherwise trip blocklists on words
+/// that are also valid hex ("bad", "dead", "cafe").
+fn validate_hard_binding(hard_binding: Option<&Value>) -> Result<(), CreatorBindingError> {
+    let object = hard_binding
+        .and_then(Value::as_object)
+        .ok_or(CreatorBindingError::InvalidHardBinding)?;
+
+    if object.len() != 2 || !object.contains_key("alg") || !object.contains_key("value") {
+        return Err(CreatorBindingError::InvalidHardBinding);
+    }
+
+    if object.get("alg").and_then(Value::as_str) != Some("sha256") {
+        return Err(CreatorBindingError::InvalidHardBinding);
+    }
+
+    let value = object
+        .get("value")
+        .and_then(Value::as_str)
+        .ok_or(CreatorBindingError::InvalidHardBinding)?;
+
+    if value.len() != 64
+        || !value
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
+    {
         return Err(CreatorBindingError::InvalidHardBinding);
     }
 
@@ -260,6 +307,50 @@ mod tests {
             err,
             CreatorBindingError::UnexpectedField("note".to_string())
         );
+    }
+
+    #[test]
+    fn rejects_non_string_created_at() {
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value["created_at"] = json!({"smuggled": "structured data"});
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(err, CreatorBindingError::InvalidCreatedAt);
+    }
+
+    #[test]
+    fn rejects_non_string_referenced_assertion() {
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value["referenced_assertions"] = json!([{"url": "self#jumbf=/c2pa"}]);
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(err, CreatorBindingError::InvalidReferencedAssertions);
+    }
+
+    #[test]
+    fn rejects_hard_binding_with_extra_or_bad_fields() {
+        let keys = Keys::generate();
+
+        for bad in [
+            json!({"alg": "sha256", "value": "a".repeat(64), "note": "extra"}),
+            json!({"alg": "scam: free text", "value": "a".repeat(64)}),
+            json!({"alg": "sha256", "value": "not-hex"}),
+            json!({"alg": "sha256", "value": "A".repeat(64)}),
+            json!({"alg": "sha256"}),
+        ] {
+            let mut value: Value =
+                serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+            value["hard_binding"] = bad.clone();
+            let payload = serde_json::to_vec(&value).unwrap();
+
+            let err = validate_creator_binding_payload(&payload, keys.public_key())
+                .expect_err(&format!("hard_binding {bad} must be rejected"));
+            assert_eq!(err, CreatorBindingError::InvalidHardBinding);
+        }
     }
 
     #[test]

--- a/core/src/creator_binding.rs
+++ b/core/src/creator_binding.rs
@@ -2,29 +2,74 @@
 // ABOUTME: Keeps non-event signing scoped to the expected Divine assertion shape
 
 use nostr_sdk::PublicKey;
+use serde::Deserialize;
 use serde_json::Value;
 use thiserror::Error;
 
 pub const MAX_CREATOR_BINDING_PAYLOAD_BYTES: usize = 64 * 1024;
 
-/// The exact top-level fields divine-mobile's `NostrCreatorBindingService` emits.
+/// divine-mobile's `NostrCreatorBindingService` assertion, as a closed shape.
 ///
-/// The allowlist is closed on purpose: every byte of the payload is signed with
-/// the user's key, so anything accepted here becomes caller-chosen content
-/// inside a signed blob. `content_filter` scans only the free-text fields
-/// (`claims`, `created_at`, `referenced_assertions`), so an unknown field would
-/// bypass policy entirely. Adding a field means updating this list, the
-/// per-field shape checks below, and `ContentFilter::can_sign_creator_binding`
-/// together, in lockstep with the mobile client.
-const ALLOWED_TOP_LEVEL_FIELDS: [&str; 7] = [
-    "version",
-    "pubkey",
-    "sig_alg",
-    "created_at",
-    "claims",
-    "referenced_assertions",
-    "hard_binding",
-];
+/// Every byte of the payload is signed with the user's key, so anything accepted
+/// here becomes caller-chosen content inside a signed blob. `ContentFilter` only
+/// scans the free-text values (`claims`, `created_at`, `referenced_assertions`),
+/// so any field it cannot see must be structurally impossible rather than merely
+/// unexpected.
+///
+/// `deny_unknown_fields` does the work at every depth, and it also makes serde
+/// reject *duplicate* keys. That second property is load-bearing: `serde_json`
+/// collapses duplicates last-wins, but the caller signs the original bytes, so a
+/// shadowed duplicate would ride into the signature without ever being validated
+/// or content-filtered — and a first-wins reader downstream would see a different
+/// assertion than the one Keycast approved.
+///
+/// Adding a field means updating this struct and
+/// `ContentFilter::can_sign_creator_binding` together, in lockstep with mobile.
+// Most fields are never read: they exist so serde enforces the shape. The
+// caller signs the original bytes, so this type is a validator, not a model.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreatorBindingPayload {
+    version: u64,
+    pubkey: String,
+    sig_alg: String,
+    #[serde(default)]
+    created_at: Option<String>,
+    claims: Claims,
+    referenced_assertions: Vec<String>,
+    hard_binding: HardBinding,
+}
+
+/// Mirrors `CreatorBindingClaims.toJson()`; every field is conditional there, so
+/// every field is optional here and `{}` is legitimate.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Claims {
+    #[serde(default)]
+    nip05: Option<String>,
+    #[serde(default)]
+    website: Option<String>,
+    #[serde(default)]
+    social_handles: Option<Vec<SocialHandle>>,
+}
+
+/// Mirrors `CreatorSocialHandle.toJson()`.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SocialHandle {
+    platform: String,
+    handle: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HardBinding {
+    alg: String,
+    value: String,
+}
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum CreatorBindingError {
@@ -32,39 +77,28 @@ pub enum CreatorBindingError {
     PayloadTooLarge,
     #[error("creator-binding payload must be UTF-8 JSON")]
     InvalidUtf8,
-    #[error("creator-binding payload must be a JSON object")]
-    NotObject,
+    #[error("creator-binding payload must not include a signature")]
+    PreSignedPayload,
+    #[error("creator-binding payload shape is invalid: {0}")]
+    InvalidShape(String),
     #[error("creator-binding version must be 1")]
     InvalidVersion,
     #[error("creator-binding sig_alg must be nostr.secp256k1")]
     InvalidSignatureAlgorithm,
     #[error("creator-binding pubkey must match signer")]
     PubkeyMismatch,
-    #[error("creator-binding claims must be an object of known string fields")]
-    InvalidClaims,
-    #[error("creator-binding claims has unexpected field: {0}")]
-    UnexpectedClaim(String),
-    #[error("creator-binding referenced_assertions must be an array of strings")]
-    InvalidReferencedAssertions,
-    #[error("creator-binding hard_binding must be {{alg: \"sha256\", value: <64 hex>}}")]
+    #[error("creator-binding hard_binding must be {{alg: \"sha256\", value: <64 lowercase hex>}}")]
     InvalidHardBinding,
-    #[error("creator-binding created_at must be a string")]
-    InvalidCreatedAt,
-    #[error("creator-binding payload must not include a signature")]
-    PreSignedPayload,
-    #[error("creator-binding payload is invalid JSON")]
-    InvalidJson,
-    #[error("creator-binding payload has unexpected field: {0}")]
-    UnexpectedField(String),
 }
 
 /// Validate that a canonical-signing payload is a creator-binding assertion for
-/// the signing key. The caller signs the original bytes after this check, so this
-/// function must not reserialize or normalize the JSON.
+/// the signing key.
 ///
-/// The accepted shape is closed, not just checked for required fields: unknown
-/// top-level fields are rejected so the signed bytes cannot carry
-/// caller-controlled content past the policy layer.
+/// The caller signs the original bytes after this check, so this function must
+/// not reserialize or normalize the JSON — which is exactly why the accepted
+/// shape is closed rather than merely checked for required fields. Unknown
+/// fields, duplicate keys, and unexpected types are all rejected, so the bytes
+/// that get signed cannot carry anything the policy layer never saw.
 pub fn validate_creator_binding_payload(
     payload: &[u8],
     signer_pubkey: PublicKey,
@@ -74,145 +108,48 @@ pub fn validate_creator_binding_payload(
     }
 
     let text = std::str::from_utf8(payload).map_err(|_| CreatorBindingError::InvalidUtf8)?;
-    let value: Value = serde_json::from_str(text).map_err(|_| CreatorBindingError::InvalidJson)?;
-    let object = value.as_object().ok_or(CreatorBindingError::NotObject)?;
 
-    if object.contains_key("signature") || object.contains_key("sig") {
-        return Err(CreatorBindingError::PreSignedPayload);
+    // Checked ahead of the struct so re-submitting an already-signed assertion
+    // gets a specific answer instead of a generic unknown-field message.
+    if let Ok(Value::Object(object)) = serde_json::from_str::<Value>(text) {
+        if object.contains_key("signature") || object.contains_key("sig") {
+            return Err(CreatorBindingError::PreSignedPayload);
+        }
     }
 
-    if let Some(unexpected) = object
-        .keys()
-        .find(|key| !ALLOWED_TOP_LEVEL_FIELDS.contains(&key.as_str()))
-    {
-        return Err(CreatorBindingError::UnexpectedField(unexpected.clone()));
+    let parsed: CreatorBindingPayload =
+        serde_json::from_str(text).map_err(|e| CreatorBindingError::InvalidShape(e.to_string()))?;
+
+    if parsed.version != 1 {
+        return Err(CreatorBindingError::InvalidVersion);
     }
 
-    match object.get("version").and_then(Value::as_u64) {
-        Some(1) => {}
-        _ => return Err(CreatorBindingError::InvalidVersion),
+    if parsed.sig_alg != "nostr.secp256k1" {
+        return Err(CreatorBindingError::InvalidSignatureAlgorithm);
     }
 
-    match object.get("sig_alg").and_then(Value::as_str) {
-        Some("nostr.secp256k1") => {}
-        _ => return Err(CreatorBindingError::InvalidSignatureAlgorithm),
+    if parsed.pubkey != signer_pubkey.to_hex() {
+        return Err(CreatorBindingError::PubkeyMismatch);
     }
 
-    match object.get("pubkey").and_then(Value::as_str) {
-        Some(pubkey) if pubkey == signer_pubkey.to_hex() => {}
-        _ => return Err(CreatorBindingError::PubkeyMismatch),
-    }
-
-    validate_claims(object.get("claims"))?;
-
-    // `created_at` is optional, but when present it must be a plain string so it
-    // cannot smuggle structured caller data.
-    if object
-        .get("created_at")
-        .is_some_and(|value| !value.is_string())
-    {
-        return Err(CreatorBindingError::InvalidCreatedAt);
-    }
-
-    // divine-mobile sends a sorted `List<String>` of assertion labels.
-    match object
-        .get("referenced_assertions")
-        .and_then(Value::as_array)
-    {
-        Some(items) if items.iter().all(Value::is_string) => {}
-        _ => return Err(CreatorBindingError::InvalidReferencedAssertions),
-    }
-
-    validate_hard_binding(object.get("hard_binding"))?;
+    validate_hard_binding(&parsed.hard_binding)?;
 
     Ok(())
 }
 
-/// `claims` is pinned to divine-mobile's `CreatorBindingClaims.toJson()` shape:
-/// every key optional, but no key outside the known set at any depth.
-///
-/// Keys are pinned rather than content-filtered on purpose. A caller-chosen key
-/// would be free text that `ContentFilter` never sees, since
-/// `contains_blocked_word` only walks values. Scanning keys instead would deny
-/// on the fixed names themselves — a blocklist holding "and" or "for" matches
-/// `social_handles` and `platform` — which is the false-denial trap this module
-/// already avoids elsewhere.
-fn validate_claims(claims: Option<&Value>) -> Result<(), CreatorBindingError> {
-    const ALLOWED_CLAIMS: [&str; 3] = ["nip05", "website", "social_handles"];
-    const ALLOWED_HANDLE_FIELDS: [&str; 2] = ["platform", "handle"];
-
-    let object = claims
-        .and_then(Value::as_object)
-        .ok_or(CreatorBindingError::InvalidClaims)?;
-
-    if let Some(unexpected) = object
-        .keys()
-        .find(|key| !ALLOWED_CLAIMS.contains(&key.as_str()))
-    {
-        return Err(CreatorBindingError::UnexpectedClaim(unexpected.clone()));
-    }
-
-    for key in ["nip05", "website"] {
-        if object.get(key).is_some_and(|value| !value.is_string()) {
-            return Err(CreatorBindingError::InvalidClaims);
-        }
-    }
-
-    let Some(handles) = object.get("social_handles") else {
-        return Ok(());
-    };
-
-    for handle in handles
-        .as_array()
-        .ok_or(CreatorBindingError::InvalidClaims)?
-    {
-        let handle = handle
-            .as_object()
-            .ok_or(CreatorBindingError::InvalidClaims)?;
-
-        if let Some(unexpected) = handle
-            .keys()
-            .find(|key| !ALLOWED_HANDLE_FIELDS.contains(&key.as_str()))
-        {
-            return Err(CreatorBindingError::UnexpectedClaim(unexpected.clone()));
-        }
-
-        if !ALLOWED_HANDLE_FIELDS
-            .iter()
-            .all(|key| handle.get(*key).is_some_and(Value::is_string))
-        {
-            return Err(CreatorBindingError::InvalidClaims);
-        }
-    }
-
-    Ok(())
-}
-
-/// `hard_binding` is pinned to exactly `{alg: "sha256", value: <64 lowercase hex>}`.
+/// `hard_binding` is pinned to `{alg: "sha256", value: <64 lowercase hex>}`.
 ///
 /// Pinning it leaves no free-text surface here, which is what lets the content
 /// filter skip this field: a hex digest would otherwise trip blocklists on words
 /// that are also valid hex ("bad", "dead", "cafe").
-fn validate_hard_binding(hard_binding: Option<&Value>) -> Result<(), CreatorBindingError> {
-    let object = hard_binding
-        .and_then(Value::as_object)
-        .ok_or(CreatorBindingError::InvalidHardBinding)?;
-
-    if object.len() != 2 || !object.contains_key("alg") || !object.contains_key("value") {
+fn validate_hard_binding(hard_binding: &HardBinding) -> Result<(), CreatorBindingError> {
+    if hard_binding.alg != "sha256" {
         return Err(CreatorBindingError::InvalidHardBinding);
     }
 
-    if object.get("alg").and_then(Value::as_str) != Some("sha256") {
-        return Err(CreatorBindingError::InvalidHardBinding);
-    }
-
-    let value = object
-        .get("value")
-        .and_then(Value::as_str)
-        .ok_or(CreatorBindingError::InvalidHardBinding)?;
-
-    if value.len() != 64
-        || !value
+    if hard_binding.value.len() != 64
+        || !hard_binding
+            .value
             .chars()
             .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
     {
@@ -264,7 +201,7 @@ mod tests {
             validate_creator_binding_payload(b"\"divine-creator-binding-test\"", keys.public_key())
                 .expect_err("bare test vector is not a creator-binding object");
 
-        assert_eq!(err, CreatorBindingError::NotObject);
+        assert!(matches!(err, CreatorBindingError::InvalidShape(_)), "{err}");
     }
 
     #[test]
@@ -307,7 +244,7 @@ mod tests {
         let payload = serde_json::to_vec(&value).unwrap();
 
         let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
-        assert_eq!(err, CreatorBindingError::InvalidClaims);
+        assert!(matches!(err, CreatorBindingError::InvalidShape(_)), "{err}");
     }
 
     #[test]
@@ -321,7 +258,7 @@ mod tests {
         let payload = serde_json::to_vec(&value).unwrap();
 
         let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
-        assert_eq!(err, CreatorBindingError::InvalidReferencedAssertions);
+        assert!(matches!(err, CreatorBindingError::InvalidShape(_)), "{err}");
     }
 
     #[test]
@@ -332,7 +269,10 @@ mod tests {
         let payload = serde_json::to_vec(&value).unwrap();
 
         let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
-        assert_eq!(err, CreatorBindingError::InvalidHardBinding);
+        assert!(
+            err.to_string().contains("missing field `hard_binding`"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -356,17 +296,54 @@ mod tests {
     #[test]
     fn rejects_unknown_top_level_field() {
         // An extra field would otherwise ride into the signed bytes untouched by
-        // `content_filter`, which only inspects `claims`.
+        // `content_filter`, which only inspects the known free-text fields.
         let keys = Keys::generate();
         let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
         value["note"] = json!("arbitrary caller-controlled text");
         let payload = serde_json::to_vec(&value).unwrap();
 
         let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
-        assert_eq!(
-            err,
-            CreatorBindingError::UnexpectedField("note".to_string())
+        assert!(err.to_string().contains("unknown field `note`"), "{err}");
+    }
+
+    /// `serde_json::Value` collapses duplicate keys last-wins, but the caller
+    /// signs the original bytes. A shadowed duplicate would therefore be signed
+    /// without ever being validated or content-filtered, and a first-wins reader
+    /// downstream would see a different assertion than the one approved here.
+    #[test]
+    fn rejects_duplicate_top_level_key() {
+        let keys = Keys::generate();
+        let valid = String::from_utf8(valid_payload(keys.public_key())).unwrap();
+        let smuggled = valid.replacen(
+            r#""created_at":"#,
+            r#""created_at":"scam: caller text in created_at","created_at":"#,
+            1,
         );
+
+        let err =
+            validate_creator_binding_payload(smuggled.as_bytes(), keys.public_key()).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate field `created_at`"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_nested_claim_key() {
+        let keys = Keys::generate();
+        let payload = format!(
+            r#"{{"version":1,"pubkey":"{}","sig_alg":"nostr.secp256k1",
+                 "created_at":"2026-04-29T00:00:00Z",
+                 "claims":{{"nip05":"scam: caller text","nip05":"creator@example.com"}},
+                 "referenced_assertions":[],
+                 "hard_binding":{{"alg":"sha256","value":"{}"}}}}"#,
+            keys.public_key().to_hex(),
+            "3".repeat(64)
+        );
+
+        let err =
+            validate_creator_binding_payload(payload.as_bytes(), keys.public_key()).unwrap_err();
+        assert!(err.to_string().contains("duplicate field `nip05`"), "{err}");
     }
 
     #[test]
@@ -379,11 +356,10 @@ mod tests {
         let payload = serde_json::to_vec(&value).unwrap();
 
         let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
-        assert_eq!(
-            err,
-            CreatorBindingError::UnexpectedClaim(
-                "scam: arbitrary caller-controlled text".to_string()
-            )
+        assert!(
+            err.to_string()
+                .contains("unknown field `scam: arbitrary caller-controlled text`"),
+            "{err}"
         );
     }
 
@@ -397,9 +373,9 @@ mod tests {
         let payload = serde_json::to_vec(&value).unwrap();
 
         let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
-        assert_eq!(
-            err,
-            CreatorBindingError::UnexpectedClaim("scam: text".to_string())
+        assert!(
+            err.to_string().contains("unknown field `scam: text`"),
+            "{err}"
         );
     }
 
@@ -438,7 +414,7 @@ mod tests {
         let payload = serde_json::to_vec(&value).unwrap();
 
         let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
-        assert_eq!(err, CreatorBindingError::InvalidCreatedAt);
+        assert!(matches!(err, CreatorBindingError::InvalidShape(_)), "{err}");
     }
 
     #[test]
@@ -449,7 +425,7 @@ mod tests {
         let payload = serde_json::to_vec(&value).unwrap();
 
         let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
-        assert_eq!(err, CreatorBindingError::InvalidReferencedAssertions);
+        assert!(matches!(err, CreatorBindingError::InvalidShape(_)), "{err}");
     }
 
     #[test]
@@ -470,7 +446,13 @@ mod tests {
 
             let err = validate_creator_binding_payload(&payload, keys.public_key())
                 .expect_err(&format!("hard_binding {bad} must be rejected"));
-            assert_eq!(err, CreatorBindingError::InvalidHardBinding);
+            assert!(
+                matches!(
+                    err,
+                    CreatorBindingError::InvalidHardBinding | CreatorBindingError::InvalidShape(_)
+                ),
+                "{err}"
+            );
         }
     }
 

--- a/core/src/creator_binding.rs
+++ b/core/src/creator_binding.rs
@@ -101,9 +101,8 @@ mod tests {
                 "nip05": "creator@example.com",
                 "website": "https://example.com"
             },
-            "referenced_assertions": [
-                {"url": "self#jumbf=/c2pa/assertions/c2pa.hash.data"}
-            ],
+            // divine-mobile sends a sorted list of assertion label strings.
+            "referenced_assertions": ["c2pa.actions.v2", "cawg.training-mining"],
             "hard_binding": {
                 "alg": "sha256",
                 "value": "39341a12a2f77007d6e72841f667523d39463a825d82c6c98981881283fb7ed0"

--- a/core/src/creator_binding.rs
+++ b/core/src/creator_binding.rs
@@ -40,8 +40,10 @@ pub enum CreatorBindingError {
     InvalidSignatureAlgorithm,
     #[error("creator-binding pubkey must match signer")]
     PubkeyMismatch,
-    #[error("creator-binding claims must be an object")]
+    #[error("creator-binding claims must be an object of known string fields")]
     InvalidClaims,
+    #[error("creator-binding claims has unexpected field: {0}")]
+    UnexpectedClaim(String),
     #[error("creator-binding referenced_assertions must be an array of strings")]
     InvalidReferencedAssertions,
     #[error("creator-binding hard_binding must be {{alg: \"sha256\", value: <64 hex>}}")]
@@ -101,9 +103,7 @@ pub fn validate_creator_binding_payload(
         _ => return Err(CreatorBindingError::PubkeyMismatch),
     }
 
-    if !object.get("claims").is_some_and(Value::is_object) {
-        return Err(CreatorBindingError::InvalidClaims);
-    }
+    validate_claims(object.get("claims"))?;
 
     // `created_at` is optional, but when present it must be a plain string so it
     // cannot smuggle structured caller data.
@@ -124,6 +124,66 @@ pub fn validate_creator_binding_payload(
     }
 
     validate_hard_binding(object.get("hard_binding"))?;
+
+    Ok(())
+}
+
+/// `claims` is pinned to divine-mobile's `CreatorBindingClaims.toJson()` shape:
+/// every key optional, but no key outside the known set at any depth.
+///
+/// Keys are pinned rather than content-filtered on purpose. A caller-chosen key
+/// would be free text that `ContentFilter` never sees, since
+/// `contains_blocked_word` only walks values. Scanning keys instead would deny
+/// on the fixed names themselves — a blocklist holding "and" or "for" matches
+/// `social_handles` and `platform` — which is the false-denial trap this module
+/// already avoids elsewhere.
+fn validate_claims(claims: Option<&Value>) -> Result<(), CreatorBindingError> {
+    const ALLOWED_CLAIMS: [&str; 3] = ["nip05", "website", "social_handles"];
+    const ALLOWED_HANDLE_FIELDS: [&str; 2] = ["platform", "handle"];
+
+    let object = claims
+        .and_then(Value::as_object)
+        .ok_or(CreatorBindingError::InvalidClaims)?;
+
+    if let Some(unexpected) = object
+        .keys()
+        .find(|key| !ALLOWED_CLAIMS.contains(&key.as_str()))
+    {
+        return Err(CreatorBindingError::UnexpectedClaim(unexpected.clone()));
+    }
+
+    for key in ["nip05", "website"] {
+        if object.get(key).is_some_and(|value| !value.is_string()) {
+            return Err(CreatorBindingError::InvalidClaims);
+        }
+    }
+
+    let Some(handles) = object.get("social_handles") else {
+        return Ok(());
+    };
+
+    for handle in handles
+        .as_array()
+        .ok_or(CreatorBindingError::InvalidClaims)?
+    {
+        let handle = handle
+            .as_object()
+            .ok_or(CreatorBindingError::InvalidClaims)?;
+
+        if let Some(unexpected) = handle
+            .keys()
+            .find(|key| !ALLOWED_HANDLE_FIELDS.contains(&key.as_str()))
+        {
+            return Err(CreatorBindingError::UnexpectedClaim(unexpected.clone()));
+        }
+
+        if !ALLOWED_HANDLE_FIELDS
+            .iter()
+            .all(|key| handle.get(*key).is_some_and(Value::is_string))
+        {
+            return Err(CreatorBindingError::InvalidClaims);
+        }
+    }
 
     Ok(())
 }
@@ -307,6 +367,67 @@ mod tests {
             err,
             CreatorBindingError::UnexpectedField("note".to_string())
         );
+    }
+
+    #[test]
+    fn rejects_caller_controlled_claim_key() {
+        // Claim keys are caller-supplied text that the content filter never sees,
+        // because it only walks values.
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value["claims"] = json!({"scam: arbitrary caller-controlled text": ""});
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(
+            err,
+            CreatorBindingError::UnexpectedClaim(
+                "scam: arbitrary caller-controlled text".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_caller_controlled_social_handle_key() {
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value["claims"] = json!({
+            "social_handles": [{"platform": "x", "handle": "creator", "scam: text": ""}]
+        });
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(
+            err,
+            CreatorBindingError::UnexpectedClaim("scam: text".to_string())
+        );
+    }
+
+    #[test]
+    fn accepts_full_mobile_claims_shape() {
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value["claims"] = json!({
+            "nip05": "creator@example.com",
+            "website": "https://example.com",
+            "social_handles": [{"platform": "x", "handle": "creator"}]
+        });
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        validate_creator_binding_payload(&payload, keys.public_key())
+            .expect("full CreatorBindingClaims shape must validate");
+    }
+
+    #[test]
+    fn accepts_empty_claims() {
+        // Every claim field is conditional on the mobile side, so `{}` is legitimate.
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value["claims"] = json!({});
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        validate_creator_binding_payload(&payload, keys.public_key())
+            .expect("claims with no fields must validate");
     }
 
     #[test]

--- a/core/src/creator_binding.rs
+++ b/core/src/creator_binding.rs
@@ -1,0 +1,230 @@
+// ABOUTME: Validates C2PA creator-binding payloads before canonical signing
+// ABOUTME: Keeps non-event signing scoped to the expected Divine assertion shape
+
+use nostr_sdk::PublicKey;
+use serde_json::Value;
+use thiserror::Error;
+
+pub const MAX_CREATOR_BINDING_PAYLOAD_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum CreatorBindingError {
+    #[error("creator-binding payload exceeds maximum size")]
+    PayloadTooLarge,
+    #[error("creator-binding payload must be UTF-8 JSON")]
+    InvalidUtf8,
+    #[error("creator-binding payload must be a JSON object")]
+    NotObject,
+    #[error("creator-binding version must be 1")]
+    InvalidVersion,
+    #[error("creator-binding sig_alg must be nostr.secp256k1")]
+    InvalidSignatureAlgorithm,
+    #[error("creator-binding pubkey must match signer")]
+    PubkeyMismatch,
+    #[error("creator-binding claims must be an object")]
+    InvalidClaims,
+    #[error("creator-binding referenced_assertions must be an array")]
+    InvalidReferencedAssertions,
+    #[error("creator-binding hard_binding must be an object")]
+    InvalidHardBinding,
+    #[error("creator-binding payload must not include a signature")]
+    PreSignedPayload,
+    #[error("creator-binding payload is invalid JSON")]
+    InvalidJson,
+}
+
+/// Validate that a canonical-signing payload is a creator-binding assertion for
+/// the signing key. The caller signs the original bytes after this check, so this
+/// function must not reserialize or normalize the JSON.
+pub fn validate_creator_binding_payload(
+    payload: &[u8],
+    signer_pubkey: PublicKey,
+) -> Result<(), CreatorBindingError> {
+    if payload.len() > MAX_CREATOR_BINDING_PAYLOAD_BYTES {
+        return Err(CreatorBindingError::PayloadTooLarge);
+    }
+
+    let text = std::str::from_utf8(payload).map_err(|_| CreatorBindingError::InvalidUtf8)?;
+    let value: Value = serde_json::from_str(text).map_err(|_| CreatorBindingError::InvalidJson)?;
+    let object = value.as_object().ok_or(CreatorBindingError::NotObject)?;
+
+    if object.contains_key("signature") || object.contains_key("sig") {
+        return Err(CreatorBindingError::PreSignedPayload);
+    }
+
+    match object.get("version").and_then(Value::as_u64) {
+        Some(1) => {}
+        _ => return Err(CreatorBindingError::InvalidVersion),
+    }
+
+    match object.get("sig_alg").and_then(Value::as_str) {
+        Some("nostr.secp256k1") => {}
+        _ => return Err(CreatorBindingError::InvalidSignatureAlgorithm),
+    }
+
+    match object.get("pubkey").and_then(Value::as_str) {
+        Some(pubkey) if pubkey == signer_pubkey.to_hex() => {}
+        _ => return Err(CreatorBindingError::PubkeyMismatch),
+    }
+
+    if !object.get("claims").is_some_and(Value::is_object) {
+        return Err(CreatorBindingError::InvalidClaims);
+    }
+
+    if !object
+        .get("referenced_assertions")
+        .is_some_and(Value::is_array)
+    {
+        return Err(CreatorBindingError::InvalidReferencedAssertions);
+    }
+
+    if !object.get("hard_binding").is_some_and(Value::is_object) {
+        return Err(CreatorBindingError::InvalidHardBinding);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr_sdk::Keys;
+    use serde_json::json;
+
+    fn valid_payload(pubkey: PublicKey) -> Vec<u8> {
+        serde_json::to_vec(&json!({
+            "version": 1,
+            "pubkey": pubkey.to_hex(),
+            "sig_alg": "nostr.secp256k1",
+            "created_at": "2026-04-29T00:00:00Z",
+            "claims": {
+                "nip05": "creator@example.com",
+                "website": "https://example.com"
+            },
+            "referenced_assertions": [
+                {"url": "self#jumbf=/c2pa/assertions/c2pa.hash.data"}
+            ],
+            "hard_binding": {
+                "alg": "sha256",
+                "value": "39341a12a2f77007d6e72841f667523d39463a825d82c6c98981881283fb7ed0"
+            }
+        }))
+        .expect("valid JSON")
+    }
+
+    #[test]
+    fn accepts_mobile_creator_binding_shape() {
+        let keys = Keys::generate();
+        let payload = valid_payload(keys.public_key());
+
+        validate_creator_binding_payload(&payload, keys.public_key())
+            .expect("mobile creator-binding payload should validate");
+    }
+
+    #[test]
+    fn rejects_non_object_payload() {
+        let keys = Keys::generate();
+        let err =
+            validate_creator_binding_payload(b"\"divine-creator-binding-test\"", keys.public_key())
+                .expect_err("bare test vector is not a creator-binding object");
+
+        assert_eq!(err, CreatorBindingError::NotObject);
+    }
+
+    #[test]
+    fn rejects_wrong_version() {
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value["version"] = json!(2);
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(err, CreatorBindingError::InvalidVersion);
+    }
+
+    #[test]
+    fn rejects_wrong_signature_algorithm() {
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value["sig_alg"] = json!("ed25519");
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(err, CreatorBindingError::InvalidSignatureAlgorithm);
+    }
+
+    #[test]
+    fn rejects_pubkey_mismatch() {
+        let signer = Keys::generate();
+        let other = Keys::generate();
+        let payload = valid_payload(other.public_key());
+
+        let err = validate_creator_binding_payload(&payload, signer.public_key()).unwrap_err();
+        assert_eq!(err, CreatorBindingError::PubkeyMismatch);
+    }
+
+    #[test]
+    fn rejects_missing_claims() {
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value.as_object_mut().unwrap().remove("claims");
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(err, CreatorBindingError::InvalidClaims);
+    }
+
+    #[test]
+    fn rejects_missing_referenced_assertions() {
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("referenced_assertions");
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(err, CreatorBindingError::InvalidReferencedAssertions);
+    }
+
+    #[test]
+    fn rejects_missing_hard_binding() {
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value.as_object_mut().unwrap().remove("hard_binding");
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(err, CreatorBindingError::InvalidHardBinding);
+    }
+
+    #[test]
+    fn rejects_oversize_payload() {
+        let keys = Keys::generate();
+        let payload = vec![b' '; MAX_CREATOR_BINDING_PAYLOAD_BYTES + 1];
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(err, CreatorBindingError::PayloadTooLarge);
+    }
+
+    #[test]
+    fn rejects_non_utf8_payload() {
+        let keys = Keys::generate();
+        let payload = [0xff, 0xfe, 0xfd];
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(err, CreatorBindingError::InvalidUtf8);
+    }
+
+    #[test]
+    fn rejects_pre_signed_payload() {
+        let keys = Keys::generate();
+        let mut value: Value = serde_json::from_slice(&valid_payload(keys.public_key())).unwrap();
+        value["signature"] = json!("already-signed");
+        let payload = serde_json::to_vec(&value).unwrap();
+
+        let err = validate_creator_binding_payload(&payload, keys.public_key()).unwrap_err();
+        assert_eq!(err, CreatorBindingError::PreSignedPayload);
+    }
+}

--- a/core/src/custom_permissions/allowed_kinds.rs
+++ b/core/src/custom_permissions/allowed_kinds.rs
@@ -26,6 +26,7 @@ impl AllowedKinds {
 
 /// Event kind categories for DM-related kinds
 const DM_KINDS: [u16; 3] = [4, 44, 1059];
+const PROFILE_KIND: u16 = 0;
 
 /// Map a Nostr event kind to a user-friendly description
 fn kind_to_friendly_name(kind: u16) -> &'static str {
@@ -66,6 +67,13 @@ impl CustomPermission for AllowedKinds {
         match &self.config.allowed_kinds {
             None => true,
             Some(kinds) => kinds.contains(&event.kind.into()),
+        }
+    }
+
+    fn can_sign_creator_binding(&self, _payload: &[u8]) -> bool {
+        match &self.config.allowed_kinds {
+            None => true,
+            Some(kinds) => kinds.contains(&PROFILE_KIND),
         }
     }
 

--- a/core/src/custom_permissions/content_filter.rs
+++ b/core/src/custom_permissions/content_filter.rs
@@ -9,7 +9,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Returns true if any string value reachable from `value` contains a blocked
-/// word. Object keys are skipped so only creator-supplied content is matched.
+/// word.
+///
+/// Object keys are skipped: `validate_creator_binding_payload` pins every key in
+/// the payload to a known name, so keys are structure rather than creator
+/// content, and matching them would deny on the fixed names themselves.
 fn contains_blocked_word(value: &Value, words: &[String]) -> bool {
     match value {
         Value::String(text) => words.iter().any(|word| text.contains(word)),

--- a/core/src/custom_permissions/content_filter.rs
+++ b/core/src/custom_permissions/content_filter.rs
@@ -48,6 +48,17 @@ impl CustomPermission for ContentFilter {
         }
     }
 
+    fn can_sign_creator_binding(&self, payload: &[u8]) -> bool {
+        let Ok(payload) = std::str::from_utf8(payload) else {
+            return false;
+        };
+
+        match &self.config.blocked_words {
+            None => true,
+            Some(words) => !words.iter().any(|word| payload.contains(word)),
+        }
+    }
+
     fn can_encrypt(
         &self,
         plaintext: &str,

--- a/core/src/custom_permissions/content_filter.rs
+++ b/core/src/custom_permissions/content_filter.rs
@@ -6,6 +6,18 @@ use crate::{
 use async_trait::async_trait;
 use nostr_sdk::{PublicKey, UnsignedEvent};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Returns true if any string value reachable from `value` contains a blocked
+/// word. Object keys are skipped so only creator-supplied content is matched.
+fn contains_blocked_word(value: &Value, words: &[String]) -> bool {
+    match value {
+        Value::String(text) => words.iter().any(|word| text.contains(word)),
+        Value::Array(items) => items.iter().any(|item| contains_blocked_word(item, words)),
+        Value::Object(map) => map.values().any(|item| contains_blocked_word(item, words)),
+        _ => false,
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ContentFilterConfig {
@@ -49,14 +61,27 @@ impl CustomPermission for ContentFilter {
     }
 
     fn can_sign_creator_binding(&self, payload: &[u8]) -> bool {
-        let Ok(payload) = std::str::from_utf8(payload) else {
+        let Some(words) = &self.config.blocked_words else {
+            return true;
+        };
+
+        // Only the creator-supplied `claims` values are content. Matching the
+        // whole serialized payload would also match the fixed structural key
+        // names (`referenced_assertions`, `hard_binding`, `sig_alg`) and the
+        // hex characters of the hard-binding digest, so a blocklist holding a
+        // short word such as "ass", "sig", or "bad" would silently deny every
+        // creator-binding request instead of filtering creator content.
+        let Ok(text) = std::str::from_utf8(payload) else {
+            return false;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(text) else {
+            return false;
+        };
+        let Some(claims) = value.get("claims") else {
             return false;
         };
 
-        match &self.config.blocked_words {
-            None => true,
-            Some(words) => !words.iter().any(|word| payload.contains(word)),
-        }
+        !contains_blocked_word(claims, words)
     }
 
     fn can_encrypt(
@@ -106,4 +131,93 @@ impl CustomPermission for ContentFilter {
 fn test_default() {
     let config = ContentFilterConfig::default();
     assert!(config.blocked_words.is_none());
+}
+
+#[cfg(test)]
+mod creator_binding_tests {
+    use super::*;
+    use crate::types::permission::{JsonConfig, Permission};
+    use chrono::Utc;
+
+    fn filter(blocked_words: &[&str]) -> Box<dyn CustomPermission> {
+        let now = Utc::now();
+        Permission {
+            id: 1,
+            identifier: "content_filter".to_string(),
+            config: JsonConfig(serde_json::json!({ "blocked_words": blocked_words })),
+            created_at: now,
+            updated_at: now,
+        }
+        .to_custom_permission()
+        .expect("content_filter test permission")
+    }
+
+    /// Mirrors the payload divine-mobile builds in
+    /// `NostrCreatorBindingService.createAssertion`.
+    fn payload(nip05: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "version": 1,
+            "pubkey": "0".repeat(64),
+            "sig_alg": "nostr.secp256k1",
+            "created_at": "2026-04-29T00:00:00Z",
+            "claims": { "nip05": nip05 },
+            "referenced_assertions": ["c2pa.actions.v2", "cawg.training-mining"],
+            "hard_binding": {
+                "alg": "sha256",
+                "value": "badc0ffee0ddf00d39463a825d82c6c98981881283fb7ed039341a12a2f77007"
+            }
+        }))
+        .expect("valid creator binding")
+    }
+
+    #[test]
+    fn blocked_word_in_structural_key_does_not_deny() {
+        // "ass" occurs in `referenced_assertions`; it is not creator content.
+        assert!(filter(&["ass"]).can_sign_creator_binding(&payload("creator@example.com")));
+    }
+
+    #[test]
+    fn blocked_word_in_hard_binding_digest_does_not_deny() {
+        // "bad" and "c0ffee" are valid hex and appear in the digest above.
+        assert!(filter(&["bad"]).can_sign_creator_binding(&payload("creator@example.com")));
+    }
+
+    #[test]
+    fn blocked_word_in_claim_value_denies() {
+        assert!(!filter(&["blocked"]).can_sign_creator_binding(&payload("blocked@example.com")));
+    }
+
+    #[test]
+    fn nested_claim_value_is_filtered() {
+        let value = serde_json::json!({
+            "version": 1,
+            "claims": {
+                "social_handles": [{"platform": "x", "handle": "blockedhandle"}]
+            }
+        });
+        let bytes = serde_json::to_vec(&value).expect("valid JSON");
+
+        assert!(!filter(&["blockedhandle"]).can_sign_creator_binding(&bytes));
+    }
+
+    #[test]
+    fn no_blocked_words_allows() {
+        let now = Utc::now();
+        let permission = Permission {
+            id: 1,
+            identifier: "content_filter".to_string(),
+            config: JsonConfig(serde_json::json!({})),
+            created_at: now,
+            updated_at: now,
+        }
+        .to_custom_permission()
+        .expect("content_filter test permission");
+
+        assert!(permission.can_sign_creator_binding(&payload("creator@example.com")));
+    }
+
+    #[test]
+    fn non_utf8_payload_denies() {
+        assert!(!filter(&["blocked"]).can_sign_creator_binding(&[0xff, 0xfe, 0xfd]));
+    }
 }

--- a/core/src/custom_permissions/content_filter.rs
+++ b/core/src/custom_permissions/content_filter.rs
@@ -65,12 +65,15 @@ impl CustomPermission for ContentFilter {
             return true;
         };
 
-        // Only the creator-supplied `claims` values are content. Matching the
-        // whole serialized payload would also match the fixed structural key
-        // names (`referenced_assertions`, `hard_binding`, `sig_alg`) and the
-        // hex characters of the hard-binding digest, so a blocklist holding a
-        // short word such as "ass", "sig", or "bad" would silently deny every
-        // creator-binding request instead of filtering creator content.
+        // Scan every caller-controlled free-text surface, and only those.
+        //
+        // Matching the whole serialized payload instead would also match the
+        // fixed structural key names and the pinned values: `sig_alg` contains
+        // "sig", and `pubkey` plus `hard_binding.value` are hex, so a blocklist
+        // holding "sig", "bad", "dead" or "cafe" would silently deny every
+        // creator-binding request rather than filtering creator content.
+        // `version`, `pubkey`, `sig_alg` and `hard_binding` are pinned by
+        // `validate_creator_binding_payload`, so they carry no caller text.
         let Ok(text) = std::str::from_utf8(payload) else {
             return false;
         };
@@ -81,7 +84,17 @@ impl CustomPermission for ContentFilter {
             return false;
         };
 
-        !contains_blocked_word(claims, words)
+        let free_text = [
+            Some(claims),
+            value.get("created_at"),
+            value.get("referenced_assertions"),
+        ];
+        let blocked = free_text
+            .into_iter()
+            .flatten()
+            .any(|field| contains_blocked_word(field, words));
+
+        !blocked
     }
 
     fn can_encrypt(
@@ -180,6 +193,54 @@ mod creator_binding_tests {
     fn blocked_word_in_hard_binding_digest_does_not_deny() {
         // "bad" and "c0ffee" are valid hex and appear in the digest above.
         assert!(filter(&["bad"]).can_sign_creator_binding(&payload("creator@example.com")));
+    }
+
+    /// The residual-bypass proof of concept: before this was fixed, blocked text
+    /// parked in `created_at` or `referenced_assertions` passed the policy layer
+    /// and got signed with the user's key.
+    #[test]
+    fn blocked_word_in_created_at_denies() {
+        let value = serde_json::json!({
+            "version": 1,
+            "created_at": "scam: arbitrary caller-controlled text",
+            "claims": {},
+            "referenced_assertions": [],
+        });
+        let bytes = serde_json::to_vec(&value).expect("valid JSON");
+
+        assert!(!filter(&["scam"]).can_sign_creator_binding(&bytes));
+    }
+
+    #[test]
+    fn blocked_word_in_referenced_assertions_denies() {
+        let value = serde_json::json!({
+            "version": 1,
+            "created_at": "2026-04-29T00:00:00Z",
+            "claims": {},
+            "referenced_assertions": ["scam: more caller-controlled text"],
+        });
+        let bytes = serde_json::to_vec(&value).expect("valid JSON");
+
+        assert!(!filter(&["scam"]).can_sign_creator_binding(&bytes));
+    }
+
+    #[test]
+    fn blocked_word_in_pinned_pubkey_hex_does_not_deny() {
+        // `pubkey` is a 64-char hex string pinned to the signer, so hex-shaped
+        // blocklist words must not deny. Regression guard against widening the
+        // scan back to the whole document.
+        let value = serde_json::json!({
+            "version": 1,
+            "pubkey": "deadbeef".repeat(8),
+            "sig_alg": "nostr.secp256k1",
+            "created_at": "2026-04-29T00:00:00Z",
+            "claims": {},
+            "referenced_assertions": [],
+        });
+        let bytes = serde_json::to_vec(&value).expect("valid JSON");
+
+        assert!(filter(&["dead"]).can_sign_creator_binding(&bytes));
+        assert!(filter(&["sig"]).can_sign_creator_binding(&bytes));
     }
 
     #[test]

--- a/core/src/custom_permissions/decrypt_only.rs
+++ b/core/src/custom_permissions/decrypt_only.rs
@@ -41,6 +41,10 @@ impl CustomPermission for DecryptOnly {
         kind == NIP42_AUTH_KIND
     }
 
+    fn can_sign_creator_binding(&self, _payload: &[u8]) -> bool {
+        false
+    }
+
     fn can_encrypt(
         &self,
         _plaintext: &str,

--- a/core/src/custom_permissions/encrypt_to_self.rs
+++ b/core/src/custom_permissions/encrypt_to_self.rs
@@ -29,6 +29,10 @@ impl CustomPermission for EncryptToSelf {
         true
     }
 
+    fn can_sign_creator_binding(&self, _payload: &[u8]) -> bool {
+        true
+    }
+
     fn can_encrypt(
         &self,
         _plaintext: &str,

--- a/core/src/custom_permissions/full_access.rs
+++ b/core/src/custom_permissions/full_access.rs
@@ -25,6 +25,10 @@ impl CustomPermission for FullAccess {
         true
     }
 
+    fn can_sign_creator_binding(&self, _payload: &[u8]) -> bool {
+        true
+    }
+
     fn can_encrypt(
         &self,
         _plaintext: &str,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod ap_signing;
 pub mod authorization_channel;
 pub mod bunker_key;
+pub mod creator_binding;
 pub mod custom_permissions;
 pub mod database;
 pub mod encryption;

--- a/core/src/signing_session.rs
+++ b/core/src/signing_session.rs
@@ -3,8 +3,10 @@
 // ABOUTME: All CPU-bound crypto runs on spawn_blocking to avoid blocking async runtime
 
 use nostr_sdk::nips::nip44;
+use nostr_sdk::secp256k1::{Message, SECP256K1};
 use nostr_sdk::{Event, Keys, PublicKey, UnsignedEvent};
 use secrecy::SecretString;
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tokio::task::JoinError;
 
@@ -58,7 +60,7 @@ pub enum SessionError {
 }
 
 /// Pure crypto signing session wrapping Nostr Keys.
-/// Provides sign_event, nip44_encrypt, and nip44_decrypt operations.
+/// Provides sign_event, sign_canonical, nip44_encrypt, and nip44_decrypt operations.
 ///
 /// This is a building block used by HttpRpcHandler and Nip46Handler.
 /// All authorization metadata (expiration, permissions, cache keys) lives
@@ -107,6 +109,26 @@ impl SigningSession {
         })
         .await?
         .map_err(|e| SessionError::Signing(e.to_string()))
+    }
+
+    /// Sign SHA-256(payload) with deterministic BIP-340 Schnorr.
+    ///
+    /// Creator-binding signatures must match local signers byte-for-byte across
+    /// implementations, so the BIP-340 auxiliary random input is pinned to 32
+    /// zero bytes. Do not use `Keys::sign_schnorr`; it intentionally uses OS
+    /// randomness for aux data.
+    pub async fn sign_canonical(&self, payload: Vec<u8>) -> Result<String, SessionError> {
+        let keys = self.keys.clone();
+
+        tokio::task::spawn_blocking(move || {
+            let digest = Sha256::digest(&payload);
+            let message = Message::from_digest_slice(&digest)
+                .map_err(|e| SessionError::Signing(e.to_string()))?;
+            let keypair = keys.key_pair(SECP256K1);
+            let signature = SECP256K1.sign_schnorr_with_aux_rand(&message, keypair, &[0u8; 32]);
+            Ok(hex::encode(signature.as_ref()))
+        })
+        .await?
     }
 
     /// Encrypt plaintext using NIP-44 (CPU-bound crypto runs on spawn_blocking)
@@ -183,7 +205,9 @@ mod tests {
     // canonicalizes the pubkey field to `self.keys.public_key()` to keep the
     // bunker as the source of truth (NIP-46 semantics).
 
+    use nostr_sdk::secp256k1::{schnorr::Signature, XOnlyPublicKey};
     use nostr_sdk::{EventBuilder, JsonUtil, Kind, Tag, Timestamp, UnsignedEvent};
+    use std::str::FromStr;
 
     #[tokio::test]
     async fn sign_event_passthrough_when_pubkey_matches() {
@@ -201,6 +225,48 @@ mod tests {
         signed
             .verify()
             .expect("signature must verify against signer's pubkey");
+    }
+
+    #[tokio::test]
+    async fn sign_canonical_matches_cross_implementation_vector() {
+        let keys = Keys::parse("5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12")
+            .expect("valid secret key");
+        let session = SigningSession::new(keys);
+
+        let sig = session
+            .sign_canonical(b"divine-creator-binding-test".to_vec())
+            .await
+            .expect("canonical signing should succeed");
+
+        assert_eq!(
+            sig,
+            "9baed2647e5f9d059b68eb03c6e3e6dcdf53cbe94fb143af70fb6e7332ee9997cc7ba5ac9cdb9049a0e47c8c20e2031843e88c59dcba3c3ff8fc34eeae4a565f"
+        );
+    }
+
+    #[tokio::test]
+    async fn sign_canonical_is_deterministic_and_verifies() {
+        let keys = Keys::generate();
+        let session = SigningSession::new(keys.clone());
+        let payload = br#"{"version":1}"#.to_vec();
+
+        let first = session
+            .sign_canonical(payload.clone())
+            .await
+            .expect("canonical signing should succeed");
+        let second = session
+            .sign_canonical(payload.clone())
+            .await
+            .expect("canonical signing should succeed");
+        assert_eq!(first, second);
+
+        let digest = Sha256::digest(&payload);
+        let message = Message::from_digest_slice(&digest).expect("sha256 digest is 32 bytes");
+        let signature = Signature::from_str(&first).expect("valid schnorr signature");
+        let public_key: XOnlyPublicKey = keys.public_key().xonly().expect("x-only public key");
+        SECP256K1
+            .verify_schnorr(&signature, &message, &public_key)
+            .expect("canonical signature should verify");
     }
 
     #[tokio::test]

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -42,6 +42,11 @@ pub trait CustomPermission: Send + Sync {
     /// This is intentionally separate from [`Self::can_sign`] because the
     /// payload is not a Nostr event and has no event kind. Implementations should
     /// map this to their nearest signing restriction.
+    ///
+    /// Callers must validate the payload with
+    /// `validate_creator_binding_payload` before invoking this hook. Permission
+    /// implementations may rely on that closed, validated shape when deciding
+    /// which fields are caller-controlled content.
     fn can_sign_creator_binding(&self, payload: &[u8]) -> bool;
 
     /// A function that returns true if allowed to encrypt the content for the recipient.

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -37,6 +37,13 @@ pub trait CustomPermission: Send + Sync {
     /// A function that returns true if allowed to sign the event.
     fn can_sign(&self, event: &UnsignedEvent) -> bool;
 
+    /// A function that returns true if allowed to sign a creator-binding payload.
+    ///
+    /// This is intentionally separate from [`Self::can_sign`] because the
+    /// payload is not a Nostr event and has no event kind. Implementations should
+    /// map this to their nearest signing restriction.
+    fn can_sign_creator_binding(&self, payload: &[u8]) -> bool;
+
     /// A function that returns true if allowed to encrypt the content for the recipient.
     /// Sender is the pubkey of the user requesting the encryption
     fn can_encrypt(

--- a/docs/keycast-admin-api-reference.md
+++ b/docs/keycast-admin-api-reference.md
@@ -208,6 +208,27 @@ Get the user's public key.
 }
 ```
 
+#### sign_canonical
+
+Sign a base64-encoded C2PA creator-binding payload. The payload must be a
+creator-binding JSON object for the signing pubkey. Authorizations must permit
+profile/identity signing.
+
+**Request:**
+```json
+{
+  "method": "sign_canonical",
+  "params": ["<base64 creator-binding JSON bytes>"]
+}
+```
+
+**Response:**
+```json
+{
+  "result": "9baed2647e5f9d059b68eb03c6e3e6dcdf53cbe94fb143af70fb6e7332ee9997cc7ba5ac9cdb9049a0e47c8c20e2031843e88c59dcba3c3ff8fc34eeae4a565f"
+}
+```
+
 #### nip44_encrypt
 
 Encrypt a message using NIP-44.

--- a/web/src/routes/admin/+page.svelte
+++ b/web/src/routes/admin/+page.svelte
@@ -472,6 +472,7 @@
 							<tbody>
 								<tr><td><code>get_public_key</code></td><td>Returns the user's hex pubkey</td></tr>
 								<tr><td><code>sign_event</code></td><td>Signs an unsigned event</td></tr>
+								<tr><td><code>sign_canonical</code></td><td>Signs a creator-binding payload</td></tr>
 								<tr><td><code>nip04_encrypt</code></td><td>Encrypts using NIP-04</td></tr>
 								<tr><td><code>nip04_decrypt</code></td><td>Decrypts using NIP-04</td></tr>
 								<tr><td><code>nip44_encrypt</code></td><td>Encrypts using NIP-44</td></tr>


### PR DESCRIPTION
## Summary

- Add `sign_canonical` to `POST /api/nostr` for base64-encoded C2PA creator-binding payloads.
- Sign `SHA-256(payload)` with deterministic BIP-340 Schnorr using all-zero aux data and return lowercase hex.
- Gate canonical signing through creator-binding payload validation plus cached custom permissions.
- Map creator-binding permission to profile/identity signing: full access and kind `0` policies allow it; read-only and non-profile kind policies deny it.
- Update docs/admin method lists and add focused unit/integration coverage.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- OAuth-signed-in creators need Keycast to produce the same deterministic creator-binding signatures as local-key mobile users.
- The new method must not become a generic Nostr-key signing oracle, so the implementation validates the expected assertion domain and preserves policy restrictions before signing.

## Contract Notes

- `sign_canonical` is intentionally not a generic canonical signer. The HTTP method accepts only validated creator-binding JSON for the signing pubkey; arbitrary payload bytes, including the original issue test-vector payload, are rejected at the RPC layer.
- Issue #186's cross-implementation vector is still covered one layer down by `SigningSession::sign_canonical_matches_cross_implementation_vector`, which verifies the deterministic BIP-340 primitive directly.
- Creator-binding signing is treated as a profile/identity signing capability for policy purposes: full access and kind `0` policies allow it; read-only and non-profile kind policies deny it.
- Liz ratifies the branch changes pushed by dcadenas on this author-owned PR, including the security-sensitive validator and permission-boundary tightening.

## Related Issue

- Closes #186
- Follow-up: #353 tracks the pre-existing flaky PKCE logging test.

## Testing

- [ ] `cargo test --workspace --verbose`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p keycast_core --lib`
- [x] `cargo test -p keycast_api --lib`
- [x] `cargo test -p keycast_api --features integration-tests --test nostr_rpc_integration_test`
- [x] `cargo nextest run --workspace`
- [x] `cd web && bun run check`
- [ ] Manual verification completed

Notes:

- CI passed on head `db7e6b1`, including the `test` job and all five `sign_canonical` integration cases.
- Cleanup verification on `db7e6b1`: `cargo fmt --all -- --check` and `cargo test -p keycast_core --lib`.
- dcadenas separately reported `cargo nextest run --workspace` with 549 passed / 16 skipped, and `cargo test -p keycast_api --features integration-tests --test nostr_rpc_integration_test` with 23 passed.
- `cargo test --workspace --verbose` remains unchecked because the PR was validated with the narrower CI-equivalent integration target plus nextest.
- A pre-existing flaky PKCE logging unit test is tracked separately in #353 and is unrelated to this creator-binding change.

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

No screenshot attached; the web change is a one-line static addition to the admin supported-methods table and has no runtime UI path.
