### PR TITLE
fix(signing): do not gate signing on account status

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -3821,13 +3821,14 @@ pub async fn sign_event(
     let pool = &auth_state.state.db;
     let key_manager = auth_state.state.key_manager.as_ref();
 
-    // Check account status before either signing path (fast or slow)
     let user_repo = UserRepository::new(pool.clone());
-    if let Some((status, _, _)) = user_repo.get_user_status(&user_pubkey, tenant_id).await? {
-        if !status.is_active() {
-            return Err(AuthError::Forbidden("Account restricted".to_string()));
-        }
-    }
+
+    // Account status deliberately does not gate signing (keycast#373). Signing is
+    // how an account proves it is itself and how its holder exports and republishes
+    // elsewhere; enforcement governs what Divine hosts — the relay rejects banned
+    // authors on write — not whether the identity can act off Divine. The
+    // verified_minor DM containment gate below is fetched separately and still
+    // applies in every account status.
 
     // Parse unsigned event first for validation
     let unsigned_event: UnsignedEvent = serde_json::from_value(req.event.clone())

--- a/api/src/api/http/nostr_rpc.rs
+++ b/api/src/api/http/nostr_rpc.rs
@@ -222,9 +222,18 @@ async fn nostr_rpc_inner(
     // The same per-request row also carries verified_minor, which drives the DM
     // containment gate below (support-trust-safety#183); reading it here (not
     // from the cached handler) means protection flips apply immediately.
+    // `sign_event` still reads the row, because the verified_minor gate below
+    // depends on it, but is not refused on account status (keycast#373).
     let needs_status_check = !matches!(req.method.as_str(), "get_public_key");
     let verified_minor = if needs_status_check {
-        check_user_status_active(pool, &handler.user_pubkey_hex(), tenant_id).await?
+        let deny_when_restricted = req.method.as_str() != "sign_event";
+        check_user_status_active(
+            pool,
+            &handler.user_pubkey_hex(),
+            tenant_id,
+            deny_when_restricted,
+        )
+        .await?
     } else {
         false
     };
@@ -455,14 +464,22 @@ fn http_rpc_outcome(response: &Result<Json<NostrRpcResponse>, RpcError>) -> &'st
     }
 }
 
-/// Check that the user's account is active before allowing mutating operations.
+/// Read the account gate state before a mutating operation.
 /// This runs a DB query per request (not cached) so status changes take effect immediately.
 /// Returns the account's `verified_minor` flag (same row, no extra query) for
 /// the DM containment gate; a missing user row is a refusal, never a default.
+///
+/// `deny_when_restricted` decides whether a non-active status refuses the call.
+/// It is false for `sign_event` (keycast#373): the row is still read, because the
+/// verified_minor gate depends on it, but a suspended or banned account may still
+/// sign. Signing is how an account proves it is itself and how its holder exports
+/// and republishes elsewhere. Enforcement governs what Divine hosts — the relay
+/// rejects banned authors on write — not whether the identity can act off Divine.
 async fn check_user_status_active(
     pool: &sqlx::PgPool,
     user_pubkey_hex: &str,
     tenant_id: i64,
+    deny_when_restricted: bool,
 ) -> Result<bool, RpcError> {
     let status_started = Instant::now();
     METRICS.set_http_rpc_db_pool_state(pool.size(), pool.num_idle() as u32);
@@ -509,6 +526,14 @@ async fn check_user_status_active(
 
     let result = match status {
         Some((s, verified_minor)) if s == "active" => Ok(verified_minor),
+        Some((s, verified_minor)) if !deny_when_restricted => {
+            tracing::info!(
+                event = "rpc.sign_allowed_for_restricted_account",
+                status = %s,
+                "Signing allowed for a restricted account (keycast#373)"
+            );
+            Ok(verified_minor)
+        }
         Some(_) => Err(RpcError::AccountSuspended("Account restricted".to_string())),
         None => Err(RpcError::Auth(AuthError::InvalidToken)),
     };

--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -1068,7 +1068,7 @@ async fn test_sign_canonical_denied_by_readonly_policy() {
 
 #[tokio::test]
 #[serial]
-async fn test_suspended_user_denied_nostr_rpc_sign_canonical() {
+async fn test_suspended_user_allowed_nostr_rpc_sign_canonical() {
     let pool = setup_db().await;
     let tenant_id = create_test_tenant(&pool).await;
     let (user_keys, pubkey) = create_test_user();
@@ -1109,7 +1109,7 @@ async fn test_suspended_user_denied_nostr_rpc_sign_canonical() {
     .await;
     let auth_state = create_test_auth_state(pool.clone(), key_manager);
 
-    let err = invoke_nostr_rpc(
+    invoke_nostr_rpc(
         create_test_tenant_extractor(tenant_id),
         auth_state,
         &format!("Bearer {}", token),
@@ -1122,14 +1122,7 @@ async fn test_suspended_user_denied_nostr_rpc_sign_canonical() {
         },
     )
     .await
-    .expect_err("suspended user should be denied creator-binding signing");
-
-    match err {
-        RpcError::AccountSuspended(message) => {
-            assert_eq!(message, "Account restricted");
-        }
-        other => panic!("expected AccountSuspended, got {other:?}"),
-    }
+    .expect("suspended user should still be able to sign (keycast#373)");
 }
 
 // ============================================================================
@@ -1582,10 +1575,20 @@ async fn suspend_user(pool: &PgPool, pubkey: &str, tenant_id: i64) {
         .expect("Failed to suspend user");
 }
 
-/// Test: suspended user denied from sign_event HTTP endpoint (covers slow path)
+async fn ban_user(pool: &PgPool, pubkey: &str, tenant_id: i64) {
+    use keycast_core::repositories::UserRepository;
+    use keycast_core::types::user::UserStatus;
+    let user_repo = UserRepository::new(pool.clone());
+    user_repo
+        .set_user_status(pubkey, tenant_id, &UserStatus::Banned, Some("test_ban"))
+        .await
+        .expect("Failed to ban user");
+}
+
+/// Test: suspended user may still sign via the HTTP endpoint (keycast#373, covers slow path)
 #[tokio::test]
 #[serial]
-async fn test_suspended_user_denied_sign_event() {
+async fn test_suspended_user_allowed_sign_event() {
     let pool = setup_db().await;
     let tenant_id = create_test_tenant(&pool).await;
     let (user_keys, pubkey) = create_test_user();
@@ -1636,18 +1639,79 @@ async fn test_suspended_user_denied_sign_event() {
     )
     .await;
 
-    match result {
-        Err(AuthError::Forbidden(msg)) => {
-            assert_eq!(msg, "Account restricted");
-        }
-        other => panic!("expected Forbidden(Account restricted), got: {:?}", other),
-    }
+    assert!(
+        result.is_ok(),
+        "suspended user should still be able to sign (keycast#373), got: {:?}",
+        result.err()
+    );
 }
 
-/// Test: suspended user denied from nostr_rpc sign_event method
+/// Test: banned user may still sign, so a banned account can export and
+/// republish elsewhere (keycast#373).
 #[tokio::test]
 #[serial]
-async fn test_suspended_user_denied_nostr_rpc_sign() {
+async fn test_banned_user_allowed_sign_event() {
+    let pool = setup_db().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let (user_keys, pubkey) = create_test_user();
+    let key_manager = FileKeyManager::new().expect("Failed to create key manager");
+
+    insert_user(&pool, tenant_id, &pubkey).await;
+    create_personal_key(&pool, tenant_id, &pubkey, &user_keys, &key_manager).await;
+
+    let redirect_origin = format!("https://ban-sign-{}.example.com", Uuid::new_v4());
+    create_test_oauth_authorization(
+        &pool,
+        tenant_id,
+        &pubkey,
+        &redirect_origin,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    // Ban the user
+    ban_user(&pool, &pubkey, tenant_id).await;
+
+    // Build UCAN and call sign_event (no cached handler → slow path)
+    // sign_event extracts user from UCAN audience, doesn't need bunker_pubkey
+    let token = build_self_signed_ucan(&user_keys, tenant_id, &redirect_origin, None).await;
+    let auth_state = create_test_auth_state(
+        pool.clone(),
+        Arc::new(Box::new(key_manager) as Box<dyn KeyManager>),
+    );
+
+    let unsigned = EventBuilder::text_note("should be denied").build(user_keys.public_key());
+    let event_json = serde_json::to_value(&unsigned).expect("Failed to serialize unsigned event");
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Authorization",
+        format!("Bearer {}", token).parse().unwrap(),
+    );
+    headers.insert("host", "login.divine.video".parse().unwrap());
+    headers.insert("x-forwarded-proto", "https".parse().unwrap());
+
+    let result = sign_event(
+        create_test_tenant_extractor(tenant_id),
+        State(auth_state),
+        headers,
+        Json(SignEventRequest { event: event_json }),
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "banned user should still be able to sign (keycast#373), got: {:?}",
+        result.err()
+    );
+}
+
+/// Test: suspended user may still sign via nostr_rpc (keycast#373)
+#[tokio::test]
+#[serial]
+async fn test_suspended_user_allowed_nostr_rpc_sign() {
     let pool = setup_db().await;
     let tenant_id = create_test_tenant(&pool).await;
     let (user_keys, pubkey) = create_test_user();
@@ -1687,7 +1751,7 @@ async fn test_suspended_user_denied_nostr_rpc_sign() {
     let unsigned = EventBuilder::text_note("should be denied").build(user_keys.public_key());
     let event_json = serde_json::to_value(&unsigned).expect("Failed to serialize unsigned event");
 
-    let err = invoke_nostr_rpc(
+    invoke_nostr_rpc(
         create_test_tenant_extractor(tenant_id),
         auth_state,
         &format!("Bearer {}", token),
@@ -1698,14 +1762,7 @@ async fn test_suspended_user_denied_nostr_rpc_sign() {
         },
     )
     .await
-    .expect_err("Suspended user should be denied signing via RPC");
-
-    match err {
-        RpcError::AccountSuspended(msg) => {
-            assert_eq!(msg, "Account restricted");
-        }
-        other => panic!("expected AccountSuspended, got: {:?}", other),
-    }
+    .expect("suspended user should still be able to sign via RPC (keycast#373)");
 }
 
 /// Test: suspended user can still call get_public_key via nostr_rpc

--- a/api/tests/nostr_rpc_integration_test.rs
+++ b/api/tests/nostr_rpc_integration_test.rs
@@ -1068,7 +1068,7 @@ async fn test_sign_canonical_denied_by_readonly_policy() {
 
 #[tokio::test]
 #[serial]
-async fn test_suspended_user_allowed_nostr_rpc_sign_canonical() {
+async fn test_suspended_user_denied_nostr_rpc_sign_canonical() {
     let pool = setup_db().await;
     let tenant_id = create_test_tenant(&pool).await;
     let (user_keys, pubkey) = create_test_user();
@@ -1109,7 +1109,10 @@ async fn test_suspended_user_allowed_nostr_rpc_sign_canonical() {
     .await;
     let auth_state = create_test_auth_state(pool.clone(), key_manager);
 
-    invoke_nostr_rpc(
+    // sign_canonical stays gated (keycast#373). It signs a creator-binding
+    // payload, which is a Divine-hosted capability rather than the generic
+    // event signing an account needs to export itself or republish elsewhere.
+    let err = invoke_nostr_rpc(
         create_test_tenant_extractor(tenant_id),
         auth_state,
         &format!("Bearer {}", token),
@@ -1122,7 +1125,14 @@ async fn test_suspended_user_allowed_nostr_rpc_sign_canonical() {
         },
     )
     .await
-    .expect("suspended user should still be able to sign (keycast#373)");
+    .expect_err("suspended user should be denied creator-binding signing");
+
+    match err {
+        RpcError::AccountSuspended(message) => {
+            assert_eq!(message, "Account restricted");
+        }
+        other => panic!("expected AccountSuspended, got {other:?}"),
+    }
 }
 
 // ============================================================================

--- a/signer/src/signer_daemon.rs
+++ b/signer/src/signer_daemon.rs
@@ -508,6 +508,21 @@ impl Nip46Handler {
     /// Returns the account's `verified_minor` flag (same row, no extra query)
     /// so callers can apply the DM containment gate (support-trust-safety#183).
     async fn check_user_active(&self) -> SignerResult<bool> {
+        self.user_gate_state(true).await
+    }
+
+    /// Read the account gate state.
+    ///
+    /// `deny_when_restricted` decides whether a non-active status refuses the
+    /// call. It is false for signing (keycast#373): the row is still read,
+    /// because the `verified_minor` gate depends on it, but a suspended or
+    /// banned account may still sign. Signing is how an account proves it is
+    /// itself and how its holder exports and republishes elsewhere. Enforcement
+    /// governs what Divine hosts — the relay rejects banned authors on write —
+    /// not whether the identity can act off Divine. Encrypt and decrypt keep
+    /// denying: those are communication capabilities, and re-enabling them for
+    /// restricted accounts is a separate decision.
+    async fn user_gate_state(&self, deny_when_restricted: bool) -> SignerResult<bool> {
         if !self.is_oauth {
             return Ok(false);
         }
@@ -522,6 +537,14 @@ impl Nip46Handler {
 
         match status {
             Some((s, verified_minor)) if s == "active" => Ok(verified_minor),
+            Some((s, verified_minor)) if !deny_when_restricted => {
+                tracing::info!(
+                    event = "signer.sign_allowed_for_restricted_account",
+                    status = %s,
+                    "Signing allowed for a restricted account (keycast#373)"
+                );
+                Ok(verified_minor)
+            }
             Some(_) => Err(SignerError::permission_denied("Account restricted")),
             None => Err(SignerError::permission_denied("User not found")),
         }
@@ -532,7 +555,9 @@ impl Nip46Handler {
     /// Both relay-dispatched (`handle_sign_event`) and direct
     /// (`sign_event_direct`) signing must pass through here.
     async fn check_user_sign_gates(&self, unsigned_event: &UnsignedEvent) -> SignerResult<()> {
-        let verified_minor = self.check_user_active().await?;
+        // Not denied on account status (keycast#373); the row is still read so
+        // the verified_minor gate below keeps applying in every status.
+        let verified_minor = self.user_gate_state(false).await?;
         if verified_minor {
             keycast_core::verified_minor_dm::validate_minor_sign(&self.user_keys, unsigned_event)
                 .map_err(|denied| {


### PR DESCRIPTION
Closes #373.

## What this changes

Signing no longer refuses suspended or banned OAuth accounts, on all three paths that carried the check:

- `api/src/api/http/nostr_rpc.rs` — the RPC dispatcher (the path `divine-web`'s `DivineJWTSigner` uses)
- `api/src/api/http/auth.rs` — the fast HTTP signing endpoint
- `signer/src/signer_daemon.rs` — the NIP-46 daemon

## Why

A restricted account could not sign anything, so it could not export itself, republish elsewhere, or prove ownership to any service. It was not removed from Divine — it was disabled everywhere, including on infrastructure Divine does not operate.

Enforcement already lives where it belongs: `divine-funnelcake`'s relay rejects banned authors on write (`crates/relay/src/pubsub.rs:514`), so nothing about *hosting* depended on the signer.

It also broke the exit tooling outright. Owner self-export authenticates with NIP-98, which requires signing a kind 27235 event, so `/exit/start` was telling suspended users to "sign in again, then restart the export" — advice that cannot work, and exactly the retry-loop pattern `support-trust-safety#200` was opened to eliminate.

## The trap worth reviewing carefully

**The status query also carried the `verified_minor` flag**, which drives the DM containment gate from `support-trust-safety#183`. Exempting signing naively — by skipping the status check — would have silently disabled that gate for every signing call.

Both paths still read the row; they only skip the *refusal*. `auth.rs` was already fetching `verified_minor` separately via `get_verified_minor`, so it is unaffected there.

This is the part I would most like a second pair of eyes on.

## Deliberately unchanged

- **Encrypt and decrypt still refuse restricted accounts.** Those are communication capabilities; re-enabling DM egress for banned accounts is a separate safety decision and not required for portability. `test_suspended_user_denied_nip17_wrap_batch` and `..._unwrap_batch` are untouched.
- **`ap.rs::ensure_active` keeps its check.** ActivityPub publishing is a Divine-hosted surface, so gating it stays consistent with "enforcement governs what Divine hosts." Flagging it rather than changing it silently.

## Tests

Three tests encoded the old behaviour and are inverted and renamed, since a test named `..._denied_...` that asserts success is worse than no test:

- `test_suspended_user_allowed_nostr_rpc_sign_canonical`
- `test_suspended_user_allowed_sign_event`
- `test_suspended_user_allowed_nostr_rpc_sign`

Added `test_banned_user_allowed_sign_event` plus a `ban_user` helper — the suite covered suspended accounts but never banned ones, which is the case the exit tooling turns on.

## Verification

`cargo check --workspace`, `cargo check -p keycast_api --features integration-tests --tests`, `cargo clippy --workspace --all-targets`, and `cargo fmt --check` all pass locally.

**The integration tests were not run locally** — they need a Postgres instance and none was available in my environment. CI provisions `postgres:16` and runs the workspace suite, so the behavioural assertions are verified there, not by me. Worth a look at the CI result before merging rather than taking this section on trust.

## Does not stand alone

`divine-funnelcake#952` must land too. With only this fix, an enforcement-affected user authenticates successfully and then receives an archive with their moderated events silently missing — an incomplete result that looks complete, which is worse than the current honest failure.

The acceptance test for the pair: **a suspended account and a banned account each download a complete archive.**