### PR TITLE
fix(auth): keep expired resend-pin honest past reaper tick

### DIFF
--- a/api/src/api/http/headless.rs
+++ b/api/src/api/http/headless.rs
@@ -1121,6 +1121,11 @@ pub struct HeadlessResendPinRequest {
 pub struct HeadlessResendPinResponse {
     pub success: bool,
     pub message: String,
+    /// Stable machine-readable reason when `success` is false. Omitted on the uniform
+    /// anti-enumeration success path so presence of a code cannot leak registration existence.
+    /// Screaming-snake vocabulary matches `HeadlessError` codes (`REGISTRATION_EXPIRED`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
 }
 
 /// POST /api/headless/resend-pin
@@ -1141,10 +1146,12 @@ pub async fn headless_resend_pin(
     let tenant_id = tenant.0.id;
 
     // Uniform response regardless of outcome (anti-enumeration / no lockout signal).
+    // Never attach a `code` here: a code on this branch would leak whether a registration existed.
     let success = || {
         Json(HeadlessResendPinResponse {
             success: true,
             message: "If your registration is pending, a new code has been sent.".to_string(),
+            code: None,
         })
     };
 
@@ -1176,6 +1183,10 @@ pub async fn headless_resend_pin(
         return Ok(Json(HeadlessResendPinResponse {
             success: false,
             message: "This registration has expired. Please sign up again.".to_string(),
+            // Additive only: success stays false and the response stays HTTP 200 (keycast#268).
+            // Field name `code` matches HeadlessError; this route never returns an authorization
+            // grant code, so the overload is intentional (keycast#362).
+            code: Some("REGISTRATION_EXPIRED".to_string()),
         }));
     }
 
@@ -2321,10 +2332,14 @@ mod tests {
 
         let response = call_resend_pin(auth_state, &device_code).await;
         assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let body = response_json(response).await;
         assert_eq!(
-            response_json(response).await["success"],
-            false,
+            body["success"], false,
             "a resend that cannot possibly work must not claim it succeeded"
+        );
+        assert_eq!(
+            body["code"], "REGISTRATION_EXPIRED",
+            "expired resend must carry a stable machine-readable code"
         );
 
         let (new_hash,): (Option<String>,) =
@@ -2336,6 +2351,65 @@ mod tests {
         assert_eq!(
             new_hash, old_hash,
             "an expired registration must not be re-armed"
+        );
+
+        let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+            .bind(&device_code)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE pubkey = $1")
+            .bind(&pubkey)
+            .execute(&pool)
+            .await;
+    }
+
+    /// The reaper used to delete expired pending rows on the next cleanup tick, so resend-pin
+    /// fell through to the anti-enumeration uniform success once the row was gone (keycast#362).
+    /// Cleanup must leave a recently-expired row long enough for the honest expired answer.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    #[serial]
+    async fn test_resend_pin_expired_survives_cleanup_grace_and_reports_code() {
+        let auth_state = create_lazy_auth_state();
+        let pool = auth_state.state.db.clone();
+        let email = format!("resend-pin-grace-{}@example.com", uuid::Uuid::new_v4());
+        let (pubkey, device_code) = insert_pending_with_pin(&pool, &email, "123456").await;
+
+        // Within the 10-minute grace: past expires_at but not yet reaped.
+        sqlx::query("UPDATE oauth_codes SET expires_at = $2 WHERE device_code = $1")
+            .bind(&device_code)
+            .bind(Utc::now() - Duration::minutes(1))
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let oauth_code_repo = keycast_core::repositories::OAuthCodeRepository::new(pool.clone());
+        oauth_code_repo
+            .delete_expired_and_consumed()
+            .await
+            .expect("cleanup pass must succeed");
+
+        let still_present: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM oauth_codes WHERE device_code = $1)")
+                .bind(&device_code)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            still_present,
+            "a row expired within the grace window must survive cleanup"
+        );
+
+        let response = call_resend_pin(auth_state, &device_code).await;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(
+            body["success"], false,
+            "after cleanup within grace, resend must still report failure not uniform success"
+        );
+        assert_eq!(
+            body["code"], "REGISTRATION_EXPIRED",
+            "the stable code must remain available after a cleanup pass"
         );
 
         let _ = sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")

--- a/core/src/repositories/oauth_code.rs
+++ b/core/src/repositories/oauth_code.rs
@@ -1574,16 +1574,22 @@ impl OAuthCodeRepository {
         Ok(updated.rows_affected() == 1)
     }
 
-    /// Delete dead rows: anything past its expiry, plus consumed pending registrations (terminal
-    /// once their exchange code successfully issued tokens). Bounds table growth and enforces the pending row's
-    /// finite lifecycle (keycast#262). Returns the number of rows removed.
+    /// Delete dead rows: anything past expiry plus a grace interval, plus consumed pending
+    /// registrations (terminal once their exchange code successfully issued tokens).
+    ///
+    /// The grace window (10 minutes, matching the sibling users cleanup in `bcrypt_queue`) keeps
+    /// an expired pending registration reachable long enough for `resend-pin` to answer honestly
+    /// instead of falling through to the anti-enumeration uniform success after the reaper runs
+    /// (keycast#362). Bounds table growth and enforces the pending row's finite lifecycle
+    /// (keycast#262). Returns the number of rows removed.
     pub async fn delete_expired_and_consumed(&self) -> Result<u64, RepositoryError> {
         let result = sqlx::query(
             "DELETE FROM oauth_codes
              WHERE expires_at < $1
                 OR (pending_email IS NOT NULL AND consumed_at IS NOT NULL)",
         )
-        .bind(Utc::now())
+        // 10-minute grace past expires_at (keycast#362); same interval as users cleanup.
+        .bind(Utc::now() - chrono::Duration::minutes(10))
         .execute(&self.pool)
         .await?;
         Ok(result.rows_affected())
@@ -4169,13 +4175,23 @@ mod tests {
         )
         .await;
 
-        // Expired row (removed).
+        // Past grace: expired well beyond the 10-minute window (removed).
         let expired_dc = format!("dc_exp_{}", uuid::Uuid::new_v4());
         insert_pending_registration(
             &repo,
             &expired_dc,
             Some("pin"),
             Utc::now() - chrono::Duration::hours(1),
+        )
+        .await;
+
+        // Within grace: past expires_at but not yet reaped (kept for resend-pin honesty, keycast#362).
+        let grace_dc = format!("dc_grace_{}", uuid::Uuid::new_v4());
+        insert_pending_registration(
+            &repo,
+            &grace_dc,
+            Some("pin"),
+            Utc::now() - chrono::Duration::minutes(1),
         )
         .await;
 
@@ -4235,7 +4251,20 @@ mod tests {
                 .fetch_optional(&pool)
                 .await
                 .unwrap();
-        assert!(expired_still_present.is_none(), "expired row removed");
+        assert!(
+            expired_still_present.is_none(),
+            "expired row past grace removed"
+        );
+        let grace_still_present: Option<(String,)> =
+            sqlx::query_as("SELECT device_code FROM oauth_codes WHERE device_code = $1")
+                .bind(&grace_dc)
+                .fetch_optional(&pool)
+                .await
+                .unwrap();
+        assert!(
+            grace_still_present.is_some(),
+            "row expired within the 10-minute grace must be retained"
+        );
         let consumed_still_present: Option<(String,)> =
             sqlx::query_as("SELECT device_code FROM oauth_codes WHERE device_code = $1")
                 .bind(&consumed_dc)
@@ -4261,8 +4290,9 @@ mod tests {
             "live un-consumed row retained"
         );
 
-        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1")
+        sqlx::query("DELETE FROM oauth_codes WHERE device_code = $1 OR device_code = $2")
             .bind(&live_dc)
+            .bind(&grace_dc)
             .execute(&pool)
             .await
             .unwrap();


### PR DESCRIPTION
## Summary

After a pending registration expires, `POST /api/headless/resend-pin` only answers honestly while the row still exists. The cleanup task deleted expired rows with no grace period, so after the next tick the same request fell through to the anti-enumeration uniform success and told the client a new code was sent when nothing can be re-armed.

This change keeps recently expired pending rows long enough for the honest answer, and adds a stable machine-readable code on that branch so clients do not have to parse English prose.

## Motivation

The false-success trap is exactly what the expired branch was written to avoid. The reaper reintroduced it on a 5-minute timer. Clients then arm a resend cooldown and wait for mail that will never arrive.

## What Changed

- Widen the expired half of `delete_expired_and_consumed` to a 10-minute grace past `expires_at` (same interval as the sibling users cleanup).
- Add optional `code` on `HeadlessResendPinResponse`, set to `REGISTRATION_EXPIRED` only on the expired branch. `success: false` and HTTP 200 stay (pinned by #268).
- Extend cleanup unit coverage for within-grace retention.
- Add a regression test that runs cleanup between backdate and resend.

**Naming choice (issue left this open):** field `code`, value `REGISTRATION_EXPIRED`. Field is omitted on the uniform success path so a code cannot leak registration existence.

## Related Issue

- Closes #362

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A deprecated`
- [x] Pre-push `cargo test --workspace` (plus release build)
- [x] Targeted integration tests:
  - `test_delete_expired_and_consumed_removes_dead_rows`
  - `test_resend_pin_on_an_expired_registration_reports_failure`
  - `test_resend_pin_expired_survives_cleanup_grace_and_reports_code`
- [ ] Full `bun run test` / integration-feature suite beyond the targets above
- [x] Manual verification: no UI change

## Risks

- Bounded extra retention of already-dead `oauth_codes` rows (up to 10 minutes past expiry). Weakens the #262 growth bound slightly; does not remove it.
- Rows expired more than 10 minutes are still deleted and still answer through uniform success. That case remains indistinguishable from never-existed by design.

## Visuals

- [x] No visual change

## Follow-ups

Not in this PR: mobile can add `registration_expired` to its verify-style classifier once this deploys, while keeping prose match as the old-server fallback.