### PR TITLE
fix(core): shorten database acquire timeout

### DIFF
--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -1802,9 +1802,19 @@ async fn warm_status_check_pool_exhaustion_is_retryable_503() {
     .await
     .expect_err("saturated status-check acquire should fail as unavailable");
 
+    let elapsed = started.elapsed();
     assert!(
-        started.elapsed() < HTTP_RPC_HANDLER_TIMEOUT,
-        "pool acquire must fail before the handler timeout fires"
+        elapsed < HTTP_RPC_HANDLER_TIMEOUT,
+        "pool acquire must fail before the handler timeout fires, took {elapsed:?}"
+    );
+    // Without a lower bound this passes for any acquire timeout under 8s, and
+    // also for a 503 raised instantly by some unrelated failure -- neither of
+    // which is what this test claims to cover. Waiting the full acquire budget
+    // is what identifies the pool timeout as the thing that fired.
+    assert!(
+        elapsed >= SQLX_ACQUIRE_TIMEOUT,
+        "saturated acquire should have waited the full {SQLX_ACQUIRE_TIMEOUT:?} \
+         acquire budget, but failed after {elapsed:?}"
     );
     let response = err.into_response();
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);

--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -5,7 +5,12 @@
 
 mod common;
 
-use axum::{extract::State, http::HeaderMap, Json};
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    Json,
+};
 use base64::{
     engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
     Engine as _,
@@ -26,6 +31,7 @@ use keycast_api::state::KeycastState;
 use keycast_api::ucan_auth::{nostr_pubkey_to_did, NostrKeyMaterial};
 use keycast_core::encryption::file_key_manager::FileKeyManager;
 use keycast_core::encryption::KeyManager;
+use keycast_core::request_bounds::{HTTP_RPC_HANDLER_TIMEOUT, SQLX_ACQUIRE_TIMEOUT};
 use keycast_core::secret_pool::SecretPool;
 use keycast_core::signing_session::{parse_cache_key, SigningSession};
 use moka::future::Cache;
@@ -35,8 +41,9 @@ use p256::ecdsa::{Signature as P256Signature, SigningKey};
 use rand::rngs::OsRng;
 use serde_json::{json, Value};
 use serial_test::serial;
-use sqlx::PgPool;
+use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::sync::Arc;
+use std::time::Instant;
 use ucan::builder::UcanBuilder;
 use uuid::Uuid;
 
@@ -47,34 +54,55 @@ use uuid::Uuid;
 async fn setup_db() -> PgPool {
     common::assert_test_database_url();
 
-    let database_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
-
-    let pool = PgPool::connect(&database_url)
+    let pool = PgPool::connect(&test_database_url())
         .await
         .expect("Failed to connect to database");
 
+    prepare_test_db(&pool).await;
+    pool
+}
+
+async fn setup_single_connection_db() -> PgPool {
+    common::assert_test_database_url();
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .acquire_timeout(SQLX_ACQUIRE_TIMEOUT)
+        .connect(&test_database_url())
+        .await
+        .expect("Failed to connect single-connection database pool");
+
+    prepare_test_db(&pool).await;
+    pool
+}
+
+fn test_database_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string())
+}
+
+async fn prepare_test_db(pool: &PgPool) {
     // Run migrations
     sqlx::migrate!("../database/migrations")
-        .run(&pool)
+        .run(pool)
         .await
         .expect("Failed to run migrations");
 
     // Clean up test data from previous runs (preserve tenant ID 1 which is seeded)
     sqlx::query("DELETE FROM oauth_authorizations WHERE tenant_id > 1")
-        .execute(&pool)
+        .execute(pool)
         .await
         .ok();
     sqlx::query("DELETE FROM personal_keys WHERE tenant_id > 1")
-        .execute(&pool)
+        .execute(pool)
         .await
         .ok();
     sqlx::query("DELETE FROM users WHERE tenant_id > 1")
-        .execute(&pool)
+        .execute(pool)
         .await
         .ok();
     sqlx::query("DELETE FROM tenants WHERE id > 1")
-        .execute(&pool)
+        .execute(pool)
         .await
         .ok();
 
@@ -82,11 +110,9 @@ async fn setup_db() -> PgPool {
     sqlx::query(
         "SELECT setval('tenants_id_seq', (SELECT COALESCE(MAX(id), 1) FROM tenants), true)",
     )
-    .execute(&pool)
+    .execute(pool)
     .await
     .ok();
-
-    pool
 }
 
 async fn create_test_tenant(pool: &PgPool) -> i64 {
@@ -1706,6 +1732,82 @@ async fn test_suspended_user_denied_nostr_rpc_sign() {
         }
         other => panic!("expected AccountSuspended, got: {:?}", other),
     }
+}
+
+/// Test: a saturated DB pool returns retryable 503 before the handler timeout.
+#[tokio::test]
+#[serial]
+async fn warm_status_check_pool_exhaustion_is_retryable_503() {
+    let pool = setup_single_connection_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (user_keys, pubkey) = create_test_user();
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(&pool, tenant_id, &pubkey, &user_keys, &key_manager).await;
+
+    let redirect_origin = format!("https://pool-saturated-{}.example.com", Uuid::new_v4());
+    let (_auth_id, bunker_pubkey) = create_test_oauth_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        None,
+        None,
+        None,
+    )
+    .await;
+    let token = build_self_signed_ucan(
+        &user_keys,
+        tenant_id,
+        &redirect_origin,
+        Some(&bunker_pubkey),
+    )
+    .await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+    let auth_header = format!("Bearer {}", token);
+
+    invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state.clone(),
+        &auth_header,
+        None,
+        get_public_key_request(),
+    )
+    .await
+    .expect("warm-up request should load the handler into cache");
+
+    let _held_connection = pool
+        .acquire()
+        .await
+        .expect("single connection should be available before the RPC starts");
+
+    let unsigned = EventBuilder::text_note("pool saturated").build(user_keys.public_key());
+    let event_json = serde_json::to_value(&unsigned).expect("Failed to serialize unsigned event");
+    let started = Instant::now();
+
+    let err = invoke_nostr_rpc(
+        create_test_tenant_extractor(tenant_id),
+        auth_state,
+        &auth_header,
+        None,
+        NostrRpcRequest {
+            method: "sign_event".to_string(),
+            params: vec![event_json],
+        },
+    )
+    .await
+    .expect_err("saturated status-check acquire should fail as unavailable");
+
+    assert!(
+        started.elapsed() < HTTP_RPC_HANDLER_TIMEOUT,
+        "pool acquire must fail before the handler timeout fires"
+    );
+    let response = err.into_response();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 }
 
 /// Test: suspended user can still call get_public_key via nostr_rpc

--- a/core/src/database.rs
+++ b/core/src/database.rs
@@ -11,7 +11,6 @@ use tokio::time::sleep;
 // Example: 100 instances × 10 connections = 1000 client connections → 200 backend connections
 // Override with SQLX_POOL_SIZE env var (higher = better throughput per instance)
 const DEFAULT_MAX_CONNECTIONS_PER_INSTANCE: u32 = 10;
-const ACQUIRE_TIMEOUT_SECS: u64 = 60;
 const MAX_CONNECTION_ATTEMPTS: u32 = 5;
 
 #[derive(Error, Debug)]
@@ -65,7 +64,10 @@ impl Database {
                 "disabled".to_string()
             }
         );
-        eprintln!("   Acquire timeout: {}s", ACQUIRE_TIMEOUT_SECS);
+        eprintln!(
+            "   Acquire timeout: {}s",
+            crate::request_bounds::SQLX_ACQUIRE_TIMEOUT.as_secs()
+        );
         eprintln!("   ⚠️  If PoolTimedOut errors occur, check:");
         eprintln!("      - Cloud SQL max_connections (db-f1-micro ≈ 25)");
         eprintln!(
@@ -76,7 +78,7 @@ impl Database {
 
         // Main pool options - may go through connection pooler
         let pool_options = PgPoolOptions::new()
-            .acquire_timeout(Duration::from_secs(ACQUIRE_TIMEOUT_SECS))
+            .acquire_timeout(crate::request_bounds::SQLX_ACQUIRE_TIMEOUT)
             .max_connections(max_connections);
 
         // Statement cache size - configurable for PgBouncer with max_prepared_statements

--- a/core/src/database.rs
+++ b/core/src/database.rs
@@ -65,8 +65,8 @@ impl Database {
             }
         );
         eprintln!(
-            "   Acquire timeout: {}s",
-            crate::request_bounds::SQLX_ACQUIRE_TIMEOUT.as_secs()
+            "   Acquire timeout: {:?}",
+            crate::request_bounds::SQLX_ACQUIRE_TIMEOUT
         );
         eprintln!("   ⚠️  If PoolTimedOut errors occur, check:");
         eprintln!("      - Cloud SQL max_connections (db-f1-micro ≈ 25)");

--- a/core/src/encryption/gcp_key_manager.rs
+++ b/core/src/encryption/gcp_key_manager.rs
@@ -32,7 +32,10 @@ const KMS_BASE_DELAY_MS: u64 = 100;
 ///
 /// 6.3s reserves the KMS loop alone. A cold handler load does its database work
 /// before it reaches `decrypt`, so more than ~1.7s of database latency ahead of
-/// this still cancels the request mid-loop.
+/// this still cancels the request mid-loop, and the cold path does up to three
+/// pool queries before it gets here. That reservation is real but unenforced: see
+/// [`crate::request_bounds::SQLX_ACQUIRE_TIMEOUT`] for why the per-step budgets
+/// on this path cannot be summed into a guarantee, and what would close it.
 const KMS_ATTEMPT_TIMEOUT_SECS: u64 = 2;
 
 /// Worst-case wall clock for a full [`MAX_KMS_RETRIES`] loop, asserted below so

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -1862,26 +1862,31 @@ mod tests {
                 .await
         });
 
-        // Wait until PostgreSQL confirms materialization is blocked on the users row. At this
-        // point its transaction already owns the pending-row FOR UPDATE lock.
+        // Wait until this materializer owns this pending row's FOR UPDATE lock. A pg_stat_activity
+        // query-pattern probe is too broad when the integration suite runs other materialization
+        // tests concurrently; NOWAIT against this row proves the lock we care about is held.
         let wait_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
         loop {
-            let waiting: bool = sqlx::query_scalar(
-                "SELECT EXISTS (
-                    SELECT 1 FROM pg_stat_activity activity
-                    WHERE cardinality(pg_blocking_pids(activity.pid)) > 0
-                      AND activity.query LIKE '%SELECT u.email, u.email_verified%'
-                )",
+            let row_lock = sqlx::query(
+                "SELECT 1 FROM oauth_codes
+                 WHERE tenant_id = $1 AND pending_email_verification_token = $2
+                   AND pending_email IS NOT NULL
+                 FOR UPDATE NOWAIT",
             )
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-            if waiting {
+            .bind(1_i64)
+            .bind(&token)
+            .fetch_optional(&pool)
+            .await;
+            if matches!(
+                row_lock,
+                Err(sqlx::Error::Database(ref error)) if error.code().as_deref() == Some("55P03")
+            ) {
                 break;
             }
+            row_lock.unwrap();
             assert!(
                 tokio::time::Instant::now() < wait_deadline,
-                "materialization did not reach the users-row lock"
+                "materialization did not lock the pending row"
             );
             sleep(Duration::from_millis(10)).await;
         }

--- a/core/src/request_bounds.rs
+++ b/core/src/request_bounds.rs
@@ -68,17 +68,3 @@ const _: () = assert!(
     SQLX_ACQUIRE_TIMEOUT.as_nanos() < HTTP_RPC_HANDLER_TIMEOUT.as_nanos(),
     "SQLx acquire timeout must fit inside the HTTP RPC handler bound"
 );
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn sqlx_acquire_timeout_fits_inside_http_rpc_request_bound() {
-        assert!(
-            SQLX_ACQUIRE_TIMEOUT < HTTP_RPC_HANDLER_TIMEOUT,
-            "{SQLX_ACQUIRE_TIMEOUT:?} SQLx acquire timeout must fit inside \
-             {HTTP_RPC_HANDLER_TIMEOUT:?} HTTP RPC handler bound"
-        );
-    }
-}

--- a/core/src/request_bounds.rs
+++ b/core/src/request_bounds.rs
@@ -11,3 +11,28 @@ use std::time::Duration;
 /// so `core` can assert those budgets against it — a bound the code below it
 /// cannot see is a bound nothing can hold it to.
 pub const HTTP_RPC_HANDLER_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// Maximum wait for an SQLx pool connection.
+///
+/// This must stay below [`HTTP_RPC_HANDLER_TIMEOUT`] so pool saturation can
+/// surface as a retryable 503 before the HTTP RPC handler's 504 backstop fires.
+pub const SQLX_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(3);
+
+const _: () = assert!(
+    SQLX_ACQUIRE_TIMEOUT.as_secs() < HTTP_RPC_HANDLER_TIMEOUT.as_secs(),
+    "SQLx acquire timeout must fit inside the HTTP RPC handler bound"
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sqlx_acquire_timeout_fits_inside_http_rpc_request_bound() {
+        assert!(
+            SQLX_ACQUIRE_TIMEOUT < HTTP_RPC_HANDLER_TIMEOUT,
+            "{SQLX_ACQUIRE_TIMEOUT:?} SQLx acquire timeout must fit inside \
+             {HTTP_RPC_HANDLER_TIMEOUT:?} HTTP RPC handler bound"
+        );
+    }
+}

--- a/core/src/request_bounds.rs
+++ b/core/src/request_bounds.rs
@@ -16,10 +16,56 @@ pub const HTTP_RPC_HANDLER_TIMEOUT: Duration = Duration::from_secs(8);
 ///
 /// This must stay below [`HTTP_RPC_HANDLER_TIMEOUT`] so pool saturation can
 /// surface as a retryable 503 before the HTTP RPC handler's 504 backstop fires.
-pub const SQLX_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(3);
+///
+/// 1.5s is sized for the warm mutating RPC, which is the path #291's evidence
+/// is actually about: one acquire for the account-status check, no KMS, and the
+/// rest of the 8s left for the work. It governs saturation and first-connection
+/// establishment; a settled pool acquires in well under a millisecond.
+///
+/// Read this as a per-step bound and nothing more. Per-step timeouts do not
+/// compose into a path bound, and the cold handler load is the case that shows
+/// it: `load_handler_on_demand` runs up to three separate pool queries before it
+/// reaches `decrypt` (`api/src/api/http/nostr_rpc.rs`, via
+/// `OAuthAuthorizationRepository`, the conditional `PolicyRepository` and
+/// `PersonalKeysRepository`, each executing against its own `PgPool` clone),
+/// then the KMS retry loop reserves 6.3s (`KMS_TOTAL_BUDGET` in
+/// `core/src/encryption/gcp_key_manager.rs`), then the account-status check
+/// acquires once more. Stacked worst case is 4 x 1.5s + 6.3s, well past this
+/// ceiling. Shrinking this constant until that arithmetic closes would put it
+/// near 400ms, trading real warm-path headroom to bound a case the deadline
+/// already covers, so the stack is left unclosed deliberately.
+///
+/// What the value is doing between those two extremes is keeping the cold path
+/// *reachable*: at 3s the pre-KMS acquires alone can spend 9s and burn the whole
+/// deadline before the request ever reaches KMS, while at 1.5s that worst case
+/// is 4.5s and a request under contention can still get into the loop and
+/// complete a normal KMS call. That is a claim about which value is less bad on
+/// a path already known to be unbounded, not a claim that the stack fits.
+///
+/// So [`HTTP_RPC_HANDLER_TIMEOUT`] is the only real bound on the cold path, and
+/// it does its job: the request is cancelled and answered as a 504 rather than
+/// running unbounded. Closing the gap honestly means either fewer acquires
+/// ahead of KMS or a deadline threaded through the path so each step waits only
+/// the remaining budget. Issue #356 tracks the pool, acquire and operation
+/// metrics that should size that work from production rather than from
+/// worst-case arithmetic.
+///
+/// This is the process-wide pool bound, not an HTTP-RPC-only one: the signer,
+/// OAuth, login and background work all draw from the same pool and all fail
+/// fast at this value. It also bounds connection *establishment*, not just
+/// queue wait -- sqlx uses it as the deadline covering TCP, TLS and auth
+/// (`pool/inner.rs` and `pool/options.rs` in sqlx 0.8.6), so the startup
+/// connect in `crate::database` gets it per attempt, behind that module's
+/// five-attempt backoff loop. `min_connections` is left at zero there, so a
+/// fresh instance also pays a handshake inside this budget as it grows the pool
+/// for the first time.
+pub const SQLX_ACQUIRE_TIMEOUT: Duration = Duration::from_millis(1_500);
 
+// `as_nanos` rather than `as_secs`: these budgets are tuned in milliseconds, and
+// a whole-second comparison silently rounds a violation away. `Duration`'s
+// `PartialOrd` is not const, so the comparison goes through the integer form.
 const _: () = assert!(
-    SQLX_ACQUIRE_TIMEOUT.as_secs() < HTTP_RPC_HANDLER_TIMEOUT.as_secs(),
+    SQLX_ACQUIRE_TIMEOUT.as_nanos() < HTTP_RPC_HANDLER_TIMEOUT.as_nanos(),
     "SQLx acquire timeout must fit inside the HTTP RPC handler bound"
 );
 

--- a/core/tests/pool_nesting_test.rs
+++ b/core/tests/pool_nesting_test.rs
@@ -10,15 +10,15 @@
 //! rather than merely detectable; if that ever lands, delete this file, because
 //! it would be testing something that cannot happen.
 //!
-//! Production runs `max_connections = 10` per instance with
-//! `ACQUIRE_TIMEOUT_SECS = 60` (`core/src/database.rs`). A code path that holds
+//! Production runs a bounded SQLx acquire timeout below the HTTP RPC handler
+//! timeout (`core/src/request_bounds.rs`). A code path that holds
 //! an open transaction while independently acquiring a second connection from
 //! the same pool needs TWO connections to serve ONE request. That does not fail
 //! in a quiet test suite -- it fails under concurrency, by stalling every
-//! stalled request for the full acquire timeout while it keeps holding its
-//! first connection. One exposed handler can starve login, OAuth and the
-//! signer. The shorter timeout caps how long each stall lasts; it does not stop
-//! the second connection from being demanded.
+//! stalled request for the acquire timeout while it keeps holding its first
+//! connection. One exposed handler can starve login, OAuth and the signer. The
+//! shorter timeout caps how long each stall lasts; it does not stop the second
+//! connection from being demanded.
 //!
 //! Concurrency tests cannot pin this down: whether they trip depends on burst
 //! size versus pool size, which makes them knife edges that pass for the wrong

--- a/core/tests/pool_nesting_test.rs
+++ b/core/tests/pool_nesting_test.rs
@@ -10,15 +10,16 @@
 //! rather than merely detectable; if that ever lands, delete this file, because
 //! it would be testing something that cannot happen.
 //!
-//! Production runs a bounded SQLx acquire timeout below the HTTP RPC handler
-//! timeout (`core/src/request_bounds.rs`). A code path that holds
-//! an open transaction while independently acquiring a second connection from
-//! the same pool needs TWO connections to serve ONE request. That does not fail
-//! in a quiet test suite -- it fails under concurrency, by stalling every
-//! stalled request for the acquire timeout while it keeps holding its first
-//! connection. One exposed handler can starve login, OAuth and the signer. The
-//! shorter timeout caps how long each stall lasts; it does not stop the second
-//! connection from being demanded.
+//! Production runs `max_connections = 10` per instance and a bounded SQLx
+//! acquire timeout below the HTTP RPC handler timeout
+//! (`core/src/request_bounds.rs`). A code path that holds an open transaction
+//! while independently acquiring a second connection from the same pool needs
+//! TWO connections to serve ONE request. That does not fail in a quiet test
+//! suite -- it fails under concurrency, by stalling every stalled request for
+//! the acquire timeout while it keeps holding its first connection. One exposed
+//! handler can starve login, OAuth and the signer. The shorter timeout caps how
+//! long each stall lasts; it does not stop the second connection from being
+//! demanded.
 //!
 //! Concurrency tests cannot pin this down: whether they trip depends on burst
 //! size versus pool size, which makes them knife edges that pass for the wrong
@@ -127,11 +128,10 @@ where
                  This is nested pool acquisition: the path holds a transaction (or another \
                  connection) while calling something that acquires its own connection from \
                  the same pool. In production that path needs two of the ten connections per \
-                 request and stalls for {stall}s under load, holding its first connection the \
+                 request and stalls for the acquire timeout under load, holding its first connection the \
                  whole time and starving every other endpoint on the instance.\n\n\
                  Fix: thread the open transaction into the inner call (`&mut *tx`) instead of \
                  letting it reach for the pool.",
-                stall = 5,
             );
         }
         Err(error) => panic!("{label} did not reach its expected success path: {error:?}"),

--- a/core/tests/pool_nesting_test.rs
+++ b/core/tests/pool_nesting_test.rs
@@ -10,7 +10,8 @@
 //! rather than merely detectable; if that ever lands, delete this file, because
 //! it would be testing something that cannot happen.
 //!
-//! Production runs `max_connections = 10` per instance and a bounded SQLx
+//! The application pool defaults to 10 connections per instance, while deployed
+//! environments can override that with `SQLX_POOL_SIZE`, and uses a bounded SQLx
 //! acquire timeout below the HTTP RPC handler timeout
 //! (`core/src/request_bounds.rs`). A code path that holds an open transaction
 //! while independently acquiring a second connection from the same pool needs
@@ -127,8 +128,8 @@ where
                  from a max_connections(1) pool (acquire timeout {PROBE_ACQUIRE_TIMEOUT:?}).\n\n\
                  This is nested pool acquisition: the path holds a transaction (or another \
                  connection) while calling something that acquires its own connection from \
-                 the same pool. In production that path needs two of the ten connections per \
-                 request and stalls for the acquire timeout under load, holding its first connection the \
+                 the same pool. In production that path needs two pool connections per request \
+                 and stalls for the acquire timeout under load, holding its first connection the \
                  whole time and starving every other endpoint on the instance.\n\n\
                  Fix: thread the open transaction into the inner call (`&mut *tx`) instead of \
                  letting it reach for the pool.",


### PR DESCRIPTION
## Summary

- Lowers the shared SQLx pool acquire timeout to 1.5s and wires the database pool to that shared request budget.
- Ratifies 1.5s as the author-approved value for #291's warm saturated-pool path: a mutating HTTP RPC cache hit has one account-status acquire, no KMS, and enough remaining room under the 8s HTTP RPC handler timeout.
- Adds warm HTTP RPC saturated-pool regression coverage for retryable 503 behavior, including a lower-bound assertion that proves the pool acquire budget fired.
- Updates pool-nesting narration to keep the production pool-size context while avoiding stale stall-duration prose.
- Hardens a pending-registration lock integration test so it probes this row's `FOR UPDATE` lock directly instead of matching unrelated concurrent materialization queries in `pg_stat_activity`.

## Motivation

- Make pool saturation fail fast as retryable 503 instead of waiting behind the 8s HTTP RPC timeout or the previous 60s SQLx acquire ceiling.
- Keep the request-budget invariant in code instead of relying on prose.
- Accept the process-wide impact deliberately: this is the shared pool acquire bound for login, OAuth, signer, HTTP RPC, and background work, and it also bounds first connection establishment during pool growth.
- Leave the cold-path budget stack intentionally unclosed in this PR. Four 1.5s acquires plus the 6.3s KMS retry reservation can still exceed the 8s handler deadline; closing that honestly belongs with fewer hot-path acquires (#355) or deadline/metrics work (#356).

## Related Issue

- Refs #291
- Related: #355, #356

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] `cargo clippy -p keycast_core --features integration-tests --lib --tests -- -D warnings -A deprecated`
- [x] `cargo test -p keycast_core request_bounds`
- [x] `cargo test -p keycast_core --features integration-tests --test pool_nesting_test probe_samples_8_of_21_hold_sites_a_green_run_is_not_a_clean_sweep -- --nocapture`
- [x] CI on pre-rebase PR head: `cargo test -p keycast_api --features integration-tests --lib --tests --verbose` passed in Build, Test & Push.
- [x] `cargo test -p keycast_api --features integration-tests --test nostr_rpc_integration_test warm_status_check_pool_exhaustion_is_retryable_503 -- --nocapture` passed locally against isolated PostgreSQL 16.
- [x] `cargo test -p keycast_core --features integration-tests materialization_lock -- --nocapture` passed locally against isolated PostgreSQL 16.
- [x] The current-head pre-push hook passed formatting, clippy, `cargo test --workspace`, and the release build.
- [x] Current-head PR CI passed Rust `test`, Web Tests, semantic PR, and CLA.
- [x] Manual verification completed: no runtime/manual UI path; code and tests only.

## Visuals

- [ ] UI/web change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
